### PR TITLE
Do not modify the item before the operation succeeds

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -78,8 +78,10 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
         if (got == null) {
           return null;
         }
+
+        item = handleReplace(item);
         item.getMetadata().setResourceVersion(got.getMetadata().getResourceVersion());
-        return handleReplace(item);
+        return item;
       } catch (KubernetesClientException e) {
         caught = e;
         // Only retry if there's a conflict - this is normally to do with resource version & server updates.


### PR DESCRIPTION
handleReplace() can fail and generate an exception, then we should
make sure that, in this case, we do not touch the original item.