### PR TITLE
Fix createOrReplace for Loadables

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -350,11 +350,22 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
   }
 
   @Override
-  public T createOrReplace(T item) {
+  public T createOrReplace(T... items) {
+    T item = getItem();
+    if (items.length > 1) {
+      throw new IllegalArgumentException("Too many items to create.");
+    } else if (items.length == 1) {
+      item = items[0];
+    }
+
+    if (item == null) {
+      throw new IllegalArgumentException("Nothing to create.");
+    }
+
     if (Utils.isNullOrEmpty(name) && item instanceof HasMetadata) {
       return withName(((HasMetadata)item).getMetadata().getName()).createOrReplace(item);
     }
-    if (get() == null) {
+    if (fromServer().get() == null) {
       return create(item);
     } else {
       return replace(item);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -282,7 +282,11 @@ public class OperationSupport {
       } else if (response.message() != null) {
         statusMessage = response.message();
       }
-      return JSON_MAPPER.readValue(statusMessage, Status.class);
+      Status status = JSON_MAPPER.readValue(statusMessage, Status.class);
+      if (status.getCode() == null) {
+        status = new StatusBuilder(status).withCode(statusCode).build();
+      }
+      return status;
     } catch (JsonParseException e) {
       return createStatus(statusCode, statusMessage);
     } catch (IOException e) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CreateOrReplaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CreateOrReplaceable.java
@@ -17,7 +17,7 @@ package io.fabric8.kubernetes.client.dsl.internal;
 
 public interface CreateOrReplaceable<I, T, D> {
 
-  T createOrReplace(I item);
+  T createOrReplace(I... item);
 
   D createOrReplaceWithNew();
 }

--- a/kubernetes-tests/src/test/resources/test-pod-create-from-load.yml
+++ b/kubernetes-tests/src/test/resources/test-pod-create-from-load.yml
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  nodeName: awesome-node
+  containers:
+  - name: nginx
+    image: nginx


### PR DESCRIPTION
Fixes #602

This adds more tests as well as sneaking in a change to allow no args `createOrReplace` following `load` to allow `client.load(is).createOrReplace()` which is currently not possible.