### PR TITLE
Don't set Accept: header in OpenShiftOAuthInterceptor

### DIFF
--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
@@ -54,7 +54,6 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
 
         //Build new request
         Request.Builder builder = request.newBuilder();
-        builder.header("Accept", "application/json");
 
         String token = oauthToken.get();
         if (Utils.isNotNullOrEmpty(token)) {


### PR DESCRIPTION
Remove line setting `Accept: application/json` header in `OpenShiftOAuthInterceptor`. Certain API requests, e.g. Exec() do not return json, causing OpenShiftClient requests to return 406: Not Acceptable.

I initially looked into writing some tests for this behaviour, but I couldn't think of a clean way to do it. If anyone has insight on an easy way to test this (if there even is one) I'd be happy to take a look. Then again, it is a minor enough error that it should not be a problem.

See: Issue #610 