### PR TITLE
first spike at a mechanism to support using CRDs

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
  * A base class for implementing a custom resource kind
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
-public abstract class CustomResourceSupport implements HasMetadata {
+public abstract class CustomResource implements HasMetadata {
   private String kind = "Dummy";
   private String apiVersion;
   private ObjectMeta metadata;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
@@ -21,7 +21,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 
 /**
  */
-public class CustomResourceDoneable<T extends HasMetadata> implements Doneable<T> {
+public class CustomResourceDoneable<T extends CustomResource> implements Doneable<T> {
   private final T resource;
   private final Function<T,T> function;
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+/**
+ */
+public class CustomResourceDoneable<T extends HasMetadata> implements Doneable<T> {
+  private final T resource;
+  private final Function<T,T> function;
+
+  public CustomResourceDoneable(T resource, Function<T,T> function) {
+    this.resource = resource;
+    this.function = function;
+  }
+
+  @Override
+  public T done() {
+    return function.apply(resource);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ListMeta;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+public class CustomResourceList<T extends HasMetadata> implements KubernetesResource, KubernetesResourceList {
+
+  @NotNull
+  @JsonProperty("apiVersion")
+  private String apiVersion;
+  @JsonProperty("items")
+  @Valid
+  private List<T> items = new ArrayList<T>();
+  @NotNull
+  @JsonProperty("kind")
+  private String kind;
+  @JsonProperty("metadata")
+  @Valid
+  private ListMeta metadata;
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  @Override
+  public List<T> getItems() {
+    return items;
+  }
+
+  public void setItems(List<T> items) {
+    this.items = items;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  @Override
+  public ListMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(ListMeta metadata) {
+    this.metadata = metadata;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceSupport.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceSupport.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+/**
+ * A base class for implementing a custom resource kind
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+public abstract class CustomResourceSupport implements HasMetadata {
+  private String kind = "Dummy";
+  private String apiVersion;
+  private ObjectMeta metadata;
+
+  @Override
+  public String toString() {
+    return "CustomResourceSupport{" +
+        "kind='" + kind + '\'' +
+        ", apiVersion='" + apiVersion + '\'' +
+        ", metadata=" + metadata +
+        '}';
+  }
+
+  @Override
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  @Override
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  @Override
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  @Override
+  public ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public void setMetadata(ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -16,57 +16,7 @@
 package io.fabric8.kubernetes.client;
 
 import io.fabric8.kubernetes.api.builder.Visitor;
-import io.fabric8.kubernetes.api.model.ComponentStatus;
-import io.fabric8.kubernetes.api.model.ComponentStatusList;
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapList;
-import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
-import io.fabric8.kubernetes.api.model.DoneableConfigMap;
-import io.fabric8.kubernetes.api.model.DoneableEndpoints;
-import io.fabric8.kubernetes.api.model.DoneableEvent;
-import io.fabric8.kubernetes.api.model.DoneableLimitRange;
-import io.fabric8.kubernetes.api.model.DoneableNamespace;
-import io.fabric8.kubernetes.api.model.DoneableNode;
-import io.fabric8.kubernetes.api.model.DoneablePersistentVolume;
-import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.DoneablePod;
-import io.fabric8.kubernetes.api.model.DoneableReplicationController;
-import io.fabric8.kubernetes.api.model.DoneableResourceQuota;
-import io.fabric8.kubernetes.api.model.DoneableSecret;
-import io.fabric8.openshift.api.model.DoneableSecurityContextConstraints;
-import io.fabric8.kubernetes.api.model.DoneableService;
-import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-import io.fabric8.kubernetes.api.model.Endpoints;
-import io.fabric8.kubernetes.api.model.EndpointsList;
-import io.fabric8.kubernetes.api.model.Event;
-import io.fabric8.kubernetes.api.model.EventList;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.LimitRange;
-import io.fabric8.kubernetes.api.model.LimitRangeList;
-import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceList;
-import io.fabric8.kubernetes.api.model.Node;
-import io.fabric8.kubernetes.api.model.NodeList;
-import io.fabric8.kubernetes.api.model.PersistentVolume;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
-import io.fabric8.kubernetes.api.model.PersistentVolumeList;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.ReplicationControllerList;
-import io.fabric8.kubernetes.api.model.ResourceQuota;
-import io.fabric8.kubernetes.api.model.ResourceQuotaList;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretList;
-import io.fabric8.openshift.api.model.SecurityContextConstraints;
-import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.api.model.ServiceAccountList;
-import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefinition;
@@ -86,6 +36,7 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.internal.ComponentStatusOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.ConfigMapOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.CustomResourceDefinitionOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.EndpointsOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.EventOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.KubernetesListOperationsImpl;
@@ -104,12 +55,14 @@ import io.fabric8.kubernetes.client.dsl.internal.SecurityContextConstraintsOpera
 import io.fabric8.kubernetes.client.dsl.internal.ServiceAccountOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.ServiceOperationsImpl;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.openshift.api.model.DoneableSecurityContextConstraints;
+import io.fabric8.openshift.api.model.SecurityContextConstraints;
+import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
 import okhttp3.OkHttpClient;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 
 public class DefaultKubernetesClient extends BaseClient implements NamespacedKubernetesClient {
 
@@ -269,6 +222,10 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     return new CustomResourceDefinitionOperationsImpl(httpClient, getConfiguration());
   }
 
+  @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResource(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return new CustomResourceOperationsImpl<T,L,D>(httpClient, getConfiguration(), crd, resourceType, listClass, doneClass);
+  }
 
   @Override
   public NamespacedKubernetesClient inNamespace(String namespace)

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -16,56 +16,10 @@
 
 package io.fabric8.kubernetes.client;
 
-import io.fabric8.kubernetes.api.model.ComponentStatus;
-import io.fabric8.kubernetes.api.model.ComponentStatusList;
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapList;
-import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
-import io.fabric8.kubernetes.api.model.DoneableConfigMap;
-import io.fabric8.kubernetes.api.model.DoneableEndpoints;
-import io.fabric8.kubernetes.api.model.DoneableEvent;
-import io.fabric8.kubernetes.api.model.DoneableLimitRange;
-import io.fabric8.kubernetes.api.model.DoneableNamespace;
-import io.fabric8.kubernetes.api.model.DoneableNode;
-import io.fabric8.kubernetes.api.model.DoneablePersistentVolume;
-import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.DoneablePod;
-import io.fabric8.kubernetes.api.model.DoneableReplicationController;
-import io.fabric8.kubernetes.api.model.DoneableResourceQuota;
-import io.fabric8.kubernetes.api.model.DoneableSecret;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.openshift.api.model.DoneableSecurityContextConstraints;
-import io.fabric8.kubernetes.api.model.DoneableService;
-import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-import io.fabric8.kubernetes.api.model.Endpoints;
-import io.fabric8.kubernetes.api.model.EndpointsList;
-import io.fabric8.kubernetes.api.model.Event;
-import io.fabric8.kubernetes.api.model.EventList;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.LimitRange;
-import io.fabric8.kubernetes.api.model.LimitRangeList;
-import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceList;
-import io.fabric8.kubernetes.api.model.Node;
-import io.fabric8.kubernetes.api.model.NodeList;
-import io.fabric8.kubernetes.api.model.PersistentVolume;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
-import io.fabric8.kubernetes.api.model.PersistentVolumeList;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.ReplicationControllerList;
-import io.fabric8.kubernetes.api.model.ResourceQuota;
-import io.fabric8.kubernetes.api.model.ResourceQuotaList;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.openshift.api.model.SecurityContextConstraints;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.api.model.ServiceAccountList;
-import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefinition;
@@ -88,6 +42,8 @@ import java.util.Collection;
 public interface KubernetesClient extends Client {
 
   NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> customResourceDefinitions();
+
+  <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResource(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass);
 
   ExtensionsAPIGroupDSL extensions();
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -658,9 +658,7 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
         updateApiVersionResource(item);
 
         try {
-          R op = (R) getClass()
-            .getConstructor(OkHttpClient.class, getConfigType(), String.class, String.class, String.class, Boolean.class, getType(), String.class, Boolean.class, long.class, Map.class, Map.class, Map.class, Map.class, Map.class)
-            .newInstance(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), item, getResourceVersion(), true, getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields());
+          R op = createItemOperation(item);
           deleted &= op.delete();
         } catch (KubernetesClientException e) {
           if (e.getCode() != 404) {
@@ -673,6 +671,12 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
       }
     }
     return deleted;
+  }
+
+  protected R createItemOperation(T item) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    return (R) getClass()
+              .getConstructor(OkHttpClient.class, getConfigType(), String.class, String.class, String.class, Boolean.class, getType(), String.class, Boolean.class, long.class, Map.class, Map.class, Map.class, Map.class, Map.class)
+              .newInstance(client, getConfig(), getAPIVersion(), getNamespace(), getName(), isCascading(), item, getResourceVersion(), true, getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields());
   }
 
   void deleteThis() throws KubernetesClientException {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -41,6 +41,10 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
     super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
   }
 
+  public HasMetadataOperation(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
+    super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, type, listType, doneableType);
+  }
+
   @Override
   public D edit() throws KubernetesClientException {
     final Function<T, T> visitor = new Function<T, T>() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.Gettable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Replaceable;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import okhttp3.OkHttpClient;
+
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ */
+public class CustomResourceOperationsImpl<T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> extends HasMetadataOperation<T, L, D,
+    Resource<T, D>> implements MixedOperation<T, L, D, Resource<T, D>> {
+
+  public CustomResourceOperationsImpl(OkHttpClient httpClient, Config configuration, CustomResourceDefinition crd, Class<T> resourceType, Class<L> resourceListType, Class<D> doneType) {
+    this(httpClient, configuration, apiGroup(crd), apiVersion(crd), resourceT(crd), null, null, false, null, null, false, resourceType, resourceListType, doneType);
+  }
+
+  public CustomResourceOperationsImpl(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
+    super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, type, listType, doneableType);
+    this.apiGroupVersion = getAPIGroup() + "/" + getAPIVersion();
+  }
+
+  protected static String apiGroup(CustomResourceDefinition crd) {
+    return crd.getSpec().getGroup();
+  }
+
+  protected static String apiVersion(CustomResourceDefinition crd) {
+    return crd.getSpec().getVersion();
+  }
+
+  protected static String resourceT(CustomResourceDefinition crd) {
+    return crd.getSpec().getNames().getPlural();
+  }
+
+  protected static String name(CustomResourceDefinition crd) {
+    return crd.getMetadata().getName();
+  }
+
+  @Override
+  public NonNamespaceOperation<T, L, D, Resource<T, D>> inAnyNamespace() {
+    return inNamespace(null);
+  }
+
+  @Override
+  public NonNamespaceOperation<T, L, D, Resource<T, D>> inNamespace(String namespace) {
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), namespace, getName(), isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getType(), getListType(), getDoneableType());
+  }
+
+  @Override
+  public Resource<T, D> withName(String name) {
+    if (name == null || name.length() == 0) {
+      throw new IllegalArgumentException("Name must be provided.");
+    }
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), name, isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getType(), getListType(), getDoneableType());
+  }
+
+  @Override
+  public Replaceable<T, T> lockResourceVersion(String resourceVersion) {
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), getName(), isCascading(), getItem(), resourceVersion, isReloadingFromServer(), getType(), getListType(), getDoneableType());
+  }
+
+  @Override
+  protected Resource<T, D> createItemOperation(T item) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), getName(), isCascading(), item, getResourceVersion(), isReloadingFromServer(), getType(), getListType(), getDoneableType());
+  }
+
+  @Override
+  public Resource<T, D> load(InputStream is) {
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), getName(), isCascading(), unmarshal(is, getType()), getResourceVersion(), isReloadingFromServer(), getType(), getListType(), getDoneableType());
+  }
+
+  @Override
+  public Gettable<T> fromServer() {
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), getName(), isCascading(), getItem(), getResourceVersion(), true, getType(), getListType(), getDoneableType());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.client.Adapters;
 import io.fabric8.kubernetes.client.BaseClient;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.ExtensionAdapter;
 import io.fabric8.kubernetes.client.Handlers;
@@ -295,6 +296,11 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> customResourceDefinitions() {
     return delegate.customResourceDefinitions();
+  }
+
+  @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResource(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return delegate.customResource(crd, resourceType, listClass, doneClass);
   }
 
   @Override

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Red Hat, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.examples;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.RootPaths;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.examples.crds.DoneableDummy;
+import io.fabric8.kubernetes.examples.crds.Dummy;
+import io.fabric8.kubernetes.examples.crds.DummyList;
+import io.fabric8.kubernetes.examples.crds.DummySpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.List;
+
+public class CRDExample {
+
+  private static final Logger logger = LoggerFactory.getLogger(CRDExample.class);
+
+  public static String DUMMY_CRD_GROUP = "demo.fabric8.io";
+  public static String DUMMY_CRD_NAME = "dummies." +  DUMMY_CRD_GROUP;
+
+  private static boolean logRootPaths = false;
+
+  public static void main(String[] args) {
+    String namespace = null;
+    if (args.length > 0) {
+      namespace = args[0];
+    }
+    try (final KubernetesClient client = new DefaultKubernetesClient()) {
+      if (namespace == null) {
+        namespace = client.getNamespace();
+      }
+      if (namespace == null) {
+        System.err.println("No namespace specified and no default defined!");
+        return;
+      }
+
+      System.out.println("Using namespace: " + namespace);
+
+      if (logRootPaths) {
+        RootPaths rootPaths = client.rootPaths();
+        if (rootPaths != null) {
+          List<String> paths = rootPaths.getPaths();
+          if (paths != null) {
+            System.out.println("Supported API Paths:");
+            for (String path : paths) {
+              System.out.println("    " + path);
+            }
+            System.out.println();
+          }
+        }
+      }
+      CustomResourceDefinitionList crds = client.customResourceDefinitions().list();
+      List<CustomResourceDefinition> crdsItems = crds.getItems();
+      System.out.println("Found " + crdsItems.size() + " CRD(s)");
+      CustomResourceDefinition dummyCRD = null;
+      for (CustomResourceDefinition crd : crdsItems) {
+        ObjectMeta metadata = crd.getMetadata();
+        if (metadata != null) {
+          String name = metadata.getName();
+          System.out.println("    " + name + " => " + metadata.getSelfLink());
+          if (DUMMY_CRD_NAME.equals(name)) {
+            dummyCRD = crd;
+          }
+        }
+      }
+      if (dummyCRD != null) {
+        System.out.println("Found CRD: " + dummyCRD.getMetadata().getSelfLink());
+      } else {
+        dummyCRD = new CustomResourceDefinitionBuilder().
+            withApiVersion("apiextensions.k8s.io/v1beta1").
+            withNewMetadata().withName(DUMMY_CRD_NAME).endMetadata().
+            withNewSpec().withGroup(DUMMY_CRD_GROUP).withVersion("v1").withScope("Namespaced").
+              withNewNames().withKind("Dummy").withShortNames("dummy").withPlural("dummies").endNames().endSpec().
+            build();
+
+        client.customResourceDefinitions().create(dummyCRD);
+        System.out.println("Created CRD " + dummyCRD.getMetadata().getName());
+      }
+
+
+      // lets create a client for the CRD
+      NonNamespaceOperation<Dummy, DummyList, DoneableDummy, Resource<Dummy, DoneableDummy>> dummyClient = client.customResource(dummyCRD, Dummy.class, DummyList.class, DoneableDummy.class).inNamespace(namespace);
+      CustomResourceList<Dummy> dummyList = dummyClient.list();
+      List<Dummy> items = dummyList.getItems();
+      System.out.println("  found " + items.size() + " dummies");
+      for (Dummy item : items) {
+        System.out.println("    " + item);
+      }
+
+      Dummy dummy = new Dummy();
+      ObjectMeta metadata = new ObjectMeta();
+      metadata.setName("foo");
+      dummy.setMetadata(metadata);
+      DummySpec dummySpec = new DummySpec();
+      Date now = new Date();
+      dummySpec.setBar("beer: " + now);
+      dummySpec.setFoo("cheese: " + now);
+      dummy.setSpec(dummySpec);
+
+      dummyClient.createOrReplace(dummy);
+
+      System.out.println("Upserted " + dummy);
+    } catch (KubernetesClientException e) {
+      logger.error(e.getMessage(), e);
+    } catch (Exception e) {
+      logger.error(e.getMessage(), e);
+    }
+  }
+
+}

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DoneableDummy.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DoneableDummy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.kubernetes.examples.crds;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+
+/**
+ */
+public class DoneableDummy extends CustomResourceDoneable<Dummy> {
+  public DoneableDummy(Dummy resource, Function function) {
+    super(resource, function);
+  }
+}

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DoneableDummy.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DoneableDummy.java
@@ -1,17 +1,17 @@
-/*
- * Copyright 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * Red Hat licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.kubernetes.examples.crds;
 

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
@@ -1,17 +1,17 @@
-/*
- * Copyright 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * Red Hat licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.kubernetes.examples.crds;
 

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
@@ -15,11 +15,11 @@
  */
 package io.fabric8.kubernetes.examples.crds;
 
-import io.fabric8.kubernetes.client.CustomResourceSupport;
+import io.fabric8.kubernetes.client.CustomResource;
 
 /**
  */
-public class Dummy extends CustomResourceSupport {
+public class Dummy extends CustomResource {
   private DummySpec spec;
 
   @Override

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.kubernetes.examples.crds;
+
+import io.fabric8.kubernetes.client.CustomResourceSupport;
+
+/**
+ */
+public class Dummy extends CustomResourceSupport {
+  private DummySpec spec;
+
+  @Override
+  public String toString() {
+    return "Dummy{" +
+        "apiVersion='" + getApiVersion() + '\'' +
+        ", metadata=" + getMetadata() +
+        ", spec=" + spec +
+        '}';
+  }
+
+  public DummySpec getSpec() {
+    return spec;
+  }
+
+  public void setSpec(DummySpec spec) {
+    this.spec = spec;
+  }
+}

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummyList.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummyList.java
@@ -1,17 +1,17 @@
-/*
- * Copyright 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * Red Hat licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.kubernetes.examples.crds;
 

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummyList.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummyList.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.kubernetes.examples.crds;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class DummyList extends CustomResourceList<Dummy> {
+}

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummySpec.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummySpec.java
@@ -1,17 +1,17 @@
-/*
- * Copyright 2016 Red Hat, Inc.
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * Red Hat licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.fabric8.kubernetes.examples.crds;
 

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummySpec.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummySpec.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.kubernetes.examples.crds;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+/**
+ */
+public class DummySpec implements KubernetesResource {
+  private String foo;
+  private String bar;
+
+  @Override
+  public String toString() {
+    return "DummySpec{" +
+        "foo='" + foo + '\'' +
+        ", bar='" + bar + '\'' +
+        '}';
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
+  }
+
+  public String getBar() {
+    return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionLis
 import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefinition;
 import io.fabric8.kubernetes.client.AppsAPIGroupClient;
 import io.fabric8.kubernetes.client.AutoscalingAPIGroupClient;
+import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AutoscalingAPIGroupDSL;
@@ -30,6 +31,7 @@ import io.fabric8.kubernetes.client.dsl.ParameterMixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.dsl.BuildResource;
@@ -266,6 +268,11 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public MixedOperation<LimitRange, LimitRangeList, DoneableLimitRange, Resource<LimitRange, DoneableLimitRange>> limitRanges() {
     return delegate.limitRanges();
+  }
+
+  @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResource(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return new CustomResourceOperationsImpl<T,L,D>(httpClient, getConfiguration(), crd, resourceType, listClass, doneClass);
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -16,57 +16,11 @@
 
 package io.fabric8.openshift.client.osgi;
 
-import io.fabric8.kubernetes.api.model.ComponentStatus;
-import io.fabric8.kubernetes.api.model.ComponentStatusList;
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapList;
-import io.fabric8.kubernetes.api.model.DoneableComponentStatus;
-import io.fabric8.kubernetes.api.model.DoneableConfigMap;
-import io.fabric8.kubernetes.api.model.DoneableEndpoints;
-import io.fabric8.kubernetes.api.model.DoneableEvent;
-import io.fabric8.kubernetes.api.model.DoneableLimitRange;
-import io.fabric8.kubernetes.api.model.DoneableNamespace;
-import io.fabric8.kubernetes.api.model.DoneableNode;
-import io.fabric8.kubernetes.api.model.DoneablePersistentVolume;
-import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.DoneablePod;
-import io.fabric8.kubernetes.api.model.DoneableReplicationController;
-import io.fabric8.kubernetes.api.model.DoneableResourceQuota;
-import io.fabric8.kubernetes.api.model.DoneableSecret;
+import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.openshift.api.model.DoneableSecurityContextConstraints;
-import io.fabric8.kubernetes.api.model.DoneableService;
-import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-import io.fabric8.kubernetes.api.model.Endpoints;
-import io.fabric8.kubernetes.api.model.EndpointsList;
-import io.fabric8.kubernetes.api.model.Event;
-import io.fabric8.kubernetes.api.model.EventList;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.LimitRange;
-import io.fabric8.kubernetes.api.model.LimitRangeList;
-import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceList;
-import io.fabric8.kubernetes.api.model.Node;
-import io.fabric8.kubernetes.api.model.NodeList;
-import io.fabric8.kubernetes.api.model.PersistentVolume;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
-import io.fabric8.kubernetes.api.model.PersistentVolumeList;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.ReplicationControllerList;
-import io.fabric8.kubernetes.api.model.ResourceQuota;
-import io.fabric8.kubernetes.api.model.ResourceQuotaList;
-import io.fabric8.kubernetes.api.model.RootPaths;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.openshift.api.model.SecurityContextConstraints;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.api.model.ServiceAccountList;
-import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefinition;
@@ -511,6 +465,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public MixedOperation<LimitRange, LimitRangeList, DoneableLimitRange, Resource<LimitRange, DoneableLimitRange>> limitRanges() {
     return delegate.limitRanges();
+  }
+
+  @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResource(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return delegate.customResource(crd, resourceType, listClass, doneClass);
   }
 
   @Override


### PR DESCRIPTION
this PR adds the ability to register new CRD clients providing a few DTOs and reusing the kubernetes-client DSL and underlying CustomResourceDefinition metadata to implement the REST API