### PR TITLE
Remove generation check from RollableScalableResourceOperation

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
@@ -144,9 +144,4 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
     return item.getSpec().getReplicas();
   }
 
-  @Override
-  long getObservedGeneration(ReplicaSet current) {
-    return (current != null && current.getStatus() != null
-      && current.getStatus().getObservedGeneration() != null)? current.getStatus().getObservedGeneration() : -1;
-  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
@@ -101,12 +101,6 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   }
 
   @Override
-  long getObservedGeneration(ReplicationController current) {
-    return (current != null && current.getStatus() != null
-      && current.getStatus().getObservedGeneration() != null) ? current.getStatus().getObservedGeneration() : -1;
-  }
-
-  @Override
   public RollableScalableResource<ReplicationController, DoneableReplicationController> withName(String name) {
     if (name == null || name.length() == 0) {
       throw new IllegalArgumentException("Name must be provided.");

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
@@ -65,7 +65,6 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
   // There are no common interfaces through which we could get these values.
   abstract int getCurrentReplicas(T current);
   abstract int getDesiredReplicas(T item);
-  abstract long getObservedGeneration(T current);
 
   @Override
   public T scale(int count) {
@@ -118,9 +117,7 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
           int currentReplicas = getCurrentReplicas(t);
           int desiredReplicas = getDesiredReplicas(t);
           replicasRef.set(currentReplicas);
-          long generation = t.getMetadata().getGeneration() != null ? t.getMetadata().getGeneration() : -1;
-          long observedGeneration = getObservedGeneration(t);
-          if (observedGeneration >= generation && Objects.equals(desiredReplicas, currentReplicas)) {
+          if (Objects.equals(desiredReplicas, currentReplicas)) {
             queue.put(true);
           }
           Log.debug("Only {}/{} replicas scheduled for {}: {} in namespace: {} seconds so waiting...",

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -117,7 +116,7 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
           int currentReplicas = getCurrentReplicas(t);
           int desiredReplicas = getDesiredReplicas(t);
           replicasRef.set(currentReplicas);
-          if (Objects.equals(desiredReplicas, currentReplicas)) {
+          if (desiredReplicas == currentReplicas) {
             queue.put(true);
           }
           Log.debug("Only {}/{} replicas scheduled for {}: {} in namespace: {} seconds so waiting...",

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
@@ -84,12 +84,6 @@ public class StatefulSetOperationsImpl extends RollableScalableResourceOperation
   }
 
   @Override
-  long getObservedGeneration(StatefulSet current) {
-    return (current != null && current.getStatus() != null && current.getStatus().getObservedGeneration() != null)
-      ? current.getStatus().getObservedGeneration() : -1;
-  }
-
-  @Override
   public RollableScalableResource<StatefulSet, DoneableStatefulSet> withName(String name) {
     if (name == null || name.length() == 0) {
       throw new IllegalArgumentException("Name must be provided.");


### PR DESCRIPTION
[Generation](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L107-L110) and [ObservedGeneration](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L2454-L2456) are both optional, and as seen in https://github.com/fabric8io/kubernetes-client/issues/762, some versions of k8s may leave those fields unpopulated, causing a scale operation to hang forever. The scale-only operation shouldn't care about the generation anyway– if the current status has the correct number of replicas, the scale operation is complete.