### PR TITLE
[OSFUSE-667]: Regression between FIS 2 - R4 x R5: Revert [OSFUSE-640]

### DIFF
--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
@@ -21,7 +21,6 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -58,8 +57,7 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
         builder.header("Accept", "application/json");
 
         String token = oauthToken.get();
-        // avoid overwriting basic auth token with stale bearer token
-        if (Utils.isNotNullOrEmpty(token) && Utils.isNullOrEmpty(request.header(AUTHORIZATION))) {
+        if (Utils.isNotNullOrEmpty(token)) {
             setAuthHeader(builder, token);
         }
 
@@ -71,8 +69,6 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
           return response;
         } else if (Utils.isNotNullOrEmpty(config.getUsername()) && Utils.isNotNullOrEmpty(config.getPassword())) {
           synchronized (client) {
-            // current token (if exists) is borked, don't resend
-            oauthToken.set(null);
             token = authorize();
             if (token != null) {
               oauthToken.set(token);


### PR DESCRIPTION
Reverting OSFUSE-640: Fixed basic token overwriting with a stale bearer token"
because of https://issues.jboss.org/browse/OSFUSE-667 and was never asked to be baclported to this branch.

This reverts commit 464544d54a90637418b67c26e49952d0b5a3e2fb.