### PR TITLE
Allow non-required fields to be unset when processing templates locally

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/LoadAsTemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/LoadAsTemplateTest.java
@@ -49,6 +49,7 @@ public class LoadAsTemplateTest {
     OpenShiftClient client = new DefaultOpenShiftClient();
     Map<String, String> map = new HashMap<>();
     map.put("USERNAME", "root");
+    map.put("REQUIRED", "requiredValue");
 
     KubernetesList list = client.templates().load(getClass().getResourceAsStream("/template-with-params.yml")).processLocally(map);
     assertListIsProcessed(list);
@@ -57,8 +58,6 @@ public class LoadAsTemplateTest {
   @Test
   public void shouldProcessLocallyWithParametersInYaml() throws Exception {
     OpenShiftClient client = new DefaultOpenShiftClient();
-    Map<String, String> map = new HashMap<>();
-    map.put("USERNAME", "root");
 
     KubernetesList list = client.templates().load(getClass().getResourceAsStream("/template-with-params.yml")).processLocally(getClass().getResourceAsStream("/parameters.yml"));
     assertListIsProcessed(list);
@@ -72,6 +71,8 @@ public class LoadAsTemplateTest {
 
     final AtomicBoolean userIsRoot = new AtomicBoolean(false);
     final AtomicBoolean passwordIsNotNull = new AtomicBoolean(false);
+    final AtomicBoolean requiredIsSet = new AtomicBoolean(false);
+    final AtomicBoolean optionalIsEmpty = new AtomicBoolean(false);
     new KubernetesListBuilder(list).accept(new TypedVisitor<EnvVarBuilder>() {
 
       @Override
@@ -80,11 +81,17 @@ public class LoadAsTemplateTest {
           userIsRoot.set(element.getValue().equals("root"));
         } else if (element.getName().equals("PASSWORD")) {
           passwordIsNotNull.set(Utils.isNotNullOrEmpty(element.getValue()));
+        } else if (element.getName().equals("REQUIRED")) {
+          requiredIsSet.set(Utils.isNotNullOrEmpty(element.getValue()));
+        } else if (element.getName().equals("OPTIONAL")) {
+          optionalIsEmpty.set(element.getValue().isEmpty());
         }
       }
     }).build();
 
     assertTrue(userIsRoot.get());
     assertTrue(passwordIsNotNull.get());
+    assertTrue(requiredIsSet.get());
+    assertTrue(optionalIsEmpty.get());
   }
 }

--- a/kubernetes-tests/src/test/resources/parameters.yml
+++ b/kubernetes-tests/src/test/resources/parameters.yml
@@ -15,3 +15,4 @@
 #
 
 USERNAME: root
+REQUIRED: requiredValue

--- a/kubernetes-tests/src/test/resources/template-with-params.yml
+++ b/kubernetes-tests/src/test/resources/template-with-params.yml
@@ -30,6 +30,10 @@ objects:
         value: ${PASSWORD}
       - name: USERNAME
         value: ${USERNAME}
+      - name: OPTIONAL
+        value: ${OPTIONAL}
+      - name: REQUIRED
+        value: ${REQUIRED}
       image: dockerfile/redis
       name: master
       ports:
@@ -43,3 +47,8 @@ parameters:
   from: '[A-Z0-9]{8}'
   generate: expression
   name: PASSWORD
+- description: Optional parameter without value
+  name: OPTIONAL
+- description: Required parameter without value
+  name: REQUIRED
+  required: true

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
@@ -162,6 +162,8 @@ public class TemplateOperationsImpl
             } else if (EXPRESSION.equals(parameter.getGenerate())) {
               Generex generex = new Generex(parameter.getFrom());
               value = generex.random();
+            } else if (parameter.getRequired() == null || !parameter.getRequired()) {
+              value = "";
             } else {
               throw new IllegalArgumentException("No value available for parameter name: " + name);
             }


### PR DESCRIPTION
When switching from remote to local template processing using processLocal, I noticed a difference in how template parameters are handled when they are marked as required or not.

With remote processing, non-required parameters with unset values are allowed, while the local processing throws an exception. 

This fix checks the required field before throwing the exception, and sets the value to an empty string if not (as done when doing remote processing).