### PR TITLE
Add patch support

### DIFF
--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -200,6 +200,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>zjsonpatch</artifactId>
+      <version>${zjsonpatch.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.mifmif</groupId>
       <artifactId>generex</artifactId>
       <version>${generex.version}</version>

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingEditReplacePatchDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingEditReplacePatchDeletable.java
@@ -16,7 +16,7 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-public interface CascadingEditReplaceDeletable<I,D,T,B> extends
-  EditReplaceDeletable<I,D,T,B>,
-  Cascading<EditReplaceDeletable<I,D,T,B>> {
+public interface CascadingEditReplacePatchDeletable<I,D,T,B> extends
+  EditReplacePatchDeletable<I,D,T,B>,
+  Cascading<EditReplacePatchDeletable<I,D,T,B>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ClientRollableScallableResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ClientRollableScallableResource.java
@@ -16,5 +16,5 @@
 package io.fabric8.kubernetes.client.dsl;
 
 public interface ClientRollableScallableResource<T, D> extends ClientScaleableResource<T, D>,
-  Rollable<TimeoutImageEditReplaceable<T, T, D>> {
+  Rollable<TimeoutImageEditReplacePatchable<T, T, D>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchDeletable.java
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.fabric8.kubernetes.client.dsl;
 
-public interface EditReplaceable<I, T, D> extends Editable<D>, Replaceable<I, T>, Updateable<I, T> {
+import io.fabric8.kubernetes.client.GracePeriodConfigurable;
+
+public interface EditReplacePatchDeletable<I, T, D, B> extends EditReplacePatchable<I, T, D>, Deletable<B>,
+                                                          GracePeriodConfigurable<Deletable<B>>
+{
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
@@ -15,8 +15,5 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface ImageEditReplaceable<I, T, D> extends EditReplaceable<I, T, D> {
-
-  T updateImage(String image);
-
+public interface EditReplacePatchable<I, T, D> extends Editable<D>, Replaceable<I, T>, Updateable<I, T>, Patchable<I, T> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ImageEditReplacePatchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ImageEditReplacePatchable.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.fabric8.kubernetes.client.dsl;
 
-package io.fabric8.kubernetes.client.mock;
+public interface ImageEditReplacePatchable<I, T, D> extends EditReplacePatchable<I, T, D> {
 
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.Rollable;
-import io.fabric8.kubernetes.client.dsl.ScaleableResource;
-import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
-import org.easymock.IExpectationSetters;
+  T updateImage(String image);
 
-public interface MockRollableScaleableResource<T, D, B> extends ScaleableResource<T, IExpectationSetters<T>, D, IExpectationSetters<B>, IExpectationSetters<Watch>, Watcher<T>>,
-  Rollable<TimeoutImageEditReplacePatchable<T, IExpectationSetters<T>, D>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.fabric8.kubernetes.client.dsl;
 
-public interface TimeoutImageEditReplaceable<I, T, D> extends
-  Timeoutable<ImageEditReplaceable<I, T, D>>,
-  ImageEditReplaceable<I, T, D> {
+public interface Patchable<I, T> {
+
+  T patch(I item);
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
@@ -26,5 +26,5 @@ package io.fabric8.kubernetes.client.dsl;
  * @param <H>   The type of {@link io.fabric8.kubernetes.client.Watch}.
  * @param <W>   The type of {@link io.fabric8.kubernetes.client.Watcher}.
  */
-public interface Resource<I, T, D, B, H, W> extends CreateFromServerGettable<I, T, D>, Updateable<I, T>, CascadingEditReplaceDeletable<I, T, D, B>, VersionWatchable<H, W> {
+public interface Resource<I, T, D, B, H, W> extends CreateFromServerGettable<I, T, D>, Updateable<I, T>, CascadingEditReplacePatchDeletable<I, T, D, B>, VersionWatchable<H, W> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/TimeoutImageEditReplacePatchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/TimeoutImageEditReplacePatchable.java
@@ -16,9 +16,7 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.client.GracePeriodConfigurable;
-
-public interface EditReplaceDeletable<I, T, D, B> extends EditReplaceable<I, T, D>, Deletable<B>,
-                                                          GracePeriodConfigurable<Deletable<B>>
-{
+public interface TimeoutImageEditReplacePatchable<I, T, D> extends
+  Timeoutable<ImageEditReplacePatchable<I, T, D>>,
+  ImageEditReplacePatchable<I, T, D> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -31,7 +31,7 @@ import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ClientResource;
 import io.fabric8.kubernetes.client.dsl.Deletable;
-import io.fabric8.kubernetes.client.dsl.EditReplaceDeletable;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.Reaper;
@@ -202,7 +202,7 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
 
 
   @Override
-  public EditReplaceDeletable<T, T, D, Boolean> cascading(boolean cascading) {
+  public EditReplacePatchDeletable<T, T, D, Boolean> cascading(boolean cascading) {
     try {
       return getClass()
         .getConstructor(OkHttpClient.class, getConfigType(), String.class, String.class, String.class, Boolean.class, getType(), String.class, Boolean.class, long.class, Map.class, Map.class, Map.class, Map.class, Map.class)
@@ -530,6 +530,11 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
     throw new KubernetesClientException("Cannot update read-only resources");
   }
 
+  @Override
+  public T patch(T item) {
+    throw new KubernetesClientException("Cannot update read-only resources");
+  }
+
   public boolean isResourceNamespaced() {
     return true;
   }
@@ -544,6 +549,10 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
 
   protected T handleReplace(T updated) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
     return handleReplace(updated, getType());
+  }
+
+  protected T handlePatch(T current, T updated) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+    return handlePatch(current, updated, getType());
   }
 
   protected T handleGet(URL resourceUrl) throws InterruptedException, ExecutionException, IOException {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
@@ -84,6 +84,14 @@ public class DeploymentOperationsImpl extends HasMetadataOperation<Deployment, D
     return super.replace(item);
   }
 
+  @Override
+  public Deployment patch(Deployment item) {
+    if (isCascading()) {
+      return cascading(false).patch(item);
+    }
+    return super.patch(item);
+  }
+
   /**
    * Lets wait until there are enough Ready pods of the given Deployment
    */

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetRollingUpdater.java
@@ -83,23 +83,19 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
   }
 
   @Override
-  protected ReplicaSet updateDeploymentKey(ReplicaSet obj, String hash) {
-    return new ReplicaSetBuilder(obj)
-      .editSpec()
+  protected void updateDeploymentKey(DoneableReplicaSet obj, String hash) {
+    obj.editSpec()
       .editSelector().addToMatchLabels(DEPLOYMENT_KEY, hash).endSelector()
       .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, hash).endMetadata().endTemplate()
-      .endSpec()
-      .build();
+      .endSpec();
   }
 
   @Override
-  protected ReplicaSet removeDeploymentKey(ReplicaSet obj) {
-    return new ReplicaSetBuilder(obj)
-      .editSpec()
+  protected void removeDeploymentKey(DoneableReplicaSet obj) {
+    obj.editSpec()
       .editSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endSelector()
       .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
-      .endSpec()
-      .build();
+      .endSpec();
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
@@ -29,10 +29,10 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.EditReplaceDeletable;
-import io.fabric8.kubernetes.client.dsl.ImageEditReplaceable;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
+import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Reaper;
-import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplaceable;
+import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import org.slf4j.Logger;
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class ReplicationControllerOperationsImpl extends HasMetadataOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, ClientRollableScallableResource<ReplicationController, DoneableReplicationController>>
   implements ClientRollableScallableResource<ReplicationController, DoneableReplicationController>,
-  TimeoutImageEditReplaceable<ReplicationController, ReplicationController, DoneableReplicationController> {
+  TimeoutImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> {
 
   static final transient Logger LOG = LoggerFactory.getLogger(ReplicationControllerOperationsImpl.class);
 
@@ -94,12 +94,12 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
 
 
   @Override
-  public ImageEditReplaceable<ReplicationController, ReplicationController, DoneableReplicationController> withTimeout(long timeout, TimeUnit unit) {
+  public ImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> withTimeout(long timeout, TimeUnit unit) {
     return new ReplicationControllerOperationsImpl(client, getConfig(), getAPIVersion(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, timeout, unit);
   }
 
   @Override
-  public ImageEditReplaceable<ReplicationController, ReplicationController, DoneableReplicationController> withTimeoutInMillis(long timeoutInMillis) {
+  public ImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> withTimeoutInMillis(long timeoutInMillis) {
     return new ReplicationControllerOperationsImpl(client, getConfig(), getAPIVersion(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, timeoutInMillis, TimeUnit.MILLISECONDS);
   }
 
@@ -127,7 +127,7 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
   }
 
   @Override
-  public EditReplaceDeletable<ReplicationController, ReplicationController, DoneableReplicationController, Boolean> cascading(boolean enabled) {
+  public EditReplacePatchDeletable<ReplicationController, ReplicationController, DoneableReplicationController, Boolean> cascading(boolean enabled) {
     return new ReplicationControllerOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), enabled, getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerRollingUpdater.java
@@ -55,23 +55,19 @@ class ReplicationControllerRollingUpdater extends RollingUpdater<ReplicationCont
   }
 
   @Override
-  protected ReplicationController updateDeploymentKey(ReplicationController obj, String hash) {
-    return new ReplicationControllerBuilder(obj)
-      .editSpec()
+  protected void updateDeploymentKey(DoneableReplicationController obj, String hash) {
+    obj.editSpec()
       .addToSelector(DEPLOYMENT_KEY, hash)
       .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, hash).endMetadata().endTemplate()
-      .endSpec()
-      .build();
+      .endSpec();
   }
 
   @Override
-  protected ReplicationController removeDeploymentKey(ReplicationController obj) {
-    return new ReplicationControllerBuilder(obj)
-      .editSpec()
+  protected void removeDeploymentKey(DoneableReplicationController obj) {
+    obj.editSpec()
       .removeFromSelector(DEPLOYMENT_KEY)
       .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
-      .endSpec()
-      .build();
+      .endSpec();
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
@@ -51,4 +51,18 @@ public class ServiceOperationsImpl extends HasMetadataOperation<Service, Service
         throw KubernetesClientException.launderThrowable(e);
       }
   }
+
+  @Override
+  public Service patch(Service item) {
+      try {
+        Service old = getMandatory();
+        return super.patch(new ServiceBuilder(item)
+          .editSpec()
+          .withClusterIP(old.getSpec().getClusterIP())
+          .endSpec()
+          .build());
+      } catch (Exception e) {
+        throw KubernetesClientException.launderThrowable(e);
+      }
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/PatchUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/PatchUtils.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.internal.patchmixins.BuildMixIn;
+import io.fabric8.kubernetes.client.internal.patchmixins.ObjectMetaMixIn;
+import io.fabric8.openshift.api.model.Build;
+
+public class PatchUtils {
+
+  private static ObjectMapper patchMapper;
+
+  public static ObjectMapper patchMapper() {
+    if (patchMapper == null) {
+      patchMapper = new ObjectMapper();
+      patchMapper.addMixInAnnotations(ObjectMeta.class, ObjectMetaMixIn.class);
+      patchMapper.addMixInAnnotations(Build.class, BuildMixIn.class);
+    }
+    return patchMapper;
+  }
+
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/SerializationUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/SerializationUtils.java
@@ -15,14 +15,14 @@
  */
 package io.fabric8.kubernetes.client.internal;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.ReplicationControllerStatus;
+import io.fabric8.kubernetes.client.internal.serializationmixins.ObjectMetaMixIn;
+import io.fabric8.kubernetes.client.internal.serializationmixins.ReplicationControllerMixIn;
 
 public class SerializationUtils {
 
@@ -33,8 +33,8 @@ public class SerializationUtils {
   public static ObjectMapper getStatelessMapper() {
     if (statelessMapper == null) {
       statelessMapper = new ObjectMapper(new YAMLFactory());
-      statelessMapper.addMixIn(ObjectMeta.class, ObjectMetaMixIn.class);
-      statelessMapper.addMixIn(ReplicationController.class, StatelessReplicationControllerMixIn.class);
+      statelessMapper.addMixInAnnotations(ObjectMeta.class, ObjectMetaMixIn.class);
+      statelessMapper.addMixInAnnotations(ReplicationController.class, ReplicationControllerMixIn.class);
     }
     return statelessMapper;
   }
@@ -52,49 +52,6 @@ public class SerializationUtils {
 
   public static String dumpWithoutRuntimeStateAsYaml(HasMetadata obj) throws JsonProcessingException {
     return getStatelessMapper().writeValueAsString(obj);
-  }
-
-  abstract class ObjectMetaMixIn extends ObjectMeta {
-    @JsonIgnore
-    private String creationTimestamp;
-    @JsonIgnore
-    private String deletionTimestamp;
-    @JsonIgnore
-    private Long generation;
-    @JsonIgnore
-    private String resourceVersion;
-    @JsonIgnore
-    private String selfLink;
-    @JsonIgnore
-    private String uid;
-
-    @Override
-    @JsonIgnore
-    public abstract String getCreationTimestamp();
-    @Override
-    @JsonIgnore
-    public abstract String getDeletionTimestamp();
-    @Override
-    @JsonIgnore
-    public abstract Long getGeneration();
-    @Override
-    @JsonIgnore
-    public abstract String getResourceVersion();
-    @Override
-    @JsonIgnore
-    public abstract String getSelfLink();
-    @Override
-    @JsonIgnore
-    public abstract String getUid();
-  }
-
-  abstract class StatelessReplicationControllerMixIn extends ReplicationController {
-    @JsonIgnore
-    private ReplicationControllerStatus status;
-
-    @Override
-    @JsonIgnore
-    public abstract ReplicationControllerStatus getStatus();
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/patchmixins/BuildMixIn.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/patchmixins/BuildMixIn.java
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.fabric8.kubernetes.client.internal.patchmixins;
 
-package io.fabric8.kubernetes.client.mock;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildSpec;
 
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.Rollable;
-import io.fabric8.kubernetes.client.dsl.ScaleableResource;
-import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
-import org.easymock.IExpectationSetters;
+public abstract class BuildMixIn extends Build {
+  @JsonIgnore
+  private BuildSpec spec;
 
-public interface MockRollableScaleableResource<T, D, B> extends ScaleableResource<T, IExpectationSetters<T>, D, IExpectationSetters<B>, IExpectationSetters<Watch>, Watcher<T>>,
-  Rollable<TimeoutImageEditReplacePatchable<T, IExpectationSetters<T>, D>> {
+  @Override
+  @JsonIgnore
+  public abstract BuildSpec getSpec();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/patchmixins/ObjectMetaMixIn.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/patchmixins/ObjectMetaMixIn.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.patchmixins;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public abstract class ObjectMetaMixIn extends ObjectMeta {
+  @JsonIgnore
+  private String creationTimestamp;
+  @JsonIgnore
+  private String deletionTimestamp;
+  @JsonIgnore
+  private Long generation;
+  @JsonIgnore
+  private String resourceVersion;
+  @JsonIgnore
+  private String selfLink;
+  @JsonIgnore
+  private String uid;
+
+  @Override
+  @JsonIgnore
+  public abstract String getCreationTimestamp();
+  @Override
+  @JsonIgnore
+  public abstract String getDeletionTimestamp();
+  @Override
+  @JsonIgnore
+  public abstract Long getGeneration();
+  @Override
+  @JsonIgnore
+  public abstract String getResourceVersion();
+  @Override
+  @JsonIgnore
+  public abstract String getSelfLink();
+  @Override
+  @JsonIgnore
+  public abstract String getUid();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/serializationmixins/ObjectMetaMixIn.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/serializationmixins/ObjectMetaMixIn.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.serializationmixins;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public abstract class ObjectMetaMixIn extends ObjectMeta {
+  @JsonIgnore
+  private String creationTimestamp;
+  @JsonIgnore
+  private String deletionTimestamp;
+  @JsonIgnore
+  private Long generation;
+  @JsonIgnore
+  private String resourceVersion;
+  @JsonIgnore
+  private String selfLink;
+  @JsonIgnore
+  private String uid;
+
+  @Override
+  @JsonIgnore
+  public abstract String getCreationTimestamp();
+  @Override
+  @JsonIgnore
+  public abstract String getDeletionTimestamp();
+  @Override
+  @JsonIgnore
+  public abstract Long getGeneration();
+  @Override
+  @JsonIgnore
+  public abstract String getResourceVersion();
+  @Override
+  @JsonIgnore
+  public abstract String getSelfLink();
+  @Override
+  @JsonIgnore
+  public abstract String getUid();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/serializationmixins/ReplicationControllerMixIn.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/serializationmixins/ReplicationControllerMixIn.java
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.fabric8.kubernetes.client.internal.serializationmixins;
 
-package io.fabric8.kubernetes.client.mock;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.api.model.ReplicationControllerStatus;
 
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.Rollable;
-import io.fabric8.kubernetes.client.dsl.ScaleableResource;
-import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
-import org.easymock.IExpectationSetters;
+public abstract class ReplicationControllerMixIn extends ReplicationController {
+  @JsonIgnore
+  private ReplicationControllerStatus status;
 
-public interface MockRollableScaleableResource<T, D, B> extends ScaleableResource<T, IExpectationSetters<T>, D, IExpectationSetters<B>, IExpectationSetters<Watch>, Watcher<T>>,
-  Rollable<TimeoutImageEditReplacePatchable<T, IExpectationSetters<T>, D>> {
+  @Override
+  @JsonIgnore
+  public abstract ReplicationControllerStatus getStatus();
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/ReplaceExamples.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/ReplaceExamples.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.examples;
+
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReplaceExamples {
+
+  private static final Logger logger = LoggerFactory.getLogger(ReplaceExamples.class);
+
+  public static void main(String[] args) {
+    String master = "https://localhost:8443/";
+    if (args.length == 1) {
+      master = args[0];
+    }
+
+    Config config = new ConfigBuilder().withMasterUrl(master).build();
+    try (KubernetesClient client = new DefaultKubernetesClient(config)) {
+      try {
+        log("Create namespace:", client.namespaces().create(new NamespaceBuilder().withNewMetadata().withName("thisisatest").endMetadata().build()));
+
+        Pod createdPod = client.pods().inNamespace("thisisatest").createNew()
+          .withNewMetadata()
+          .withName("testpod")
+          .addToLabels("server", "nginx")
+          .endMetadata()
+          .withNewSpec()
+          .addNewContainer().withName("nginx").withImage("nginx")
+          .addNewPort().withContainerPort(80).endPort()
+          .endContainer()
+          .endSpec().done();
+        log("Created testPod:", createdPod);
+
+        Pod updatedPod = client.pods().inNamespace("thisisatest").withName("testpod").edit()
+          .editMetadata()
+          .addToLabels("server2", "nginx2")
+          .and().done();
+        log("Replaced testPod:", updatedPod);
+
+      } catch (KubernetesClientException e) {
+        logger.error(e.getMessage(), e);
+      } finally {
+        client.namespaces().withName("thisisatest").delete();
+      }
+    }
+  }
+
+  private static void log(String action, Object obj) {
+    logger.info("{}: {}", action, obj);
+  }
+
+  private static void log(String action) {
+    logger.info(action);
+  }
+
+}

--- a/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/BaseMockOperation.java
+++ b/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/BaseMockOperation.java
@@ -177,7 +177,7 @@ public class BaseMockOperation<T, L extends KubernetesResourceList, D extends Do
   }
 
   @Override
-  public EditReplaceDeletable<T, IExpectationSetters<T>, B, IExpectationSetters<Boolean>> cascading(boolean enabled) {
+  public EditReplacePatchDeletable<T, IExpectationSetters<T>, B, IExpectationSetters<Boolean>> cascading(boolean enabled) {
     IArgumentMatcher matcher = getArgument(enabled);
     BaseMockOperation<T, L, D, B, R, E> op = cascadingMap.get(matcher);
     if (op == null) {
@@ -196,6 +196,11 @@ public class BaseMockOperation<T, L extends KubernetesResourceList, D extends Do
 
   @Override
   public IExpectationSetters<T> replace(T item) {
+    return null;
+  }
+
+  @Override
+  public IExpectationSetters<T> patch(T item) {
     return null;
   }
 

--- a/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/impl/MockReplicaSet.java
+++ b/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/impl/MockReplicaSet.java
@@ -21,10 +21,10 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetList;
 import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.ImageEditReplaceable;
+import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Rollable;
 import io.fabric8.kubernetes.client.dsl.Scaleable;
-import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplaceable;
+import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.mock.BaseMockOperation;
 import io.fabric8.kubernetes.client.mock.MockRollableScaleableResource;
 import io.fabric8.kubernetes.client.mock.impl.donable.MockDoneableReplicaSet;
@@ -39,12 +39,12 @@ public class MockReplicaSet extends BaseMockOperation<ReplicaSet, ReplicaSetList
   MockDoneableReplicaSet, ClientRollableScallableResource<ReplicaSet, DoneableReplicaSet>,
   MockRollableScaleableResource<ReplicaSet, MockDoneableReplicaSet, Boolean>>
   implements MockRollableScaleableResource<ReplicaSet, MockDoneableReplicaSet, Boolean>,
-  TimeoutImageEditReplaceable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> {
+  TimeoutImageEditReplacePatchable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> {
 
   private MockReplicaSet rolling;
 
   @Override
-  public TimeoutImageEditReplaceable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> rolling() {
+  public TimeoutImageEditReplacePatchable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> rolling() {
     if (rolling == null) {
       rolling = (MockReplicaSet) newInstance();
       expect(((Rollable<?>)getDelegate()).rolling())
@@ -67,16 +67,16 @@ public class MockReplicaSet extends BaseMockOperation<ReplicaSet, ReplicaSetList
 
   @Override
   public IExpectationSetters<ReplicaSet> updateImage(String image) {
-    return expect(((ImageEditReplaceable<ReplicaSet, ReplicaSet, DoneableReplicaSet>) getDelegate()).updateImage(image));
+    return expect(((ImageEditReplacePatchable<ReplicaSet, ReplicaSet, DoneableReplicaSet>) getDelegate()).updateImage(image));
   }
 
   @Override
-  public ImageEditReplaceable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> withTimeout(long timeout, TimeUnit unit) {
+  public ImageEditReplacePatchable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> withTimeout(long timeout, TimeUnit unit) {
     return null;
   }
 
   @Override
-  public ImageEditReplaceable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> withTimeoutInMillis(long timeoutInMillis) {
+  public ImageEditReplacePatchable<ReplicaSet, IExpectationSetters<ReplicaSet>, MockDoneableReplicaSet> withTimeoutInMillis(long timeoutInMillis) {
     return null;
   }
 
@@ -84,7 +84,7 @@ public class MockReplicaSet extends BaseMockOperation<ReplicaSet, ReplicaSetList
   private interface ReplicaSetDelegate
     extends ClientMixedOperation<ReplicaSet, ReplicaSet, DoneableReplicaSet, ClientRollableScallableResource<ReplicaSet, DoneableReplicaSet>>,
     ClientRollableScallableResource<ReplicaSet, DoneableReplicaSet>,
-    TimeoutImageEditReplaceable<ReplicaSet, ReplicaSet, DoneableReplicaSet> {
+    TimeoutImageEditReplacePatchable<ReplicaSet, ReplicaSet, DoneableReplicaSet> {
 
   }
 

--- a/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/impl/MockReplicationController.java
+++ b/kubernetes-mock/src/main/java/io/fabric8/kubernetes/client/mock/impl/MockReplicationController.java
@@ -21,10 +21,10 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerList;
 import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.ImageEditReplaceable;
+import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Rollable;
 import io.fabric8.kubernetes.client.dsl.Scaleable;
-import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplaceable;
+import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.mock.BaseMockOperation;
 import io.fabric8.kubernetes.client.mock.MockRollableScaleableResource;
 import io.fabric8.kubernetes.client.mock.impl.donable.MockDoneableReplicationController;
@@ -39,16 +39,16 @@ public class MockReplicationController  extends BaseMockOperation<ReplicationCon
   MockDoneableReplicationController, ClientRollableScallableResource<ReplicationController, DoneableReplicationController>,
   MockRollableScaleableResource<ReplicationController, MockDoneableReplicationController, Boolean>>
   implements MockRollableScaleableResource<ReplicationController, MockDoneableReplicationController, Boolean>,
-  TimeoutImageEditReplaceable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> {
+  TimeoutImageEditReplacePatchable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> {
 
 
   @Override
-  public ImageEditReplaceable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> withTimeout(long timeout, TimeUnit unit) {
+  public ImageEditReplacePatchable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> withTimeout(long timeout, TimeUnit unit) {
     return null;
   }
 
   @Override
-  public ImageEditReplaceable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> withTimeoutInMillis(long timeoutInMillis) {
+  public ImageEditReplacePatchable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> withTimeoutInMillis(long timeoutInMillis) {
     return null;
   }
 
@@ -56,7 +56,7 @@ public class MockReplicationController  extends BaseMockOperation<ReplicationCon
   private interface ReplicationControllerDelegate
     extends ClientMixedOperation<ReplicationController, ReplicationController, DoneableReplicationController, ClientRollableScallableResource<ReplicationController, DoneableReplicationController>>,
     ClientRollableScallableResource<ReplicationController, DoneableReplicationController>,
-    TimeoutImageEditReplaceable<ReplicationController, ReplicationController, DoneableReplicationController> {
+    TimeoutImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> {
 
   }
 
@@ -82,11 +82,11 @@ public class MockReplicationController  extends BaseMockOperation<ReplicationCon
 
   @Override
   public IExpectationSetters<ReplicationController> updateImage(String image) {
-    return expect(((ImageEditReplaceable<ReplicationController, ReplicationController, DoneableReplicationController>) getDelegate()).updateImage(image));
+    return expect(((ImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController>) getDelegate()).updateImage(image));
   }
 
   @Override
-  public TimeoutImageEditReplaceable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> rolling() {
+  public TimeoutImageEditReplacePatchable<ReplicationController, IExpectationSetters<ReplicationController>, MockDoneableReplicationController> rolling() {
     if (rolling == null) {
       rolling = (MockReplicationController) newInstance();
       expect(((Rollable<?>)getDelegate()).rolling())

--- a/platforms/karaf/features/src/main/resources/feature.xml
+++ b/platforms/karaf/features/src/main/resources/feature.xml
@@ -30,6 +30,7 @@
     <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml.version}</bundle>
 
     <bundle>mvn:io.fabric8/kubernetes-model/${kubernetes.model.version}</bundle>
+    <bundle>mvn:io.fabric8/zjsonpatch/${zjsonpatch.version}</bundle>
     <bundle>mvn:io.fabric8/kubernetes-client/${project.version}/jar/bundle</bundle>
   </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,15 +75,16 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockwebserver.version>0.0.2</mockwebserver.version>
-    <okhttp.version>2.7.2</okhttp.version>
+    <okhttp.version>2.7.5</okhttp.version>
     <okio.version>1.6.0</okio.version>
     <easymock.version>3.4</easymock.version>
     <felix.scr.annotations.version>1.9.8</felix.scr.annotations.version>
     <generex.version>0.0.4</generex.version>
     <jackson.version>2.7.0</jackson.version>
     <junit.version>4.12</junit.version>
-    <kubernetes.model.version>1.0.49</kubernetes.model.version>
+    <kubernetes.model.version>1.0.51</kubernetes.model.version>
     <log4j.version>2.5</log4j.version>
+    <zjsonpatch.version>0.2.3</zjsonpatch.version>
 
     <slf4j.version>1.7.13</slf4j.version>
     <snakeyaml.version>1.16</snakeyaml.version>


### PR DESCRIPTION
This change adds `Patchable.patch()` to all resources & also switches `edit()`
to call `patch` instead of `replace`.

@iocanel This could cause problems for users so if I'm not about & it does cause
issues we should probably revert the `edit()` change.