### PR TITLE
OSFUSE-490: Add capability to override Jackson bundle version

### DIFF
--- a/platforms/karaf/features/src/main/resources/feature.xml
+++ b/platforms/karaf/features/src/main/resources/feature.xml
@@ -19,10 +19,10 @@
 
   <feature name="kubernetes-client" description="Fabric8 Kubernetes Client" version="${project.version}">
     <bundle dependency='true'>mvn:javax.validation/validation-api/${validation.api.version}</bundle>
-    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
-    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
-    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
-    <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson.version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.generex/${generex.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.automaton/${automaton.bundle.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <automaton.version>1.11-8</automaton.version>
     <automaton.bundle.version>1.11-8_1</automaton.bundle.version>
     <jackson.version>2.7.7</jackson.version>
+    <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
     <junit.version>4.12</junit.version>
     <kubernetes.model.version>1.0.73</kubernetes.model.version>
     <log4j.version>2.5</log4j.version>


### PR DESCRIPTION
Syncing back from RH FIS 2.0 branch:

https://issues.jboss.org/browse/OSFUSE-490