### PR TITLE
Updating zjsonpatch to 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <junit.version>4.12</junit.version>
     <kubernetes.model.version>1.0.65</kubernetes.model.version>
     <log4j.version>2.5</log4j.version>
-    <zjsonpatch.version>0.2.3</zjsonpatch.version>
+    <zjsonpatch.version>0.3.0</zjsonpatch.version>
 
     <slf4j.version>1.7.13</slf4j.version>
     <snakeyaml.version>1.17</snakeyaml.version>


### PR DESCRIPTION
Need to update zjsonpatch version due to the license issue. Basically, once the project was forked from https://github.com/flipkart-incubator/zjsonpatch all copyright were changed to Red Hat inc. which is not valid from IP perspective. More details can be found in CQ - https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12451
Update to 0.3.0 version is safe - the only changes are coupled with reverting copyrights headers to original state and Jenkinsfile update. 