### PR TITLE
waitUntilReady is ignoring the TimeUnit

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollableScalableResourceOperation.java
@@ -89,7 +89,7 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
       throw new IllegalArgumentException(getType().getSimpleName() + " with name:[" + name + "] in namespace:[" + namespace + "] not found!");
     }
 
-    return periodicWatchUntilReady(10, System.currentTimeMillis(), Math.max(timeUnit.toMillis(amount) / 10, 1000L), amount);
+    return periodicWatchUntilReady(10, System.currentTimeMillis(), Math.max(timeUnit.toMillis(amount) / 10, 1000L), timeUnit.toMillis(amount));
   }
 
   /**


### PR DESCRIPTION
The workaround is to use TimeUnit.MILLISECONDS

The error I was getting

```
Timed out waiting for [0] milliseconds for [StatefulSet] with name:[test] in namespace [testns]
```