### PR TITLE
Various fixes for WatchConnectionManager

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -646,7 +646,7 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
       );
       watch.waitUntilReady();
       return watch;
-    } catch (MalformedURLException | InterruptedException | ExecutionException e) {
+    } catch (MalformedURLException e) {
       throw KubernetesClientException.launderThrowable(e);
     }
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -39,14 +39,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -55,7 +56,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.fabric8.kubernetes.client.utils.Utils.isNotNullOrEmpty;
 import static java.net.HttpURLConnection.HTTP_GONE;
 
-public class WatchConnectionManager<T, L extends KubernetesResourceList> implements Watch {
+public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesResourceList<T>> implements Watch {
 
   private static final Logger logger = LoggerFactory.getLogger(WatchConnectionManager.class);
 
@@ -66,21 +67,35 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
   private final Watcher<T> watcher;
   private final int reconnectLimit;
   private final int reconnectInterval;
+  // TODO maybe make this configurable, either as is (an exponent) or a max time
+  private final static int maxIntervalExponent = 5; // max 32x slowdown from base interval
   private final long websocketTimeout;
   private final long websocketPingInterval;
   private final AtomicInteger currentReconnectAttempt = new AtomicInteger(0);
   private final AtomicReference<WebSocket> webSocketRef = new AtomicReference<>();
-  private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
+  // single threaded serial executor
+  private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+    @Override
+    public Thread newThread(Runnable r) {
+      Thread ret = new Thread(r, "Executor for Watch " + System.identityHashCode(WatchConnectionManager.this));
+      ret.setDaemon(true);
+      return ret;
+    }
+  });
+  /** True if an onOpen callback was received on the first connect attempt, ie. the watch was successfully started. */
   private final AtomicBoolean started = new AtomicBoolean(false);
+  private final AtomicBoolean reconnectPending = new AtomicBoolean(false);
+  /** Blocking queue for startup exceptions. */
   private final ArrayBlockingQueue<Object> queue = new ArrayBlockingQueue<>(1);
+  private final URL requestUrl;
 
   private WebSocketCall webSocketCall;
-  private ScheduledFuture pingFuture;
+  private ScheduledFuture<?> pingFuture;
   private OkHttpClient clonedClient;
 
-  public WatchConnectionManager(final OkHttpClient client, final BaseOperation<T, L, ?, ?> baseOperation, final String version, final Watcher<T> watcher, final int reconnectInterval, final int reconnectLimit, long websocketTimeout, long websocketPingInterval) throws InterruptedException, ExecutionException, MalformedURLException {
+  public WatchConnectionManager(final OkHttpClient client, final BaseOperation<T, L, ?, ?> baseOperation, final String version, final Watcher<T> watcher, final int reconnectInterval, final int reconnectLimit, long websocketTimeout, long websocketPingInterval) throws MalformedURLException {
     if (version == null) {
-      KubernetesResourceList currentList = baseOperation.list();
+      L currentList = baseOperation.list();
       this.resourceVersion = new AtomicReference<>(currentList.getMetadata().getResourceVersion());
     } else {
       this.resourceVersion = new AtomicReference<>(version);
@@ -94,11 +109,14 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
 
     this.clonedClient = client.newBuilder().readTimeout(this.websocketTimeout, TimeUnit.MILLISECONDS).build();
 
+    // The URL is created, validated and saved once, so that reconnect attempts don't have to deal with
+    // MalformedURLExceptions that would never occur
+    requestUrl = baseOperation.getNamespacedUrl();
     runWatch();
   }
 
-  private final void runWatch() throws MalformedURLException, ExecutionException, InterruptedException {
-    URL requestUrl = baseOperation.getNamespacedUrl();
+  private final void runWatch() {
+    logger.debug("Connecting websocket ... {}", this);
 
     HttpUrl.Builder httpUrlBuilder = HttpUrl.get(requestUrl).newBuilder();
 
@@ -133,68 +151,74 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
     webSocketCall.enqueue(new WebSocketListener() {
       @Override
       public void onOpen(final WebSocket webSocket, Response response) {
-        if(response != null && response.body() != null) {
+        if (response != null && response.body() != null) {
           response.body().close();
         }
-        logger.debug("WebSocket successfully opened");
+        logger.info("WebSocket successfully opened");
         webSocketRef.set(webSocket);
         currentReconnectAttempt.set(0);
         started.set(true);
         queue.clear();
         queue.add(true);
-        pingFuture = executor.scheduleAtFixedRate(
-          new Runnable() {
-            @Override
-            public void run() {
-              if (!forceClosed.get()) {
-                try {
-                    webSocket.sendPing(new Buffer().writeUtf8("Alive?"));
-                } catch (IOException e) {
-                  logger.debug("Failed to send ping", e);
-                  onClose(4000, "Connection unexpectedly closed");
-                }
-              }
+        pingFuture = executor.scheduleAtFixedRate(new NamedRunnable("websocket ping") {
+          @Override
+          public void execute() {
+            WebSocket ws = webSocketRef.get();
+            if (ws == null) // not currently running
+              return;
+            try {
+              ws.sendPing(new Buffer().writeUtf8("Alive?"));
+            } catch (IOException e) {
+              logger.debug("Failed to send ping", e);
+              // sendPing: IOException - if unable to write the ping. Clients must call close when this happens to
+              // ensure resources are cleaned up.
+              closeWebSocket(ws);
+              // onFailure expects that the socket was already closed by okhttp
+              onFailure(e, null);
+            } catch (IllegalStateException e) {
+              logger.error("Tried to send ping in already closed websocket");
             }
-          }, 0, websocketPingInterval, TimeUnit.MILLISECONDS
-        );
+          }
+        }, websocketPingInterval, websocketPingInterval, TimeUnit.MILLISECONDS);
       }
 
       @Override
       public void onFailure(IOException e, Response response) {
+        if (forceClosed.get()) {
+          logger.warn("Ignoring onFailure for already closed/closing websocket", e);
+          // avoid resource leak though
+          if (response != null && response.body() != null) {
+            response.body().close();
+          }
+          return;
+        }
+
         if (response != null) {
-          //We only need to queue startup failures.
+          // We only need to queue startup failures.
           Status status = OperationSupport.createStatus(response);
-          logger.error("Exec Failure: HTTP:" + status.getCode() + ". Message:" + status.getMessage(), e);
+          if (response.body() != null) {
+            response.body().close();
+          }
+          logger.warn("Exec Failure: HTTP {}, Status: {} - {}", response.code(), status.getCode(), status.getMessage(),
+              e);
           if (!started.get()) {
             queue.add(new KubernetesClientException(status));
+            return; // no reconnect
           }
         } else {
-          logger.error("Exec Failure", e);
+          logger.warn("Exec Failure", e);
           if (!started.get()) {
-            queue.add(KubernetesClientException.launderThrowable(e));
+            queue.add(new KubernetesClientException("Failed to start websocket", e));
+            return; // no reconnect
           }
         }
 
-        if (response != null && response.body() != null){
-          response.body().close();
-        }
-
-        if (forceClosed.get()) {
-          watcher.onClose(null);
+        if (currentReconnectAttempt.get() >= reconnectLimit && reconnectLimit >= 0) {
+          watcher.onClose(new KubernetesClientException("Connection failure", e));
           return;
         }
 
-        if (reconnectLimit >= 0 && currentReconnectAttempt.getAndIncrement() >= reconnectLimit) {
-          watcher.onClose(new KubernetesClientException("Connection unexpectedly closed", e));
-          return;
-        }
-        try {
-          TimeUnit.MILLISECONDS.sleep(reconnectInterval);
-        } catch (InterruptedException e1) {
-          watcher.onClose(new KubernetesClientException("Connection unexpectedly closed", e1));
-          return;
-        }
-        onClose(4000, "Connection unexpectedly closed");
+        scheduleReconnect();
       }
 
       @Override
@@ -205,8 +229,9 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
           WatchEvent event = mapper.readValue(messageSource, WatchEvent.class);
 
           if (event.getObject() instanceof HasMetadata) {
+            @SuppressWarnings("unchecked")
             T obj = (T) event.getObject();
-            //Dirty cast - should always be valid though
+            // Dirty cast - should always be valid though
             String currentResourceVersion = resourceVersion.get();
             String newResourceVersion = ((HasMetadata) obj).getMetadata().getResourceVersion();
             if (currentResourceVersion.compareTo(newResourceVersion) < 0) {
@@ -214,17 +239,22 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
             }
             Watcher.Action action = Watcher.Action.valueOf(event.getType());
             watcher.eventReceived(action, obj);
-          } else if (event.getObject() instanceof Status){
+          } else if (event.getObject() instanceof Status) {
             Status status = (Status) event.getObject();
 
             // The resource version no longer exists - this has to be handled by the caller.
             if (status.getCode() == HTTP_GONE) {
+              webSocketRef.set(null); // lose the ref: closing in close() would only generate a Broken pipe
+                                      // exception
+              // shut down executor, etc.
               close();
               watcher.onClose(new KubernetesClientException(status));
               return;
             }
 
             logger.error("Error received: {}", status.toString());
+          } else {
+            logger.error("Unknown message received: {}", messageSource);
           }
         } catch (IOException e) {
           logger.error("Could not deserialize watch event: {}", messageSource, e);
@@ -242,62 +272,67 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
         try {
           if (!buffer.equals(new Buffer().writeUtf8("Alive?"))) {
             logger.error("Failed to verify pong");
-            onClose(4000, "Connection unexpectedly closed");
+            // onClose expects that the socket was already closed by okhttp
+            closeWebSocket(webSocketRef.get());
+            onClose(4000, "WebSocket pong verification error");
           }
-        } finally{
+        } finally {
           buffer.close();
         }
       }
 
       @Override
       public void onClose(final int code, final String reason) {
-        if (!pingFuture.isCancelled() && !pingFuture.isDone()) {
-          pingFuture.cancel(true);
-        }
-
+        logger.info("WebSocket close received. code: {}, reason: {}", code, reason);
         if (forceClosed.get()) {
-          watcher.onClose(null);
+          logger.warn("Ignoring onClose for already closed/closing websocket");
           return;
         }
-
-        // Let's close the websocket before trying to reopen a new one.
-        try {
-          WebSocket ws = webSocketRef.get();
-          if (ws != null) {
-            ws.close(0, null);
-            webSocketRef.set(null);
-          }
-        } catch (IOException e) {
-          logger.warn("Could not properly close websocket", e);
-        } catch (IllegalStateException e) {
-          // Ignore...
+        if (currentReconnectAttempt.get() >= reconnectLimit && reconnectLimit >= 0) {
+          watcher.onClose(new KubernetesClientException("Connection unexpectedly closed"));
+          return;
         }
+        scheduleReconnect();
+      }
+    });
+  }
 
-        executor.submit(new Runnable() {
-          @Override
-          public void run() {
-            try {
-              queue.clear();
-              runWatch();
-            } catch (ExecutionException e) {
-              if (e.getCause() != null && e.getCause().getCause() != null && e.getCause().getCause() instanceof ConnectException) {
-                if (reconnectLimit >= 0 && currentReconnectAttempt.getAndIncrement() >= reconnectLimit) {
-                  watcher.onClose(new KubernetesClientException("Connection unexpectedly closed", e));
-                  return;
-                }
-                try {
-                  TimeUnit.MILLISECONDS.sleep(reconnectInterval);
-                } catch (InterruptedException e1) {
-                  watcher.onClose(new KubernetesClientException("Connection unexpectedly closed", e1));
-                  return;
-                }
-                onClose(code, reason);
+  private void scheduleReconnect() {
+
+    logger.debug("Submitting reconnect task to the executor");
+    // make sure that whichever thread calls this method, the tasks are
+    // performed serially in the executor
+    executor.submit(new NamedRunnable("scheduleReconnect") {
+      @Override
+      public void execute() {
+        if (!reconnectPending.compareAndSet(false, true)) {
+          logger.debug("Reconnect already scheduled");
+          return;
+        }
+        stopWsPing();
+        webSocketRef.set(null);
+        try {
+          // actual reconnect only after the back-off time has passed, without
+          // blocking the thread
+          logger.debug("Scheduling reconnect task");
+          executor.schedule(new NamedRunnable("reconnectAttempt") {
+            @Override
+            public void execute() {
+              try {
+                runWatch();
+                reconnectPending.set(false);
+              } catch (Exception e) {
+                // An unexpected error occurred and we didn't even get an onFailure callback.
+                logger.error("Exception in reconnect", e);
+                webSocketRef.set(null);
+                close();
+                watcher.onClose(new KubernetesClientException("Unhandled exception in reconnect attempt", e));
               }
-            } catch (MalformedURLException | InterruptedException e) {
-              throw KubernetesClientException.launderThrowable(e);
             }
-          }
-        });
+          }, nextReconnectInterval(), TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException e) {
+          reconnectPending.set(false);
+        }
       }
     });
   }
@@ -308,26 +343,80 @@ public class WatchConnectionManager<T, L extends KubernetesResourceList> impleme
 
   @Override
   public void close() {
+    logger.debug("Force closing the watch {}", this);
     forceClosed.set(true);
-    try {
-      WebSocket ws = webSocketRef.get();
-      if (ws != null) {
-        ws.close(0, null);
-        webSocketRef.set(null);
-      }
-    } catch (IOException | IllegalStateException e) {
-      logger.warn("Failed to cleanly close websocket", e);
-    }
-
+    stopWsPing();
+    closeWebSocket(webSocketRef.getAndSet(null));
     if (!executor.isShutdown()) {
       try {
         executor.shutdown();
         if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+          logger.warn("Executor didn't terminate in time after shutdown in close(), killing it in: {}", this);
           executor.shutdownNow();
         }
       } catch (Throwable t) {
         throw KubernetesClientException.launderThrowable(t);
       }
     }
+  }
+
+  private void stopWsPing() {
+    if (pingFuture != null && !pingFuture.isCancelled() && !pingFuture.isDone()) {
+      pingFuture.cancel(true);
+    }
+    pingFuture = null;
+  }
+
+  private void closeWebSocket(WebSocket ws) {
+    if (ws != null) {
+      logger.debug("Closing websocket {}", ws);
+      try {
+        ws.close(0, null);
+      } catch (IOException e) {
+        if ("closed".equals(e.getMessage())) {
+          logger.debug("Socket already closed");
+        } else {
+          logger.warn("Failed to write websocket close message: {} {}", e.getClass(), e.getMessage());
+        }
+      } catch (IllegalStateException e) {
+        logger.error("Called close on already closed websocket: {} {}", e.getClass(), e.getMessage());
+      }
+    }
+  }
+
+  private long nextReconnectInterval() {
+    int exponentOfTwo = currentReconnectAttempt.getAndIncrement();
+    if (exponentOfTwo > maxIntervalExponent)
+      exponentOfTwo = maxIntervalExponent;
+    long ret = reconnectInterval * (1 << exponentOfTwo);
+    logger.info("Current reconnect backoff is " + ret + " milliseconds (T" + exponentOfTwo + ")");
+    return ret;
+  }
+
+  private static abstract class NamedRunnable implements Runnable {
+    private final String name;
+
+    public NamedRunnable(String name) {
+      this.name = Objects.requireNonNull(name);
+    }
+
+    private void tryToSetName(String value) {
+      try {
+        Thread.currentThread().setName(value);
+      } catch (SecurityException ignored) {
+      }
+    }
+
+    public final void run() {
+      String oldName = Thread.currentThread().getName();
+      tryToSetName(this.name + "|" + oldName);
+      try {
+        execute();
+      } finally {
+        tryToSetName(oldName);
+      }
+    }
+
+    protected abstract void execute();
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/WatchTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/WatchTest.java
@@ -1,0 +1,125 @@
+package io.fabric8.kubernetes.client;
+
+import static org.junit.Assert.assertTrue;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.WatchEventBuilder;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import junit.framework.AssertionFailedError;
+
+import java.net.HttpURLConnection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WatchTest {
+  Logger logger = LoggerFactory.getLogger(WatchTest.class);
+
+  @Rule
+  public KubernetesServer server = new KubernetesServer(false);
+
+  static final Pod pod1 = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
+      .withResourceVersion("1").endMetadata().build();
+
+  static final Status outdatedStatus = new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
+      .withMessage(
+          "401: The event in requested index is outdated and cleared (the requested history has been cleared [3/1]) [2]")
+      .build();
+  static final WatchEvent outdatedEvent = new WatchEventBuilder().withStatusObject(outdatedStatus).build();
+
+  @Test
+  public void testDeletedAndOutdated() throws InterruptedException {
+    logger.info("testDeletedAndOutdated");
+    KubernetesClient client = server.getClient().inNamespace("test");
+
+    // DELETED event, then history outdated
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+        .andUpgradeToWebSocket().open().waitFor(2000).andEmit(new WatchEvent(pod1, "DELETED")).waitFor(2000)
+        .andEmit(outdatedEvent).done().once();
+
+    final CountDownLatch deleteLatch = new CountDownLatch(1);
+    final CountDownLatch closeLatch = new CountDownLatch(1);
+    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
+      @Override
+      public void eventReceived(Action action, Pod resource) {
+        switch (action) {
+        case DELETED:
+          deleteLatch.countDown();
+          break;
+        default:
+          throw new AssertionFailedError();
+        }
+      }
+
+      @Override
+      public void onClose(KubernetesClientException cause) {
+        closeLatch.countDown();
+      }
+    })) /* autoclose */ {
+      assertTrue(deleteLatch.await(10, TimeUnit.SECONDS));
+      assertTrue(closeLatch.await(10, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test(expected = KubernetesClientException.class)
+  public void testHttpErrorWithOutdated() {
+    logger.info("testHttpErrorWithOutdated");
+    KubernetesClient client = server.getClient().inNamespace("test");
+    // http error: history outdated
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+        .andReturn(410, outdatedEvent).once();
+    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
+      @Override
+      public void eventReceived(Action action, Pod resource) {
+        throw new AssertionFailedError();
+      }
+
+      @Override
+      public void onClose(KubernetesClientException cause) {
+        throw new AssertionFailedError();
+      }
+    })) {
+
+    }
+  }
+
+  @Test
+  public void testHttpErrorReconnect() throws InterruptedException {
+    logger.info("testHttpErrorReconnect");
+    String path = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true";
+    KubernetesClient client = server.getClient().inNamespace("test");
+    // accept watch and disconnect
+    server.expect().withPath(path).andUpgradeToWebSocket().open().done().once();
+    // refuse reconnect attempts 6 times
+    server.expect().withPath(path).andReturn(503, new StatusBuilder().withCode(503).build()).times(6);
+    // accept next reconnect and send outdated event to stop the watch
+    server.expect().withPath(path).andUpgradeToWebSocket().open(outdatedEvent).done().once();
+
+    final CountDownLatch closeLatch = new CountDownLatch(1);
+    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
+      @Override
+      public void eventReceived(Action action, Pod resource) {
+        throw new AssertionFailedError();
+      }
+
+      @Override
+      public void onClose(KubernetesClientException cause) {
+        logger.debug("onClose", cause);
+        closeLatch.countDown();
+      }
+    })) /* autoclose */ {
+      assertTrue(closeLatch.await(3, TimeUnit.MINUTES));
+    }
+  }
+
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/WatchTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/WatchTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.fabric8.kubernetes.client;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
- Removed never thrown exceptions from the ctor signature
- Only validate the watch URL once on startup
- **Changed reconnect timing to an exponential backoff capped at 32*baseInterval**
- **Now using a single threaded executor for serial event handling (this eliminates an issue where in some cases the connection gets duplicated)**
- Don't try to send ping while the websocket is inactive during a reconnect backoff
- Delay the first ping with the ping interval, don't send right away on open
- Added/modified level of some log statements
- **Ensure that websocket is:**
  - **always properly closed (e.g. ping failure) to avoid leaked connections**
  - **never double closed (this removes some unnecessary exceptions from the log)**
- Properly queue startup exceptions and don't reconnect in that case
- Fixed some type warning issues
- Introduced thread-renaming tasks for the executor for better logging
- Added test case for Watch