### PR TITLE
Fix #579 - add Timestampable interface to PodOperationsImpl and set timestamps parameter

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/TimestampBytesLimitTerminateTimeTailPrettyLoggable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/TimestampBytesLimitTerminateTimeTailPrettyLoggable.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.fabric8.kubernetes.client.dsl;
 
-public interface ContainerResource<S,W, I, PI, O, PO, X, T>
-        extends TtyExecInputOutputErrorable<X, O, PO, I, PI, T>,
-  TimestampBytesLimitTerminateTimeTailPrettyLoggable<S, W> {
+public interface TimestampBytesLimitTerminateTimeTailPrettyLoggable<T, W> extends Timestampable<BytesLimitTerminateTimeTailPrettyLoggable<T, W>>, BytesLimitTerminateTimeTailPrettyLoggable<T, W> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
@@ -134,6 +134,9 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
         if (limitBytes != null) {
           sb.append("&limitBytes=").append(limitBytes);
         }
+        if (withTimestamps) {
+          sb.append("&timestamps=true");
+        }
         return sb.toString();
     }
 
@@ -373,6 +376,11 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
     @Override
     public BytesLimitTerminateTimeTailPrettyLoggable<String, LogWatch> limitBytes(int limitBytes) {
         return new PodOperationsImpl(client, getConfig(), apiVersion, namespace, name, isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), containerId, in, inPipe, out, outPipe, err, errPipe, errChannel, errChannelPipe, withTTY, withTerminatedStatus, withTimestamps, sinceTimestamp, sinceSeconds, withTailingLines, withPrettyOutput, execListener, limitBytes);
+    }
+
+    @Override
+    public BytesLimitTerminateTimeTailPrettyLoggable<String, LogWatch> usingTimestamps() {
+        return new PodOperationsImpl(client, getConfig(), apiVersion, namespace, name, isCascading(), getItem(), getResourceVersion(), isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), containerId, in, inPipe, out, outPipe, err, errPipe, withTTY, withTerminatedStatus, true, sinceTimestamp, sinceSeconds, withTailingLines, withPrettyOutput, execListener, limitBytes);
     }
 }
 


### PR DESCRIPTION
The Timestampable interface already existed but was just not added to the ContainerResource.  I validated timestamps are returned appropriately if `usingTimestamps` by publishing a version of the client locally

Fixes #579 