### PR TITLE
manually updating to next development version.  I dont know why this …

### DIFF
--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kubernetes-examples/pom.xml
+++ b/kubernetes-examples/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kubernetes-mock/pom.xml
+++ b/kubernetes-mock/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/openshift-mock/pom.xml
+++ b/openshift-mock/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/platforms/karaf/features/pom.xml
+++ b/platforms/karaf/features/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>karaf</artifactId>
     <groupId>io.fabric8.kubernetes</groupId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/platforms/karaf/itests/pom.xml
+++ b/platforms/karaf/itests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>karaf</artifactId>
         <groupId>io.fabric8.kubernetes</groupId>
-        <version>1.3.69</version>
+        <version>1.3.70-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platforms/karaf/pom.xml
+++ b/platforms/karaf/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.fabric8.kubernetes</groupId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/platforms/pom.xml
+++ b/platforms/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>1.3.69</version>
+    <version>1.3.70-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>kubernetes-client-project</artifactId>
-  <version>1.3.69</version>
+  <version>1.3.70-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Fabric8 :: Kubernetes :: Project</name>
 


### PR DESCRIPTION
…wasnt automatically done.  It only seem to happen with kubernetes-client, all six other repos have their poms updated correctly.  The CD process will change very soon which will help each project be responsible for its own pipelibe, hopefully that will help