### PR TITLE
Ensure that only non-namespaced resources can perform CRUD operations…

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ClientMixedOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ClientMixedOperation.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.client.ClientAware;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
-public interface ClientOperation<C extends KubernetesClient, T, L, D, R extends ClientResource<T, D>> extends
-  ClientAware<C>,
-  Namespaceable<ClientNonNamespaceOperation<C, T, L, D, R>>,
-  FilterWatchListDeleteable<T, L, Boolean> {
+public interface ClientMixedOperation<C extends KubernetesClient, T, L, D, R extends ClientResource<T, D>>
+  extends  ClientResource<T,D>,
+  ClientOperation<C, T, L, D, R>,
+  ClientNonNamespaceOperation<C, T, L, D, R> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ClientOperation;
 import io.fabric8.kubernetes.client.dsl.ClientResource;
@@ -51,7 +52,7 @@ import java.util.concurrent.Future;
 import static io.fabric8.kubernetes.client.internal.Utils.join;
 
 public class BaseOperation<C extends KubernetesClient, T, L extends KubernetesResourceList, D extends Doneable<T>, R extends ClientResource<T, D>>
-  implements ClientOperation<C, T, L, D, R> {
+  implements ClientMixedOperation<C, T, L, D, R> {
 
   protected static final ObjectMapper mapper = new ObjectMapper();
 

--- a/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/BaseMockOperation.java
+++ b/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/BaseMockOperation.java
@@ -22,6 +22,8 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
+import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ClientOperation;
 import io.fabric8.kubernetes.client.dsl.ClientResource;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeleteable;
@@ -46,14 +48,14 @@ public class BaseMockOperation<C extends KubernetesClient, T, L extends Kubernet
   E extends Resource<T, IExpectationSetters<T>, D, IExpectationSetters<Boolean>>>
   implements MockOperation<T, L, D, E>, Mockable {
 
-  private final ClientOperation<C, T, L, D, R> delegate;
+  private final ClientMixedOperation<C, T, L, D, R> delegate;
   private final Set<Mockable> nested = new LinkedHashSet<>();
 
   public BaseMockOperation() {
-    this(EasyMock.createMock(ClientOperation.class));
+    this(EasyMock.createMock(ClientMixedOperation.class));
   }
 
-  public BaseMockOperation(ClientOperation delegate) {
+  public BaseMockOperation(ClientMixedOperation delegate) {
     this.delegate = delegate;
   }
 
@@ -90,7 +92,7 @@ public class BaseMockOperation<C extends KubernetesClient, T, L extends Kubernet
     return new BaseMockOperation();
   }
 
-  public ClientOperation<C, T, L, D, R> getDelegate() {
+  public ClientMixedOperation<C, T, L, D, R> getDelegate() {
     return delegate;
   }
 
@@ -143,7 +145,7 @@ public class BaseMockOperation<C extends KubernetesClient, T, L extends Kubernet
     BaseMockOperation<C, T, L, D, R, E> op = namespaceMap.get(matcher);
     if (op == null) {
       op = newInstance();
-      expect(delegate.inNamespace(namespace)).andReturn(op.getDelegate()).anyTimes();
+      expect(delegate.inNamespace(namespace)).andReturn((ClientNonNamespaceOperation<C, T, L, D, R>) op.getDelegate()).anyTimes();
       nested.add(op);
       namespaceMap.put(matcher, op);
     }


### PR DESCRIPTION
… without specifying a namespace first.