### PR TITLE
Fix watch close

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -324,11 +324,10 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   }
 
   private void closeEvent(KubernetesClientException cause) {
-    if (forceClosed.get()) {
+    if (forceClosed.getAndSet(true)) {
       logger.debug("Ignoring duplicate firing of onClose event");
       return;
     }
-    forceClosed.set(true);
     watcher.onClose(cause);
   }
 


### PR DESCRIPTION
Fixes https://github.com/fabric8io/kubernetes-client/issues/674.
It was a regression introduced by https://github.com/fabric8io/kubernetes-client/pull/634 which made the `onClose()` event not get called when `close()` is called. 

cc @iocanel @jimmidyson @ash211 @gyoetam 