### PR TITLE
Componentstatus is not namespaced. Removing namespace from query

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -113,7 +113,7 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
 
   @Override
   public ClientMixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, ClientResource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {
-    return new ComponentStatusOperationsImpl(httpClient, getConfiguration(), getNamespace());
+    return new ComponentStatusOperationsImpl(httpClient, getConfiguration());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
@@ -31,12 +31,16 @@ public class ComponentStatusOperationsImpl extends HasMetadataOperation<Componen
 ClientResource<ComponentStatus, DoneableComponentStatus>> {
 
 	public ComponentStatusOperationsImpl(OkHttpClient client, Config config) {
-		this(client, config, null, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
+		this(client, config, null, null, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
 	}
 
 
-	public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String apiVersion, String name, Boolean cascading, ComponentStatus item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
+	public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, ComponentStatus item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
 		super(client, config, null, apiVersion, "componentstatuses", null, name, cascading, item, resourceVersion, reloadingFromServer, -1, labels, labelsNot, labelsIn, labelsNotIn, fields);
 	}
 
+	@Override
+	public boolean isResourceNamespaced() {
+		return false;
+	}
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
@@ -30,13 +30,13 @@ import java.util.TreeMap;
 public class ComponentStatusOperationsImpl extends HasMetadataOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus,
 ClientResource<ComponentStatus, DoneableComponentStatus>> {
 
-	public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String namespace) {
-		this(client, config, null, namespace, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
+	public ComponentStatusOperationsImpl(OkHttpClient client, Config config) {
+		this(client, config, null, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
 	}
 
 
-	public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, ComponentStatus item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
-		super(client, config, null, apiVersion, "componentstatuses", namespace, name, cascading, item, resourceVersion, reloadingFromServer, -1, labels, labelsNot, labelsIn, labelsNotIn, fields);
+	public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String apiVersion, String name, Boolean cascading, ComponentStatus item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
+		super(client, config, null, apiVersion, "componentstatuses", null, name, cascading, item, resourceVersion, reloadingFromServer, -1, labels, labelsNot, labelsIn, labelsNotIn, fields);
 	}
 
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ComponentStatusTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ComponentStatusTest.java
@@ -36,7 +36,7 @@ public class ComponentStatusTest extends KubernetesMockServerTestBase	 {
 	
 	@Test
 	public void testComponentStatus() {
-		expect().withPath("/api/v1/namespaces/test/componentstatuses/scheduler").andReturn(200, status).once();
+		expect().withPath("/api/v1/componentstatuses/scheduler").andReturn(200, status).once();
 	
 		KubernetesClient client = getClient();
 		ComponentStatus stat = client.componentstatuses().withName("scheduler").get();
@@ -46,7 +46,7 @@ public class ComponentStatusTest extends KubernetesMockServerTestBase	 {
 	
 	@Test
 	public void testComponentStatusList() {
-		expect().withPath("/api/v1/namespaces/test/componentstatuses").andReturn(200, status).once();
+		expect().withPath("/api/v1/componentstatuses").andReturn(200, status).once();
 	
 		KubernetesClient client = getClient();
 		ComponentStatusList stats = client.componentstatuses().list();

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -208,7 +208,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
 
   @Override
   public ClientMixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, ClientResource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {
-    return new ComponentStatusOperationsImpl(httpClient, getConfiguration(), getNamespace());
+    return new ComponentStatusOperationsImpl(httpClient, getConfiguration());
   }
 
   @Override


### PR DESCRIPTION
APIResourceList shows that componentstatuses endpoint is not namespaced and hence queries to the componentstatuses is failing.

```
{
  "kind": "APIResourceList",
  "groupVersion": "v1",
  "resources": [
    {
      "name": "bindings",
      "namespaced": true,
      "kind": "Binding"
    },
    {
      "name": "componentstatuses",
      "namespaced": false,
      "kind": "ComponentStatus"
    },
    
....
```

Hence removing namespace support for componentstatuses query.