### PR TITLE
Avoid "java.lang.IllegalStateException: Queue full" 

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -185,11 +185,13 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
           logger.warn("Exec Failure: HTTP {}, Status: {} - {}", response.code(), status.getCode(), status.getMessage(),
               t);
           if (!started.get()) {
+            queue.clear();
             queue.add(new KubernetesClientException(status));
           }
         } else {
           logger.warn("Exec Failure", t);
           if (!started.get()) {
+            queue.clear();
             queue.add(new KubernetesClientException("Failed to start websocket", t));
           }
         }


### PR DESCRIPTION
Running the latest release (3.1.6) we have seen the following exception in the logs:
```2017-12-27 13:10:26,769 WARN  [i.f.k.c.d.i.WatchConnectionManager:191] Exec Failure
java.net.SocketTimeoutException: connect timed out
        at java.net.PlainSocketImpl.socketConnect(Native Method)
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
        at java.net.Socket.connect(Socket.java:589)
        at okhttp3.internal.platform.Platform.connectSocket(Platform.java:125)
        at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:238)
        at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:158)
        at okhttp3.internal.connection.StreamAllocation.findConnection(StreamAllocation.java:256)
        at okhttp3.internal.connection.StreamAllocation.findHealthyConnection(StreamAllocation.java:134)
        at okhttp3.internal.connection.StreamAllocation.newStream(StreamAllocation.java:113)
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:42)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:93)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:125)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
        at io.fabric8.kubernetes.client.utils.HttpClientUtils$2.intercept(HttpClientUtils.java:95)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
        at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:200)
        at okhttp3.RealCall$AsyncCall.execute(RealCall.java:147)
        at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
[error] (OkHttp Dispatcher) java.lang.IllegalStateException: Queue full
java.lang.IllegalStateException: Queue full
        at java.util.AbstractQueue.add(AbstractQueue.java:98)
        at java.util.concurrent.ArrayBlockingQueue.add(ArrayBlockingQueue.java:312)
        at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$2.onFailure(WatchConnectionManager.java:193)
        at okhttp3.internal.ws.RealWebSocket.failWebSocket(RealWebSocket.java:546)
        at okhttp3.internal.ws.RealWebSocket$2.onFailure(RealWebSocket.java:211)
        at okhttp3.RealCall$AsyncCall.execute(RealCall.java:161)
        at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
[trace] Stack trace suppressed: run last compile:run for the full output.
```

Before adding `KubernetesException` to the `WatchConnectionManager#queue` first the queue is cleared. 