### PR TITLE
Delete job always taking "scaleTimeout" time to delete a job

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/JobOperationsImpl.java
@@ -94,7 +94,11 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Doneab
       public void run() {
         Job job = getMandatory();
         atomicJob.set(job);
-        if (Objects.equals(job.getSpec().getParallelism(), job.getStatus().getActive())) {
+        Integer activeJobs  = job.getStatus().getActive();
+        if (activeJobs == null){
+          activeJobs = 0;
+        }
+        if (Objects.equals(job.getSpec().getParallelism(), activeJobs)) {
           countDownLatch.countDown();
         } else {
           LOG.debug("Only {}/{} pods scheduled for Job: {} in namespace: {} seconds so waiting...",


### PR DESCRIPTION
countDownLatch.countDown() is never getting called.
job.getStatus().getActive() is returning null if job is scalled down to 0
The reason here is that the api server does not send "active" field inside the response JSON.
Hence jackson deserializes it to null. Only if the job is active is the active field set to some int.
Hence delete job always takes getConfig().getScaleTimeout() amount of time to terminate.