### PR TITLE
Upgraded kubernetes-model version to 1.0.60

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetRollingUpdater.java
@@ -49,7 +49,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
       .endMetadata()
       .editSpec()
       .withReplicas(0)
-      .editSelector().addToMatchLabels(DEPLOYMENT_KEY, newDeploymentHash).endSelector()
+      .editExtensionsSelector().addToMatchLabels(DEPLOYMENT_KEY, newDeploymentHash).endExtensionsSelector()
       .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, newDeploymentHash).endMetadata().endTemplate()
       .endSpec()
       .build();
@@ -85,7 +85,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
   @Override
   protected void updateDeploymentKey(DoneableReplicaSet obj, String hash) {
     obj.editSpec()
-      .editSelector().addToMatchLabels(DEPLOYMENT_KEY, hash).endSelector()
+      .editExtensionsSelector().addToMatchLabels(DEPLOYMENT_KEY, hash).endExtensionsSelector()
       .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, hash).endMetadata().endTemplate()
       .endSpec();
   }
@@ -93,7 +93,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
   @Override
   protected void removeDeploymentKey(DoneableReplicaSet obj) {
     obj.editSpec()
-      .editSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endSelector()
+      .editExtensionsSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endExtensionsSelector()
       .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
       .endSpec();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <automaton.bundle.version>1.11-8_1</automaton.bundle.version>
     <jackson.version>2.7.5</jackson.version>
     <junit.version>4.12</junit.version>
-    <kubernetes.model.version>1.0.59</kubernetes.model.version>
+    <kubernetes.model.version>1.0.60</kubernetes.model.version>
     <log4j.version>2.5</log4j.version>
     <zjsonpatch.version>0.2.3</zjsonpatch.version>
 


### PR DESCRIPTION
Update to use the version 1.0.60 of kubernetes-model. I also had to fix up some method calls, as editSelector must have become editExtensionsSelector at some stage. 