### PR TITLE
Allow to use non default context

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -198,7 +198,6 @@ public class ConfigTest {
 
   @Test
   public void testWithKubeConfig() {
-
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE);
     Config config = new Config();
     assertNotNull(config);
@@ -206,6 +205,19 @@ public class ConfigTest {
     assertEquals("https://172.28.128.4:8443/", config.getMasterUrl());
     assertEquals("testns", config.getNamespace());
     assertEquals("token", config.getOauthToken());
+    assertTrue(config.getCaCertFile().endsWith("testns/ca.pem"));
+    assertTrue(new File(config.getCaCertFile()).isAbsolute());
+  }
+
+  @Test
+  public void testWithKubeConfigAndOverrideContext() {
+    System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE);
+    Config config = Config.autoConfigure("production/172-28-128-4:8443/root");
+    assertNotNull(config);
+
+    assertEquals("https://172.28.128.4:8443/", config.getMasterUrl());
+    assertEquals("production", config.getNamespace());
+    assertEquals("supertoken", config.getOauthToken());
     assertTrue(config.getCaCertFile().endsWith("testns/ca.pem"));
     assertTrue(new File(config.getCaCertFile()).isAbsolute());
   }

--- a/kubernetes-client/src/test/resources/test-kubeconfig
+++ b/kubernetes-client/src/test/resources/test-kubeconfig
@@ -11,6 +11,11 @@ contexts:
     namespace: testns
     user: user/172-28-128-4:8443
   name: testns/172-28-128-4:8443/user
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: production
+    user: root/172-28-128-4:8443
+  name: production/172-28-128-4:8443/root
 current-context: testns/172-28-128-4:8443/user
 kind: Config
 preferences: {}
@@ -18,3 +23,6 @@ users:
 - name: user/172-28-128-4:8443
   user:
     token: token
+- name: root/172-28-128-4:8443
+  user:
+    token: supertoken


### PR DESCRIPTION
In my case I'm trying to manage clusters in my Kubernetes Federation.  When you have a federation you end up with a context per each cluster as well as federation context to apply things across clusters. 

But some things like `StatefulSet` doesn't have a federation equivalent and therefore you can't apply them to the "global" context. For such things it will be useful to be able to configure each one of them per cluster in a federation. And in order to do this it will be nice to be able to configure context for a config.

This PR adds this ability to specify which context to try to create configuration from.

## Testing 

 Added a test. `mvn test` passes.