### PR TITLE
Watcher onClose method is not called #963

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -186,13 +186,11 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
               t);
           if (!started.get()) {
             queue.add(new KubernetesClientException(status));
-            return; // no reconnect
           }
         } else {
           logger.warn("Exec Failure", t);
           if (!started.get()) {
             queue.add(new KubernetesClientException("Failed to start websocket", t));
-            return; // no reconnect
           }
         }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -96,8 +96,8 @@ public class WatchTest {
     KubernetesClient client = server.getClient().inNamespace("test");
     // http error: history outdated
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
-        .andReturn(410, outdatedEvent).once();
+      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+      .andReturn(410, outdatedEvent).once();
     try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
       @Override
       public void eventReceived(Action action, Pod resource) {


### PR DESCRIPTION
Avoid returning from the WebSocketListener#onFailure if the websocket connection failed (even if the `start`  flag hasn't been set)
Let the code flow to the check if max retries has been reached. 
This way the Watcher#onClose will eventually be called.