### PR TITLE
Close response body on failure responses

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -120,9 +120,9 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
       @Override
       public void onFailure(IOException e, Response response) {
         if (!forceClosed.get()) {
-          if (response != null) {
-            try {
-              Status responseStatus = mapper.readValue(response.body().byteStream(), Status.class);
+          if (response != null && response.body() != null) {
+            try (ResponseBody body = response.body()) {
+              Status responseStatus = mapper.readValue(body.byteStream(), Status.class);
               watcher.onClose(
                 new KubernetesClientException("Connection unexpectedly closed", response.code(),
                                               responseStatus));


### PR DESCRIPTION
Fixes two issues:

1. A NPE would be thrown on failures that did not have a response body (such as the underlying websocket throwing a ProtocolException)
2. For cases when there is a response body, the body is not closed