### PR TITLE
Upgrade Okhttp to version 3.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockwebserver.version>0.0.4</mockwebserver.version>
     <okhttp.version>3.4.2</okhttp.version>
-    <okhttp.bundle.version>3.4.1_1</okhttp.bundle.version>
+    <okhttp.bundle.version>3.4.2_1</okhttp.bundle.version>
     <okio.version>1.9.0</okio.version>
     <okio.bundle.version>1.9.0_1</okio.bundle.version>
     <generex.version>1.0.1</generex.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockwebserver.version>0.0.4</mockwebserver.version>
-    <okhttp.version>3.4.1</okhttp.version>
+    <okhttp.version>3.4.2</okhttp.version>
     <okhttp.bundle.version>3.4.1_1</okhttp.bundle.version>
     <okio.version>1.9.0</okio.version>
     <okio.bundle.version>1.9.0_1</okio.bundle.version>


### PR DESCRIPTION
Just a little upgrade.

As a side note, the Okhttp-ws artifacts are no longer available from Okhttp 3.5.0

https://github.com/square/okhttp/blob/master/CHANGELOG.md