### PR TITLE
Update README.md add Compatability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,5 +285,10 @@ Then you can use the server like:
     }
 
 
+## Compatability
 
+|                           | Kubernetes 1.4.9 | Kubernetes 1.6.2 | Kubernetes 1.7.10 | 
+|---------------------------|------------------|------------------|-------------------|
+| kubernetes-client 1.3.92  | +                | +                | -                 | 
+| kubernetes-client 3.0.3   | -                | -                | ✓                 |
 


### PR DESCRIPTION
I think we should add a section refer to the k8s version compatability.

I work on f8 java client version 3.0.3 but it doesn't support k8s 1.6.2&1.4.9. Return error while update nodes. But it works fine with k8s 1.7.10.

a version compatability on the readme.md would be helpful for new users.