### PR TITLE
Compile in client project version

### DIFF
--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -137,6 +137,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/kubernetes-client/src/main/java-templates/io/fabric8/kubernetes/client/Version.java
+++ b/kubernetes-client/src/main/java-templates/io/fabric8/kubernetes/client/Version.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+public final class Version {
+  public static String clientVersion() {
+    return "${project.version}";
+  }
+
+  private Version() {
+  }
+}


### PR DESCRIPTION
@iocanel, @lwander This enables the client version to be compiiled in (no properties files - yay!) available as ``Version.clientVersion()``
that you can use in the default user agent string.