### PR TITLE
Support for StatefulSets

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AppsAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AppsAPIGroupClient.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.extensions.DoneableStatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.internal.StatefulSetOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class AppsAPIGroupClient extends BaseClient implements AppsAPIGroupDSL {
+
+  public AppsAPIGroupClient() throws KubernetesClientException {
+    super();
+  }
+
+  public AppsAPIGroupClient(OkHttpClient httpClient, final Config config) throws KubernetesClientException {
+    super(httpClient, config);
+  }
+
+  @Override
+  public MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>> statefulSets() {
+    return new StatefulSetOperationsImpl(httpClient, getConfiguration(), getNamespace());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AppsAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AppsAPIGroupClient.java
@@ -20,7 +20,7 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.internal.StatefulSetOperationsImpl;
 import okhttp3.OkHttpClient;
 
@@ -35,7 +35,7 @@ public class AppsAPIGroupClient extends BaseClient implements AppsAPIGroupDSL {
   }
 
   @Override
-  public MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>> statefulSets() {
+  public MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>> statefulSets() {
     return new StatefulSetOperationsImpl(httpClient, getConfiguration(), getNamespace());
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AppsAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AppsAPIGroupExtensionAdapter.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+
+@Component
+@Service
+public class AppsAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<AppsAPIGroupClient> {
+
+  @Override
+  protected String getAPIGroupName() {
+    return "apps";
+  }
+
+  @Override
+  public Class<AppsAPIGroupClient> getExtensionType() {
+    return AppsAPIGroupClient.class;
+  }
+
+  @Override
+  protected AppsAPIGroupClient newInstance(Client client) {
+    return new AppsAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
@@ -75,7 +75,7 @@ import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRe
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import okhttp3.OkHttpClient;
 
 import java.io.InputStream;
@@ -200,7 +200,7 @@ public class AutoAdaptableKubernetesClient extends DefaultKubernetesClient {
   }
 
   @Override
-  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
+  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
     return delegate.replicationControllers();
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
@@ -15,13 +15,6 @@
  */
 package io.fabric8.kubernetes.client;
 
-import io.fabric8.kubernetes.api.model.DoneableLimitRange;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.LimitRange;
-import io.fabric8.kubernetes.api.model.LimitRangeList;
-import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.model.ComponentStatus;
 import io.fabric8.kubernetes.api.model.ComponentStatusList;
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -30,6 +23,7 @@ import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
 import io.fabric8.kubernetes.api.model.DoneableConfigMap;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.DoneableEvent;
+import io.fabric8.kubernetes.api.model.DoneableLimitRange;
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
 import io.fabric8.kubernetes.api.model.DoneableNode;
 import io.fabric8.kubernetes.api.model.DoneablePersistentVolume;
@@ -46,6 +40,9 @@ import io.fabric8.kubernetes.api.model.EndpointsList;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LimitRange;
+import io.fabric8.kubernetes.api.model.LimitRangeList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceList;
 import io.fabric8.kubernetes.api.model.Node;
@@ -69,13 +66,17 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
-import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
+import okhttp3.OkHttpClient;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -126,6 +127,12 @@ public class AutoAdaptableKubernetesClient extends DefaultKubernetesClient {
   public ExtensionsAPIGroupDSL extensions() {
     return delegate.extensions();
   }
+
+  @Override
+  public AppsAPIGroupDSL apps() {
+    return delegate.apps();
+  }
+
 
   @Override
   public MixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, Resource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -77,7 +77,7 @@ import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRe
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.internal.ComponentStatusOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.ConfigMapOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.EndpointsOperationsImpl;
@@ -213,7 +213,7 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
-  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
+  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
     return new ReplicationControllerOperationsImpl(httpClient, getConfiguration(), getNamespace());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -15,17 +15,6 @@
  */
 package io.fabric8.kubernetes.client;
 
-import io.fabric8.kubernetes.api.model.DoneableLimitRange;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.LimitRange;
-import io.fabric8.kubernetes.api.model.LimitRangeList;
-import io.fabric8.kubernetes.client.dsl.FunctionCallable;
-import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
-import io.fabric8.kubernetes.client.dsl.internal.LimitRangeOperationsImpl;
-import io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.ComponentStatus;
 import io.fabric8.kubernetes.api.model.ComponentStatusList;
@@ -35,6 +24,7 @@ import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
 import io.fabric8.kubernetes.api.model.DoneableConfigMap;
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
 import io.fabric8.kubernetes.api.model.DoneableEvent;
+import io.fabric8.kubernetes.api.model.DoneableLimitRange;
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
 import io.fabric8.kubernetes.api.model.DoneableNode;
 import io.fabric8.kubernetes.api.model.DoneablePersistentVolume;
@@ -51,6 +41,10 @@ import io.fabric8.kubernetes.api.model.EndpointsList;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LimitRange;
+import io.fabric8.kubernetes.api.model.LimitRangeList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceList;
 import io.fabric8.kubernetes.api.model.Node;
@@ -73,20 +67,25 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
-import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.internal.ComponentStatusOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.ConfigMapOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.EndpointsOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.EventOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.KubernetesListOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.LimitRangeOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.NamespaceOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl;
 import io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl;
 import io.fabric8.kubernetes.client.dsl.internal.NodeOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.PersistentVolumeClaimOperationsImpl;
@@ -98,6 +97,8 @@ import io.fabric8.kubernetes.client.dsl.internal.SecretOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.SecurityContextConstraintsOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.ServiceAccountOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.ServiceOperationsImpl;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import okhttp3.OkHttpClient;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -273,9 +274,15 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   public FunctionCallable<NamespacedKubernetesClient> withRequestConfig(RequestConfig requestConfig) {
     return new WithRequestCallable<NamespacedKubernetesClient>(this, requestConfig);
   }
+
   @Override
   public ExtensionsAPIGroupDSL extensions() {
     return adapt(ExtensionsAPIGroupClient.class);
+  }
+
+  @Override
+  public AppsAPIGroupDSL apps() {
+    return adapt(AppsAPIGroupClient.class);
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ExtensionsAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ExtensionsAPIGroupClient.java
@@ -87,7 +87,7 @@ public class ExtensionsAPIGroupClient extends BaseClient implements ExtensionsAP
     return new ThirdPartyResourceOperationsImpl(httpClient, getConfiguration());
   }
 
-  public MixedOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>> replicaSets() {
+  public MixedOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScalableResource<ReplicaSet, DoneableReplicaSet>> replicaSets() {
     return new ReplicaSetOperationsImpl(httpClient, getConfiguration(), getNamespace());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -66,15 +66,16 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
-import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
-import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 
 import java.io.InputStream;
 import java.util.Collection;
@@ -82,6 +83,8 @@ import java.util.Collection;
 public interface KubernetesClient extends Client {
 
   ExtensionsAPIGroupDSL extensions();
+
+  AppsAPIGroupDSL apps();
 
   MixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, Resource<ComponentStatus, DoneableComponentStatus>> componentstatuses();
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -75,7 +75,7 @@ import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRe
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 
 import java.io.InputStream;
 import java.util.Collection;
@@ -116,7 +116,7 @@ public interface KubernetesClient extends Client {
 
   MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> pods();
 
-  MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> replicationControllers();
+  MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> replicationControllers();
 
   MixedOperation<ResourceQuota, ResourceQuotaList, DoneableResourceQuota, Resource<ResourceQuota, DoneableResourceQuota>> resourceQuotas();
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/AppsAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/AppsAPIGroupDSL.java
@@ -23,6 +23,6 @@ import io.fabric8.kubernetes.client.Client;
 
 public interface AppsAPIGroupDSL extends Client {
 
-  MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>> statefulSets();
+  MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>> statefulSets();
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/AppsAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/AppsAPIGroupDSL.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.api.model.extensions.DoneableStatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
+import io.fabric8.kubernetes.client.Client;
+
+public interface AppsAPIGroupDSL extends Client {
+
+  MixedOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>> statefulSets();
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ExtensionsAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ExtensionsAPIGroupDSL.java
@@ -54,7 +54,7 @@ public interface ExtensionsAPIGroupDSL extends Client {
 
   NonNamespaceOperation<ThirdPartyResource, ThirdPartyResourceList, DoneableThirdPartyResource, Resource<ThirdPartyResource, DoneableThirdPartyResource>> thirdPartyResources();
 
-  MixedOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>> replicaSets();
+  MixedOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScalableResource<ReplicaSet, DoneableReplicaSet>> replicaSets();
 
   MixedOperation<HorizontalPodAutoscaler, HorizontalPodAutoscalerList, DoneableHorizontalPodAutoscaler, Resource<HorizontalPodAutoscaler, DoneableHorizontalPodAutoscaler>> horizontalPodAutoscalers();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/RollableScalableResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/RollableScalableResource.java
@@ -15,6 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface RollableScallableResource<T, D> extends ScalableResource<T, D>,
+public interface RollableScalableResource<T, D> extends ScalableResource<T, D>,
   Rollable<TimeoutImageEditReplacePatchable<T, T, D>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
@@ -15,22 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DoneableReplicaSet;
@@ -41,27 +25,20 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
-import io.fabric8.kubernetes.client.dsl.Reaper;
+import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
-import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.kubernetes.client.internal.readiness.ReadinessWatcher;
-import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.OkHttpClient;
 
-public class ReplicaSetOperationsImpl extends HasMetadataOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>>
-  implements RollableScallableResource<ReplicaSet, DoneableReplicaSet>,
-  TimeoutImageEditReplacePatchable<ReplicaSet, ReplicaSet, DoneableReplicaSet> {
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
-  static final transient Logger LOG = LoggerFactory.getLogger(ReplicaSetOperationsImpl.class);
-
-  private final Boolean rolling;
-  private final long rollingTimeout;
-  private final TimeUnit rollingTimeUnit;
+public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>>
+  implements TimeoutImageEditReplacePatchable<ReplicaSet, ReplicaSet, DoneableReplicaSet> {
 
   public ReplicaSetOperationsImpl(OkHttpClient client, Config config, String namespace) {
     this(client, config, "v1beta1", namespace, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), false, config.getRollingTimeout(), TimeUnit.MILLISECONDS);
@@ -72,11 +49,7 @@ public class ReplicaSetOperationsImpl extends HasMetadataOperation<ReplicaSet, R
   }
 
   public ReplicaSetOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, ReplicaSet item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Boolean rolling, long rollingTimeout, TimeUnit rollingTimeUnit) {
-    super(client, config, "extensions", apiVersion, "replicasets", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
-    this.rolling = rolling;
-    this.rollingTimeout = rollingTimeout;
-    this.rollingTimeUnit = rollingTimeUnit;
-    reaper = new ReplicaSetReaper(this);
+    super(client, config, "extensions", apiVersion, "replicasets", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields, rolling, rollingTimeout, rollingTimeUnit);
   }
 
   @Override
@@ -87,11 +60,6 @@ public class ReplicaSetOperationsImpl extends HasMetadataOperation<ReplicaSet, R
   @Override
   public ImageEditReplacePatchable<ReplicaSet, ReplicaSet, DoneableReplicaSet> withTimeoutInMillis(long timeoutInMillis) {
     return new ReplicaSetOperationsImpl(client, getConfig(), getAPIVersion(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, timeoutInMillis, TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public ReplicaSet scale(int count) {
-    return scale(count, false);
   }
 
   @Override
@@ -115,70 +83,6 @@ public class ReplicaSetOperationsImpl extends HasMetadataOperation<ReplicaSet, R
   @Override
   public EditReplacePatchDeletable<ReplicaSet, ReplicaSet, DoneableReplicaSet, Boolean> cascading(boolean enabled) {
     return new ReplicaSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), enabled, getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
-  }
-
-  @Override
-  public ReplicaSet scale(int count, boolean wait) {
-    ReplicaSet res = cascading(false).edit().editSpec().withReplicas(count).endSpec().done();
-    if (wait) {
-      waitUntilScaled(count);
-      res = getMandatory();
-    }
-    return res;
-  }
-
-  /**
-   * Lets wait until there are enough Ready pods
-   */
-  private void waitUntilScaled(final int count) {
-    final ArrayBlockingQueue<Object> queue = new ArrayBlockingQueue<>(1);
-    final AtomicReference<Integer> replicasRef = new AtomicReference<>(0);
-
-    final String name = checkName(getItem());
-    final String namespace = checkNamespace(getItem());
-
-    final Runnable rcPoller = new Runnable() {
-      public void run() {
-        try {
-          ReplicaSet rc = get();
-          //If the rs is gone, we shouldn't wait.
-          if (rc == null) {
-            if (count == 0) {
-              queue.put(true);
-              return;
-            } else {
-              queue.put(new IllegalStateException("Can't wait for ReplicaSet: " +name + " in namespace: " + namespace + " to scale. Resource is no longer available."));
-              return;
-            }
-          }
-          replicasRef.set(rc.getStatus().getReplicas());
-          long generation = rc.getMetadata().getGeneration() != null ? rc.getMetadata().getGeneration() : 0;
-          long observedGeneration = rc.getStatus() != null && rc.getStatus().getObservedGeneration() != null ? rc.getStatus().getObservedGeneration() : -1;
-           if (observedGeneration >= generation && Objects.equals(rc.getSpec().getReplicas(), rc.getStatus().getReplicas())) {
-             queue.put(true);
-          }
-          LOG.debug("Only {}/{} replicas scheduled for ReplicaSet: {} in namespace: {} seconds so waiting...",
-              rc.getStatus().getReplicas(), rc.getSpec().getReplicas(), rc.getMetadata().getName(), namespace);
-        } catch (Throwable t) {
-          LOG.error("Error while waiting for ReplicaSet to be scaled.", t);
-        }
-      }
-    };
-
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    ScheduledFuture poller = executor.scheduleWithFixedDelay(rcPoller, 0, POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
-    try {
-      if (Utils.waitUntilReady(queue, rollingTimeout, rollingTimeUnit)) {
-        LOG.debug("{}/{} pod(s) ready for ReplicaSet: {} in namespace: {}.",
-          replicasRef.get(), count, name, namespace);
-      } else {
-        LOG.error("{}/{} pod(s) ready for ReplicaSet: {} in namespace: {}  after waiting for {} seconds so giving up",
-          replicasRef.get(), count, name, namespace, rollingTimeUnit.toSeconds(rollingTimeout));
-      }
-    } finally {
-      poller.cancel(true);
-      executor.shutdown();
-    }
   }
 
   @Override
@@ -211,46 +115,6 @@ public class ReplicaSetOperationsImpl extends HasMetadataOperation<ReplicaSet, R
   }
 
   @Override
-  public DoneableReplicaSet edit() {
-    if (!rolling) {
-      return super.edit();
-    }
-
-    final Visitor<ReplicaSet> visitor = new Visitor<ReplicaSet>() {
-      @Override
-      public void visit(ReplicaSet rc) {
-        try {
-          new ReplicaSetRollingUpdater(client, config, namespace).rollUpdate(getMandatory(), rc);
-        } catch (Exception e) {
-          throw KubernetesClientException.launderThrowable(e);
-        }
-      }
-    };
-
-    try {
-      return getDoneableType().getDeclaredConstructor(getType(), Visitor.class).newInstance(get(), visitor);
-    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException | InstantiationException e) {
-      throw KubernetesClientException.launderThrowable(e);
-    }
-  }
-
-  @Override
-  public ReplicaSet replace(ReplicaSet rc) {
-    if (!rolling) {
-      return super.replace(rc);
-    }
-    return new ReplicaSetRollingUpdater(client, config, namespace, rollingTimeUnit.toMillis(rollingTimeout), getConfig().getLoggingInterval()).rollUpdate(getMandatory(), rc);
-  }
-
-  @Override
-  public ReplicaSet patch(ReplicaSet rc) {
-    if (!rolling) {
-      return super.patch(rc);
-    }
-    return new ReplicaSetRollingUpdater(client, config, namespace, rollingTimeUnit.toMillis(rollingTimeout), getConfig().getLoggingInterval()).rollUpdate(getMandatory(), rc);
-  }
-
-  @Override
   public ReplicaSet waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
     ReplicaSet rs = get();
     if (rs == null) {
@@ -260,17 +124,29 @@ public class ReplicaSetOperationsImpl extends HasMetadataOperation<ReplicaSet, R
     return periodicWatchUntilReady(10, System.currentTimeMillis(), Math.max(timeUnit.toMillis(amount) / 10, 1000L), amount);
   }
 
-  private static class ReplicaSetReaper implements Reaper {
-    private ReplicaSetOperationsImpl oper;
+  @Override
+  ReplicaSet withReplicas(int count) {
+    return cascading(false).edit().editSpec().withReplicas(count).endSpec().done();
+  }
 
-    public ReplicaSetReaper(ReplicaSetOperationsImpl oper) {
-      this.oper = oper;
-    }
+  @Override
+  RollingUpdater<ReplicaSet, ReplicaSetList, DoneableReplicaSet> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit) {
+    return new ReplicaSetRollingUpdater(client, config, getNamespace(), rollingTimeUnit.toMillis(rollingTimeout), config.getLoggingInterval());
+  }
 
-    @Override
-    public boolean reap() {
-      oper.scale(0, true);
-      return false;
-    }
+  @Override
+  int getCurrentReplicas(ReplicaSet current) {
+    return current.getStatus().getReplicas();
+  }
+
+  @Override
+  int getDesiredReplicas(ReplicaSet item) {
+    return item.getSpec().getReplicas();
+  }
+
+  @Override
+  long getObservedGeneration(ReplicaSet current) {
+    return (current != null && current.getStatus() != null
+      && current.getStatus().getObservedGeneration() != null)? current.getStatus().getObservedGeneration() : -1;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
@@ -27,7 +27,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
 import okhttp3.OkHttpClient;
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>>
+public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScalableResource<ReplicaSet, DoneableReplicaSet>>
   implements TimeoutImageEditReplacePatchable<ReplicaSet, ReplicaSet, DoneableReplicaSet> {
 
   public ReplicaSetOperationsImpl(OkHttpClient client, Config config, String namespace) {
@@ -63,7 +63,7 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public RollableScallableResource<ReplicaSet, DoneableReplicaSet> withName(String name) {
+  public RollableScalableResource<ReplicaSet, DoneableReplicaSet> withName(String name) {
     if (name == null || name.length() == 0) {
       throw new IllegalArgumentException("Name must be provided.");
     }
@@ -71,7 +71,7 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public RollableScallableResource<ReplicaSet, DoneableReplicaSet> fromServer() {
+  public RollableScalableResource<ReplicaSet, DoneableReplicaSet> fromServer() {
     return new ReplicaSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), getItem(), getResourceVersion(), true, getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetRollingUpdater.java
@@ -27,7 +27,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Operation;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 
 class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList, DoneableReplicaSet> {
@@ -109,7 +109,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
   }
 
   @Override
-  protected Operation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScallableResource<ReplicaSet, DoneableReplicaSet>> resources() {
+  protected Operation<ReplicaSet, ReplicaSetList, DoneableReplicaSet, RollableScalableResource<ReplicaSet, DoneableReplicaSet>> resources() {
     return new ReplicaSetOperationsImpl(client, config, namespace);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
@@ -28,7 +28,7 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
 import okhttp3.OkHttpClient;
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-public class ReplicationControllerOperationsImpl extends RollableScalableResourceOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>>
+public class ReplicationControllerOperationsImpl extends RollableScalableResourceOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>>
   implements TimeoutImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> {
 
   public ReplicationControllerOperationsImpl(OkHttpClient client, Config config, String namespace) {
@@ -55,7 +55,7 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   }
 
   @Override
-  public RollableScallableResource<ReplicationController, DoneableReplicationController> load(InputStream is) {
+  public RollableScalableResource<ReplicationController, DoneableReplicationController> load(InputStream is) {
     try {
       ReplicationController item = unmarshal(is, ReplicationController.class);
       return new ReplicationControllerOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), item, getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
@@ -65,7 +65,7 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   }
 
   @Override
-  public NonNamespaceOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> inNamespace(String namespace) {
+  public NonNamespaceOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> inNamespace(String namespace) {
     return new ReplicationControllerOperationsImpl(client, getConfig(), getAPIVersion(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
   }
 
@@ -107,7 +107,7 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   }
 
   @Override
-  public RollableScallableResource<ReplicationController, DoneableReplicationController> withName(String name) {
+  public RollableScalableResource<ReplicationController, DoneableReplicationController> withName(String name) {
     if (name == null || name.length() == 0) {
       throw new IllegalArgumentException("Name must be provided.");
     }
@@ -115,7 +115,7 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   }
 
   @Override
-  public RollableScallableResource<ReplicationController, DoneableReplicationController> fromServer() {
+  public RollableScalableResource<ReplicationController, DoneableReplicationController> fromServer() {
     return new ReplicationControllerOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), getItem(), getResourceVersion(), true, getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
@@ -15,24 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.DoneableReplicationController;
@@ -41,31 +23,24 @@ import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
-import io.fabric8.kubernetes.client.dsl.Reaper;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
-import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.kubernetes.client.internal.readiness.ReadinessWatcher;
-import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.OkHttpClient;
 
-public class ReplicationControllerOperationsImpl extends HasMetadataOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>>
-  implements RollableScallableResource<ReplicationController, DoneableReplicationController>,
-  TimeoutImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> {
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
-  static final transient Logger LOG = LoggerFactory.getLogger(ReplicationControllerOperationsImpl.class);
-
-  private final Boolean rolling;
-  private final long rollingTimeout;
-  private final TimeUnit rollingTimeUnit;
+public class ReplicationControllerOperationsImpl extends RollableScalableResourceOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>>
+  implements TimeoutImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> {
 
   public ReplicationControllerOperationsImpl(OkHttpClient client, Config config, String namespace) {
     this(client, config, null, namespace, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), false, config.getRollingTimeout(), TimeUnit.MILLISECONDS);
@@ -76,11 +51,7 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
   }
 
   public ReplicationControllerOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, ReplicationController item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Boolean rolling, long rollingTimeout, TimeUnit rollingTimeUnit) {
-    super(client, config, null, apiVersion, "replicationcontrollers", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
-    this.rolling = rolling;
-    this.rollingTimeout = rollingTimeout;
-    this.rollingTimeUnit = rollingTimeUnit;
-    reaper = new ReplicationControllerReaper(this);
+    super(client, config, null, apiVersion, "replicationcontrollers", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields, rolling, rollingTimeout, rollingTimeUnit);
   }
 
   @Override
@@ -110,8 +81,29 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
   }
 
   @Override
-  public ReplicationController scale(int count) {
-    return scale(count, false);
+  ReplicationController withReplicas(int count) {
+    return cascading(false).edit().editSpec().withReplicas(count).endSpec().done();
+  }
+
+  @Override
+  RollingUpdater<ReplicationController, ReplicationControllerList, DoneableReplicationController> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit) {
+    return new ReplicationControllerRollingUpdater(client, config, namespace, rollingTimeUnit.toMillis(rollingTimeout), config.getLoggingInterval());
+  }
+
+  @Override
+  int getCurrentReplicas(ReplicationController current) {
+    return current.getStatus().getReplicas();
+  }
+
+  @Override
+  int getDesiredReplicas(ReplicationController item) {
+    return item.getSpec().getReplicas();
+  }
+
+  @Override
+  long getObservedGeneration(ReplicationController current) {
+    return (current != null && current.getStatus() != null
+      && current.getStatus().getObservedGeneration() != null) ? current.getStatus().getObservedGeneration() : -1;
   }
 
   @Override
@@ -135,69 +127,6 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
   @Override
   public EditReplacePatchDeletable<ReplicationController, ReplicationController, DoneableReplicationController, Boolean> cascading(boolean enabled) {
     return new ReplicationControllerOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), enabled, getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
-  }
-
-  @Override
-  public ReplicationController scale(int count, boolean wait) {
-    ReplicationController res = cascading(false).edit().editSpec().withReplicas(count).endSpec().done();
-    if (wait) {
-      waitUntilRCIsScaled(count);
-      res = getMandatory();
-    }
-    return res;
-  }
-
-  /**
-   * Lets wait until there are enough Ready pods of the given RC
-   */
-  private void waitUntilRCIsScaled(final int count) {
-    final BlockingQueue<Object> queue = new ArrayBlockingQueue<>(1);
-    final AtomicReference<Integer> replicasRef = new AtomicReference<>(0);
-
-    final String name = checkName(getItem());
-    final String namespace = checkNamespace(getItem());
-
-    final Runnable rcPoller = new Runnable() {
-      public void run() {
-        try {
-          ReplicationController rc = get();
-          //If the rc is gone, we shouldn't wait.
-          if (rc == null) {
-            if (count == 0) {
-              queue.put(true);
-              return;
-            } else {
-              queue.put(new IllegalStateException("Can't wait for ReplicationController: " + checkName(getItem()) + " in namespace: " + checkName(getItem()) + " to scale. Resource is no longer available."));
-            }
-          }
-
-          replicasRef.set(rc.getStatus().getReplicas());
-          if (Objects.equals(rc.getSpec().getReplicas(), rc.getStatus().getReplicas())) {
-            queue.put(true);
-          } else {
-            LOG.debug("Only {}/{} replicas scheduled for ReplicationController: {} in namespace: {} seconds so waiting...",
-              rc.getStatus().getReplicas(), rc.getSpec().getReplicas(), rc.getMetadata().getName(), namespace);
-          }
-        } catch (Throwable t) {
-          LOG.error("Error while waiting for ReplicationController to be scaled.", t);
-        }
-      }
-    };
-
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    ScheduledFuture poller = executor.scheduleWithFixedDelay(rcPoller, 0, POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
-    try {
-      if (Utils.waitUntilReady(queue, rollingTimeout, rollingTimeUnit)) {
-        LOG.debug("{}/{} pod(s) ready for ReplicationController: {} in namespace: {}.",
-          replicasRef.get(), count, name, namespace);
-      } else {
-        LOG.error("{}/{} pod(s) ready for ReplicationController: {} in namespace: {}  after waiting for {} seconds so giving up",
-          replicasRef.get(), count, name, namespace, rollingTimeUnit.toSeconds(rollingTimeout));
-      }
-    } finally {
-      poller.cancel(true);
-      executor.shutdown();
-    }
   }
 
   @Override
@@ -229,60 +158,4 @@ public class ReplicationControllerOperationsImpl extends HasMetadataOperation<Re
     return new ReplicationControllerRollingUpdater(client, config, namespace).rollUpdate(oldRC, newRCBuilder.build());
   }
 
-  @Override
-  public DoneableReplicationController edit() {
-    if (!rolling) {
-      return super.edit();
-    }
-
-    final Visitor<ReplicationController> visitor = new Visitor<ReplicationController>() {
-      @Override
-      public void visit(ReplicationController rc) {
-        try {
-          new ReplicationControllerRollingUpdater(client, config, namespace).rollUpdate(getMandatory(), rc);
-        } catch (Exception e) {
-          throw KubernetesClientException.launderThrowable(e);
-        }
-      }
-    };
-
-    try {
-      return getDoneableType().getDeclaredConstructor(getType(), Visitor.class).newInstance(get(), visitor);
-    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException | InstantiationException e) {
-      throw KubernetesClientException.launderThrowable(e);
-    }
-  }
-
-  @Override
-  public ReplicationController replace(ReplicationController rc) {
-    if (!rolling) {
-      return super.replace(rc);
-    }
-    return new ReplicationControllerRollingUpdater(client, config, namespace, rollingTimeUnit.toMillis(rollingTimeout), getConfig().getLoggingInterval()).rollUpdate(getMandatory(), rc);
-  }
-
-
-  @Override
-  public ReplicationController waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
-    ReplicationController rc = get();
-    if (rc == null) {
-      throw new IllegalArgumentException("ReplicationController with name:[" + name + "] in namespace:[" + namespace + "] not found!");
-    }
-
-    return periodicWatchUntilReady(10, System.currentTimeMillis(), Math.max(timeUnit.toMillis(amount) / 10, 1000L), amount);
-  }
-
-  private static class ReplicationControllerReaper implements Reaper {
-    private ReplicationControllerOperationsImpl oper;
-
-    public ReplicationControllerReaper(ReplicationControllerOperationsImpl oper) {
-      this.oper = oper;
-    }
-
-    @Override
-    public boolean reap() {
-      oper.scale(0, true);
-      return false;
-    }
-  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerRollingUpdater.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.Operation;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 
 class ReplicationControllerRollingUpdater extends RollingUpdater<ReplicationController, ReplicationControllerList, DoneableReplicationController> {
 
@@ -81,7 +81,7 @@ class ReplicationControllerRollingUpdater extends RollingUpdater<ReplicationCont
   }
 
   @Override
-  protected Operation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> resources() {
+  protected Operation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> resources() {
     return new ReplicationControllerOperationsImpl(client, config, namespace);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.OkHttpClient;
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * Operations for resources that represent scalable, rolling-updatable sets of Pods.
  */
 public abstract class RollableScalableResourceOperation<T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>, R extends Resource<T, D>>
-  extends HasMetadataOperation<T, L, D, R> implements RollableScallableResource<T, D> {
+  extends HasMetadataOperation<T, L, D, R> implements RollableScalableResource<T, D> {
 
   private final Logger Log = LoggerFactory.getLogger(this.getClass());
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import io.fabric8.kubernetes.client.utils.Utils;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Operations for resources that represent scalable, rolling-updatable sets of Pods.
+ */
+public abstract class RollableScalableResourceOperation<T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>, R extends Resource<T, D>>
+  extends HasMetadataOperation<T, L, D, R> implements RollableScallableResource<T, D> {
+
+  private final Logger Log = LoggerFactory.getLogger(this.getClass());
+
+  final Boolean rolling;
+  final long rollingTimeout;
+  final TimeUnit rollingTimeUnit;
+
+  public RollableScalableResourceOperation(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Boolean rolling, long rollingTimeout, TimeUnit rollingTimeUnit) {
+    super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
+    this.rolling = rolling;
+    this.rollingTimeout = rollingTimeout;
+    this.rollingTimeUnit = rollingTimeUnit;
+    reaper = new ScalableReaper(this);
+  }
+
+  abstract T withReplicas(int count);
+  abstract RollingUpdater<T, L, D> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit);
+
+  // There are no common interfaces through which we could get these values.
+  abstract int getCurrentReplicas(T current);
+  abstract int getDesiredReplicas(T item);
+  abstract long getObservedGeneration(T current);
+
+  @Override
+  public T scale(int count) {
+    return scale(count, false);
+  }
+
+  @Override
+  public T scale(int count, boolean wait) {
+    T res = withReplicas(count);
+    if (wait) {
+      waitUntilScaled(count);
+      res = getMandatory();
+    }
+    return res;
+  }
+
+  @Override
+  public T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
+    T t = get();
+    if (t == null) {
+      throw new IllegalArgumentException(getType().getSimpleName() + " with name:[" + name + "] in namespace:[" + namespace + "] not found!");
+    }
+
+    return periodicWatchUntilReady(10, System.currentTimeMillis(), Math.max(timeUnit.toMillis(amount) / 10, 1000L), amount);
+  }
+
+  /**
+   * Let's wait until there are enough Ready pods.
+   */
+  private void waitUntilScaled(final int count) {
+    final ArrayBlockingQueue<Object> queue = new ArrayBlockingQueue<>(1);
+    final AtomicReference<Integer> replicasRef = new AtomicReference<>(0);
+
+    final String name = checkName(getItem());
+    final String namespace = checkNamespace(getItem());
+
+    final Runnable tPoller = new Runnable() {
+      public void run() {
+        try {
+          T t = get();
+          //If the resource is gone, we shouldn't wait.
+          if (t == null) {
+            if (count == 0) {
+              queue.put(true);
+            } else {
+              queue.put(new IllegalStateException("Can't wait for " + getType().getSimpleName() + ": " +name + " in namespace: " + namespace + " to scale. Resource is no longer available."));
+            }
+            return;
+          }
+          int currentReplicas = getCurrentReplicas(t);
+          int desiredReplicas = getDesiredReplicas(t);
+          replicasRef.set(currentReplicas);
+          long generation = t.getMetadata().getGeneration() != null ? t.getMetadata().getGeneration() : -1;
+          long observedGeneration = getObservedGeneration(t);
+          if (observedGeneration >= generation && Objects.equals(desiredReplicas, currentReplicas)) {
+            queue.put(true);
+          }
+          Log.debug("Only {}/{} replicas scheduled for {}: {} in namespace: {} seconds so waiting...",
+            currentReplicas, desiredReplicas, t.getKind(), t.getMetadata().getName(), namespace);
+        } catch (Throwable t) {
+          Log.error("Error while waiting for resource to be scaled.", t);
+        }
+      }
+    };
+
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    ScheduledFuture poller = executor.scheduleWithFixedDelay(tPoller, 0, POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+    try {
+      if (Utils.waitUntilReady(queue, rollingTimeout, rollingTimeUnit)) {
+        Log.debug("{}/{} pod(s) ready for {}: {} in namespace: {}.",
+          replicasRef.get(), count, getType().getSimpleName(), name, namespace);
+      } else {
+        Log.error("{}/{} pod(s) ready for {}: {} in namespace: {}  after waiting for {} seconds so giving up",
+          replicasRef.get(), count, getType().getSimpleName(), name, namespace, rollingTimeUnit.toSeconds(rollingTimeout));
+      }
+    } finally {
+      poller.cancel(true);
+      executor.shutdown();
+    }
+  }
+
+  @Override
+  public D edit() {
+    if (!rolling) {
+      return super.edit();
+    }
+
+    final Visitor<T> visitor = new Visitor<T>() {
+      @Override
+      public void visit(T t) {
+        try {
+          getRollingUpdater(rollingTimeout, rollingTimeUnit).rollUpdate(getMandatory(), t);
+        } catch (Exception e) {
+          throw KubernetesClientException.launderThrowable(e);
+        }
+      }
+    };
+
+    try {
+      return getDoneableType().getDeclaredConstructor(getType(), Visitor.class).newInstance(get(), visitor);
+    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException | InstantiationException e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  @Override
+  public T replace(T t) {
+    if (!rolling) {
+      return super.replace(t);
+    }
+    return getRollingUpdater(rollingTimeout, rollingTimeUnit).rollUpdate(getMandatory(), t);
+  }
+
+  @Override
+  public T patch(T t) {
+    if (!rolling) {
+      return super.patch(t);
+    }
+    return getRollingUpdater(rollingTimeout, rollingTimeUnit).rollUpdate(getMandatory(), t);
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollingUpdater.java
@@ -27,7 +27,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Operation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -265,7 +265,7 @@ abstract class RollingUpdater<T extends HasMetadata, L, D extends Doneable<T>> {
     return String.format("%1$032x", i);
   }
 
-  protected abstract Operation<T, L, D, RollableScallableResource<T, D>> resources();
+  protected abstract Operation<T, L, D, RollableScalableResource<T, D>> resources();
 
   protected Operation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> pods() {
     return new PodOperationsImpl(client, config, namespace);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ScalableReaper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ScalableReaper.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.client.dsl.Reaper;
+import io.fabric8.kubernetes.client.dsl.ScalableResource;
+
+class ScalableReaper implements Reaper {
+  private ScalableResource<?, ?> oper;
+
+  public ScalableReaper(ScalableResource<?, ?> oper) {
+    this.oper = oper;
+  }
+
+  @Override
+  public boolean reap() {
+    oper.scale(0, true);
+    return false;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.extensions.DoneableStatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
+import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
+import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
+import io.fabric8.kubernetes.client.dsl.Watchable;
+import okhttp3.OkHttpClient;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+public class StatefulSetOperationsImpl extends RollableScalableResourceOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>>
+  implements TimeoutImageEditReplacePatchable<StatefulSet, StatefulSet, DoneableStatefulSet>
+{
+
+  public StatefulSetOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(client, config, "v1beta1", namespace, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), false, config.getRollingTimeout(), TimeUnit.MILLISECONDS);
+  }
+
+  public StatefulSetOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, StatefulSet item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
+    this(client, config, apiVersion, namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields, false, config.getRollingTimeout(), TimeUnit.MILLISECONDS);
+  }
+
+  public StatefulSetOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, StatefulSet item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Boolean rolling, long rollingTimeout, TimeUnit rollingTimeUnit) {
+    super(client, config, "apps", apiVersion, "statefulsets", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields, rolling, rollingTimeout, rollingTimeUnit);
+  }
+
+  @Override
+  public ImageEditReplacePatchable<StatefulSet, StatefulSet, DoneableStatefulSet> withTimeout(long timeout, TimeUnit unit) {
+    return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, timeout, unit);
+  }
+
+  @Override
+  public ImageEditReplacePatchable<StatefulSet, StatefulSet, DoneableStatefulSet> withTimeoutInMillis(long timeoutInMillis) {
+    return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, timeoutInMillis, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  StatefulSet withReplicas(int count) {
+    return cascading(false).edit().editSpec().withReplicas(count).endSpec().done();
+  }
+
+  @Override
+  RollingUpdater<StatefulSet, StatefulSetList, DoneableStatefulSet> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit) {
+    return new StatefulSetRollingUpdater(client, config, getNamespace(), rollingTimeUnit.toMillis(rollingTimeout), config.getLoggingInterval());
+  }
+
+  @Override
+  int getCurrentReplicas(StatefulSet current) {
+    return current.getStatus().getReplicas();
+  }
+
+  @Override
+  int getDesiredReplicas(StatefulSet item) {
+    return item.getSpec().getReplicas();
+  }
+
+  @Override
+  long getObservedGeneration(StatefulSet current) {
+    return (current != null && current.getStatus() != null && current.getStatus().getObservedGeneration() != null)
+      ? current.getStatus().getObservedGeneration() : -1;
+  }
+
+  @Override
+  public RollableScallableResource<StatefulSet, DoneableStatefulSet> withName(String name) {
+    if (name == null || name.length() == 0) {
+      throw new IllegalArgumentException("Name must be provided.");
+    }
+    return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), name, isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
+  }
+
+  @Override
+  public RollableScallableResource<StatefulSet, DoneableStatefulSet> fromServer() {
+    return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), getItem(), getResourceVersion(), true, getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
+  }
+
+  @Override
+  public Watchable<Watch, Watcher<StatefulSet>> withResourceVersion(String resourceVersion) {
+    return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), getItem(), resourceVersion, isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
+  }
+
+  @Override
+  public EditReplacePatchDeletable<StatefulSet, StatefulSet, DoneableStatefulSet, Boolean> cascading(boolean enabled) {
+    return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), enabled, getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
+  }
+
+  @Override
+  public StatefulSetOperationsImpl rolling() {
+    return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), true, rollingTimeout, rollingTimeUnit);
+  }
+
+  @Override
+  public StatefulSet updateImage(String image) {
+    StatefulSet oldRC = get();
+
+    if (oldRC == null) {
+      throw new KubernetesClientException("Existing StatefulSet doesn't exist");
+    }
+    if (oldRC.getSpec().getTemplate().getSpec().getContainers().size() > 1) {
+      throw new KubernetesClientException("Image update is not supported for multicontainer pods");
+    }
+    if (oldRC.getSpec().getTemplate().getSpec().getContainers().size() == 0) {
+      throw new KubernetesClientException("Pod has no containers!");
+    }
+
+    Container updatedContainer = new ContainerBuilder(oldRC.getSpec().getTemplate().getSpec().getContainers().iterator().next()).withImage(image).build();
+
+    StatefulSetBuilder newRCBuilder = new StatefulSetBuilder(oldRC);
+    newRCBuilder.editMetadata().withResourceVersion(null).endMetadata()
+      .editSpec().editTemplate().editSpec().withContainers(Collections.singletonList(updatedContainer))
+      .endSpec().endTemplate().endSpec();
+
+    return new StatefulSetRollingUpdater(client, config, namespace).rollUpdate(oldRC, newRCBuilder.build());
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
@@ -27,7 +27,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.ImageEditReplacePatchable;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
 import okhttp3.OkHttpClient;
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-public class StatefulSetOperationsImpl extends RollableScalableResourceOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>>
+public class StatefulSetOperationsImpl extends RollableScalableResourceOperation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>>
   implements TimeoutImageEditReplacePatchable<StatefulSet, StatefulSet, DoneableStatefulSet>
 {
 
@@ -90,7 +90,7 @@ public class StatefulSetOperationsImpl extends RollableScalableResourceOperation
   }
 
   @Override
-  public RollableScallableResource<StatefulSet, DoneableStatefulSet> withName(String name) {
+  public RollableScalableResource<StatefulSet, DoneableStatefulSet> withName(String name) {
     if (name == null || name.length() == 0) {
       throw new IllegalArgumentException("Name must be provided.");
     }
@@ -98,7 +98,7 @@ public class StatefulSetOperationsImpl extends RollableScalableResourceOperation
   }
 
   @Override
-  public RollableScallableResource<StatefulSet, DoneableStatefulSet> fromServer() {
+  public RollableScalableResource<StatefulSet, DoneableStatefulSet> fromServer() {
     return new StatefulSetOperationsImpl(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), getItem(), getResourceVersion(), true, getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), rolling, rollingTimeout, rollingTimeUnit);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetRollingUpdater.java
@@ -27,7 +27,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Operation;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import okhttp3.OkHttpClient;
 
 class StatefulSetRollingUpdater extends RollingUpdater<StatefulSet, StatefulSetList, DoneableStatefulSet> {
@@ -109,7 +109,7 @@ class StatefulSetRollingUpdater extends RollingUpdater<StatefulSet, StatefulSetL
   }
 
   @Override
-  protected Operation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>> resources() {
+  protected Operation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>> resources() {
     return new StatefulSetOperationsImpl(client, config, namespace);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetRollingUpdater.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.extensions.DoneableStatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.Operation;
+import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import okhttp3.OkHttpClient;
+
+class StatefulSetRollingUpdater extends RollingUpdater<StatefulSet, StatefulSetList, DoneableStatefulSet> {
+
+  StatefulSetRollingUpdater(OkHttpClient client, Config config, String namespace) {
+    super(client, config, namespace);
+  }
+
+  StatefulSetRollingUpdater(OkHttpClient client, Config config, String namespace, long rollingTimeoutMillis, long loggingIntervalMillis) {
+    super(client, config, namespace, rollingTimeoutMillis, loggingIntervalMillis);
+  }
+
+  @Override
+  protected StatefulSet createClone(StatefulSet obj, String newName, String newDeploymentHash) {
+    return new StatefulSetBuilder(obj)
+      .editMetadata()
+      .withResourceVersion(null)
+      .withName(newName)
+      .endMetadata()
+      .editSpec()
+      .withReplicas(0)
+      .editSelector().addToMatchLabels(DEPLOYMENT_KEY, newDeploymentHash).endSelector()
+      .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, newDeploymentHash).endMetadata().endTemplate()
+      .endSpec()
+      .build();
+  }
+
+  @Override
+  protected PodList listSelectedPods(StatefulSet obj) {
+    FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister = pods().inNamespace(namespace);
+    if (obj.getSpec().getSelector().getMatchLabels() != null) {
+      podLister.withLabels(obj.getSpec().getSelector().getMatchLabels());
+    }
+    if (obj.getSpec().getSelector().getMatchExpressions() != null) {
+      for (LabelSelectorRequirement req : obj.getSpec().getSelector().getMatchExpressions()) {
+        switch (req.getOperator()) {
+          case "In":
+            podLister.withLabelIn(req.getKey(), req.getValues().toArray(new String[]{}));
+            break;
+          case "NotIn":
+            podLister.withLabelNotIn(req.getKey(), req.getValues().toArray(new String[]{}));
+            break;
+          case "DoesNotExist":
+            podLister.withoutLabel(req.getKey());
+            break;
+          case "Exists":
+            podLister.withLabel(req.getKey());
+            break;
+        }
+      }
+    }
+    return podLister.list();
+  }
+
+  @Override
+  protected void updateDeploymentKey(DoneableStatefulSet obj, String hash) {
+    obj.editSpec()
+      .editSelector().addToMatchLabels(DEPLOYMENT_KEY, hash).endSelector()
+      .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, hash).endMetadata().endTemplate()
+      .endSpec();
+  }
+
+  @Override
+  protected void removeDeploymentKey(DoneableStatefulSet obj) {
+    obj.editSpec()
+      .editSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endSelector()
+      .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
+      .endSpec();
+  }
+
+  @Override
+  protected int getReplicas(StatefulSet obj) {
+    return obj.getSpec().getReplicas();
+  }
+
+  @Override
+  protected StatefulSet setReplicas(StatefulSet obj, int replicas) {
+    return new StatefulSetBuilder(obj).editSpec().withReplicas(replicas).endSpec().build();
+  }
+
+  @Override
+  protected Operation<StatefulSet, StatefulSetList, DoneableStatefulSet, RollableScallableResource<StatefulSet, DoneableStatefulSet>> resources() {
+    return new StatefulSetOperationsImpl(client, config, namespace);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -87,7 +87,7 @@ import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRe
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
@@ -314,7 +314,7 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
     return delegate.events();
   }
 
-  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
+  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
     return delegate.replicationControllers();
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -16,11 +16,6 @@
 
 package io.fabric8.kubernetes.client.osgi;
 
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Collection;
-import java.util.Map;
-
 import io.fabric8.kubernetes.api.model.ComponentStatus;
 import io.fabric8.kubernetes.api.model.ComponentStatusList;
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -82,16 +77,17 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.ResourceHandler;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
-import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
-import io.fabric8.kubernetes.client.dsl.FunctionCallable;
-import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
-import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
@@ -101,6 +97,11 @@ import org.apache.felix.scr.annotations.ReferenceCardinality;
 import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.apache.felix.scr.annotations.References;
 import org.apache.felix.scr.annotations.Service;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
 
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_API_VERSION_SYSTEM_PROPERTY;
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_AUTH_BASIC_PASSWORD_SYSTEM_PROPERTY;
@@ -329,6 +330,11 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public ExtensionsAPIGroupDSL extensions() {
     return delegate.extensions();
+  }
+
+  @Override
+  public AppsAPIGroupDSL apps() {
+    return delegate.apps();
   }
 
   @Override

--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
+io.fabric8.kubernetes.client.AppsAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.ExtensionsAPIGroupExtensionAdapter

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetList;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSetList;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSetListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ReplicaSetTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  public void testList() {
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets").andReturn(200, new ReplicaSetListBuilder().build()).once();
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/ns1/replicasets").andReturn(200,  new ReplicaSetListBuilder()
+      .addNewItem().and()
+      .addNewItem().and().build())
+      .once();
+
+    KubernetesClient client = server.getClient();
+    ReplicaSetList replicaSetList = client.extensions().replicaSets().list();
+    assertNotNull(replicaSetList);
+    assertEquals(0, replicaSetList.getItems().size());
+
+    replicaSetList = client.extensions().replicaSets().inNamespace("ns1").list();
+    assertNotNull(replicaSetList);
+    assertEquals(2, replicaSetList.getItems().size());
+  }
+
+
+  @Test
+  public void testGet() {
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, new ReplicaSetBuilder().build()).once();
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/ns1/replicasets/repl2").andReturn(200, new ReplicaSetBuilder().build()).once();
+
+    KubernetesClient client = server.getClient();
+
+    ReplicaSet repl1 = client.extensions().replicaSets().withName("repl1").get();
+    assertNotNull(repl1);
+
+    repl1 = client.extensions().replicaSets().withName("repl2").get();
+    assertNull(repl1);
+
+    repl1 = client.extensions().replicaSets().inNamespace("ns1").withName("repl2").get();
+    assertNotNull(repl1);
+  }
+
+
+  @Test
+  public void testDelete() {
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, new ReplicaSetBuilder() .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(1)
+      .endStatus()
+      .build()).once();
+
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, new ReplicaSetBuilder() .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(0)
+      .endStatus()
+      .build()).times(5);
+
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/ns1/replicasets/repl2").andReturn(200, new ReplicaSetBuilder() .withNewMetadata()
+      .withName("repl2")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(1)
+      .endStatus()
+      .build()).once();
+
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/ns1/replicasets/repl2").andReturn(200, new ReplicaSetBuilder() .withNewMetadata()
+      .withName("repl2")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(0)
+      .endStatus()
+      .build()).times(5);
+
+    KubernetesClient client = server.getClient();
+
+    Boolean deleted = client.extensions().replicaSets().withName("repl1").delete();
+    assertNotNull(deleted);
+
+    deleted = client.extensions().replicaSets().withName("repl2").delete();
+    assertFalse(deleted);
+
+    deleted = client.extensions().replicaSets().inNamespace("ns1").withName("repl2").delete();
+    assertTrue(deleted);
+  }
+
+  @Test
+  public void testScale() {
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, new ReplicaSetBuilder()
+      .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(5)
+      .endSpec()
+      .withNewStatus()
+        .withReplicas(1)
+      .endStatus()
+      .build()).always();
+
+    KubernetesClient client = server.getClient();
+    ReplicaSet repl = client.extensions().replicaSets().withName("repl1").scale(5);
+    assertNotNull(repl);
+    assertNotNull(repl.getSpec());
+    assertEquals(5, repl.getSpec().getReplicas().intValue());
+    assertEquals(1, repl.getStatus().getReplicas().intValue());
+  }
+
+  @Test
+  public void testScaleAndWait() {
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, new ReplicaSetBuilder()
+      .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(5)
+      .endSpec()
+      .withNewStatus()
+        .withReplicas(1)
+      .endStatus()
+      .build()).once();
+
+    server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, new ReplicaSetBuilder()
+        .withNewMetadata()
+        .withName("repl1")
+        .withResourceVersion("1")
+        .endMetadata()
+        .withNewSpec()
+        .withReplicas(5)
+        .endSpec()
+        .withNewStatus()
+        .withReplicas(5)
+        .endStatus()
+        .build()).always();
+
+    KubernetesClient client = server.getClient();
+    ReplicaSet repl = client.extensions().replicaSets().withName("repl1").scale(5, true);
+    assertNotNull(repl);
+    assertNotNull(repl.getSpec());
+    assertEquals(5, repl.getSpec().getReplicas().intValue());
+    assertEquals(5, repl.getStatus().getReplicas().intValue());
+  }
+
+  @Ignore
+  @Test
+  public void testUpdate() {
+    ReplicaSet repl1 = new ReplicaSetBuilder()
+      .withNewMetadata()
+      .withName("repl1")
+      .withNamespace("test")
+      .endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .withNewTemplate()
+          .withNewMetadata().withLabels(new HashMap<String, String>()).endMetadata()
+          .withNewSpec()
+            .addNewContainer()
+              .withImage("img1")
+            .endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .withNewStatus().withReplicas(1).endStatus()
+      .build();
+
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, repl1).once();
+   server.expect().put().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets/repl1").andReturn(200, repl1).once();
+   server.expect().get().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets").andReturn(200, new ReplicaSetListBuilder().withItems(repl1).build()).once();
+   server.expect().post().withPath("/apis/extensions/v1beta1/namespaces/test/replicasets").andReturn(201, repl1).once();
+   server.expect().withPath("/apis/extensions/v1beta1/namespaces/test/pods").andReturn(200, new KubernetesListBuilder().build()).once();
+    KubernetesClient client = server.getClient();
+
+    repl1 = client.extensions().replicaSets().withName("repl1")
+      .rolling()
+      .withTimeout(5, TimeUnit.MINUTES)
+      .updateImage("");
+    assertNotNull(repl1);
+  }
+
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSetListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetList;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class StatefulSetTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  public void testList() {
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets").andReturn(200, new StatefulSetListBuilder().build()).once();
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/ns1/statefulsets").andReturn(200,  new StatefulSetListBuilder()
+      .addNewItem().and()
+      .addNewItem().and().build())
+      .once();
+
+    KubernetesClient client = server.getClient();
+    StatefulSetList statefulSetList = client.apps().statefulSets().list();
+    assertNotNull(statefulSetList);
+    assertEquals(0, statefulSetList.getItems().size());
+
+    statefulSetList = client.apps().statefulSets().inNamespace("ns1").list();
+    assertNotNull(statefulSetList);
+    assertEquals(2, statefulSetList.getItems().size());
+  }
+
+
+  @Test
+  public void testGet() {
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, new StatefulSetBuilder().build()).once();
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/ns1/statefulsets/repl2").andReturn(200, new StatefulSetBuilder().build()).once();
+
+    KubernetesClient client = server.getClient();
+
+    StatefulSet repl1 = client.apps().statefulSets().withName("repl1").get();
+    assertNotNull(repl1);
+
+    repl1 = client.apps().statefulSets().withName("repl2").get();
+    assertNull(repl1);
+
+    repl1 = client.apps().statefulSets().inNamespace("ns1").withName("repl2").get();
+    assertNotNull(repl1);
+  }
+
+
+  @Test
+  public void testDelete() {
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, new StatefulSetBuilder() .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(1)
+      .endStatus()
+      .build()).once();
+
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, new StatefulSetBuilder() .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(0)
+      .endStatus()
+      .build()).times(5);
+
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/ns1/statefulsets/repl2").andReturn(200, new StatefulSetBuilder() .withNewMetadata()
+      .withName("repl2")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(1)
+      .endStatus()
+      .build()).once();
+
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/ns1/statefulsets/repl2").andReturn(200, new StatefulSetBuilder() .withNewMetadata()
+      .withName("repl2")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(0)
+      .endSpec()
+      .withNewStatus()
+      .withReplicas(0)
+      .endStatus()
+      .build()).times(5);
+
+    KubernetesClient client = server.getClient();
+
+    Boolean deleted = client.apps().statefulSets().withName("repl1").delete();
+    assertNotNull(deleted);
+
+    deleted = client.apps().statefulSets().withName("repl2").delete();
+    assertFalse(deleted);
+
+    deleted = client.apps().statefulSets().inNamespace("ns1").withName("repl2").delete();
+    assertTrue(deleted);
+  }
+
+  @Test
+  public void testScale() {
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, new StatefulSetBuilder()
+      .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(5)
+      .endSpec()
+      .withNewStatus()
+        .withReplicas(1)
+      .endStatus()
+      .build()).always();
+
+    KubernetesClient client = server.getClient();
+    StatefulSet repl = client.apps().statefulSets().withName("repl1").scale(5);
+    assertNotNull(repl);
+    assertNotNull(repl.getSpec());
+    assertEquals(5, repl.getSpec().getReplicas().intValue());
+    assertEquals(1, repl.getStatus().getReplicas().intValue());
+  }
+
+  @Test
+  public void testScaleAndWait() {
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, new StatefulSetBuilder()
+      .withNewMetadata()
+      .withName("repl1")
+      .withResourceVersion("1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(5)
+      .endSpec()
+      .withNewStatus()
+        .withReplicas(1)
+      .endStatus()
+      .build()).once();
+
+    server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, new StatefulSetBuilder()
+        .withNewMetadata()
+        .withName("repl1")
+        .withResourceVersion("1")
+        .endMetadata()
+        .withNewSpec()
+        .withReplicas(5)
+        .endSpec()
+        .withNewStatus()
+        .withReplicas(5)
+        .endStatus()
+        .build()).always();
+
+    KubernetesClient client = server.getClient();
+    StatefulSet repl = client.apps().statefulSets().withName("repl1").scale(5, true);
+    assertNotNull(repl);
+    assertNotNull(repl.getSpec());
+    assertEquals(5, repl.getSpec().getReplicas().intValue());
+    assertEquals(5, repl.getStatus().getReplicas().intValue());
+  }
+
+  @Ignore
+  @Test
+  public void testUpdate() {
+    StatefulSet repl1 = new StatefulSetBuilder()
+      .withNewMetadata()
+      .withName("repl1")
+      .withNamespace("test")
+      .endMetadata()
+      .withNewSpec()
+        .withReplicas(1)
+        .withNewTemplate()
+          .withNewMetadata().withLabels(new HashMap<String, String>()).endMetadata()
+          .withNewSpec()
+            .addNewContainer()
+              .withImage("img1")
+            .endContainer()
+          .endSpec()
+        .endTemplate()
+      .endSpec()
+      .withNewStatus().withReplicas(1).endStatus()
+      .build();
+
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, repl1).once();
+   server.expect().put().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/repl1").andReturn(200, repl1).once();
+   server.expect().get().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets").andReturn(200, new StatefulSetListBuilder().withItems(repl1).build()).once();
+   server.expect().post().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets").andReturn(201, repl1).once();
+   server.expect().withPath("/apis/apps/v1beta1/namespaces/test/pods").andReturn(200, new KubernetesListBuilder().build()).once();
+    KubernetesClient client = server.getClient();
+
+    repl1 = client.apps().statefulSets().withName("repl1")
+      .rolling()
+      .withTimeout(5, TimeUnit.MINUTES)
+      .updateImage("");
+    assertNotNull(repl1);
+  }
+
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -19,7 +19,9 @@ import io.fabric8.kubernetes.api.model.DoneableLimitRange;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LimitRange;
 import io.fabric8.kubernetes.api.model.LimitRangeList;
+import io.fabric8.kubernetes.client.AppsAPIGroupClient;
 import io.fabric8.kubernetes.client.RequestConfig;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
@@ -420,6 +422,11 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public ExtensionsAPIGroupClient extensions() {
     return adapt(ExtensionsAPIGroupClient.class);
+  }
+
+  @Override
+  public AppsAPIGroupDSL apps() {
+    return adapt(AppsAPIGroupClient.class);
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -93,7 +93,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.internal.ComponentStatusOperationsImpl;
 import io.fabric8.openshift.client.dsl.BuildConfigResource;
@@ -261,7 +261,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
+  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
     return delegate.replicationControllers();
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
@@ -20,6 +20,7 @@ import java.net.URL;
 
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -93,6 +94,8 @@ public interface OpenShiftClient extends KubernetesClient {
   URL getOpenshiftUrl();
 
   ExtensionsAPIGroupDSL extensions();
+
+  AppsAPIGroupDSL apps();
 
   MixedOperation<Build, BuildList, DoneableBuild, BuildResource<Build, DoneableBuild, String, LogWatch>> builds();
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -76,7 +76,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.RollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
@@ -463,7 +463,7 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScallableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
+  public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
     return delegate.replicationControllers();
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -70,6 +70,7 @@ import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.BaseClient;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.RequestConfig;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -544,6 +545,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public ExtensionsAPIGroupDSL extensions() {
     return delegate.extensions();
+  }
+
+  @Override
+  public AppsAPIGroupDSL apps() {
+    return delegate.apps();
   }
 
   @Override


### PR DESCRIPTION
Added StatefulSet support, under the new "apps" API group. The code is almost identical to ReplicaSet and ReplicationController, so I made some attempt to dedupe the three impls (in `RollableScalableResourceOperation`).