### PR TITLE
OSFUSE-390: Eliminating leaked connections

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
@@ -95,7 +95,7 @@ public class LogWatchCallback implements LogWatch, Callback, AutoCloseable {
     }
 
     @Override
-    public void onResponse(Call call, Response response) throws IOException {
+    public void onResponse(Call call, final Response response) throws IOException {
         if (out instanceof PipedOutputStream && output != null) {
             output.connect((PipedOutputStream) out);
         }
@@ -108,6 +108,11 @@ public class LogWatchCallback implements LogWatch, Callback, AutoCloseable {
                 } catch (IOException e) {
                     throw KubernetesClientException.launderThrowable(e);
                 }
+            }
+        }, new Runnable() {
+            @Override
+            public void run() {
+                response.close();
             }
         });
         executorService.submit(pumper);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/InputStreamPumper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/InputStreamPumper.java
@@ -31,12 +31,18 @@ public class InputStreamPumper implements Runnable, Closeable {
 
     private final InputStream in;
     private final Callback<byte[]> callback;
+    private final Runnable onClose;
     private boolean keepReading = true;
     private Thread thread;
 
     public InputStreamPumper(InputStream in, Callback<byte[]> callback) {
+      this(in, callback, null);
+    }
+
+    public InputStreamPumper(InputStream in, Callback<byte[]> callback, Runnable onClose) {
         this.in = in;
         this.callback = callback;
+        this.onClose = onClose;
     }
 
     @Override
@@ -65,6 +71,9 @@ public class InputStreamPumper implements Runnable, Closeable {
         keepReading = false;
         if (thread != null) {
             thread.interrupt();
+        }
+        if (onClose != null) {
+          onClose.run();
         }
     }
 }


### PR DESCRIPTION
The okhttp response was never closed so a warning was being logged in all Kubernetes tests.

"Did you forget to close a response body?"