### PR TITLE
Fix ClassCastException when creating a RoleBinding with rolebindings(…

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingTest.java
@@ -246,4 +246,23 @@ public class RoleBindingTest {
     );
   }
 
+  @Test
+  public void testCreateInline() throws Exception {
+    server.expect().post().withPath("/oapi/v1/namespaces/test/rolebindings").andReturn(201, expectedRoleBinding).once();
+
+    NamespacedOpenShiftClient client = server.getOpenshiftClient();
+
+    RoleBinding response = client.roleBindings().createNew()
+      .withNewMetadata().endMetadata()
+      .addNewSubject().withKind("User").withName("testuser1").endSubject()
+      .addNewSubject().withKind("User").withName("testuser2").endSubject()
+      .addNewSubject().withKind("ServiceAccount").withName("svcacct").endSubject()
+      .addNewSubject().withKind("Group").withName("testgroup").endSubject()
+      .done();
+    assertEquals(expectedRoleBinding, response);
+
+    RecordedRequest request = server.getMockServer().takeRequest();
+    assertEquals(expectedRoleBinding, new ObjectMapper().readerFor(RoleBinding.class).readValue(request.getBody().inputStream()));
+  }
+
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/RoleBindingOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/RoleBindingOperationsImpl.java
@@ -27,9 +27,11 @@ import io.fabric8.openshift.api.model.RoleBindingList;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import okhttp3.OkHttpClient;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
 
 import static io.fabric8.openshift.client.OpenShiftAPIGroups.AUTHORIZATION;
 
@@ -55,12 +57,8 @@ public class RoleBindingOperationsImpl extends OpenShiftOperation<RoleBinding, R
   }
 
   @Override
-  public RoleBinding create(RoleBinding... resources) throws KubernetesClientException {
-    RoleBinding[] enriched = new RoleBinding[resources.length];
-    for (int i = 0; i < resources.length; i++) {
-      enriched[i] = enrichRoleBinding(resources[i]);
-    }
-    return super.create(enriched);
+  protected RoleBinding handleCreate(RoleBinding resource) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+    return super.handleCreate(enrichRoleBinding(resource));
   }
 
   private RoleBinding enrichRoleBinding(RoleBinding binding) {


### PR DESCRIPTION
…).createNew()

Here's the CCE that occurs if you try to create a RoleBinding inline: 
```
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Lio.fabric8.openshift.api.model.RoleBinding;
        at io.fabric8.openshift.client.dsl.internal.RoleBindingOperationsImpl.create(RoleBindingOperationsImpl.java:36)
        at io.fabric8.kubernetes.client.dsl.base.BaseOperation$1.apply(BaseOperation.java:361)
        at io.fabric8.openshift.api.model.DoneableRoleBinding.done(DoneableRoleBinding.java:27)
        at io.enmasse.controller.common.KubernetesHelper.addDefaultEditPolicy(KubernetesHelper.java:166)
        at io.enmasse.controller.ControllerHelper.create(ControllerHelper.java:67)
        at io.enmasse.controller.Controller.createAddressSpaces(Controller.java:132)
        at io.enmasse.controller.Controller.resourcesUpdated(Controller.java:108)
        at io.enmasse.k8s.api.ResourceController.run(ResourceController.java:72)
        at java.lang.Thread.run(Thread.java:748)
```