### PR TITLE
Fix HPA adapter

### DIFF
--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
@@ -16,3 +16,4 @@
 
 io.fabric8.kubernetes.client.AppsAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.ExtensionsAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.AutoscalingAPIGroupExtensionAdapter


### PR DESCRIPTION
I'm seeing an exception when trying to use the new HPA endpoint with an adapted client:

```
java.lang.IllegalStateException: No adapter available for type:class io.fabric8.kubernetes.client.AutoscalingAPIGroupClient
	at io.fabric8.kubernetes.client.BaseClient.adapt(BaseClient.java:133)
	at io.fabric8.kubernetes.client.DefaultKubernetesClient.autoscaling(DefaultKubernetesClient.java:293)
	at io.fabric8.kubernetes.client.KubernetesClient$autoscaling$6.call(Unknown Source)
	at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor$_getAutoscalers_closure47.doCall(KubernetesApiAdaptor.groovy:434)
	at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor$_getAutoscalers_closure47.doCall(KubernetesApiAdaptor.groovy)
	at sun.reflect.GeneratedMethodAccessor2645.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:57)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117)
	at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor.exceptionWrapper(KubernetesApiAdaptor.groovy:97)
	at sun.reflect.GeneratedMethodAccessor97.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:190)
	at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor.getAutoscalers(KubernetesApiAdaptor.groovy:433)
	at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor$getAutoscalers$10.call(Unknown Source)
	at com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent$_buildCacheResult_closure22.doCall(KubernetesServerGroupCachingAgent.groovy:295)
	at sun.reflect.GeneratedMethodAccessor2644.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
	at groovy.lang.Closure.call(Closure.java:414)
	at groovy.lang.Closure.call(Closure.java:430)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2030)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2015)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2056)
	at org.codehaus.groovy.runtime.dgm$162.invoke(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:274)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent.buildCacheResult(KubernetesServerGroupCachingAgent.groovy:294)
	at sun.reflect.GeneratedMethodAccessor2643.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:190)
	at com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent.loadData(KubernetesServerGroupCachingAgent.groovy:242)
	at com.netflix.spinnaker.cats.agent.CachingAgent$CacheExecution.executeAgentWithoutStore(CachingAgent.java:66)
	at com.netflix.spinnaker.cats.agent.CachingAgent$CacheExecution.executeAgent(CachingAgent.java:59)
	at com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler$AgentExecutionAction.execute(ClusteredAgentScheduler.java:193)
	at com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler$AgentJob.run(ClusteredAgentScheduler.java:167)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

I believe this should address the issue.