### PR TITLE
OSFUSE-481: allow using short OPENSHIFT_URL env variable

### DIFF
--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -27,8 +27,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
-
 public class OpenShiftConfig extends Config {
 
   public static final String KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY = "kubernetes.oapi.version";
@@ -111,7 +109,7 @@ public class OpenShiftConfig extends Config {
   private static boolean isRootURL(String url) {
     try {
       String path = new URL(url).getPath();
-      return StringUtils.isBlank(path) || "/".equals(path);
+      return "".equals(path) || "/".equals(path);
     } catch (MalformedURLException e) {
       return false;
     }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -92,7 +92,16 @@ public class OpenShiftConfig extends Config {
   }
 
   private static String getDefaultOpenShiftUrl(Config config) {
-    return Utils.getSystemPropertyOrEnvVar(OPENSHIFT_URL_SYTEM_PROPERTY, URLUtils.join(config.getMasterUrl(), "oapi", getDefaultOapiVersion(config)));
+    String openshiftUrl = Utils.getSystemPropertyOrEnvVar(OPENSHIFT_URL_SYTEM_PROPERTY);
+    if (openshiftUrl != null) {
+      // The OPENSHIFT_URL environment variable may be provided without the 'oapi' path in some configurations
+      if (!openshiftUrl.contains("/oapi/")) {
+        openshiftUrl = URLUtils.join(openshiftUrl, "oapi", getDefaultOapiVersion(config));
+      }
+      return openshiftUrl;
+    } else {
+      return URLUtils.join(config.getMasterUrl(), "oapi", getDefaultOapiVersion(config));
+    }
   }
 
   public String getOapiVersion() {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -23,7 +23,11 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
 
 public class OpenShiftConfig extends Config {
 
@@ -94,13 +98,22 @@ public class OpenShiftConfig extends Config {
   private static String getDefaultOpenShiftUrl(Config config) {
     String openshiftUrl = Utils.getSystemPropertyOrEnvVar(OPENSHIFT_URL_SYTEM_PROPERTY);
     if (openshiftUrl != null) {
-      // The OPENSHIFT_URL environment variable may be provided without the 'oapi' path in some configurations
-      if (!openshiftUrl.contains("/oapi/")) {
+      // The OPENSHIFT_URL environment variable may be set to the root url (i.e. without the '/oapi/version' path) in some configurations
+      if (isRootURL(openshiftUrl)) {
         openshiftUrl = URLUtils.join(openshiftUrl, "oapi", getDefaultOapiVersion(config));
       }
       return openshiftUrl;
     } else {
       return URLUtils.join(config.getMasterUrl(), "oapi", getDefaultOapiVersion(config));
+    }
+  }
+
+  private static boolean isRootURL(String url) {
+    try {
+      String path = new URL(url).getPath();
+      return StringUtils.isBlank(path) || "/".equals(path);
+    } catch (MalformedURLException e) {
+      return false;
     }
   }
 

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/OpenShiftConfigTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/OpenShiftConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/OpenShiftConfigTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/OpenShiftConfigTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OpenShiftConfigTest {
+
+
+  private Config kubernetesConfig;
+
+  private String version;
+
+  @Before
+  public void setup() {
+    this.kubernetesConfig = new ConfigBuilder()
+      .withMasterUrl("https://2.2.2.2")
+      .build();
+
+    this.version = "v1";
+    System.setProperty(OpenShiftConfig.KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY, this.version);
+  }
+
+  @After
+  public void tearDown() {
+    System.clearProperty(OpenShiftConfig.OPENSHIFT_URL_SYTEM_PROPERTY);
+    System.clearProperty(OpenShiftConfig.KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY);
+  }
+
+
+  @Test
+  public void testOpenshiftURLAsRoot() {
+    System.setProperty(OpenShiftConfig.OPENSHIFT_URL_SYTEM_PROPERTY, "https://1.1.1.1");
+    OpenShiftConfig config = new OpenShiftConfig(kubernetesConfig);
+    assertEquals("https://1.1.1.1/oapi/" + version + "/", config.getOpenShiftUrl());
+  }
+
+  @Test
+  public void testOpenshiftURLAsRootWithSlash() {
+    System.setProperty(OpenShiftConfig.OPENSHIFT_URL_SYTEM_PROPERTY, "https://1.1.1.1/");
+    OpenShiftConfig config = new OpenShiftConfig(kubernetesConfig);
+    assertEquals("https://1.1.1.1/oapi/" + version + "/", config.getOpenShiftUrl());
+  }
+
+  @Test
+  public void testFullOpenshiftURL() {
+    System.setProperty(OpenShiftConfig.OPENSHIFT_URL_SYTEM_PROPERTY, "https://1.1.1.1/xxx");
+    OpenShiftConfig config = new OpenShiftConfig(kubernetesConfig);
+    assertEquals("https://1.1.1.1/xxx/", config.getOpenShiftUrl());
+  }
+
+  @Test
+  public void testNoOpenshiftURL() {
+    System.clearProperty(OpenShiftConfig.OPENSHIFT_URL_SYTEM_PROPERTY);
+    OpenShiftConfig config = new OpenShiftConfig(kubernetesConfig);
+    // Use the master URL
+    assertEquals("https://2.2.2.2/oapi/" + version + "/", config.getOpenShiftUrl());
+  }
+
+}


### PR DESCRIPTION
Some environments (like CDK) put the root URL in the `OPENSHIFT_URL` environment variable, instead of the `oapi` base URL. With this fix, both versions will be supported.