### PR TITLE
complete top-level thirdPartyResource impl

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ExtensionsAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ExtensionsAPIGroupClient.java
@@ -36,11 +36,7 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetList;
 import io.fabric8.kubernetes.api.model.extensions.ThirdPartyResource;
 import io.fabric8.kubernetes.api.model.extensions.ThirdPartyResourceList;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.ScalableResource;
-import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.*;
 import io.fabric8.kubernetes.client.dsl.internal.DaemonSetOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.DeploymentOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.HorizontalPodAutoscalerOperationsImpl;
@@ -87,8 +83,8 @@ public class ExtensionsAPIGroupClient extends BaseClient implements ExtensionsAP
     return new DaemonSetOperationsImpl(httpClient, getConfiguration(), getNamespace());
   }
 
-  public MixedOperation<ThirdPartyResource, ThirdPartyResourceList, DoneableThirdPartyResource, Resource<ThirdPartyResource, DoneableThirdPartyResource>> thirdPartyResources() {
-    return new ThirdPartyResourceOperationsImpl(httpClient, getConfiguration(), getNamespace());
+  public NonNamespaceOperation<ThirdPartyResource, ThirdPartyResourceList, DoneableThirdPartyResource, Resource<ThirdPartyResource, DoneableThirdPartyResource>> thirdPartyResources() {
+    return new ThirdPartyResourceOperationsImpl(httpClient, getConfiguration());
   }
 
   public MixedOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>> replicaSets() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ExtensionsAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ExtensionsAPIGroupDSL.java
@@ -52,7 +52,7 @@ public interface ExtensionsAPIGroupDSL extends Client {
 
   MixedOperation<DaemonSet, DaemonSetList, DoneableDaemonSet, Resource<DaemonSet, DoneableDaemonSet>> daemonSets();
 
-  MixedOperation<ThirdPartyResource, ThirdPartyResourceList, DoneableThirdPartyResource, Resource<ThirdPartyResource, DoneableThirdPartyResource>> thirdPartyResources();
+  NonNamespaceOperation<ThirdPartyResource, ThirdPartyResourceList, DoneableThirdPartyResource, Resource<ThirdPartyResource, DoneableThirdPartyResource>> thirdPartyResources();
 
   MixedOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>> replicaSets();
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/MixedOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/MixedOperation.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.dsl;
 
 /**
  * A Client Namespace or Non Namespace Operation. This acts as an umbrella for {@link Operation} and {@link NonNamespaceOperation}.
- * Its not intended to be exposed directly into the client and is only usable as a convinient interface internally.
+ * Its not intended to be exposed directly into the client and is only usable as a convenient interface internally.
  *
  * @param <T> The Kubernetes resource type.
  * @param <L> The list variant of the Kubernetes resource type.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ThirdPartyResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ThirdPartyResourceOperationsImpl.java
@@ -28,11 +28,16 @@ import java.util.TreeMap;
 
 public class ThirdPartyResourceOperationsImpl extends HasMetadataOperation<ThirdPartyResource, ThirdPartyResourceList, DoneableThirdPartyResource, Resource<ThirdPartyResource, DoneableThirdPartyResource>>{
 
-  public ThirdPartyResourceOperationsImpl(OkHttpClient client, Config config, String namespace) {
-    this(client, config, "v1beta1", namespace, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
+  public ThirdPartyResourceOperationsImpl(OkHttpClient client, Config config) {
+    this(client, config, "v1beta1", null, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
   }
 
   public ThirdPartyResourceOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, ThirdPartyResource item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
     super(client, config, "extensions", apiVersion, "thirdpartyresources", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
+  }
+
+  @Override
+  public boolean isResourceNamespaced() {
+    return false;
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TPRTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TPRTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.extensions.ThirdPartyResource;
+import io.fabric8.kubernetes.api.model.extensions.ThirdPartyResourceBuilder;
+import io.fabric8.kubernetes.api.model.extensions.ThirdPartyResourceList;
+import io.fabric8.kubernetes.api.model.extensions.ThirdPartyResourceListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TPRTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  public void testList() {
+    server.expect().withPath("/apis/extensions/v1beta1/thirdpartyresources")
+      .andReturn(200, new ThirdPartyResourceListBuilder().addNewItem().and().build()).once();
+
+    KubernetesClient client = server.getClient();
+    ThirdPartyResourceList tprList = client.extensions().thirdPartyResources().list();
+    assertNotNull(tprList);
+    assertEquals(1, tprList.getItems().size());
+  }
+
+  @Test
+  public void testGet(){
+    Map<String, String> labelMap = new HashMap<>();
+
+    labelMap.put("resource", "spark-job");
+    labelMap.put("object", "spark");
+
+    ThirdPartyResource tpr1 = new ThirdPartyResourceBuilder()
+      .withApiVersion("extensions/v1beta1")
+      .withKind("ThirdPartyResource")
+      .withDescription("A resource that manages a spark job")
+      .withVersions()
+      .addNewVersion("v1")
+      .withNewMetadata()
+      .withName("spark-job.apache.io")
+      .withLabels(labelMap)
+      .endMetadata()
+      .build();
+
+    ThirdPartyResource tpr2 = new ThirdPartyResourceBuilder()
+      .withApiVersion("extensions/v1beta1")
+      .withKind("ThirdPartyResource")
+      .withDescription("A test job")
+      .withVersions()
+      .addNewVersion("v1")
+      .withNewMetadata()
+      .withName("test-job.apache.io")
+      .withLabels(labelMap)
+      .endMetadata()
+      .build();
+
+    server.expect().withPath("/apis/extensions/v1beta1/thirdpartyresources/tpr1")
+      .andReturn(200, tpr1).once();
+    server.expect().withPath("/apis/extensions/v1beta1/thirdpartyresources/tpr2")
+      .andReturn(200, tpr2).once();
+
+    KubernetesClient client = server.getClient();
+
+    ThirdPartyResource tpr = client.extensions().thirdPartyResources().withName("tpr1").get();
+    assertNotNull(tpr);
+
+    tpr = client.extensions().thirdPartyResources().withName("tpr2").get();
+    assertNotNull(tpr);
+
+    tpr = client.extensions().thirdPartyResources().withName("tpr3").get();
+    assertNull(tpr);
+  }
+
+  @Test
+  public void testDelete() {
+    Map<String, String> labelMap = new HashMap<>();
+
+    labelMap.put("resource", "spark-job");
+    labelMap.put("object", "spark");
+
+    ThirdPartyResource tpr1 = new ThirdPartyResourceBuilder()
+      .withApiVersion("extensions/v1beta1")
+      .withKind("ThirdPartyResource")
+      .withDescription("A resource that manages a spark job")
+      .withVersions()
+        .addNewVersion("v1")
+      .withNewMetadata()
+        .withName("spark-job.apache.io")
+        .withLabels(labelMap)
+      .endMetadata()
+      .build();
+
+    ThirdPartyResource tpr2 = new ThirdPartyResourceBuilder()
+      .withApiVersion("extensions/v1beta1")
+      .withKind("ThirdPartyResource")
+      .withDescription("A test job")
+      .withVersions()
+        .addNewVersion("v1")
+      .withNewMetadata()
+        .withName("test-job.apache.io")
+        .withLabels(labelMap)
+      .endMetadata()
+      .build();
+
+    server.expect().withPath("/apis/extensions/v1beta1/thirdpartyresources/tpr1")
+      .andReturn(200, tpr1).once();
+    server.expect().withPath("/apis/extensions/v1beta1/thirdpartyresources/tpr2")
+      .andReturn(200, tpr2).once();
+
+    KubernetesClient client = server.getClient();
+
+    Boolean deleted = client.extensions().thirdPartyResources().withName("tpr1").delete();
+    assertTrue(deleted);
+
+    deleted = client.extensions().thirdPartyResources().withName("tpr2").delete();
+    assertTrue(deleted);
+
+    deleted = client.extensions().thirdPartyResources().withName("tpr3").delete();
+    assertFalse(deleted);
+  }
+
+  @Test(expected = KubernetesClientException.class)
+  public void testDeleteMulti(){
+
+    Map<String, String> labelMap = new HashMap<>();
+
+    labelMap.put("resource", "spark-job");
+    labelMap.put("object", "spark");
+
+    ThirdPartyResource tpr1 = new ThirdPartyResourceBuilder()
+      .withApiVersion("extensions/v1beta1")
+      .withKind("ThirdPartyResource")
+      .withDescription("A resource that manages a spark job")
+      .withVersions()
+      .addNewVersion("v1")
+      .withNewMetadata()
+      .withName("spark-job.apache.io")
+      .withLabels(labelMap)
+      .endMetadata()
+      .build();
+
+    ThirdPartyResource tpr2 = new ThirdPartyResourceBuilder()
+      .withApiVersion("extensions/v1beta1")
+      .withKind("ThirdPartyResource")
+      .withDescription("A test job")
+      .withVersions()
+      .addNewVersion("v1")
+      .withNewMetadata()
+      .withName("test-job.apache.io")
+      .withLabels(labelMap)
+      .endMetadata()
+      .build();
+
+    ThirdPartyResourceList tpr = new ThirdPartyResourceListBuilder().withItems(tpr1, tpr2).build();
+
+    server.expect().withPath("/apis/extensions/v1beta1/thirdpartyresources").andReturn(200, tpr).times(2);
+
+    KubernetesClient client = server.getClient();
+
+    ThirdPartyResourceList tprList = client.extensions().thirdPartyResources().list();
+    assertNotNull(tprList);
+    assertEquals(2, tprList.getItems().size());
+
+    client.extensions().thirdPartyResources().delete();
+    client.extensions().thirdPartyResources().list();
+  }
+}


### PR DESCRIPTION
**What's In this PR ?**
Completes the implementation of the top-level ThirdPartyResources as a nonNamespaceOperation based on [k8s-doc](https://kubernetes.io/docs/user-guide/thirdpartyresources/#creating-a-thirdpartyresource)

This is a pre-req to a downstream [project ](https://github.com/apache-spark-on-k8s/spark) tracked at [issue](https://github.com/apache-spark-on-k8s/spark/issues/153). Also a pre-req to supporting CustomObjects (future PR).

**How it was tested**
Unit tests

The final goal is to add support for CustomObjects in k8s through the client. I feel I might need to add the Builder/Model classes to the kubernetes-model project to get this done. I will open an issue at the kubernetes-model to open discussions on this.

/cc @foxish @iocanel @jimmidyson @mccheah @ash211 