### PR TITLE
Upgrade to latest OKHttp client and related bundle 3.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
     <mockwebserver.version>0.0.12</mockwebserver.version>
     <okhttp.version>3.7.0</okhttp.version>
     <okhttp.bundle.version>3.7.0_1</okhttp.bundle.version>
-    <okio.version>1.11.0</okio.version>
-    <okio.bundle.version>1.11.0_1</okio.bundle.version>
+    <okio.version>1.12.0</okio.version>
+    <okio.bundle.version>1.12.0_1</okio.bundle.version>
     <generex.version>1.0.1</generex.version>
     <generex.bundle.version>1.0.1_1</generex.bundle.version>
     <automaton.version>1.11-8</automaton.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockwebserver.version>0.0.12</mockwebserver.version>
-    <okhttp.version>3.6.0</okhttp.version>
-    <okhttp.bundle.version>3.6.0_1</okhttp.bundle.version>
+    <okhttp.version>3.7.0</okhttp.version>
+    <okhttp.bundle.version>3.7.0_1</okhttp.bundle.version>
     <okio.version>1.11.0</okio.version>
     <okio.bundle.version>1.11.0_1</okio.bundle.version>
     <generex.version>1.0.1</generex.version>


### PR DESCRIPTION
Now that we have the 3.7.0 bundle too we can upgrade.