### PR TITLE
fix: #918 Adds support for multiple documents in single yaml file.

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -18,34 +18,35 @@ package io.fabric8.kubernetes.client.dsl.internal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mifmif.common.regex.Generex;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
-import io.fabric8.kubernetes.client.internal.SerializationUtils;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.HasMetadataVisitiableBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.dsl.*;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.handlers.KubernetesListHandler;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.kubernetes.client.utils.ResourceCompare;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.api.model.Parameter;
 import io.fabric8.openshift.api.model.Template;
+import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -59,6 +60,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.fabric8.kubernetes.client.utils.Utils.isNotNullOrEmpty;
 import static io.fabric8.kubernetes.client.utils.Utils.isNullOrEmpty;
@@ -69,6 +72,7 @@ Waitable<List<HasMetadata>>, Readiable {
     private static final Logger LOGGER = LoggerFactory.getLogger(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.class);
     private static final String EXPRESSION = "expression";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String DOCUMENT_DELIMITER = "---";
 
     private final String fallbackNamespace;
     private final String explicitNamespace;
@@ -182,7 +186,9 @@ Waitable<List<HasMetadata>>, Readiable {
         if (item != null) {
           this.item = item;
         } else if (inputStream != null) {
-          this.item = Serialization.unmarshal(inputStream, parameters);
+          String specFile = readSpecFileFromInputStream(inputStream);
+          this.item = (containsMultipleDocuments(specFile)) ? getKubernetesResourceList(parameters, specFile)
+            : Serialization.unmarshal(new ByteArrayInputStream(specFile.getBytes()), parameters);
         } else {
           throw new IllegalArgumentException("Need to either specify an Object or an InputStream.");
         }
@@ -193,8 +199,48 @@ Waitable<List<HasMetadata>>, Readiable {
         this.visitors.add(new ChangeNamespace(explicitNamespace, fallbackNamespace));
     }
 
-    @Override
-    public List<HasMetadata> apply() {
+  private List<KubernetesResource> getKubernetesResourceList(Map<String, String> parameters, String specFile) {
+    List<KubernetesResource> documentList = new ArrayList<>();
+    String[] documents = specFile.split(DOCUMENT_DELIMITER);
+    for (String document : documents) {
+      ByteArrayInputStream documentInputStream = new ByteArrayInputStream(document.getBytes());
+      Object resource = Serialization.unmarshal(documentInputStream, parameters);
+      documentList.add((KubernetesResource) resource);
+    }
+    return documentList;
+  }
+
+  private boolean containsMultipleDocuments(String specFile) {
+    Pattern p = Pattern.compile(DOCUMENT_DELIMITER);
+    Matcher m = p.matcher(specFile);
+    int count = 0;
+    while (m.find()) {
+      count++;
+    }
+    if (count == 1) {
+      String[] documents = specFile.split(DOCUMENT_DELIMITER);
+      Matcher keyValueMatcher = Pattern.compile("(\\S+):\\s(\\S*)(?:\\b(?!:)|$)").matcher(documents[0]);
+      return !documents[0].isEmpty() && keyValueMatcher.find();
+    }
+    return count > 1;
+  }
+
+  private String readSpecFileFromInputStream(InputStream inputStream) {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int length;
+    try {
+      while ((length = inputStream.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, length);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return outputStream.toString();
+  }
+
+  @Override
+  public List<HasMetadata> apply() {
        return createOrReplace();
     }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -35,8 +35,8 @@ import io.fabric8.kubernetes.client.dsl.*;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.handlers.KubernetesListHandler;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.kubernetes.client.internal.SerializationUtils;
 import io.fabric8.kubernetes.client.utils.ResourceCompare;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.api.model.Parameter;
 import io.fabric8.openshift.api.model.Template;
@@ -181,7 +181,7 @@ Waitable<List<HasMetadata>>, Readiable {
         if (item != null) {
           this.item = item;
         } else if (inputStream != null) {
-          this.item = SerializationUtils.unmarshal(inputStream, parameters);
+          this.item = Serialization.unmarshal(inputStream, parameters);
         } else {
           throw new IllegalArgumentException("Need to either specify an Object or an InputStream.");
         }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/SerializationUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/SerializationUtils.java
@@ -19,12 +19,26 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.client.internal.serializationmixins.ObjectMetaMixIn;
 import io.fabric8.kubernetes.client.internal.serializationmixins.ReplicationControllerMixIn;
+import io.fabric8.kubernetes.client.utils.Serialization;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SerializationUtils {
+
+  private static final String DOCUMENT_DELIMITER = "---";
 
   private static ObjectMapper mapper;
 
@@ -54,4 +68,57 @@ public class SerializationUtils {
     return getStatelessMapper().writeValueAsString(obj);
   }
 
+  public static Object unmarshal(InputStream inputStream, Map<String, String> parameters) {
+    String specFile = readSpecFileFromInputStream(inputStream);
+    if (containsMultipleDocuments(specFile)) {
+      return getKubernetesResourceList(parameters, specFile);
+    }
+    return Serialization.unmarshal(new ByteArrayInputStream(specFile.getBytes()), parameters);
+  }
+
+  private static List<KubernetesResource> getKubernetesResourceList(Map<String, String> parameters, String specFile) {
+    List<KubernetesResource> documentList = new ArrayList<>();
+    String[] documents = specFile.split(DOCUMENT_DELIMITER);
+    for (String document : documents) {
+      if (validate(document)) {
+        ByteArrayInputStream documentInputStream = new ByteArrayInputStream(document.getBytes());
+        Object resource = Serialization.unmarshal(documentInputStream, parameters);
+        documentList.add((KubernetesResource) resource);
+      }
+    }
+    return documentList;
+  }
+
+  private static boolean containsMultipleDocuments(String specFile) {
+    Pattern p = Pattern.compile(DOCUMENT_DELIMITER);
+    Matcher m = p.matcher(specFile);
+    int count = 0;
+    while (m.find()) {
+      count++;
+    }
+    if (count == 1) {
+      String[] documents = specFile.split(DOCUMENT_DELIMITER);
+      return validate(documents[0]);
+    }
+    return count > 1;
+  }
+
+  private static boolean validate(String document) {
+    Matcher keyValueMatcher = Pattern.compile("(\\S+):\\s(\\S*)(?:\\b(?!:)|$)").matcher(document);
+    return !document.isEmpty() && keyValueMatcher.find();
+  }
+
+  private static String readSpecFileFromInputStream(InputStream inputStream) {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int length;
+    try {
+      while ((length = inputStream.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, length);
+      }
+      return outputStream.toString();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to read InputStream." + e);
+    }
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -33,10 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import io.fabric8.kubernetes.api.model.KubernetesResource;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.internal.SerializationUtils;
 
 public class Serialization {
 
@@ -92,7 +90,7 @@ public class Serialization {
     if (containsMultipleDocuments(specFile)) {
       return (T) getKubernetesResourceList(parameters, specFile);
     }
-    return unmarshal(is, JSON_MAPPER, parameters);
+    return unmarshal(new ByteArrayInputStream(specFile.getBytes()), JSON_MAPPER, parameters);
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -22,21 +22,27 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.internal.SerializationUtils;
 
 public class Serialization {
 
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
-
+  private static final String DOCUMENT_DELIMITER = "---";
 
   public static ObjectMapper jsonMapper() {
     return JSON_MAPPER;
@@ -82,6 +88,10 @@ public class Serialization {
    * @throws KubernetesClientException
    */
   public static <T> T unmarshal(InputStream is, Map<String, String> parameters) throws KubernetesClientException {
+    String specFile = readSpecFileFromInputStream(is);
+    if (containsMultipleDocuments(specFile)) {
+      return (T) getKubernetesResourceList(parameters, specFile);
+    }
     return unmarshal(is, JSON_MAPPER, parameters);
   }
 
@@ -227,6 +237,53 @@ public class Serialization {
       return mapper.readValue(bis, type);
     } catch (IOException e) {
       throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+
+  private static List<KubernetesResource> getKubernetesResourceList(Map<String, String> parameters, String specFile) {
+    List<KubernetesResource> documentList = new ArrayList<>();
+    String[] documents = specFile.split(DOCUMENT_DELIMITER);
+    for (String document : documents) {
+      if (validate(document)) {
+        ByteArrayInputStream documentInputStream = new ByteArrayInputStream(document.getBytes());
+        Object resource = Serialization.unmarshal(documentInputStream, parameters);
+        documentList.add((KubernetesResource) resource);
+      }
+    }
+    return documentList;
+  }
+
+  private static boolean containsMultipleDocuments(String specFile) {
+    Pattern p = Pattern.compile(DOCUMENT_DELIMITER);
+    Matcher m = p.matcher(specFile);
+    int count = 0;
+    while (m.find()) {
+      count++;
+    }
+    if (count == 1) {
+      String[] documents = specFile.split(DOCUMENT_DELIMITER);
+      return validate(documents[0]);
+    }
+    return count > 1;
+  }
+
+  private static boolean validate(String document) {
+    Matcher keyValueMatcher = Pattern.compile("(\\S+):\\s(\\S*)(?:\\b(?!:)|$)").matcher(document);
+    return !document.isEmpty() && keyValueMatcher.find();
+  }
+
+  private static String readSpecFileFromInputStream(InputStream inputStream) {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int length;
+    try {
+      while ((length = inputStream.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, length);
+      }
+      return outputStream.toString();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to read InputStream." + e);
     }
   }
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
@@ -34,7 +34,6 @@ public class LoadMultipleDocumentsFromFileExample {
       System.out.println(display(meta));
     }
 
-
     list = client.load(TemplateExample.class.getResourceAsStream("/multiple-document-template.yml")).accept(new Visitor<ObjectMetaBuilder>() {
 
       @Override
@@ -68,6 +67,5 @@ public class LoadMultipleDocumentsFromFileExample {
     }
     sb.append(" ]");
     return sb.toString();
-
   }
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.examples;
 
 import io.fabric8.kubernetes.api.builder.Visitor;

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
@@ -1,0 +1,73 @@
+package io.fabric8.kubernetes.examples;
+
+import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.utils.Utils;
+import io.fabric8.openshift.examples.LoadExample;
+import io.fabric8.openshift.examples.TemplateExample;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class LoadMultipleDocumentsFromFileExample {
+  private static final Logger logger = LoggerFactory.getLogger(LoadExample.class);
+
+  public static void main(String[] args) throws InterruptedException {
+    String master = "https://localhost:8443/";
+    if (args.length == 1) {
+      master = args[0];
+    }
+
+    Config config = new ConfigBuilder().build();
+    KubernetesClient client = new DefaultKubernetesClient(config);
+
+    List<HasMetadata> list = client.load(TemplateExample.class.getResourceAsStream("/multiple-document-template.yml")).get();
+    System.out.println("Found in file:" + list.size() + " items.");
+    for (HasMetadata meta : list) {
+      System.out.println(display(meta));
+    }
+
+
+    list = client.load(TemplateExample.class.getResourceAsStream("/multiple-document-template.yml")).accept(new Visitor<ObjectMetaBuilder>() {
+
+      @Override
+      public void visit(ObjectMetaBuilder item) {
+        item.addToLabels("visitorkey", "visitorvalue");
+      }
+    }).get();
+
+    System.out.println("Visited:" + list.size() + " items.");
+    for (HasMetadata meta : list) {
+      System.out.println(display(meta));
+    }
+  }
+
+  private static String display(HasMetadata item) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[ ");
+    if (Utils.isNotNullOrEmpty(item.getKind())) {
+      sb.append("Kind:").append(item.getKind());
+    }
+    if (Utils.isNotNullOrEmpty(item.getMetadata().getName())) {
+      sb.append("Name:").append(item.getMetadata().getName());
+    }
+
+    if (item.getMetadata().getLabels()!=null && !item.getMetadata().getLabels().isEmpty()) {
+      sb.append("Lables: [ ");
+      for (Map.Entry<String,String> entry : item.getMetadata().getLabels().entrySet()) {
+        sb.append(entry.getKey()).append(":").append(entry.getValue()).append(" ");
+      }
+      sb.append("]");
+    }
+    sb.append(" ]");
+    return sb.toString();
+
+  }
+}

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
@@ -8,16 +8,12 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.Utils;
-import io.fabric8.openshift.examples.LoadExample;
 import io.fabric8.openshift.examples.TemplateExample;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 
 public class LoadMultipleDocumentsFromFileExample {
-  private static final Logger logger = LoggerFactory.getLogger(LoadExample.class);
 
   public static void main(String[] args) throws InterruptedException {
     String master = "https://localhost:8443/";
@@ -58,9 +54,9 @@ public class LoadMultipleDocumentsFromFileExample {
       sb.append("Name:").append(item.getMetadata().getName());
     }
 
-    if (item.getMetadata().getLabels()!=null && !item.getMetadata().getLabels().isEmpty()) {
+    if (item.getMetadata().getLabels() != null && !item.getMetadata().getLabels().isEmpty()) {
       sb.append("Lables: [ ");
-      for (Map.Entry<String,String> entry : item.getMetadata().getLabels().entrySet()) {
+      for (Map.Entry<String, String> entry : item.getMetadata().getLabels().entrySet()) {
         sb.append(entry.getKey()).append(":").append(entry.getValue()).append(" ");
       }
       sb.append("]");

--- a/kubernetes-examples/src/main/resources/multiple-document-template.yml
+++ b/kubernetes-examples/src/main/resources/multiple-document-template.yml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    tier: backend
+    role: slave
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: slave
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google_samples/gb-redisslave:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access an environment variable to find the master
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below:
+          # value: env
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  # type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below:
+          # value: env
+        ports:
+        - containerPort: 80

--- a/kubernetes-examples/src/main/resources/multiple-document-template.yml
+++ b/kubernetes-examples/src/main/resources/multiple-document-template.yml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/kubernetes-examples/src/main/resources/multiple-document-template.yml
+++ b/kubernetes-examples/src/main/resources/multiple-document-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Red Hat, Inc.
+# Copyright (C) 2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
@@ -1,0 +1,69 @@
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LoadTest {
+
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  public void testResourceGetFromLoadWhenMultipleDocumentsWithDelimiter() throws Exception {
+    // given
+    KubernetesClient client = server.getClient();
+
+    // when
+    List<HasMetadata> result = client.load(getClass().getResourceAsStream("/multiple-document-template.yml")).get();
+
+    // then
+    assertNotNull(result);
+    assertEquals(6, result.size());
+    HasMetadata deploymentResource = result.get(1);
+    assertEquals("extensions/v1beta1", deploymentResource.getApiVersion());
+    assertEquals("Deployment", deploymentResource.getKind());
+    assertEquals("redis-master", deploymentResource.getMetadata().getName());
+  }
+
+  @Test
+  public void testResourceGetFromLoadWhenSingleDocumentsWithoutDelimiter() throws Exception {
+    // given
+    KubernetesClient client = server.getClient();
+
+    // when
+    List<HasMetadata> result = client.load(getClass().getResourceAsStream("/template-with-params.yml")).get();
+
+    // then
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    HasMetadata deploymentResource = result.get(0);
+    assertEquals("v1", deploymentResource.getApiVersion());
+    assertEquals("Pod", deploymentResource.getKind());
+    assertEquals("example-pod", deploymentResource.getMetadata().getName());
+  }
+
+  @Test
+  public void testResourceGetFromLoadWhenSingleDocumentsWithStartingDelimiter() throws Exception {
+    // given
+    KubernetesClient client = server.getClient();
+
+    // when
+    List<HasMetadata> result = client.load(getClass().getResourceAsStream("/test-template.yml")).get();
+
+    // then
+    assertNotNull(result);
+    assertEquals(5, result.size());
+    HasMetadata deploymentResource = result.get(1);
+    assertEquals("v1", deploymentResource.getApiVersion());
+    assertEquals("ImageStream", deploymentResource.getKind());
+    assertEquals("eap-app", deploymentResource.getMetadata().getName());
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;

--- a/kubernetes-tests/src/test/resources/multiple-document-template.yml
+++ b/kubernetes-tests/src/test/resources/multiple-document-template.yml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    tier: backend
+    role: slave
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: slave
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google_samples/gb-redisslave:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access an environment variable to find the master
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below:
+          # value: env
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  # type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below:
+          # value: env
+        ports:
+        - containerPort: 80

--- a/kubernetes-tests/src/test/resources/multiple-document-template.yml
+++ b/kubernetes-tests/src/test/resources/multiple-document-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Red Hat, Inc.
+# Copyright (C) 2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubernetes-tests/src/test/resources/multiple-document-template.yml
+++ b/kubernetes-tests/src/test/resources/multiple-document-template.yml
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/kubernetes-tests/src/test/resources/test-template.yml
+++ b/kubernetes-tests/src/test/resources/test-template.yml
@@ -1,0 +1,233 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+  kind: "Template"
+  apiVersion: "v1"
+  metadata: 
+    annotations: 
+      iconClass: "icon-jboss"
+      description: "Application template for EAP 6 applications built using STI."
+    name: "eap6-basic-sti"
+  labels: 
+    template: "eap6-basic-sti"
+  parameters: 
+    - 
+      description: "EAP Release version, e.g. 6.4, etc."
+      name: "EAP_RELEASE"
+      value: "6.4"
+      required: true
+    - 
+      description: "The name for the application."
+      name: "APPLICATION_NAME"
+      value: "eap-app"
+      required: true
+    - 
+      description: "Custom hostname for service routes. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>"
+      name: "APPLICATION_HOSTNAME"
+      value: ""
+      required: false
+    - 
+      description: "Git source URI for application"
+      name: "GIT_URI"
+      value: "https://github.com/jboss-developer/jboss-eap-quickstarts"
+      required: false
+    - 
+      description: "Git branch/tag reference"
+      name: "GIT_REF"
+      value: "6.4.x"
+      required: false
+    - 
+      description: "Path within Git project to build; empty for root project directory."
+      name: "GIT_CONTEXT_DIR"
+      value: "kitchensink"
+      required: false
+    - 
+      description: "Queue names"
+      name: "HORNETQ_QUEUES"
+      value: ""
+      required: false
+    - 
+      description: "Topic names"
+      name: "HORNETQ_TOPICS"
+      value: ""
+      required: false
+    - 
+      description: "HornetQ cluster admin password"
+      name: "HORNETQ_CLUSTER_PASSWORD"
+      from: "[a-zA-Z0-9]{8}"
+      generate: "expression"
+      required: true
+    - 
+      description: "GitHub trigger secret"
+      name: "GITHUB_TRIGGER_SECRET"
+      from: "[a-zA-Z0-9]{8}"
+      generate: "expression"
+      required: true
+    - 
+      description: "Generic build trigger secret"
+      name: "GENERIC_TRIGGER_SECRET"
+      from: "[a-zA-Z0-9]{8}"
+      generate: "expression"
+      required: true
+    - 
+      description: "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project."
+      name: "IMAGE_STREAM_NAMESPACE"
+      value: "openshift"
+      required: true
+  objects: 
+    - 
+      kind: "Service"
+      apiVersion: "v1"
+      spec: 
+        ports: 
+          - 
+            port: 8080
+            targetPort: 8080
+        selector: 
+          deploymentConfig: "${APPLICATION_NAME}"
+      metadata: 
+        name: "${APPLICATION_NAME}"
+        labels: 
+          application: "${APPLICATION_NAME}"
+        annotations: 
+          description: "The web server's http port."
+    - 
+      kind: "Route"
+      apiVersion: "v1"
+      id: "${APPLICATION_NAME}-http-route"
+      metadata: 
+        name: "${APPLICATION_NAME}-http-route"
+        labels: 
+          application: "${APPLICATION_NAME}"
+        annotations: 
+          description: "Route for application's http service."
+      spec: 
+        host: "${APPLICATION_HOSTNAME}"
+        to: 
+          name: "${APPLICATION_NAME}"
+    - 
+      kind: "ImageStream"
+      apiVersion: "v1"
+      metadata: 
+        name: "${APPLICATION_NAME}"
+        labels: 
+          application: "${APPLICATION_NAME}"
+    - 
+      kind: "BuildConfig"
+      apiVersion: "v1"
+      metadata: 
+        name: "${APPLICATION_NAME}"
+        labels: 
+          application: "${APPLICATION_NAME}"
+      spec: 
+        source: 
+          type: "Git"
+          git: 
+            uri: "${GIT_URI}"
+            ref: "${GIT_REF}"
+          contextDir: "${GIT_CONTEXT_DIR}"
+        strategy: 
+          type: "Source"
+          sourceStrategy: 
+            from: 
+              kind: "ImageStreamTag"
+              namespace: "${IMAGE_STREAM_NAMESPACE}"
+              name: "jboss-eap6-openshift:${EAP_RELEASE}"
+        output: 
+          to: 
+            kind: "ImageStreamTag"
+            name: "${APPLICATION_NAME}:latest"
+        triggers: 
+          - 
+            type: "GitHub"
+            github: 
+              secret: "${GITHUB_TRIGGER_SECRET}"
+          - 
+            type: "Generic"
+            generic: 
+              secret: "${GENERIC_TRIGGER_SECRET}"
+          - 
+            type: "ImageChange"
+            imageChange: {}
+    - 
+      kind: "DeploymentConfig"
+      apiVersion: "v1"
+      metadata: 
+        name: "${APPLICATION_NAME}"
+        labels: 
+          application: "${APPLICATION_NAME}"
+      spec: 
+        strategy: 
+          type: "Recreate"
+        triggers: 
+          - 
+            type: "ImageChange"
+            imageChangeParams: 
+              automatic: true
+              containerNames: 
+                - "${APPLICATION_NAME}"
+              from: 
+                kind: "ImageStream"
+                name: "${APPLICATION_NAME}"
+        replicas: 1
+        selector: 
+          deploymentConfig: "${APPLICATION_NAME}"
+        template: 
+          metadata: 
+            name: "${APPLICATION_NAME}"
+            labels: 
+              deploymentConfig: "${APPLICATION_NAME}"
+              application: "${APPLICATION_NAME}"
+          spec: 
+            containers: 
+              - 
+                name: "${APPLICATION_NAME}"
+                image: "${APPLICATION_NAME}"
+                imagePullPolicy: "Always"
+                readinessProbe: 
+                  exec: 
+                    command: 
+                      - "/bin/bash"
+                      - "-c"
+                      - "/opt/eap/bin/readinessProbe.sh"
+                ports: 
+                  - 
+                    name: "http"
+                    containerPort: 8080
+                    protocol: "TCP"
+                  - 
+                    name: "ping"
+                    containerPort: 8888
+                    protocol: "TCP"
+                env: 
+                  - 
+                    name: "OPENSHIFT_KUBE_PING_LABELS"
+                    value: "application=${APPLICATION_NAME}"
+                  - 
+                    name: "OPENSHIFT_KUBE_PING_NAMESPACE"
+                    valueFrom: 
+                      fieldRef: 
+                        fieldPath: "metadata.namespace"
+                  - 
+                    name: "HORNETQ_CLUSTER_PASSWORD"
+                    value: "${HORNETQ_CLUSTER_PASSWORD}"
+                  - 
+                    name: "HORNETQ_QUEUES"
+                    value: "${HORNETQ_QUEUES}"
+                  - 
+                    name: "HORNETQ_TOPICS"
+                    value: "${HORNETQ_TOPICS}"


### PR DESCRIPTION
### Short description of what this resolves:
[yaml spec v1.2 ](http://www.yaml.org/spec/1.2/spec.html#id2760395) contains information about files with multiple documents structure.

> YAML uses three dashes (“---”) to separate directives from document content. This also serves to signal the start of a document if no directives are present. Three dots ( “...”) indicate the end of a document without starting a new one, for use in communication channels.

Example:
```
---
  - Mark McGwire
  - Sammy Sosa
  - Ken Griffey
---
  - Chicago Cubs
  - St Louis Cardinals
```
The above mentioned structure is supported by Kubernetes but the support for the same was missing in Kuberenetes client.

### Changes proposed in this pull request:
- Check for presence of multiple document structure in the given input stream based on `---` delimiter,  split it into valid yaml documents and unmarshal each document separately.
- Adds load test example for the multiple document structure in a single yaml file.

Fixes #918 
