### PR TITLE
Reaper now reports if the target resource has been deleted. Deploymen…

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Reaper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Reaper.java
@@ -17,6 +17,10 @@ package io.fabric8.kubernetes.client.dsl;
 
 public interface Reaper {
 
-  void reap();
+  /**
+   * Reaps the dependants of the target resource.
+   * @return  True if the target resource has also been reaped, false otherwise.
+   */
+  boolean reap();
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -457,7 +457,10 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
         if (cascading && !isReaping()) {
           if (reaper != null) {
             setReaping(true);
-            reaper.reap();
+            //If the reaper also removes the target resource, we can return asap.
+            if (reaper.reap()) {
+              return true;
+            }
           }
         }
         deleteThis();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
@@ -136,10 +136,11 @@ public class DeploymentOperationsImpl extends HasMetadataOperation<Deployment, D
     }
 
     @Override
-    public void reap() {
+    public boolean reap() {
       Deployment deployment = oper.cascading(false).edit().editSpec().withReplicas(0).withPaused(true).withRevisionHistoryLimit(0).endSpec().done();
       waitForObservedGeneration(deployment.getStatus().getObservedGeneration());
       reapMatchingReplicaSets(deployment.getSpec().getSelector());
+      return false;
     }
 
     private void waitForObservedGeneration(final long observedGeneration) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/JobOperationsImpl.java
@@ -128,8 +128,9 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Doneab
     }
 
     @Override
-    public void reap() {
+    public boolean reap() {
       oper.scale(0, true);
+      return false;
     }
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
@@ -234,8 +234,9 @@ public class ReplicaSetOperationsImpl extends HasMetadataOperation<ReplicaSet, R
     }
 
     @Override
-    public void reap() {
+    public boolean reap() {
       oper.scale(0, true);
+      return false;
     }
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
@@ -244,8 +244,9 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
     }
 
     @Override
-    public void reap() {
+    public boolean reap() {
       oper.scale(0, true);
+      return false;
     }
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationsImpl.java
@@ -343,8 +343,9 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
     }
 
     @Override
-    public void reap() {
+    public boolean reap() {
       oper.deleteBuilds();
+      return false;
     }
   }
 }


### PR DESCRIPTION
…tConfig reaper now deletes DC before attempting to delete DC. Improve the DeploymentConfigExamples.

Conflicts:
	openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/DeploymentConfigOperationsImpl.java