### PR TITLE
fixes #746 to support loading templates with number parameters

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
@@ -73,6 +73,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
@@ -140,7 +141,7 @@ public class AutoAdaptableKubernetesClient extends DefaultKubernetesClient {
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
     return delegate.load(is);
   }
 
@@ -150,7 +151,7 @@ public class AutoAdaptableKubernetesClient extends DefaultKubernetesClient {
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
     return delegate.resourceList(s);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -75,6 +75,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
@@ -103,6 +104,7 @@ import okhttp3.OkHttpClient;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class DefaultKubernetesClient extends BaseClient implements NamespacedKubernetesClient {
 
@@ -137,14 +139,14 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), is, false) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), is, null, false) {
     };
   }
 
   @Override
   public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(KubernetesResourceList item) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, -1, false) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, null, null, -1, false) {
     };
   }
 
@@ -159,8 +161,8 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), s, -1, false) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), s, null, null, -1, false) {
     };
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -73,6 +73,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
@@ -88,9 +89,9 @@ public interface KubernetesClient extends Client {
 
   MixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, Resource<ComponentStatus, DoneableComponentStatus>> componentstatuses();
 
-  NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata,Boolean> load(InputStream is);
+  ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata,Boolean> load(InputStream is);
 
-  NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s);
+  ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s);
 
   NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(KubernetesResourceList list);
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ParameterMixedOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ParameterMixedOperation.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.dsl;
+
+/**
+ * A Client Namespace or Non Namespace Operation. This acts as an umbrella for {@link Operation} and {@link NonNamespaceOperation}.
+ * Its not intended to be exposed directly into the client and is only usable as a convenient interface internally.
+ *
+ * @param <T> The Kubernetes resource type.
+ * @param <L> The list variant of the Kubernetes resource type.
+ * @param <D> The doneable variant of the Kubernetes resource type.
+ * @param <R> The resource operations.
+ */
+public interface ParameterMixedOperation<T, L, D, R extends Resource<T, D>>
+  extends MixedOperation<T, L, D, R>, Parameterizable<MixedOperation<T, L, D, R>> {
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable.java
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.openshift.client.dsl;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.dsl.ParameterMixedOperation;
-import io.fabric8.openshift.api.model.DoneableTemplate;
-import io.fabric8.openshift.api.model.Template;
-import io.fabric8.openshift.api.model.TemplateList;
+package io.fabric8.kubernetes.client.dsl;
 
-public interface TemplateOperation extends TemplateResource<Template, KubernetesList, DoneableTemplate>,
-  ParameterMixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> {
+public interface ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<T, B>
+  extends NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<T, B>, Parameterizable<NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<T, B>> {
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Parameterizable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Parameterizable.java
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.openshift.client.dsl;
+package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.client.dsl.ParameterMixedOperation;
-import io.fabric8.openshift.api.model.DoneableTemplate;
-import io.fabric8.openshift.api.model.Template;
-import io.fabric8.openshift.api.model.TemplateList;
+import java.util.Map;
 
-public interface TemplateOperation extends TemplateResource<Template, KubernetesList, DoneableTemplate>,
-  ParameterMixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> {
+public interface Parameterizable<T> {
+
+  T withParameters(Map<String, String> parameters);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -45,6 +45,8 @@ import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
@@ -203,45 +205,180 @@ public class OperationSupport {
     requestBody = RequestBody.create(JSON, JSON_MAPPER.writeValueAsString(deleteOptions));
 
     Request.Builder requestBuilder = new Request.Builder().delete(requestBody).url(requestUrl);
-    handleResponse(requestBuilder, null);
+    handleResponse(requestBuilder, null, Collections.<String, String>emptyMap());
   }
 
+  /**
+   * Create a resource.
+   * @param resource
+   * @param outputType
+   * @param <T>
+   * @param <I>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+     * @throws IOException
+     */
   protected <T, I> T handleCreate(I resource, Class<T> outputType) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
     RequestBody body = RequestBody.create(JSON, JSON_MAPPER.writeValueAsString(resource));
     Request.Builder requestBuilder = new Request.Builder().post(body).url(getNamespacedUrl(checkNamespace(resource)));
-    return handleResponse(requestBuilder, outputType);
+    return handleResponse(requestBuilder, outputType, Collections.<String, String>emptyMap());
   }
 
+
+  /**
+   * Replace a resource.
+   * @param updated
+   * @param type
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+   * @throws IOException
+   */
   protected <T> T handleReplace(T updated, Class<T> type) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+    return handleReplace(updated, type, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Replace a resource, optionally performing placeholder substitution to the response.
+   * @param updated
+   * @param type
+   * @param parameters
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+     * @throws IOException
+     */
+  protected <T> T handleReplace(T updated, Class<T> type, Map<String, String> parameters) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
     RequestBody body = RequestBody.create(JSON, JSON_MAPPER.writeValueAsString(updated));
     Request.Builder requestBuilder = new Request.Builder().put(body).url(getResourceUrl(checkNamespace(updated), checkName(updated)));
-    return handleResponse(requestBuilder, type);
+    return handleResponse(requestBuilder, type, parameters);
   }
 
+  /**
+   * Send an http patch and handle the response.
+   * @param current
+   * @param updated
+   * @param type
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+     * @throws IOException
+     */
   protected <T> T handlePatch(T current, T updated, Class<T> type) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
     JsonNode diff = JsonDiff.asJson(patchMapper().valueToTree(current), patchMapper().valueToTree(updated));
     RequestBody body = RequestBody.create(JSON_PATCH, JSON_MAPPER.writeValueAsString(diff));
     Request.Builder requestBuilder = new Request.Builder().patch(body).url(getResourceUrl(checkNamespace(updated), checkName(updated)));
-    return handleResponse(requestBuilder, type);
+    return handleResponse(requestBuilder, type, Collections.<String, String>emptyMap());
   }
 
+
+  /**
+   * Send an http get.
+   * @param resourceUrl
+   * @param type
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+   * @throws IOException
+   */
   protected <T> T handleGet(URL resourceUrl, Class<T> type) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+    return handleGet(resourceUrl, type, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Send an http, optionally performing placeholder substitution to the response.
+   * @param resourceUrl
+   * @param type
+   * @param parameters
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+     * @throws IOException
+     */
+  protected <T> T handleGet(URL resourceUrl, Class<T> type, Map<String, String> parameters) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
     Request.Builder requestBuilder = new Request.Builder().get().url(resourceUrl);
-    return handleResponse(requestBuilder, type);
+    return handleResponse(requestBuilder, type, parameters);
   }
 
+  /**
+   * Send an http request and handle the response.
+   * @param requestBuilder
+   * @param type
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+   * @throws IOException
+   */
   protected <T> T handleResponse(Request.Builder requestBuilder, Class<T> type) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
-    return handleResponse(client, requestBuilder, type);
+    return handleResponse(requestBuilder, type, Collections.<String, String>emptyMap());
   }
 
+  /**
+   * Send an http request and handle the response, optionally performing placeholder substitution to the response.
+   * @param requestBuilder
+   * @param type
+   * @param parameters
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+   * @throws IOException
+   */
+  protected <T> T handleResponse(Request.Builder requestBuilder, Class<T> type, Map<String, String> parameters) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+    return handleResponse(client, requestBuilder, type, parameters);
+  }
+
+  /**
+   * Send an http request and handle the response.
+   * @param client
+   * @param requestBuilder
+   * @param type
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+   * @throws IOException
+   */
   protected <T> T handleResponse(OkHttpClient client, Request.Builder requestBuilder, Class<T> type) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+    return handleResponse(client, requestBuilder, type, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Send an http request and handle the response, optionally performing placeholder substitution to the response.
+   * @param client
+   * @param requestBuilder
+   * @param type
+   * @param parameters
+   * @param <T>
+   * @return
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws KubernetesClientException
+   * @throws IOException
+   */
+  protected <T> T handleResponse(OkHttpClient client, Request.Builder requestBuilder, Class<T> type, Map<String, String> parameters) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
     Request request = requestBuilder.build();
     Response response = client.newCall(request).execute();
     try (ResponseBody body = response.body()) {
       assertResponseCode(request, response);
       if (type != null) {
-        InputStream is = body.byteStream();
-        return unmarshal(type, is);
+        return Serialization.unmarshal(body.byteStream(), type, parameters);
       } else {
         return null;
       }
@@ -251,10 +388,6 @@ public class OperationSupport {
       }
       throw requestException(request, e);
     }
-  }
-
-  protected <T> T unmarshal(Class<T> type, InputStream is) throws IOException {
-    return JSON_MAPPER.readValue(is, type);
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -240,7 +240,8 @@ public class OperationSupport {
     try (ResponseBody body = response.body()) {
       assertResponseCode(request, response);
       if (type != null) {
-        return JSON_MAPPER.readValue(body.byteStream(), type);
+        InputStream is = body.byteStream();
+        return unmarshal(type, is);
       } else {
         return null;
       }
@@ -250,6 +251,10 @@ public class OperationSupport {
       }
       throw requestException(request, e);
     }
+  }
+
+  protected <T> T unmarshal(Class<T> type, InputStream is) throws IOException {
+    return JSON_MAPPER.readValue(is, type);
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -85,6 +85,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
@@ -237,7 +238,7 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
     return delegate.load(is);
   }
 
@@ -257,7 +258,7 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
     return delegate.resourceList(s);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
@@ -1,13 +1,12 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ */
+public class IOHelpers {
+
+    public static String readFully(InputStream in) throws IOException {
+        Reader r = new BufferedReader(new InputStreamReader(in));
+        return readFully(r);
+    }
+
+    public static String readFully(Reader r) throws IOException {
+        try (StringWriter w = new StringWriter()) {
+            copy(r, w);
+            return w.toString();
+        }
+    }
+
+
+    private static void copy(Reader reader, Writer writer) throws IOException {
+        char[] buffer = new char[8192];
+        int len;
+        for (; ; ) {
+            len = reader.read(buffer);
+            if (len > 0) {
+                writer.write(buffer, 0, len);
+            } else {
+                writer.flush();
+                break;
+            }
+        }
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ReplaceValueStream.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ReplaceValueStream.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.openshift.client.dsl.internal;
+package io.fabric8.kubernetes.client.utils;
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.utils.IOHelpers;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -211,7 +211,8 @@ public class Serialization {
    * @throws KubernetesClientException
    */
   public static <T> T unmarshal(InputStream is, TypeReference<T> type, Map<String, String> parameters) throws KubernetesClientException {
-    try (BufferedInputStream bis = new BufferedInputStream(is)) {
+    InputStream wrapped = parameters != null && !parameters.isEmpty() ? new ReplaceValueStream(parameters).createInputStream(is) : is;
+    try (BufferedInputStream bis = new BufferedInputStream(wrapped)) {
       bis.mark(-1);
       int intch;
       do {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -61,6 +61,10 @@ public class Serialization {
   }
 
   public static <T> T unmarshal(InputStream is) throws KubernetesClientException {
+    return unmarshal(is, JSON_MAPPER);
+  }
+
+  public static <T> T unmarshal(InputStream is, ObjectMapper mapper) {
     try (BufferedInputStream bis = new BufferedInputStream(is)) {
       bis.mark(-1);
       int intch;
@@ -69,7 +73,6 @@ public class Serialization {
       } while (intch > -1 && Character.isWhitespace(intch));
       bis.reset();
 
-      ObjectMapper mapper = JSON_MAPPER;
       if (intch != '{') {
         mapper = YAML_MAPPER;
       }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -62,11 +62,51 @@ public class Serialization {
     }
   }
 
+  /**
+   * Unmarshals a stream.
+   * @param is    The {@link InputStream}.
+   * @param <T>   The target type.
+   * @return
+   * @throws KubernetesClientException
+   */
   public static <T> T unmarshal(InputStream is) throws KubernetesClientException {
     return unmarshal(is, JSON_MAPPER);
   }
 
+  /**
+   * Unmarshals a stream optionally performing placeholder substitution to the stream.
+   * @param is    The {@link InputStream}.
+   * @param parameters  A {@link Map} with parameters for placeholder substitution.
+   * @param <T>   The target type.
+   * @return
+   * @throws KubernetesClientException
+   */
+  public static <T> T unmarshal(InputStream is, Map<String, String> parameters) throws KubernetesClientException {
+    return unmarshal(is, JSON_MAPPER, parameters);
+  }
+
+  /**
+   * Unmarshals a stream.
+   * @param is      The {@link InputStream}.
+   * @param mapper  The {@link ObjectMapper} to use.
+   * @param <T>     The target type.
+   * @return
+   * @throws KubernetesClientException
+   */
   public static <T> T unmarshal(InputStream is, ObjectMapper mapper) {
+   return unmarshal(is, mapper, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Unmarshals a stream optionally performing placeholder substitution to the stream.
+   * @param is          The {@link InputStream}.
+   * @param mapper      The {@link ObjectMapper} to use.
+   * @param parameters  A {@link Map} with parameters for placeholder substitution.
+   * @param <T>         The target type.
+   * @return
+   * @throws KubernetesClientException
+   */
+  public static <T> T unmarshal(InputStream is, ObjectMapper mapper, Map<String, String> parameters) {
     try (BufferedInputStream bis = new BufferedInputStream(is)) {
       bis.mark(-1);
       int intch;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -82,29 +84,93 @@ public class Serialization {
     }
   }
 
+  /**
+   * Unmarshals a {@link String}
+   * @param str   The {@link String}.
+   * @param type  The target type.
+   * @param <T>
+   * @return
+   * @throws KubernetesClientException
+   */
   public static <T> T unmarshal(String str, final Class<T> type) throws KubernetesClientException {
+    return unmarshal(str, type, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Unmarshals a {@link String} optionally performing placeholder substitution to the String.
+   * @param str   The {@link String}.
+   * @param type  The target type.
+   * @param <T>
+   * @return
+   * @throws KubernetesClientException
+     */
+  public static <T> T unmarshal(String str, final Class<T> type, Map<String, String> parameters) throws KubernetesClientException {
     try (InputStream is = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));) {
       return unmarshal(is, new TypeReference<T>() {
         @Override
         public Type getType() {
           return type;
         }
-      });
+      }, parameters);
     } catch (IOException e) {
       throw KubernetesClientException.launderThrowable(e);
     }
   }
 
+  /**
+   * Unmarshals an {@link InputStream}.
+   * @param is              The {@link InputStream}.
+   * @param type            The type.
+   * @param <T>
+   * @return
+   * @throws KubernetesClientException
+   */
   public static <T> T unmarshal(InputStream is, final Class<T> type) throws KubernetesClientException {
+    return unmarshal(is, type, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Unmarshals an {@link InputStream} optionally performing placeholder substitution to the stream.
+   * @param is              The {@link InputStream}.
+   * @param type            The type.
+   * @param parameters      A {@link Map} with parameters for placeholder substitution.
+   * @param <T>
+   * @return
+   * @throws KubernetesClientException
+   */
+  public static <T> T unmarshal(InputStream is, final Class<T> type, Map<String, String> parameters) throws KubernetesClientException {
     return unmarshal(is, new TypeReference<T>() {
       @Override
       public Type getType() {
         return type;
       }
-    });
+    }, parameters);
   }
 
+
+  /**
+   * Unmarshals an {@link InputStream}.
+   * @param is            The {@link InputStream}.
+   * @param type          The {@link TypeReference}.
+   * @param <T>
+   * @return
+   * @throws KubernetesClientException
+   */
   public static <T> T unmarshal(InputStream is, TypeReference<T> type) throws KubernetesClientException {
+   return unmarshal(is, type, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Unmarshals an {@link InputStream} optionally performing placeholder substitution to the stream.
+   *
+   * @param is            The {@link InputStream}.
+   * @param type          The {@link TypeReference}.
+   * @param parameters    A {@link Map} with parameters for placeholder substitution.
+   * @param <T>
+   * @return
+   * @throws KubernetesClientException
+   */
+  public static <T> T unmarshal(InputStream is, TypeReference<T> type, Map<String, String> parameters) throws KubernetesClientException {
     try (BufferedInputStream bis = new BufferedInputStream(is)) {
       bis.mark(-1);
       int intch;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +36,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 public class Utils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
+  private static final String ALL_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
 
   public static <T> T checkNotNull(T ref, String message) {
     if (ref == null) {
@@ -243,5 +245,25 @@ public class Utils {
           }
       }
       return text;
+  }
+
+  public static String randomString(int length) {
+    Random random = new Random();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < length; i++) {
+      int index = random.nextInt(ALL_CHARS.length());
+      sb.append(ALL_CHARS.charAt(index));
+    }
+    return sb.toString();
+  }
+
+  public static String randomString(String prefix, int length) {
+    Random random = new Random();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < length - prefix.length(); i++) {
+      int index = random.nextInt(ALL_CHARS.length());
+      sb.append(ALL_CHARS.charAt(index));
+    }
+    return sb.toString();
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -221,4 +221,27 @@ public class Utils {
   public static void closeQuietly(Closeable... closeables) {
     closeQuietly(Arrays.asList(closeables));
   }
+
+
+  /**
+   * Replaces all occurrencies of the from text with to text without any regular expressions
+   */
+  public static String replaceAllWithoutRegex(String text, String from, String to) {
+      if (text == null) {
+          return null;
+      }
+      int idx = 0;
+      while (true) {
+          idx = text.indexOf(from, idx);
+          if (idx >= 0) {
+              text = text.substring(0, idx) + to + text.substring(idx + from.length());
+
+              // lets start searching after the end of the `to` to avoid possible infinite recursion
+              idx += to.length();
+          } else {
+              break;
+          }
+      }
+      return text;
+  }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -16,18 +16,29 @@
 
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.client.utils.IOHelpers;
 import io.fabric8.openshift.api.model.Template;
 import io.fabric8.openshift.api.model.TemplateBuilder;
 import io.fabric8.openshift.api.model.TemplateList;
 import io.fabric8.openshift.api.model.TemplateListBuilder;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.ParameterValue;
-
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.fabric8.openshift.client.dsl.internal.ReplaceValueStream.replaceValues;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -118,5 +129,43 @@ public class TemplateTest {
     OpenShiftClient client = server.getOpenshiftClient();
     KubernetesList list = client.templates().withName("tmpl1").process(new ParameterValue("name1", "value1"));
     assertNotNull(list);
+  }
+
+  @Test
+  public void shouldLoadTemplateWithNumberParameters() throws Exception {
+    OpenShiftClient client = new DefaultOpenShiftClient();
+    Map<String,String> map = new HashMap<>();
+    map.put("PORT", "8080");
+    KubernetesList list = client.templates().load(replaceValues(getClass().getResourceAsStream("/template-with-number-params.yml"), map)).processLocally(map);
+    assertListIsServiceWithPort8080(list);
+  }
+
+  protected void assertListIsServiceWithPort8080(KubernetesList list) {
+    assertNotNull(list);
+    List<HasMetadata> items = list.getItems();
+    assertNotNull(items);
+    assertEquals(1, items.size());
+    HasMetadata item = items.get(0);
+    assertTrue(item instanceof Service);
+    Service service = (Service) item;
+    ServiceSpec serviceSpec = service.getSpec();
+    assertNotNull(serviceSpec);
+    List<ServicePort> ports = serviceSpec.getPorts();
+    assertEquals(1, ports.size());
+    ServicePort port = ports.get(0);
+    assertEquals(new Integer(8080), port.getPort());
+  }
+
+  @Test
+  public void testLoadParameterizedNumberTemplate() throws IOException {
+    String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-with-number-params.json"));
+    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
+
+    Map<String,String> map = new HashMap<>();
+    map.put("PORT", "8080");
+
+    OpenShiftClient client = server.getOpenshiftClient();
+    KubernetesList list = client.templates().withName("tmpl1").processLocally(map);
+    assertListIsServiceWithPort8080(list);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -168,7 +168,7 @@ public class TemplateTest {
     map.put("PORT", "8080");
 
     OpenShiftClient client = server.getOpenshiftClient();
-    Template template = client.templates().withName("tmpl1").replaceParameters(map).get();
+    Template template = client.templates().withName("tmpl1").get(map);
     List<HasMetadata> list = template.getObjects();
     assertListIsServiceWithPort8080(list);
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.fabric8.openshift.client.dsl.internal.ReplaceValueStream.replaceValues;
+import static io.fabric8.kubernetes.client.utils.ReplaceValueStream.replaceValues;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -75,6 +75,22 @@ public class TemplateTest {
     templateList = client.templates().inAnyNamespace().list();
     assertNotNull(templateList);
     assertEquals(3, templateList.getItems().size());
+  }
+
+  @Test
+  public void testListWithParams() throws IOException {
+    String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-list-with-number-params.json"));
+
+    server.expect().withPath("/oapi/v1/namespaces/test/templates").andReturn(200, json).always();
+
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    Map<String,String> map = new HashMap<>();
+    map.put("PORT", "8080");
+
+    TemplateList templateList = client.templates().withParameters(map).list();
+    assertNotNull(templateList);
+    assertEquals(1, templateList.getItems().size());
   }
 
 
@@ -168,7 +184,7 @@ public class TemplateTest {
     map.put("PORT", "8080");
 
     OpenShiftClient client = server.getOpenshiftClient();
-    Template template = client.templates().withName("tmpl1").get(map);
+    Template template = client.templates().withParameters(map).withName("tmpl1").get();
     List<HasMetadata> list = template.getObjects();
     assertListIsServiceWithPort8080(list);
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -142,7 +142,10 @@ public class TemplateTest {
 
   protected void assertListIsServiceWithPort8080(KubernetesList list) {
     assertNotNull(list);
-    List<HasMetadata> items = list.getItems();
+    assertListIsServiceWithPort8080(list.getItems());
+  }
+
+  protected static void assertListIsServiceWithPort8080(List<HasMetadata> items) {
     assertNotNull(items);
     assertEquals(1, items.size());
     HasMetadata item = items.get(0);
@@ -158,6 +161,20 @@ public class TemplateTest {
 
   @Test
   public void testLoadParameterizedNumberTemplate() throws IOException {
+    String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-with-number-params.json"));
+    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
+
+    Map<String,String> map = new HashMap<>();
+    map.put("PORT", "8080");
+
+    OpenShiftClient client = server.getOpenshiftClient();
+    Template template = client.templates().withName("tmpl1").replaceParameters(map).get();
+    List<HasMetadata> list = template.getObjects();
+    assertListIsServiceWithPort8080(list);
+  }
+
+  @Test
+  public void testProcessParameterizedNumberTemplate() throws IOException {
     String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-with-number-params.json"));
     server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
 

--- a/kubernetes-tests/src/test/resources/template-list-with-number-params.json
+++ b/kubernetes-tests/src/test/resources/template-list-with-number-params.json
@@ -1,0 +1,37 @@
+{
+  "apiVersion": "v1",
+  "kind": "TemplateList",
+  "items": [{
+    "apiVersion": "v1",
+    "kind": "Template",
+    "metadata": {
+      "name": "foo"
+    },
+    "parameters": [
+      {
+        "name": "PORT",
+        "value": 80
+      }
+    ],
+    "objects": [
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "name": "bar"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": "${PORT}"
+            }
+          ],
+          "selector": {
+            "cheese": "edam"
+          },
+          "type": "ExternalName"
+        }
+      }
+    ]
+  }]
+}

--- a/kubernetes-tests/src/test/resources/template-with-number-params.json
+++ b/kubernetes-tests/src/test/resources/template-with-number-params.json
@@ -1,0 +1,33 @@
+{
+  "apiVersion": "v1",
+  "kind": "Template",
+  "metadata": {
+    "name": "foo"
+  },
+  "parameters": [
+    {
+      "name": "PORT",
+      "value": 80
+    }
+  ],
+  "objects": [
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "bar"
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": "${PORT}"
+          }
+        ],
+        "selector": {
+          "cheese": "edam"
+        },
+        "type": "ExternalName"
+      }
+    }
+  ]
+}

--- a/kubernetes-tests/src/test/resources/template-with-number-params.yml
+++ b/kubernetes-tests/src/test/resources/template-with-number-params.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: foo
+parameters:
+- name: PORT
+  value: 80
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: bar
+  spec:
+    ports:
+    - port: ${PORT}
+    selector:
+      cheese: edam
+    type: ExternalName

--- a/kubernetes-tests/src/test/resources/template-with-number-params.yml
+++ b/kubernetes-tests/src/test/resources/template-with-number-params.yml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 apiVersion: v1
 kind: Template

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -24,8 +24,10 @@ import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.kubernetes.client.dsl.ParameterMixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.WithRequestCallable;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.dsl.BuildResource;
@@ -191,7 +193,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
     return delegate.load(is);
   }
 
@@ -221,7 +223,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
     return delegate.resourceList(s);
   }
 
@@ -386,7 +388,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates() {
+  public ParameterMixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates() {
     return new TemplateOperationsImpl(httpClient, OpenShiftConfig.wrap(getConfiguration()), getNamespace());
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ParameterMixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
@@ -130,7 +131,7 @@ public interface OpenShiftClient extends KubernetesClient {
 
   MixedOperation<Route, RouteList, DoneableRoute, Resource<Route, DoneableRoute>> routes();
 
-  MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates();
+  ParameterMixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates();
 
   NonNamespaceOperation<User, UserList, DoneableUser, Resource<User, DoneableUser>> users();
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
@@ -15,5 +15,16 @@
  */
 package io.fabric8.openshift.client.dsl;
 
+import java.util.Map;
+
 public interface TemplateResource<T, L, D> extends ProcessableResource<T, L, D> {
+
+  /**
+   * Returns a new template resource which replaces the given template parameter values so that the template can be
+   * loaded if the template contains parameterized expressions for numeric values on resources such as the Service
+   * port number or the Deployment replicas
+   *
+   * @param valuesMap a map of template parameter names to their values to be used in any expressions in the templates
+   */
+  TemplateResource<T, L, D> replaceParameters(Map<String, String> valuesMap);
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
@@ -15,16 +15,6 @@
  */
 package io.fabric8.openshift.client.dsl;
 
-import java.util.Map;
-
 public interface TemplateResource<T, L, D> extends ProcessableResource<T, L, D> {
 
-  /**
-   * Returns a new {@link io.fabric8.openshift.api.model.Template} which replaces the given template parameter values so that the template can be
-   * loaded if the template contains parameterized expressions for numeric values on resources such as the Service
-   * port number or the Deployment replicas
-   *
-   * @param valuesMap a map of template parameter names to their values to be used in any expressions in the templates
-   */
-  T get(Map<String, String> valuesMap);
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/TemplateResource.java
@@ -20,11 +20,11 @@ import java.util.Map;
 public interface TemplateResource<T, L, D> extends ProcessableResource<T, L, D> {
 
   /**
-   * Returns a new template resource which replaces the given template parameter values so that the template can be
+   * Returns a new {@link io.fabric8.openshift.api.model.Template} which replaces the given template parameter values so that the template can be
    * loaded if the template contains parameterized expressions for numeric values on resources such as the Service
    * port number or the Deployment replicas
    *
    * @param valuesMap a map of template parameter names to their values to be used in any expressions in the templates
    */
-  TemplateResource<T, L, D> replaceParameters(Map<String, String> valuesMap);
+  T get(Map<String, String> valuesMap);
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ReplaceValueStream.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ReplaceValueStream.java
@@ -1,13 +1,12 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ReplaceValueStream.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ReplaceValueStream.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.dsl.internal;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.IOHelpers;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static io.fabric8.kubernetes.client.utils.Utils.replaceAllWithoutRegex;
+
+/**
+ * Replaces template parameter values in the stream to avoid
+ * parsing issues of templates with numeric expressions
+ */
+public class ReplaceValueStream {
+    private final Map<String, String> valuesMap;
+
+    /**
+     * Returns a stream with the template parameter expressions replaced
+     */
+    public static InputStream replaceValues(InputStream is, Map<String, String> valuesMap) {
+        return new ReplaceValueStream(valuesMap).createInputStream(is);
+    }
+
+    public ReplaceValueStream(Map<String, String> valuesMap) {
+        this.valuesMap = valuesMap;
+    }
+
+    public InputStream createInputStream(InputStream is) {
+        try {
+            String json = IOHelpers.readFully(is);
+            String replaced = replaceValues(json);
+            return new ByteArrayInputStream(replaced.getBytes());
+        } catch (IOException e) {
+          throw KubernetesClientException.launderThrowable(e);
+        }
+    }
+
+    private String replaceValues(String json) {
+        String answer = json;
+        for (Map.Entry<String, String> entry : valuesMap.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            answer = replaceAllWithoutRegex(answer, "${" + key + "}", value);
+        }
+        return answer;
+    }
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/TemplateOperationsImpl.java
@@ -148,14 +148,13 @@ public class TemplateOperationsImpl
     return processLocally(valuesMap);
   }
 
-  public TemplateResource<Template, KubernetesList, DoneableTemplate> replaceParameters(Map<String, String> valuesMap) {
+  public Template get(Map<String, String> valuesMap) {
     return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), getAPIVersion(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(),
-      getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), new ReplaceValueStream(valuesMap));
+      getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), new ReplaceValueStream(valuesMap)).get();
   }
 
   public KubernetesList processLocally(Map<String, String> valuesMap)  {
-    TemplateResource<Template, KubernetesList, DoneableTemplate> resource = replaceParameters(valuesMap);
-    Template t = resource.get();
+    Template t = get(valuesMap);
 
     List<Parameter> parameters = t != null ? t.getParameters() : null;
     KubernetesList list = new KubernetesListBuilder()
@@ -246,7 +245,4 @@ public class TemplateOperationsImpl
     }
     return unmarshal(is);
   }
-
-  
-
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/TemplateHandler.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/TemplateHandler.java
@@ -41,17 +41,17 @@ public class TemplateHandler implements ResourceHandler<Template, TemplateBuilde
 
   @Override
   public Template create(OkHttpClient client, Config config, String namespace, Template item) {
-      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).create();
+      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).create();
   }
 
   @Override
   public Template replace(OkHttpClient client, Config config, String namespace, Template item) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, true, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).replace(item);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, true, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).replace(item);
   }
 
   @Override
   public Template reload(OkHttpClient client, Config config, String namespace, Template item) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).fromServer().get();
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).fromServer().get();
   }
 
   @Override
@@ -62,21 +62,21 @@ public class TemplateHandler implements ResourceHandler<Template, TemplateBuilde
 
   @Override
   public Boolean delete(OkHttpClient client, Config config, String namespace, Template item) {
-      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).delete(item);
+      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).delete(item);
   }
 
   @Override
   public Watch watch(OkHttpClient client, Config config, String namespace, Template item, Watcher<Template> watcher) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).watch(watcher);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).watch(watcher);
   }
 
   @Override
   public Watch watch(OkHttpClient client, Config config, String namespace, Template item, String resourceVersion, Watcher<Template> watcher) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).watch(resourceVersion, watcher);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).watch(resourceVersion, watcher);
   }
 
   @Override
   public Template waitUntilReady(OkHttpClient client, Config config, String namespace, Template item, long amount, TimeUnit timeUnit) throws InterruptedException {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).waitUntilReady(amount, timeUnit);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).waitUntilReady(amount, timeUnit);
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -74,6 +74,8 @@ import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ParameterMixedOperation;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
@@ -373,7 +375,7 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public MixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates() {
+  public ParameterMixedOperation<Template, TemplateList, DoneableTemplate, TemplateResource<Template, KubernetesList, DoneableTemplate>> templates() {
     return delegate.templates();
   }
 
@@ -393,7 +395,7 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
     return delegate.load(is);
   }
 
@@ -413,7 +415,7 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
+  public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
     return delegate.resourceList(s);
   }
 


### PR DESCRIPTION
now the processLocal(map) allows the numeric parameters to be replaced so that the template can be properly loaded providing the numeric properties are in the supplied map