### PR TITLE
remove WebSocket close in ExecWebSocketListener close function

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -97,15 +97,6 @@ public class ExecWebSocketListener implements ExecWatch, WebSocketListener, Auto
         } catch (Throwable t) {
             throw KubernetesClientException.launderThrowable(t);
         }
-
-        WebSocket ws = webSocketRef.get();
-        try {
-            if (ws != null) {
-                ws.close(1000, "Closing...");
-            }
-        } catch (Throwable t) {
-            throw KubernetesClientException.launderThrowable(t);
-        }
     }
 
     public void waitUntilReady() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
@@ -206,7 +206,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
             Request.Builder r = new Request.Builder().url(url).get();
             OkHttpClient clone = client.newBuilder().readTimeout(0, TimeUnit.MILLISECONDS).build();
             WebSocketCall webSocketCall = WebSocketCall.create(clone, r.build());
-            final ExecWebSocketListener execWebSocketListener = new ExecWebSocketListener(in, out, err, inPipe, outPipe, errPipe, execListener);
+            final ExecWebSocketListener execWebSocketListener = new ExecWebSocketListener(in, out, err, inPipe, outPipe, errPipe, execListener, clone);
             webSocketCall.enqueue(execWebSocketListener);
             execWebSocketListener.waitUntilReady();
             return execWebSocketListener;


### PR DESCRIPTION
the webSocket have bean closed when dkc.pods().withName("xxxxx").xxxxx.exec(""), so it need't close the socket again.