### PR TITLE
Add missing resource type string in template handler

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -16,17 +16,9 @@
 
 package io.fabric8.openshift.client.server.mock;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServicePort;
-import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.utils.IOHelpers;
-import io.fabric8.openshift.api.model.Template;
-import io.fabric8.openshift.api.model.TemplateBuilder;
-import io.fabric8.openshift.api.model.TemplateList;
-import io.fabric8.openshift.api.model.TemplateListBuilder;
+import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
@@ -135,6 +127,24 @@ public class TemplateTest {
 
     deleted = client.templates().inNamespace("ns1").withName("tmpl2").delete();
     assertTrue(deleted);
+  }
+
+  @Test
+  public void testCreateWithHandler() {
+    Template template = new TemplateBuilder()
+      .editOrNewMetadata()
+      .withName("tmpl3")
+      .withNamespace("test")
+      .endMetadata()
+      .build();
+
+    server.expect().withPath("/oapi/v1/namespaces/test/templates").andReturn(200, template).once();
+    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl3").andReturn(404, new StatusBuilder().withCode(404).build()).once();
+
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    Template created = client.resource(template).createOrReplace();
+    assertNotNull(created);
   }
 
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/TemplateHandler.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/TemplateHandler.java
@@ -41,17 +41,17 @@ public class TemplateHandler implements ResourceHandler<Template, TemplateBuilde
 
   @Override
   public Template create(OkHttpClient client, Config config, String namespace, Template item) {
-      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).create();
+      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, "templates", namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).create();
   }
 
   @Override
   public Template replace(OkHttpClient client, Config config, String namespace, Template item) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, null, namespace, null, true, item, null, true, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).replace(item);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, "templates", namespace, null, true, item, null, true, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).replace(item);
   }
 
   @Override
   public Template reload(OkHttpClient client, Config config, String namespace, Template item) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).fromServer().get();
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, "templates", namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).fromServer().get();
   }
 
   @Override
@@ -62,21 +62,21 @@ public class TemplateHandler implements ResourceHandler<Template, TemplateBuilde
 
   @Override
   public Boolean delete(OkHttpClient client, Config config, String namespace, Template item) {
-      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).delete(item);
+      return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, "templates", namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).delete(item);
   }
 
   @Override
   public Watch watch(OkHttpClient client, Config config, String namespace, Template item, Watcher<Template> watcher) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).watch(watcher);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, "templates", namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).watch(watcher);
   }
 
   @Override
   public Watch watch(OkHttpClient client, Config config, String namespace, Template item, String resourceVersion, Watcher<Template> watcher) {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).watch(resourceVersion, watcher);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, "templates", namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).watch(resourceVersion, watcher);
   }
 
   @Override
   public Template waitUntilReady(OkHttpClient client, Config config, String namespace, Template item, long amount, TimeUnit timeUnit) throws InterruptedException {
-    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).waitUntilReady(amount, timeUnit);
+    return new TemplateOperationsImpl(client, OpenShiftConfig.wrap(config), null, "templates", namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>(), null).waitUntilReady(amount, timeUnit);
   }
 }


### PR DESCRIPTION
Without this fix, creating templates using client.resource().createOrReplace, or creating a template as part of a list fails.