### PR TITLE
Support for 'exists' type label selector

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
@@ -29,7 +29,11 @@ public interface Filterable<T> {
 
   T withLabel(String key, String value);
 
+  T withLabel(String key);
+
   T withoutLabel(String key, String value);
+
+  T withoutLabel(String key);
 
   T withFields(Map<String, String> labels);
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -289,10 +289,19 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabel(String key, String value) throws
-    KubernetesClientException {
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabel(String key) {
+    return withLabel(key, null);
+  }
+
+  @Override
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabel(String key, String value) {
     labelsNot.put(key, value);
     return this;
+  }
+
+  @Override
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabel(String key) {
+    return withoutLabel(key, null);
   }
 
   @Override
@@ -315,7 +324,11 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
           sb.append(",");
         }
         Map.Entry<String, String> entry = iter.next();
-        sb.append(entry.getKey()).append("=").append(entry.getValue());
+        if (entry.getValue() != null) {
+            sb.append(entry.getKey()).append("=").append(entry.getValue());
+        } else {
+            sb.append(entry.getKey());
+        }
       }
     }
 
@@ -325,7 +338,11 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
           sb.append(",");
         }
         Map.Entry<String, String> entry = iter.next();
-        sb.append(entry.getKey()).append("!=").append(entry.getValue());
+        if (entry.getValue() != null) {
+            sb.append(entry.getKey()).append("!=").append(entry.getValue());
+        } else {
+            sb.append('!').append(entry.getKey());
+        }
       }
     }
 

--- a/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/BaseMockOperation.java
+++ b/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/BaseMockOperation.java
@@ -279,6 +279,20 @@ public class BaseMockOperation<T, L extends KubernetesResourceList, D extends Do
   }
 
   @Override
+  public FilterWatchListDeletable<IExpectationSetters<T>, IExpectationSetters<L>, IExpectationSetters<Boolean>, IExpectationSetters<Watch>, Watcher<T>> withLabel(String key) {
+    IArgumentMatcher matcher = getArgument(key);
+
+    BaseMockOperation<T, L, D, B, R, E> op = labelMap.get(matcher);
+    if (op == null) {
+      op = newInstance();
+      expect(delegate.withLabel(key)).andReturn(op.getDelegate()).anyTimes();
+      nested.add(op);
+      labelMap.put(matcher, op);
+    }
+    return op;
+  }
+
+  @Override
   public FilterWatchListDeletable<IExpectationSetters<T>, IExpectationSetters<L>, IExpectationSetters<Boolean>, IExpectationSetters<Watch>, Watcher<T>> withoutLabel(String key, String value) {
     IArgumentMatcher keyMatcher = getArgument(key);
     IArgumentMatcher valueMatcher = getArgument(value);
@@ -288,6 +302,20 @@ public class BaseMockOperation<T, L extends KubernetesResourceList, D extends Do
     if (op == null) {
       op = newInstance();
       expect(delegate.withoutLabel(key, value)).andReturn(op.getDelegate()).anyTimes();
+      nested.add(op);
+      labelNotMap.put(matcher, op);
+    }
+    return op;
+  }
+
+  @Override
+  public FilterWatchListDeletable<IExpectationSetters<T>, IExpectationSetters<L>, IExpectationSetters<Boolean>, IExpectationSetters<Watch>, Watcher<T>> withoutLabel(String key) {
+    IArgumentMatcher matcher = getArgument(key);
+
+    BaseMockOperation<T, L, D, B, R, E> op = labelNotMap.get(matcher);
+    if (op == null) {
+      op = newInstance();
+      expect(delegate.withoutLabel(key)).andReturn(op.getDelegate()).anyTimes();
       nested.add(op);
       labelNotMap.put(matcher, op);
     }


### PR DESCRIPTION
Allow filtering for the presence/lack of a label without specifying a value to check.
Providing a null value parameter to the `withLabel(key, value)` and `withoutLabel(key,value)` methods results in queries like: `?labelSelector=key1,key2,!key3`. Convenience methods `withLabel(key)` and `withoutLabel(key)` are also added to the interface.

Note that to be consistent with the other methods of the class, special values are not checked in the key, making it possible to abuse these methods with calls like `withLabel("key=value,key2")`...