### PR TITLE
Merge fix NPE on getProxyUrl when no NoProxy is null

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -148,10 +148,12 @@ public class HttpClientUtils {
     private static URL getProxyUrl(Config config) throws MalformedURLException {
         URL master = new URL(config.getMasterUrl());
         String host = master.getHost();
-        for (String noProxy : config.getNoProxy()) {
-            if (host.endsWith(noProxy)) {
-                return null;
-            }
+        if (config.getNoProxy() != null) {
+	        for (String noProxy : config.getNoProxy()) {
+	            if (host.endsWith(noProxy)) {
+	                return null;
+	            }
+	        }
         }
         String proxy = config.getHttpsProxy();
         if (master.getProtocol().equals("http")) {


### PR DESCRIPTION
Adding null check to the NoProxy string array. As it fails when I write client code in the form:

Config config = new Config();
client = new DefaultKubernetesClient(config);

It returns:
java.lang.NullPointerException
	at io.fabric8.kubernetes.client.utils.HttpClientUtils.getProxyUrl(HttpClientUtils.java:148)
	at io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClient(HttpClientUtils.java:130)
	at io.fabric8.kubernetes.client.BaseClient.<init>(BaseClient.java:41)
	at io.fabric8.kubernetes.client.DefaultKubernetesClient.<init>(DefaultKubernetesClient.java:90)
