### PR TITLE
Fixes #767: adding lock replace

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Lockable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Lockable.java
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.fabric8.kubernetes.client.dsl;
 
-public interface CascadingEditReplacePatchDeletable<I,D,T,B> extends
-  EditReplacePatchDeletable<I,D,T,B>,
-  Cascading<EditReplacePatchDeletable<I,D,T,B>>,
-  Lockable<Replaceable<I, I>> {
+public interface Lockable<T> {
+
+  T lockResourceVersion(String resourceVersion);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
 import io.fabric8.kubernetes.client.OperationInfo;
+import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.internal.DefaultOperationInfo;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
@@ -247,6 +248,17 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
       return (R) getClass()
         .getConstructor(OkHttpClient.class, getConfigType(), String.class, String.class, String.class, Boolean.class, getType(), String.class, Boolean.class, long.class, Map.class, Map.class, Map.class, Map.class, Map.class)
         .newInstance(client, getConfig(), getAPIVersion(), getNamespace(), name, isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields());
+    } catch (Throwable t) {
+      throw KubernetesClientException.launderThrowable(t);
+    }
+  }
+
+  @Override
+  public Replaceable<T, T> lockResourceVersion(String resourceVersion) {
+    try {
+      return getClass()
+        .getConstructor(OkHttpClient.class, getConfigType(), String.class, String.class, String.class, Boolean.class, getType(), String.class, Boolean.class, long.class, Map.class, Map.class, Map.class, Map.class, Map.class)
+        .newInstance(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), getItem(), resourceVersion, isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields());
     } catch (Throwable t) {
       throw KubernetesClientException.launderThrowable(t);
     }


### PR DESCRIPTION
Adding a `.lockResourceVersion("...")` to replace to perform optimistic locking.