### PR TITLE
A couple more improvements on waitables.

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -95,7 +95,7 @@ public interface KubernetesClient extends Client {
 
   NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(Collection<HasMetadata> items);
 
-  NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<HasMetadata,Boolean> resource(HasMetadata is);
+  <T extends HasMetadata> NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<T ,Boolean> resource(T is);
 
   NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<HasMetadata,Boolean> resource(String s);
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetWatchDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetWatchDeleteRecreateWaitApplicable.java
@@ -26,5 +26,6 @@ public interface VisitFromServerGetWatchDeleteRecreateWaitApplicable<T, B> exten
                                                                           FromServerGettable<T>, RecreateApplicable<T>,
                                                                           CascadingDeletable<B>,
                                                                           Watchable<Watch, Watcher<T>>,
+                                                                          Waitable<T>,
                                                                           GracePeriodConfigurable<CascadingDeletable<B>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/EndpointsOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/EndpointsOperationsImpl.java
@@ -15,10 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
-import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.kubernetes.client.internal.readiness.ReadinessWatcher;
 import okhttp3.OkHttpClient;
@@ -31,7 +28,7 @@ import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.CountDownLatch;
+
 import java.util.concurrent.TimeUnit;
 
 public class EndpointsOperationsImpl extends HasMetadataOperation<Endpoints, EndpointsList, DoneableEndpoints,
@@ -57,13 +54,9 @@ public class EndpointsOperationsImpl extends HasMetadataOperation<Endpoints, End
       return endpoints;
     }
 
-    final CountDownLatch latch = new CountDownLatch(1);
-    Watcher<Endpoints> watcher = new ReadinessWatcher<>(latch);
+    ReadinessWatcher<Endpoints> watcher = new ReadinessWatcher<>(endpoints.getKind(), getName(), getNamespace());
     try (Watch watch = watch(watcher)) {
-      if (latch.await(amount, timeUnit)) {
-        return get();
-      }
+      return watcher.await(amount, timeUnit);
     }
-    throw new KubernetesClientTimeoutException(endpoints.getKind(), getName(), getNamespace(), amount, timeUnit);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -245,7 +245,7 @@ Waitable<HasMetadata>,
 
   @Override
   public HasMetadata waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
-    HasMetadata meta = acceptVisitors(asHasMetadata(item), visitors);
+    HasMetadata meta = acceptVisitors(asHasMetadata(get()), visitors);
     ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(meta);
     return h.waitUntilReady(client, config, meta.getMetadata().getNamespace(), meta, amount, timeUnit);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
@@ -314,13 +314,9 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
       return pod;
     }
 
-    final CountDownLatch latch = new CountDownLatch(1);
-    Watcher<Pod> watcher = new ReadinessWatcher<>(latch);
+    ReadinessWatcher<Pod> watcher = new ReadinessWatcher<>(pod.getKind(), getName(), getNamespace());
     try (Watch watch = watch(watcher)) {
-      if (latch.await(amount, timeUnit)) {
-        return get();
-      }
-      throw new KubernetesClientTimeoutException(pod.getKind(), getName(), getNamespace(), amount, timeUnit);
+      return watcher.await(amount, timeUnit);
     }
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
@@ -274,13 +274,9 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
       return rc;
     }
 
-    final CountDownLatch latch = new CountDownLatch(1);
-    Watcher<ReplicationController> watcher = new ReadinessWatcher<>(latch);
+    ReadinessWatcher<ReplicationController> watcher = new ReadinessWatcher<>(rc.getKind(), getName(), getNamespace());
     try (Watch watch = watch(watcher)) {
-      if (latch.await(amount, timeUnit)) {
-        return get();
-      }
-      throw new KubernetesClientTimeoutException(rc.getKind(), getName(), getNamespace(), amount, timeUnit);
+      return watcher.await(amount, timeUnit);
     }
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/DeploymentConfigOperationsImpl.java
@@ -183,13 +183,9 @@ public class DeploymentConfigOperationsImpl extends OpenShiftOperation<Deploymen
       return dc;
     }
 
-    final CountDownLatch latch = new CountDownLatch(1);
-    Watcher<DeploymentConfig> watcher = new ReadinessWatcher<>(latch);
+    ReadinessWatcher<DeploymentConfig> watcher = new ReadinessWatcher<>(dc.getKind(), getName(), getNamespace());
     try (Watch watch = watch(watcher)) {
-      if (latch.await(amount, timeUnit)) {
-        return get();
-      }
-      throw new KubernetesClientTimeoutException(dc.getKind(), getName(), getNamespace(), amount, timeUnit);
+      return watcher.await(amount, timeUnit);
     }
   }
 


### PR DESCRIPTION
1. client.resource(<instance of hasmetadata>) should make use of the type parameter (rather than using HasMetadata). 

2. We should be able to use waitUntilReady() on  exisiting resource.
3. waitUntilReady() should return the instance on which the readiness check was performed rather than performing internally a new get().
4. Reduce the boilerplate code that is used internally in waitUntilReady().

5. Added a test that for client.resource(pod).waitUntilReady() and client.resource(pod).createAnd().waitUntilReady().
