### PR TITLE
Misc

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -122,13 +122,13 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
 
   @Override
   public NamespaceVisitFromServerGetDeleteRecreateApplicable<List<HasMetadata>, Boolean> load(InputStream is) {
-    return new NamespaceVisitFromServerGetDeleteRecreateApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), is) {
+    return new NamespaceVisitFromServerGetDeleteRecreateApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), is, false) {
     };
   }
 
   @Override
   public NamespaceVisitFromServerGetDeleteRecreateApplicable<List<HasMetadata>, Boolean> resource(HasMetadata item) {
-    return new NamespaceVisitFromServerGetDeleteRecreateApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, -1) {
+    return new NamespaceVisitFromServerGetDeleteRecreateApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, -1, false) {
     };
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
@@ -1,0 +1,7 @@
+package io.fabric8.kubernetes.client.dsl;
+
+/**
+ * Created by iocanel on 9/15/16.
+ */
+public interface CascadingDeletable<B> extends Deletable<B>, Cascading<Deletable<B>> {
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.client.dsl;
 
 /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetDeleteRecreateApplicable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetDeleteRecreateApplicable.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.client.GracePeriodConfigurable;
 
 public interface VisitFromServerGetDeleteRecreateApplicable<T, B> extends Visitable<VisitFromServerGetDeleteRecreateApplicable<T, B>>,
                                                                           FromServerGettable<T>, RecreateApplicable<T>,
-                                                                          Deletable<B>,
-                                                                          GracePeriodConfigurable<Deletable<B>>
+                                                                          CascadingDeletable<B>,
+                                                                          GracePeriodConfigurable<CascadingDeletable<B>>
 {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.base;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -97,7 +98,7 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
   }
 
   protected BaseOperation(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
-    super(client, config, apiGroup, apiVersion, resourceT, namespace, name);
+    super(client, config, apiGroup, apiVersion(item, apiVersion), resourceT, namespace, name);
     this.cascading = cascading;
     this.item = item;
     this.resourceVersion = resourceVersion;
@@ -112,6 +113,22 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
     this.labelsIn = new TreeMap<>();
     this.labelsNotIn = new TreeMap<>();
     this.fields = new TreeMap<>();
+  }
+
+  /**
+   * Returns the api version falling back to the items apiVersion if not null.
+   * @param <T>
+   * @param item
+   * @param apiVersion
+   * @return
+   */
+  private static <T> String apiVersion(T item, String apiVersion) {
+    if (apiVersion != null && !apiVersion.isEmpty()) {
+      return apiVersion;
+    } else if (item instanceof HasMetadata) {
+      return ((HasMetadata)item).getApiVersion();
+    }
+    return null;
   }
 
   @Override


### PR DESCRIPTION
This pull request adds:

 Cascading support for external resource. (e.g. client.resource(myresource).cascading(true).delete().

Fallback to items api version if one is not specified. Currently we always fallback to v1 which is problematic when we use extensions. So if an existing object is specified, we can fallback to its version.