### PR TITLE
Fix watcher resourceVersion problem with 3.6

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -130,11 +130,11 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
       }
     }
 
-    httpUrlBuilder.addQueryParameter("watch", "true");
-
     if (this.resourceVersion.get() != null) {
       httpUrlBuilder.addQueryParameter("resourceVersion", this.resourceVersion.get());
     }
+
+    httpUrlBuilder.addQueryParameter("watch", "true");
 
     Request request = new Request.Builder()
       .get()

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -82,12 +82,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   private OkHttpClient clonedClient;
 
   public WatchConnectionManager(final OkHttpClient client, final BaseOperation<T, L, ?, ?> baseOperation, final String version, final Watcher<T> watcher, final int reconnectInterval, final int reconnectLimit, long websocketTimeout) throws MalformedURLException {
-    if (version == null) {
-      L currentList = baseOperation.list();
-      this.resourceVersion = new AtomicReference<>(currentList.getMetadata().getResourceVersion());
-    } else {
-      this.resourceVersion = new AtomicReference<>(version);
-    }
+    this.resourceVersion = new AtomicReference<>(version); // may be a reference to null
     this.baseOperation = baseOperation;
     this.watcher = watcher;
     this.reconnectInterval = reconnectInterval;
@@ -135,9 +130,11 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
       }
     }
 
-    httpUrlBuilder
-      .addQueryParameter("resourceVersion", this.resourceVersion.get())
-      .addQueryParameter("watch", "true");
+    httpUrlBuilder.addQueryParameter("watch", "true");
+
+    if (this.resourceVersion.get() != null) {
+      httpUrlBuilder.addQueryParameter("resourceVersion", this.resourceVersion.get());
+    }
 
     Request request = new Request.Builder()
       .get()
@@ -223,7 +220,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
             // Dirty cast - should always be valid though
             String currentResourceVersion = resourceVersion.get();
             String newResourceVersion = ((HasMetadata) obj).getMetadata().getResourceVersion();
-            if (currentResourceVersion.compareTo(newResourceVersion) < 0) {
+            if (currentResourceVersion == null || currentResourceVersion.compareTo(newResourceVersion) < 0) {
               resourceVersion.compareAndSet(currentResourceVersion, newResourceVersion);
             }
             Watcher.Action action = Watcher.Action.valueOf(event.getType());
@@ -235,7 +232,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
             // Dirty cast - should always be valid though
             String currentResourceVersion = resourceVersion.get();
             String newResourceVersion = list.getMetadata().getResourceVersion();
-            if (currentResourceVersion.compareTo(newResourceVersion) < 0) {
+            if (currentResourceVersion == null || currentResourceVersion.compareTo(newResourceVersion) < 0) {
               resourceVersion.compareAndSet(currentResourceVersion, newResourceVersion);
             }
             Watcher.Action action = Watcher.Action.valueOf(event.getType());

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -133,11 +133,11 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
       httpUrlBuilder.addQueryParameter("fieldSelector", fieldQueryString);
     }
 
-    httpUrlBuilder.addQueryParameter("watch", "true");
-
     if (this.resourceVersion.get() != null) {
       httpUrlBuilder.addQueryParameter("resourceVersion", this.resourceVersion.get());
     }
+
+    httpUrlBuilder.addQueryParameter("watch", "true");
 
     final Request request = new Request.Builder()
       .get()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -268,7 +268,7 @@ public class PodTest {
             .build()
     ).once();
 
-   server.expect().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+   server.expect().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true")
             .andUpgradeToWebSocket()
             .open()
             .waitFor(15000).andEmit(new WatchEvent(pod1, "DELETED"))
@@ -350,7 +350,7 @@ public class PodTest {
       .endMetadata()
       .withItems(notReady).build()).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
       .open()
       .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
       .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -98,7 +98,7 @@ public class ResourceTest {
       server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pod1).once();
       server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, pod1).once();
 
-     server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
+     server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
         .open()
           .waitFor(1000).andEmit(new WatchEvent(pod1, "DELETED"))
         .done()
@@ -149,7 +149,7 @@ public class ResourceTest {
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, noReady).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
       .open()
       .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
       .done()
@@ -187,7 +187,7 @@ public class ResourceTest {
     server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, noReady).once();
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, noReady).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
       .open()
       .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
       .done()


### PR DESCRIPTION
This should fix #852 by not using a resource version on the first call.

Since old versions of kubernetes, if you don't provide a resource version, [the watch starts from the latest observed state](https://github.com/kubernetes/kubernetes/blob/v1.4.2/pkg/storage/watch_cache.go#L292-L296), so there's no need to do a lookup before starting the watch.

Tested with Openshift origin 1.5 and 3.6.