### PR TITLE
fixing the url by removing the namespace

### DIFF
--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/UserOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/UserOperationsImpl.java
@@ -24,11 +24,11 @@ import io.fabric8.openshift.client.OpenShiftConfig;
 
 public class UserOperationsImpl extends OpenShiftOperation<User, UserList, DoneableUser, ClientResource<User, DoneableUser>> {
   public UserOperationsImpl(OkHttpClient client, OpenShiftConfig config, String namespace) {
-    this(client, config, null, namespace, null, true, null, null, false, -1);
+    this(client, config, null, null, null, true, null, null, false, -1);
   }
 
   public UserOperationsImpl(OkHttpClient client, OpenShiftConfig config, String apiVersion, String namespace, String name, Boolean cascading, User item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds) {
-    super(client, config, null, apiVersion, "users", namespace, name, cascading, item, resourceVersion, reloadingFromServer, -1);
+    super(client, config, null, apiVersion, "users", null, name, cascading, item, resourceVersion, reloadingFromServer, -1);
   }
 
   @Override


### PR DESCRIPTION
The users url on kubernetes is 

http://<kubernetes_master//oapi/v1/users, 

but if the namespace is not set to null is results in 

http://<kubernetes_master//oapi/v1/namespace/default/users 

which then fails. Please verify since there are no unit tests to check I'm not breaking something else.

