### PR TITLE
Add the ability to call a function with custom request configuration

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Adapters.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Adapters.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 
+import okhttp3.OkHttpClient;
+
 public final class Adapters {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Adapters.class);
@@ -35,13 +37,35 @@ public final class Adapters {
   private static final Set<ClassLoader> CLASS_LOADERS = new HashSet<>();
   private static final Map<Class, ExtensionAdapter> EXTENSION_ADAPTER_MAP = new HashMap<>();
 
-  private Adapters() {
-    //Utility
-  }
+  private static final ExtensionAdapter<OkHttpClient> OK_HTTP_CLIENT_EXTENSION_ADAPTER = new ExtensionAdapter<OkHttpClient>() {
+
+    @Override
+    public Class<OkHttpClient> getExtensionType() {
+      return OkHttpClient.class;
+    }
+
+    @Override
+    public Boolean isAdaptable(Client client) {
+      return client instanceof HttpClientAware;
+    }
+
+    @Override
+    public OkHttpClient adapt(Client client) {
+      if (client instanceof HttpClientAware) {
+        return ((HttpClientAware)client).getHttpClient().newBuilder().build();
+      }
+      throw new IllegalArgumentException("This adapter only supports instances of HttpClientAware.");
+    }
+  };
 
   static {
     //Register adapters
     discoverServices(Adapters.class.getClassLoader());
+    register(OK_HTTP_CLIENT_EXTENSION_ADAPTER);
+  }
+
+  private Adapters() {
+    //Utility
   }
 
   public static <C> void register(ExtensionAdapter<C> adapter) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -53,28 +53,6 @@ public abstract class BaseClient implements Client, HttpClientAware {
           " or environment variable \"" + Utils.convertSystemPropertyNameToEnvVar(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY) + "\"");
       }
       this.masterUrl = new URL(config.getMasterUrl());
-
-      Adapters.register(new ExtensionAdapter<OkHttpClient>() {
-
-        @Override
-        public Class<OkHttpClient> getExtensionType() {
-          return OkHttpClient.class;
-        }
-
-        @Override
-        public Boolean isAdaptable(Client client) {
-          return client instanceof HttpClientAware;
-        }
-
-        @Override
-        public OkHttpClient adapt(Client client) {
-          if (client instanceof HttpClientAware) {
-            return ((HttpClientAware)client).getHttpClient().newBuilder().build();
-          }
-          throw new IllegalArgumentException("This adapter only supports instances of HttpClientAware.");
-        }
-      });
-
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(e);
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -37,6 +37,10 @@ public abstract class BaseClient implements Client, HttpClientAware {
     this(new ConfigBuilder().build());
   }
 
+  public BaseClient(String masterUrl) throws KubernetesClientException {
+    this(new ConfigBuilder().withMasterUrl(masterUrl).build());
+  }
+
   public BaseClient(final Config config) throws KubernetesClientException {
     this(HttpClientUtils.createHttpClient(config), config);
   }
@@ -56,12 +60,6 @@ public abstract class BaseClient implements Client, HttpClientAware {
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(e);
     }
-  }
-
-
-
-  public BaseClient(String masterUrl) throws KubernetesClientException {
-    this(new ConfigBuilder().withMasterUrl(masterUrl).build());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -107,6 +107,12 @@ public class Config {
   private String clientKeyData;
   private String clientKeyAlgo = "RSA";
   private String clientKeyPassphrase = "changeit";
+
+  private RequestConfig requestConfig = new RequestConfig();
+
+  /**
+   * fields not used but needed for builder generation.
+   */
   private String username;
   private String password;
   private String oauthToken;
@@ -119,6 +125,10 @@ public class Config {
   private int loggingInterval = DEFAULT_LOGGING_INTERVAL;
   private long websocketTimeout = DEFAULT_WEBSOCKET_TIMEOUT;
   private long websocketPingInterval = DEFAULT_WEBSOCKET_PING_INTERVAL;
+  /**
+   * end of fields not used but needed for builder generation.
+   */
+
   private String httpProxy;
   private String httpsProxy;
   private String proxyUsername;
@@ -159,16 +169,9 @@ public class Config {
     this.clientKeyData = clientKeyData;
     this.clientKeyAlgo = clientKeyAlgo;
     this.clientKeyPassphrase = clientKeyPassphrase;
-    this.username = username;
-    this.password = password;
-    this.oauthToken = oauthToken;
-    this.watchReconnectInterval = watchReconnectInterval;
-    this.watchReconnectLimit = watchReconnectLimit;
-    this.connectionTimeout = connectionTimeout;
-    this.requestTimeout = requestTimeout;
-    this.rollingTimeout = rollingTimeout;
-    this.scaleTimeout = scaleTimeout;
-    this.loggingInterval = loggingInterval;
+
+    this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval);
+
     this.httpProxy= httpProxy;
     this.httpsProxy= httpsProxy;
     this.noProxy= noProxy;
@@ -177,8 +180,6 @@ public class Config {
     this.errorMessages = errorMessages;
     this.userAgent = userAgent;
     this.tlsVersions = tlsVersions;
-    this.websocketTimeout = websocketTimeout;
-    this.websocketPingInterval = websocketPingInterval;
 
     if (!this.masterUrl.toLowerCase().startsWith(HTTP_PROTOCOL_PREFIX) && !this.masterUrl.startsWith(HTTPS_PROTOCOL_PREFIX)) {
       this.masterUrl = (SSLUtils.isHttpsAvailable(this) ? HTTPS_PROTOCOL_PREFIX : HTTP_PROTOCOL_PREFIX) + this.masterUrl;
@@ -415,27 +416,27 @@ public class Config {
   }
 
   public String getOauthToken() {
-    return oauthToken;
+    return getRequestConfig().getOauthToken();
   }
 
   public void setOauthToken(String oauthToken) {
-    this.oauthToken = oauthToken;
+    this.requestConfig.setOauthToken(oauthToken);
   }
 
   public String getPassword() {
-    return password;
+    return getRequestConfig().getPassword();
   }
 
   public void setPassword(String password) {
-    this.password = password;
+   this.requestConfig.setPassword(password);
   }
 
   public String getUsername() {
-    return username;
+    return getRequestConfig().getUsername();
   }
 
   public void setUsername(String username) {
-    this.username = username;
+    this.requestConfig.setUsername(username);
   }
 
   public String getClientKeyPassphrase() {
@@ -527,19 +528,19 @@ public class Config {
   }
 
   public int getWatchReconnectInterval() {
-    return watchReconnectInterval;
+    return requestConfig.getWatchReconnectInterval();
   }
 
   public void setWatchReconnectInterval(int watchReconnectInterval) {
-    this.watchReconnectInterval = watchReconnectInterval;
+    this.requestConfig.setWatchReconnectInterval(watchReconnectInterval);
   }
 
   public int getWatchReconnectLimit() {
-    return watchReconnectLimit;
+    return getRequestConfig().getWatchReconnectLimit();
   }
 
   public void setWatchReconnectLimit(int watchReconnectLimit) {
-    this.watchReconnectLimit = watchReconnectLimit;
+    this.requestConfig.setWatchReconnectLimit(watchReconnectLimit);
   }
 
   public Map<Integer, String> getErrorMessages() {
@@ -555,43 +556,43 @@ public class Config {
   }
 
   public int getConnectionTimeout() {
-    return connectionTimeout;
+    return getRequestConfig().getConnectionTimeout();
   }
 
   public void setConnectionTimeout(int connectionTimeout) {
-    this.connectionTimeout = connectionTimeout;
+    this.requestConfig.setConnectionTimeout(connectionTimeout);
   }
 
   public int getRequestTimeout() {
-    return requestTimeout;
+    return getRequestConfig().getRequestTimeout();
   }
 
   public void setRequestTimeout(int requestTimeout) {
-    this.requestTimeout = requestTimeout;
+    this.requestConfig.setRequestTimeout(requestTimeout);
   }
 
   public long getRollingTimeout() {
-    return rollingTimeout;
+    return getRequestConfig().getRollingTimeout();
   }
 
   public void setRollingTimeout(long rollingTimeout) {
-    this.rollingTimeout = rollingTimeout;
+    this.requestConfig.setRollingTimeout(rollingTimeout);
   }
 
   public long getScaleTimeout() {
-    return scaleTimeout;
+    return getRequestConfig().getScaleTimeout();
   }
 
   public void setScaleTimeout(long scaleTimeout) {
-    this.scaleTimeout = scaleTimeout;
+    this.requestConfig.setScaleTimeout(scaleTimeout);
   }
 
   public int getLoggingInterval() {
-    return loggingInterval;
+    return getRequestConfig().getLoggingInterval();
   }
 
   public void setLoggingInterval(int loggingInterval) {
-    this.loggingInterval = loggingInterval;
+    this.requestConfig.setLoggingInterval(loggingInterval);
   }
 
   public void setHttpProxy(String httpProxy) {
@@ -643,19 +644,19 @@ public class Config {
   }
 
   public long getWebsocketTimeout() {
-    return websocketTimeout;
+    return getRequestConfig().getWebsocketTimeout();
   }
 
   public void setWebsocketTimeout(long websocketTimeout) {
-    this.websocketTimeout = websocketTimeout;
+    this.requestConfig.setWebsocketTimeout(websocketTimeout);
   }
 
   public long getWebsocketPingInterval() {
-    return websocketPingInterval;
+    return getRequestConfig().getWebsocketPingInterval();
   }
 
   public void setWebsocketPingInterval(long websocketPingInterval) {
-    this.websocketPingInterval = websocketPingInterval;
+    this.requestConfig.setWebsocketPingInterval(websocketPingInterval);
   }
   public String getProxyUsername() {
     return proxyUsername;
@@ -671,5 +672,10 @@ public class Config {
 
   public void setProxyPassword(String proxyPassword) {
     this.proxyPassword = proxyPassword;
+  }
+
+  public RequestConfig getRequestConfig() {
+    RequestConfig rc = RequestConfigHolder.get();
+    return rc != null ? rc : this.requestConfig;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -107,16 +107,17 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     super();
   }
 
-  public DefaultKubernetesClient(OkHttpClient httpClient, Config config) throws KubernetesClientException {
-    super(httpClient, config);
+  public DefaultKubernetesClient(String masterUrl) throws KubernetesClientException {
+    super(masterUrl);
   }
 
   public DefaultKubernetesClient(Config config) throws KubernetesClientException {
     super(config);
   }
 
-  public DefaultKubernetesClient(String masterUrl) throws KubernetesClientException {
-    super(masterUrl);
+
+  public DefaultKubernetesClient(OkHttpClient httpClient, Config config) throws KubernetesClientException {
+    super(httpClient, config);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.internal.LimitRangeOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl;
-import io.fabric8.kubernetes.client.internal.WithRequestCallable;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.ComponentStatus;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -20,9 +20,11 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LimitRange;
 import io.fabric8.kubernetes.api.model.LimitRangeList;
+import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.internal.LimitRangeOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl;
+import io.fabric8.kubernetes.client.internal.WithRequestCallable;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.ComponentStatus;
@@ -258,8 +260,14 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     return inNamespace(null);
   }
 
+
+  @Override
+  public FunctionCallable<NamespacedKubernetesClient> withRequestConfig(RequestConfig requestConfig) {
+    return new WithRequestCallable<NamespacedKubernetesClient>(this, requestConfig);
+  }
   @Override
   public ExtensionsAPIGroupDSL extensions() {
     return adapt(ExtensionsAPIGroupClient.class);
   }
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.client;
 
 import io.sundr.builder.annotations.Buildable;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -1,0 +1,143 @@
+package io.fabric8.kubernetes.client;
+
+import io.sundr.builder.annotations.Buildable;
+
+import static io.fabric8.kubernetes.client.Config.DEFAULT_LOGGING_INTERVAL;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_ROLLING_TIMEOUT;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_SCALE_TIMEOUT;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_WEBSOCKET_PING_INTERVAL;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_WEBSOCKET_TIMEOUT;
+
+public class RequestConfig {
+
+  private String username;
+  private String password;
+  private String oauthToken;
+  private int watchReconnectInterval = 1000;
+  private int watchReconnectLimit = -1;
+  private int connectionTimeout = 10 * 1000;
+  private int requestTimeout = 10 * 1000;
+  private long rollingTimeout = DEFAULT_ROLLING_TIMEOUT;
+  private long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
+  private int loggingInterval = DEFAULT_LOGGING_INTERVAL;
+  private long websocketTimeout = DEFAULT_WEBSOCKET_TIMEOUT;
+  private long websocketPingInterval = DEFAULT_WEBSOCKET_PING_INTERVAL;
+
+  RequestConfig() {
+  }
+
+  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
+  public RequestConfig(String username, String password, String oauthToken,
+                       int watchReconnectLimit, int watchReconnectInterval,
+                       int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
+                       long websocketTimeout, long websocketPingInterval) {
+    this.username = username;
+    this.oauthToken = oauthToken;
+    this.password = password;
+    this.watchReconnectLimit = watchReconnectLimit;
+    this.watchReconnectInterval = watchReconnectInterval;
+    this.connectionTimeout = connectionTimeout;
+    this.rollingTimeout = rollingTimeout;
+    this.requestTimeout = requestTimeout;
+    this.scaleTimeout = scaleTimeout;
+    this.websocketTimeout = websocketTimeout;
+    this.loggingInterval = loggingInterval;
+    this.websocketPingInterval = websocketPingInterval;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public int getWatchReconnectInterval() {
+    return watchReconnectInterval;
+  }
+
+  public void setWatchReconnectInterval(int watchReconnectInterval) {
+    this.watchReconnectInterval = watchReconnectInterval;
+  }
+
+  public String getOauthToken() {
+    return oauthToken;
+  }
+
+  public void setOauthToken(String oauthToken) {
+    this.oauthToken = oauthToken;
+  }
+
+  public int getWatchReconnectLimit() {
+    return watchReconnectLimit;
+  }
+
+  public void setWatchReconnectLimit(int watchReconnectLimit) {
+    this.watchReconnectLimit = watchReconnectLimit;
+  }
+
+  public int getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public void setRequestTimeout(int requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+
+  public int getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public void setConnectionTimeout(int connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+
+  public long getRollingTimeout() {
+    return rollingTimeout;
+  }
+
+  public void setRollingTimeout(long rollingTimeout) {
+    this.rollingTimeout = rollingTimeout;
+  }
+
+  public long getScaleTimeout() {
+    return scaleTimeout;
+  }
+
+  public void setScaleTimeout(long scaleTimeout) {
+    this.scaleTimeout = scaleTimeout;
+  }
+
+  public int getLoggingInterval() {
+    return loggingInterval;
+  }
+
+  public void setLoggingInterval(int loggingInterval) {
+    this.loggingInterval = loggingInterval;
+  }
+
+  public long getWebsocketTimeout() {
+    return websocketTimeout;
+  }
+
+  public void setWebsocketTimeout(long websocketTimeout) {
+    this.websocketTimeout = websocketTimeout;
+  }
+
+  public long getWebsocketPingInterval() {
+    return websocketPingInterval;
+  }
+
+  public void setWebsocketPingInterval(long websocketPingInterval) {
+    this.websocketPingInterval = websocketPingInterval;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfigHolder.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfigHolder.java
@@ -1,0 +1,18 @@
+package io.fabric8.kubernetes.client;
+
+public class RequestConfigHolder {
+
+  private static final ThreadLocal<RequestConfig> REQUEST_CONFIG = new ThreadLocal<>();
+
+  public static RequestConfig get() {
+    return REQUEST_CONFIG.get();
+  }
+
+  public static void set(RequestConfig requestConfig) {
+    REQUEST_CONFIG.set(requestConfig);
+  }
+
+  public static void remove() {
+    REQUEST_CONFIG.remove();
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfigHolder.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfigHolder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.client;
 
 class RequestConfigHolder {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfigHolder.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfigHolder.java
@@ -1,18 +1,18 @@
 package io.fabric8.kubernetes.client;
 
-public class RequestConfigHolder {
+class RequestConfigHolder {
 
   private static final ThreadLocal<RequestConfig> REQUEST_CONFIG = new ThreadLocal<>();
 
-  public static RequestConfig get() {
+  static RequestConfig get() {
     return REQUEST_CONFIG.get();
   }
 
-  public static void set(RequestConfig requestConfig) {
+  static void set(RequestConfig requestConfig) {
     REQUEST_CONFIG.set(requestConfig);
   }
 
-  public static void remove() {
+  static void remove() {
     REQUEST_CONFIG.remove();
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/WithRequestCallable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/WithRequestCallable.java
@@ -1,15 +1,17 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.kubernetes.client;
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/WithRequestCallable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/WithRequestCallable.java
@@ -11,12 +11,9 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.fabric8.kubernetes.client.internal;
+package io.fabric8.kubernetes.client;
 
 import io.fabric8.kubernetes.api.builder.Function;
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.RequestConfig;
-import io.fabric8.kubernetes.client.RequestConfigHolder;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 
 public class WithRequestCallable<C extends Client> implements FunctionCallable<C> {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/FunctionCallable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/FunctionCallable.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+
+import io.fabric8.kubernetes.api.builder.Function;
+
+public interface FunctionCallable<I> {
+
+  <O> O call(Function<I, O> function);
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/FunctionCallable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/FunctionCallable.java
@@ -1,15 +1,17 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.kubernetes.client.dsl;
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/RequestConfigurable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/RequestConfigurable.java
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client;
+package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.client.dsl.AnyNamespaceable;
-import io.fabric8.kubernetes.client.dsl.Namespaceable;
-import io.fabric8.kubernetes.client.dsl.RequestConfigurable;
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.RequestConfig;
 
+public interface RequestConfigurable<C extends Client> {
 
-public interface GenericKubernetesClient<C extends Client> extends Client, KubernetesClient,
-  Namespaceable<C>,
-  AnyNamespaceable<C>,
-  RequestConfigurable<C> {
+  FunctionCallable<C> withRequestConfig(RequestConfig requestConfig);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/WithRequestCallable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/WithRequestCallable.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.fabric8.kubernetes.client.internal;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.RequestConfig;
+import io.fabric8.kubernetes.client.RequestConfigHolder;
+import io.fabric8.kubernetes.client.dsl.FunctionCallable;
+
+public class WithRequestCallable<C extends Client> implements FunctionCallable<C> {
+
+  private final C client;
+  private final RequestConfig requestConfig;
+
+  public WithRequestCallable(C client, RequestConfig requestConfig) {
+    this.client = client;
+    this.requestConfig = requestConfig;
+  }
+
+  @Override
+  public <O> O call(Function<C, O> function) {
+    try {
+      RequestConfigHolder.set(requestConfig);
+      return function.apply(client);
+    } finally {
+      RequestConfigHolder.remove();
+    }
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -80,6 +80,7 @@ import io.fabric8.kubernetes.client.ExtensionAdapter;
 import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.dsl.ClientKubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
@@ -88,6 +89,7 @@ import io.fabric8.kubernetes.client.dsl.ClientPodResource;
 import io.fabric8.kubernetes.client.dsl.ClientResource;
 import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import org.apache.felix.scr.annotations.Activate;
@@ -383,5 +385,10 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public NamespacedKubernetesClient inNamespace(String name) {
     return delegate.inNamespace(name);
+  }
+
+  @Override
+  public FunctionCallable<NamespacedKubernetesClient> withRequestConfig(RequestConfig requestConfig) {
+    return delegate.withRequestConfig(requestConfig);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -81,23 +81,20 @@ public class HttpClientUtils {
               httpClientBuilder.sslSocketFactory(context.getSocketFactory(), (X509TrustManager) trustManagers[0]);
             }
 
-            if (isNotNullOrEmpty(config.getUsername()) && isNotNullOrEmpty(config.getPassword())) {
-                httpClientBuilder.addInterceptor(new Interceptor() {
-                    @Override
-                    public Response intercept(Chain chain) throws IOException {
-                        Request authReq = chain.request().newBuilder().addHeader("Authorization", Credentials.basic(config.getUsername(), config.getPassword())).build();
-                        return chain.proceed(authReq);
-                    }
-                });
-            } else if (config.getOauthToken() != null) {
-                httpClientBuilder.addInterceptor(new Interceptor() {
-                    @Override
-                    public Response intercept(Chain chain) throws IOException {
-                        Request authReq = chain.request().newBuilder().addHeader("Authorization", "Bearer " + config.getOauthToken()).build();
-                        return chain.proceed(authReq);
-                    }
-                });
+          httpClientBuilder.addInterceptor(new Interceptor() {
+            @Override
+            public Response intercept(Chain chain) throws IOException {
+              Request request = chain.request();
+              if (isNotNullOrEmpty(config.getUsername()) && isNotNullOrEmpty(config.getPassword())) {
+                Request authReq = chain.request().newBuilder().addHeader("Authorization", Credentials.basic(config.getUsername(), config.getPassword())).build();
+                return chain.proceed(authReq);
+              } else if (isNotNullOrEmpty(config.getOauthToken())) {
+                Request authReq = chain.request().newBuilder().addHeader("Authorization", "Bearer " + config.getOauthToken()).build();
+                return chain.proceed(authReq);
+              }
+              return chain.proceed(request);
             }
+          });
 
             Logger reqLogger = LoggerFactory.getLogger(HttpLoggingInterceptor.class);
             if (reqLogger.isTraceEnabled()) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.mock;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.RequestConfigBuilder;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class RequestConfigTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  public void testList() throws InterruptedException {
+   server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder()
+     .withNewMetadata()
+        .withName("testPod")
+     .endMetadata()
+     .build()).always();
+
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod2").andReturn(200, new PodBuilder()
+      .withNewMetadata()
+      .withName("testPod")
+      .endMetadata()
+      .build()).always();
+
+    NamespacedKubernetesClient client = server.getClient();
+
+    Pod pod1 = client.withRequestConfig(new RequestConfigBuilder().withOauthToken("TOKEN").build()).call(new Function<NamespacedKubernetesClient, Pod>() {
+      @Override
+      public Pod apply(NamespacedKubernetesClient c) {
+        return c.pods().inNamespace("test").withName("pod1").get();
+      }
+    });
+
+    //Let's check that request config actually works
+    RecordedRequest request1 = server.getMockServer().takeRequest();
+    String authHeader1 = request1.getHeader("Authorization");
+    Assert.assertEquals("Bearer TOKEN", authHeader1);
+
+    //Let's also check that we didn't pollute client config.
+    Pod pod2 = client.pods().inNamespace("test").withName("pod2").get();
+    RecordedRequest request2 = server.getMockServer().takeRequest();
+    String authHeader2 = request2.getHeader("Authorization");
+    Assert.assertNotEquals("Bearer TOKEN", authHeader2);
+  }
+
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -19,8 +19,11 @@ import io.fabric8.kubernetes.api.model.DoneableLimitRange;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LimitRange;
 import io.fabric8.kubernetes.api.model.LimitRangeList;
+import io.fabric8.kubernetes.client.RequestConfig;
+import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.internal.WithRequestCallable;
 import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.dsl.ClientBuildResource;
 import io.fabric8.openshift.client.dsl.ClientDeployableScalableResource;
@@ -408,5 +411,10 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public ExtensionsAPIGroupClient extensions() {
     return adapt(ExtensionsAPIGroupClient.class);
+  }
+
+  @Override
+  public FunctionCallable<NamespacedOpenShiftClient> withRequestConfig(RequestConfig requestConfig) {
+    return new WithRequestCallable<NamespacedOpenShiftClient>(this, requestConfig);
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
-import io.fabric8.kubernetes.client.internal.WithRequestCallable;
+import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.dsl.ClientBuildResource;
 import io.fabric8.openshift.client.dsl.ClientDeployableScalableResource;

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -130,6 +130,10 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
     this(new OpenShiftConfigBuilder().build());
   }
 
+  public DefaultOpenShiftClient(String masterUrl) throws KubernetesClientException {
+    this(new OpenShiftConfigBuilder().withMasterUrl(masterUrl).build());
+  }
+
   public DefaultOpenShiftClient(final Config config) throws KubernetesClientException {
     this(new OpenShiftConfig(config));
   }
@@ -143,10 +147,6 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
     } catch (MalformedURLException e) {
       throw new KubernetesClientException("Could not create client", e);
     }
-  }
-
-  public DefaultOpenShiftClient(String masterUrl) throws KubernetesClientException {
-    this(new OpenShiftConfigBuilder().withMasterUrl(masterUrl).build());
   }
 
   protected DefaultOpenShiftClient(OkHttpClient httpClient, OpenShiftConfig config) throws KubernetesClientException {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -69,6 +69,7 @@ import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.BaseClient;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.dsl.ClientKubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
@@ -76,6 +77,7 @@ import io.fabric8.kubernetes.client.dsl.ClientPodResource;
 import io.fabric8.kubernetes.client.dsl.ClientResource;
 import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
@@ -552,5 +554,10 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public NamespacedOpenShiftClient inNamespace(String name) {
     return delegate.inNamespace(name);
+  }
+
+  @Override
+  public FunctionCallable<NamespacedOpenShiftClient> withRequestConfig(RequestConfig requestConfig) {
+    return delegate.withRequestConfig(requestConfig);
   }
 }


### PR DESCRIPTION
This is a fix for #631.

It actually allows the call of a function with custom request configuration. In detail:

1. It moves the request specific configuration to a new object called RequestConfig _(forward compatible change)_.
2. The config object internally delegates to RequestConfig (to limit the code changes to the minimum).
3. The RequestConfig delegate is overridable by a thread local variable.

The code actually looks like:  

       Pod pod1 = client.withRequestConfig(new RequestConfigBuilder().withOauthToken("TOKEN").build()).call(new Function<NamespacedKubernetesClient, Pod>() {
       @Override
       public Pod apply(NamespacedKubernetesClient c) {
         return c.pods().inNamespace("test").withName("pod1").get();
       }
    });

Worths mentioning that despite the functional feel, it works with JDK7 too as it uses the Function interface that is generated  as part of the kubernetes-model (generated by sundrio).