### PR TITLE
How about client.adapt(OkHttpClient.class)

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Adapters.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Adapters.java
@@ -35,15 +35,15 @@ public final class Adapters {
     }
   }
 
-  public static <C extends Client> void register(ExtensionAdapter<C> adapter) {
+  public static <C> void register(ExtensionAdapter<C> adapter) {
     EXTENSION_ADAPTER_MAP.put(adapter.getExtensionType(), adapter);
   }
 
-  public static <C extends Client> void unregister(ExtensionAdapter<C> adapter) {
+  public static <C> void unregister(ExtensionAdapter<C> adapter) {
     EXTENSION_ADAPTER_MAP.remove(adapter.getExtensionType());
   }
 
-  public static <C extends Client> ExtensionAdapter<C> get(Class<C> type) {
+  public static <C> ExtensionAdapter<C> get(Class<C> type) {
     return EXTENSION_ADAPTER_MAP.get(type);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -94,20 +94,24 @@ public class BaseClient implements Client {
   }
 
   @Override
-  public <C extends Client> Boolean isAdaptable(Class<C> type) {
+  public <C> Boolean isAdaptable(Class<C> type) {
     ExtensionAdapter<C> adapter = Adapters.get(type);
     if (adapter != null) {
       return adapter.isAdaptable(this);
-    } else {
+    } else if (type.isAssignableFrom(OkHttpClient.class)) {
+      return true;
+    }else {
       return false;
     }
   }
 
   @Override
-  public <C extends Client> C adapt(Class<C> type) {
+  public <C> C adapt(Class<C> type) {
     ExtensionAdapter<C> adapter = Adapters.get(type);
     if (adapter != null) {
       return adapter.adapt(this);
+    } else if (type.isAssignableFrom(OkHttpClient.class)) {
+      return (C) httpClient;
     }
     throw new IllegalStateException("No adapter available for type:" + type);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ExtensionAdapter.java
@@ -22,7 +22,7 @@ package io.fabric8.kubernetes.client;
  *
  * @param <C> The Client.
  */
-public interface ExtensionAdapter<C extends Client> {
+public interface ExtensionAdapter<C> {
 
   /**
    * @return The concrete class of the {@link io.fabric8.kubernetes.client.Client}.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -284,7 +284,7 @@ public class ManagedKubernetesClient extends BaseClient implements KubernetesCli
   }
 
   @Override
-  public <C extends Client> C adapt(Class<C> type) {
+  public <C> C adapt(Class<C> type) {
     return delegate.adapt(type);
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/AdaptTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/AdaptTest.java
@@ -16,30 +16,16 @@
 
 package io.fabric8.kubernetes.client;
 
-import io.fabric8.kubernetes.api.model.RootPaths;
+import com.squareup.okhttp.OkHttpClient;
+import org.junit.Assert;
+import org.junit.Test;
 
-import java.io.Closeable;
-import java.net.URL;
+public class AdaptTest {
 
-public interface Client extends ConfigAware, Closeable {
-
-  /**
-   * Checks if the client can be adapted to an other client type.
-   * @param type  The target client class.
-   * @param <C>   The target client type.
-   * @return      Returns true if a working {@link io.fabric8.kubernetes.client.ExtensionAdapter} is found.
-   */
-  <C> Boolean  isAdaptable(Class<C> type);
-
-  <C> C adapt(Class<C> type);
-
-  URL getMasterUrl();
-
-  String getApiVersion();
-
-  String getNamespace();
-
-  RootPaths rootPaths();
-
-  void close();
+    @Test
+    public void testAdaptToHttpClient() {
+        KubernetesClient client = new DefaultKubernetesClient();
+        Assert.assertTrue(client.isAdaptable(OkHttpClient.class));
+        Assert.assertNotNull(client.adapt(OkHttpClient.class));
+    }
 }

--- a/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/KubernetesMockClient.java
+++ b/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/KubernetesMockClient.java
@@ -273,11 +273,11 @@ public class KubernetesMockClient implements Replayable<KubernetesClient>, Verif
     return expect(client.getNamespace());
   }
 
-  public  <T extends Client> IExpectationSetters<Boolean> isAdaptable(Class<T> type) {
+  public  <T> IExpectationSetters<Boolean> isAdaptable(Class<T> type) {
     return expect(client.isAdaptable(type));
   }
 
-  public <T extends Client> IExpectationSetters<T> adapt(Class<T> type) {
+  public <T> IExpectationSetters<T> adapt(Class<T> type) {
     return expect(client.adapt(type));
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -417,7 +417,7 @@ public class ManagedOpenShiftClient extends BaseClient implements OpenShiftClien
   }
 
   @Override
-  public <C extends Client> C adapt(Class<C> type) {
+  public <C> C adapt(Class<C> type) {
     return delegate.adapt(type);
   }
 

--- a/openshift-mock/src/main/java/io/fabric8/openshift/client/mock/OpenShiftMockClient.java
+++ b/openshift-mock/src/main/java/io/fabric8/openshift/client/mock/OpenShiftMockClient.java
@@ -486,11 +486,11 @@ public class OpenShiftMockClient implements Replayable<OpenShiftClient>, Verifia
     return expect(client.getNamespace());
   }
 
-  public  <T extends Client> IExpectationSetters<Boolean> isAdaptable(Class<T> type) {
+  public  <T> IExpectationSetters<Boolean> isAdaptable(Class<T> type) {
     return expect(client.isAdaptable(type));
   }
 
-  public <T extends Client> IExpectationSetters<T> adapt(Class<T> type) {
+  public <T> IExpectationSetters<T> adapt(Class<T> type) {
     return expect(client.adapt(type));
   }
 }


### PR DESCRIPTION
Since we no longer expose the client, but there are ppl still want to use it, I am wondering if it makes sense to do it via adapt().

This pull request makes all the required changes to adapt to support adapting things other than just clients. It also implements support of OkHttpClient adaptor (as part of the main adapt impl, not via service loader). Of course we could change that if we'd like.

This is more for review guys.@jimmidyson @alesj. Does it solve the issue we discussed yesterday? 