### PR TITLE
Adding support for componentstatuses API call

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -16,6 +16,10 @@
 package io.fabric8.kubernetes.client;
 
 import com.squareup.okhttp.OkHttpClient;
+
+import io.fabric8.kubernetes.api.model.ComponentStatus;
+import io.fabric8.kubernetes.api.model.ComponentStatusList;
+import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.DoneableEvent;
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
@@ -61,6 +65,7 @@ import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ClientResource;
 import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.internal.ComponentStatusOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.EndpointsOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.EventOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.KubernetesListOperationsImpl;
@@ -92,6 +97,11 @@ public class DefaultKubernetesClient extends BaseClient implements KubernetesCli
 
   public DefaultKubernetesClient(String masterUrl) throws KubernetesClientException {
     super(masterUrl);
+  }
+  
+  @Override
+  public ClientMixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, ClientResource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {
+    return new ComponentStatusOperationsImpl(httpClient, getConfiguration(), getNamespace());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/KubernetesDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/KubernetesDSL.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
+import io.fabric8.kubernetes.api.model.ComponentStatus;
+import io.fabric8.kubernetes.api.model.ComponentStatusList;
+import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.DoneableEvent;
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
@@ -57,6 +60,8 @@ import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.ServiceList;
 
 public interface KubernetesDSL {
+	
+  ClientMixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, ClientResource<ComponentStatus, DoneableComponentStatus>> componentstatuses();
 
   ClientMixedOperation<Endpoints, EndpointsList, DoneableEndpoints, ClientResource<Endpoints, DoneableEndpoints>> endpoints();
 
@@ -85,4 +90,5 @@ public interface KubernetesDSL {
   ClientKubernetesListMixedOperation lists();
 
   ClientNonNamespaceOperation<SecurityContextConstraints, SecurityContextConstraintsList, DoneableSecurityContextConstraints, ClientResource<SecurityContextConstraints, DoneableSecurityContextConstraints>> securityContextConstraints();
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
@@ -1,0 +1,24 @@
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import com.squareup.okhttp.OkHttpClient;
+
+import io.fabric8.kubernetes.api.model.ComponentStatus;
+import io.fabric8.kubernetes.api.model.ComponentStatusList;
+import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.ClientResource;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+
+public class ComponentStatusOperationsImpl extends HasMetadataOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus,
+ClientResource<ComponentStatus, DoneableComponentStatus>> {
+
+	public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String namespace) {
+		this(client, config, null, namespace, null, true, null, null);
+	}
+
+
+	public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, ComponentStatus item, String resourceVersion) {
+		super(client, config, null, apiVersion, "componentstatuses", namespace, name, cascading, item, resourceVersion);
+	}
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.kubernetes.client.osgi;
 
+import io.fabric8.kubernetes.api.model.ComponentStatus;
+import io.fabric8.kubernetes.api.model.ComponentStatusList;
+import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.DoneableEvent;
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
@@ -198,6 +201,10 @@ public class ManagedKubernetesClient extends BaseClient implements KubernetesCli
   @Deactivate
   public void deactivate() {
     delegate.close();
+  }
+  
+  public ClientMixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, ClientResource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {
+	return delegate.componentstatuses();
   }
 
   public ClientMixedOperation<Endpoints, EndpointsList, DoneableEndpoints, ClientResource<Endpoints, DoneableEndpoints>> endpoints() {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/mock/ComponentStatusTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/mock/ComponentStatusTest.java
@@ -1,0 +1,40 @@
+package io.fabric8.kubernetes.client.mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import io.fabric8.kubernetes.api.model.ComponentCondition;
+import io.fabric8.kubernetes.api.model.ComponentStatus;
+import io.fabric8.kubernetes.api.model.ComponentStatusBuilder;
+import io.fabric8.kubernetes.api.model.ComponentStatusList;
+import io.fabric8.kubernetes.api.model.ComponentStatusListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+public class ComponentStatusTest extends KubernetesMockServerTestBase	 {
+	ComponentStatus status = new ComponentStatusBuilder().withConditions(new ComponentCondition(null, "ok", 
+			"True", "Healthy")).build();
+	
+	ComponentStatusList list = new ComponentStatusListBuilder().addNewItem().addNewCondition()
+			.and().endItem().build();
+	
+	@Test
+	public void testComponentStatus() {
+		expect().withPath("/api/v1/namespaces/test/componentstatuses/scheduler").andReturn(200, status).once();
+	
+		KubernetesClient client = getClient();
+		ComponentStatus stat = client.componentstatuses().withName("scheduler").get();
+	    assertNotNull(stat);
+	    assertEquals(1, stat.getConditions().size());
+	}
+	
+	@Test
+	public void testComponentStatusList() {
+		expect().withPath("/api/v1/namespaces/test/componentstatuses").andReturn(200, status).once();
+	
+		KubernetesClient client = getClient();
+		ComponentStatusList stats = client.componentstatuses().list();
+	    assertNotNull(stats);
+	}
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -16,6 +16,10 @@
 package io.fabric8.openshift.client;
 
 import com.squareup.okhttp.OkHttpClient;
+
+import io.fabric8.kubernetes.api.model.ComponentStatus;
+import io.fabric8.kubernetes.api.model.ComponentStatusList;
+import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.DoneableEvent;
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
@@ -67,6 +71,7 @@ import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ClientResource;
 import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.internal.ComponentStatusOperationsImpl;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigList;
@@ -187,6 +192,11 @@ public class DefaultOpenShiftClient extends BaseClient implements OpenShiftClien
   @Override
   public URL getOpenshiftUrl() {
     return openShiftUrl;
+  }
+  
+  @Override
+  public ClientMixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, ClientResource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {
+    return new ComponentStatusOperationsImpl(httpClient, getConfiguration(), getNamespace());
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.openshift.client.osgi;
 
+import io.fabric8.kubernetes.api.model.ComponentStatus;
+import io.fabric8.kubernetes.api.model.ComponentStatusList;
+import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.DoneableEvent;
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
@@ -263,6 +266,11 @@ public class ManagedOpenShiftClient extends BaseClient implements OpenShiftClien
   @Override
   public ClientMixedOperation<Build, BuildList, DoneableBuild, ClientResource<Build, DoneableBuild>> builds() {
     return delegate.builds();
+  }
+  
+  @Override
+  public ClientMixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, ClientResource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {
+    return delegate.componentstatuses();
   }
 
   @Override


### PR DESCRIPTION
Kindly review this PR which enables querying of:
*  "api/v1/namespaces/test/componentstatuses" and
*  "api/v1/namespaces/test/componentstatuses/scheduler" type of endpoints and returns ComponentStatus objects.

Thanks in advance.