### PR TITLE
Allow from load(), resource() and resourceList() to access the specific resource operation.

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceFactories.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceFactories.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+
+public final class ResourceFactories {
+
+  private static final Set<ClassLoader> CLASS_LOADERS = new HashSet<>();
+  private static final Map<Class, ResourceFactory> RESOURCE_FACTORY_MAP = new HashMap<>();
+
+  private ResourceFactories() {
+    //Utility
+  }
+
+  static {
+    //Register factories
+    discoverHandlers(ResourceHandler.class.getClassLoader());
+  }
+
+  public static <R extends Resource> void register(ResourceFactory<R> factory) {
+    RESOURCE_FACTORY_MAP.put(factory.getResourceType(), factory);
+  }
+
+  public static <R extends Resource> void unregister(ResourceFactory<R> factory) {
+    RESOURCE_FACTORY_MAP.remove(factory.getResourceType());
+  }
+
+  public static <R extends Resource> ResourceFactory<R> get(Class<R> operationType) {
+    if (RESOURCE_FACTORY_MAP.containsKey(operationType)) {
+      return RESOURCE_FACTORY_MAP.get(operationType);
+    } else {
+      for (ResourceFactory factory : ServiceLoader.load(ResourceFactory.class, Thread.currentThread().getContextClassLoader())) {
+        if (factory.getResourceType().equals(operationType)) {
+          return factory;
+        }
+      }
+      return null;
+    }
+  }
+
+  private static void discoverHandlers(ClassLoader classLoader) {
+    if (classLoader != null && CLASS_LOADERS.add(classLoader)) {
+      for (ResourceFactory factory : ServiceLoader.load(ResourceFactory.class, classLoader)) {
+        register(factory);
+      }
+    }
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceFactory.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceFactory.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import okhttp3.OkHttpClient;
+
+/**
+ * A Factory class for {@link Resource}.
+ * @param <O> The operation type.
+ */
+public interface ResourceFactory<O extends Resource> {
+
+  Class<O> getResourceType();
+
+  /**
+   * Create a new operation for the specified items.
+   * @param client        An instance of the http client.
+   * @param config        The client config.
+   * @param namespace     The target namespace.
+   * @param items         The resources to use.
+   * @return              The created operation.
+   */
+  O create(OkHttpClient client, Config config, String namespace, HasMetadata... items);
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/AsResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/AsResource.java
@@ -15,11 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.api.model.DoneableKubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesList;
+public interface AsResource {
 
-public interface KubernetesListNonNamespaceOperation extends
-  Createable<KubernetesList, KubernetesList, DoneableKubernetesList>,
-  MultiDeleteable<KubernetesList, Boolean>,
-  Loadable<RecreateFromServerGettable<KubernetesList, KubernetesList, DoneableKubernetesList>> {
+  <R extends Resource> R as(Class<R> operationType);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ListVisitFromServerGetDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ListVisitFromServerGetDeleteRecreateWaitApplicable.java
@@ -26,5 +26,5 @@ public interface ListVisitFromServerGetDeleteRecreateWaitApplicable<T, B> extend
                                                                           FromServerGettable<List<T>>, RecreateApplicable<List<T>>,
                                                                           CascadingDeletable<B>,
                                                                           Waitable<List<T>>,
-                                                                          GracePeriodConfigurable<CascadingDeletable<B>> {
+                                                                          GracePeriodConfigurable<CascadingDeletable<B>>, AsResource {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetWatchDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetWatchDeleteRecreateWaitApplicable.java
@@ -27,5 +27,5 @@ public interface VisitFromServerGetWatchDeleteRecreateWaitApplicable<T, B> exten
                                                                           CascadingDeletable<B>,
                                                                           Watchable<Watch, Watcher<T>>,
                                                                           Waitable<T>,
-                                                                          GracePeriodConfigurable<CascadingDeletable<B>> {
+                                                                          GracePeriodConfigurable<CascadingDeletable<B>>, AsResource {
 }

--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ResourceFactory
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ResourceFactory
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/kubernetes-examples/src/main/java/io/fabric8/openshift/examples/TemplateExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/openshift/examples/TemplateExample.java
@@ -19,8 +19,11 @@ package io.fabric8.openshift.examples;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.openshift.api.model.Parameter;
 import io.fabric8.openshift.api.model.Template;
+import io.fabric8.openshift.api.model.TemplateList;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.dsl.TemplateOperation;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kubernetes-tests/pom.xml
+++ b/kubernetes-tests/pom.xml
@@ -39,6 +39,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadAsTemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadAsTemplateTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import io.fabric8.openshift.client.dsl.TemplateResource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class LoadAsTemplateTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  public void shouldLoadPodAsTemplate() throws Exception {
+    KubernetesClient client = server.getClient();
+    KubernetesList list = client.load(getClass().getResourceAsStream("/test-pod-create-from-load.yml")).as(TemplateResource.class).processLocally();
+    assertNotNull(list);
+    assertNotNull(list.getItems());
+    assertEquals(1, list.getItems().size());
+  }
+
+  @Test
+  public void shouldProcessLocally() throws Exception {
+    KubernetesClient client = server.getClient();
+    Map<String, String> map = new HashMap<>();
+    map.put("USERNAME", "root");
+
+    KubernetesList list = client.load(getClass().getResourceAsStream("/template-with-params.yml")).as(TemplateResource.class).processLocally(map);
+    assertNotNull(list);
+    assertNotNull(list.getItems());
+    assertEquals(1, list.getItems().size());
+
+    final AtomicBoolean userIsRoot = new AtomicBoolean(false);
+    final AtomicBoolean passwordIsNotNull = new AtomicBoolean(false);
+    new KubernetesListBuilder(list).accept(new TypedVisitor<EnvVarBuilder>() {
+
+      @Override
+      public void visit(EnvVarBuilder element) {
+        if (element.getName().equals("USERNAME")) {
+          userIsRoot.set(element.getValue().equals("root"));
+        } else if (element.getName().equals("PASSWORD")) {
+          passwordIsNotNull.set(element.getValue() != null);
+        }
+      }
+    }).build();
+
+    assertTrue(userIsRoot.get());
+    assertTrue(passwordIsNotNull.get());
+  }
+}

--- a/kubernetes-tests/src/test/resources/template-with-params.yml
+++ b/kubernetes-tests/src/test/resources/template-with-params.yml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: v1
 kind: Template
 metadata:

--- a/kubernetes-tests/src/test/resources/template-with-params.yml
+++ b/kubernetes-tests/src/test/resources/template-with-params.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: example-template
+objects:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: example-pod
+  spec:
+    containers:
+    - env:
+      - name: PASSWORD
+        value: ${PASSWORD}
+      - name: USERNAME
+        value: ${USERNAME}
+      image: dockerfile/redis
+      name: master
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+parameters:
+- description: Username used for authentication
+  name: USERNAME
+  value: admin
+- description: Password used for Redis authentication
+  from: '[A-Z0-9]{8}'
+  generate: expression
+  name: PASSWORD

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -375,7 +375,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates() {
+  public MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource> templates() {
     return new TemplateOperationsImpl(httpClient, OpenShiftConfig.wrap(getConfiguration()), getNamespace());
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
@@ -18,7 +18,6 @@ package io.fabric8.openshift.client;
 
 import java.net.URL;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -127,7 +126,7 @@ public interface OpenShiftClient extends KubernetesClient {
 
   MixedOperation<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> routes();
 
-  MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates();
+  MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource> templates();
 
   NonNamespaceOperation<User, UserList, DoneableUser, Resource<User, DoneableUser>> users();
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/Processable.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/Processable.java
@@ -16,10 +16,18 @@
 
 package io.fabric8.openshift.client.dsl;
 
+import java.util.Map;
+
 import io.fabric8.openshift.client.ParameterValue;
 
 public interface Processable<T> {
 
   T process(ParameterValue... values);
+
+  T process(Map<String, String> map);
+
+  T processLocally(ParameterValue... values);
+
+  T processLocally(Map<String, String> map);
 
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateOperation.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.openshift.client.dsl;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.openshift.api.model.DoneableTemplate;
 import io.fabric8.openshift.api.model.Template;
 import io.fabric8.openshift.api.model.TemplateList;
 
-public interface TemplateOperation extends TemplateResource<Template, KubernetesList, DoneableTemplate>,
-  MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> {
+public interface TemplateOperation extends TemplateResource,
+  MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource> {
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
@@ -15,5 +15,9 @@
  */
 package io.fabric8.openshift.client.dsl;
 
-public interface TemplateResource<T, L, D> extends ProcessableResource<T, L, D> {
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.openshift.api.model.DoneableTemplate;
+import io.fabric8.openshift.api.model.Template;
+
+public interface TemplateResource extends ProcessableResource<Template, KubernetesList, DoneableTemplate> {
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class TemplateOperationsImpl
-  extends OpenShiftOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>>
+  extends OpenShiftOperation<Template, TemplateList, DoneableTemplate, TemplateResource>
   implements TemplateOperation {
 
   public TemplateOperationsImpl(OkHttpClient client, OpenShiftConfig config, String namespace) {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
@@ -15,6 +15,10 @@
  */
 package io.fabric8.openshift.client.dsl.internal;
 
+import com.mifmif.common.regex.Generex;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -30,15 +34,20 @@ import io.fabric8.openshift.client.ParameterValue;
 import io.fabric8.openshift.client.dsl.TemplateResource;
 import io.fabric8.openshift.client.dsl.TemplateOperation;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
 public class TemplateOperationsImpl
   extends OpenShiftOperation<Template, TemplateList, DoneableTemplate, TemplateResource>
   implements TemplateOperation {
+
+  private static final String EXPRESSION = "expression";
 
   public TemplateOperationsImpl(OkHttpClient client, OpenShiftConfig config, String namespace) {
     this(client, config, null, namespace, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
@@ -50,11 +59,16 @@ public class TemplateOperationsImpl
 
   @Override
   public KubernetesList process(ParameterValue... values) {
-    Template t = get();
     Map<String, String> valuesMap = new HashMap<>(values.length);
     for (ParameterValue pv : values) {
       valuesMap.put(pv.getName(), pv.getValue());
     }
+    return process(valuesMap);
+  }
+
+  @Override
+  public KubernetesList process(Map<String, String> valuesMap) {
+    Template t = get();
     try {
       for (Parameter p : t.getParameters()) {
         String v = valuesMap.get(p.getName());
@@ -73,6 +87,52 @@ public class TemplateOperationsImpl
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(e);
     }
+  }
+
+  @Override
+  public KubernetesList processLocally(ParameterValue... values) {
+    Map<String, String> valuesMap = new HashMap<>(values.length);
+    for (ParameterValue pv : values) {
+      valuesMap.put(pv.getName(), pv.getValue());
+    }
+    return processLocally(valuesMap);
+  }
+
+  public KubernetesList processLocally(Map<String, String> valuesMap)  {
+    Template t = get();
+
+    List<Parameter> parameters = t != null ? t.getParameters() : null;
+    KubernetesList list = new KubernetesListBuilder()
+      .withItems(t != null && t.getObjects() != null ? t.getObjects() : Collections.<HasMetadata>emptyList())
+      .build();
+
+    try {
+      String json = JSON_MAPPER.writeValueAsString(list);
+      if (parameters != null && !parameters.isEmpty()) {
+        // lets make a few passes in case there's expressions in values
+        for (int i = 0; i < 5; i++) {
+          for (Parameter parameter : parameters) {
+            String name = parameter.getName();
+            String regex = "${" + name + "}";
+            String value;
+            if (valuesMap.containsKey(name)) {
+              value = valuesMap.get(name);
+            } else if (EXPRESSION.equals(parameter.getGenerate())) {
+              Generex generex = new Generex(parameter.getFrom());
+              value = generex.random();
+            } else {
+              throw new IllegalArgumentException("No value available for parameter name: " + name);
+            }
+            json = json.replace(regex, value);
+          }
+        }
+      }
+
+      list = JSON_MAPPER.readValue(json, KubernetesList.class);
+    } catch (IOException e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+    return list;
   }
 
   private URL getProcessUrl() throws MalformedURLException {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/operations/TemplateResourceFactory.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/operations/TemplateResourceFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.operations;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ResourceFactory;
+import io.fabric8.openshift.api.model.Template;
+import io.fabric8.openshift.api.model.TemplateBuilder;
+import io.fabric8.openshift.client.OpenShiftConfig;
+import io.fabric8.openshift.client.dsl.TemplateOperation;
+import io.fabric8.openshift.client.dsl.TemplateResource;
+import io.fabric8.openshift.client.dsl.internal.TemplateOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class TemplateResourceFactory implements ResourceFactory<TemplateResource> {
+  @Override
+  public Class<TemplateResource> getResourceType() {
+    return TemplateResource.class;
+  }
+
+  @Override
+  public TemplateOperation create(OkHttpClient client, Config config, String namespace, HasMetadata... items) {
+    Template template = null;
+    if (items.length != 1) {
+      template = new TemplateBuilder().withNewMetadata().endMetadata().withObjects(items).build();
+    } else if (items[0] instanceof Template) {
+      template = (Template) items[0];
+    } else if (items[0] instanceof KubernetesResourceList) {
+      List<HasMetadata> list = ((KubernetesResourceList<HasMetadata>)items[0]).getItems();
+      template = new TemplateBuilder().withNewMetadata().endMetadata().withObjects(list.toArray(new HasMetadata[list.size()])).build();
+    } else {
+      template = new TemplateBuilder().withNewMetadata().endMetadata().withObjects(items[0]).build();
+    }
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, false, template, null, false, 0L,
+      null, null, null, null, null);
+  }
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -41,7 +41,6 @@ import io.fabric8.kubernetes.api.model.EndpointsList;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LimitRange;
 import io.fabric8.kubernetes.api.model.LimitRangeList;
@@ -372,7 +371,7 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates() {
+  public MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource> templates() {
     return delegate.templates();
   }
 

--- a/openshift-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ResourceFactory
+++ b/openshift-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ResourceFactory
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+io.fabric8.openshift.client.operations.TemplateResourceFactory


### PR DESCRIPTION
The goal here is to be able to do something like:

    client.load(is).as(TemplateResource.class).process(parameters)    (implemented)

or stuff like:

    client.load(is).as(PodResource).log() (not implemented yet).


So this pull request adds the base for all that and adds an implementation specific to Template.

This will eventually allow us to clean the `kubernetes-client` module from openshift specific code: https://github.com/fabric8io/kubernetes-client/blob/c64d7e15ac0cb088d19a905e4a80e30a58f99820/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java#L380

It will also allow tooling e.g. arquillian to be able to easily load and handle resources as templates (when running against openshift) in a clean way.

