### PR TITLE
#36: Allow Openshift url to be specified via system properties or env…

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -316,6 +316,7 @@ public class DefaultKubernetesClient implements KubernetesClient {
     return configuration;
   }
 
+
   @Override
   public <T extends Extension> T adapt(Class<T> type) {
     for (ExtensionAdapter<T> adapter : ServiceLoader.load(ExtensionAdapter.class)) {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenshiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenshiftClient.java
@@ -18,6 +18,7 @@ package io.fabric8.openshift.client;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.Extension;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.client.dsl.BuildConfigClientResource;
 import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftConfig.java
@@ -30,6 +30,9 @@ public class OpenshiftConfig extends Config {
 
   public static final String KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY = "kubernetes.oapi.version";
 
+  public static final String OPENSHIFT_URL_SYTEM_PROPERTY_NAME = "openshift.url";
+  public static final String OPENSHIFT_URL_ENV_VARIABLE_NAME = "OPENSHIFT_URL";
+
   private String oapiVersion = "v1";
   private String openShiftUrl;
   private Config kubernetesConfig;
@@ -58,13 +61,20 @@ public class OpenshiftConfig extends Config {
     this.oapiVersion = Utils.getSystemPropertyOrEnvVar(KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY, oapiVersion);
     this.openShiftUrl = openShiftUrl;
 
-    if (this.openShiftUrl == null) {
-      try {
-        this.openShiftUrl = new URL(new URL(getMasterUrl()), "/oapi/" + this.oapiVersion + "/").toString();
-      } catch (MalformedURLException e) {
-        throw KubernetesClientException.launderThrowable(e);
+    if (this.openShiftUrl == null || this.openShiftUrl.isEmpty()) {
+      this.openShiftUrl = getCustomOpenshiftUrl();
+      if (this.openShiftUrl == null || this.openShiftUrl.isEmpty()) {
+        try {
+          this.openShiftUrl = new URL(new URL(getMasterUrl()), "/oapi/" + this.oapiVersion + "/").toString();
+        } catch (MalformedURLException e) {
+          throw KubernetesClientException.launderThrowable(e);
+        }
       }
     }
+  }
+
+  public static String getCustomOpenshiftUrl() {
+    return Utils.getSystemPropertyOrEnvVar(OPENSHIFT_URL_SYTEM_PROPERTY_NAME, OPENSHIFT_URL_ENV_VARIABLE_NAME, null);
   }
 
   public Config getKubernetesConfig() {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftExtensionAdapter.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftExtensionAdapter.java
@@ -17,7 +17,6 @@
 package io.fabric8.openshift.client;
 
 import io.fabric8.kubernetes.api.model.RootPaths;
-import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ExtensionAdapter;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -37,10 +36,11 @@ public class OpenshiftExtensionAdapter implements ExtensionAdapter<OpenShiftClie
 
   @Override
   public OpenShiftClient adapt(KubernetesClient client) {
-    if (!isOpenShift(client)) {
+    String customOpenshiftUrl = OpenshiftConfig.getCustomOpenshiftUrl();
+    if ((customOpenshiftUrl == null || customOpenshiftUrl.isEmpty()) && !isOpenShift(client)) {
       throw new IllegalArgumentException("Client is not pointing to an OpenShift installation");
     }
-    return new DefaultOpenshiftClient((Config) client.getConfiguration());
+    return new DefaultOpenshiftClient(client.getConfiguration());
   }
 
   public static boolean isOpenShift(KubernetesClient client) {


### PR DESCRIPTION
… variable (if not explicitly specified in config). When using custom Openshift Url the adapter should not consult root paths.