### PR TITLE
Avoid WatchConnectionManager thread leak

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -690,8 +690,9 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
   }
 
   public Watch watch(String resourceVersion, final Watcher<T> watcher) throws KubernetesClientException {
+    WatchConnectionManager watch = null;
     try {
-      WatchConnectionManager watch = new WatchConnectionManager(
+      watch = new WatchConnectionManager(
         client,
         this,
         resourceVersion,
@@ -705,6 +706,10 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
     } catch (MalformedURLException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("watch"), e);
     } catch (KubernetesClientException ke) {
+      if(watch != null){
+        //release the watch
+        watch.close();
+      }
       if (ke.getCode() != 200) {
         throw ke;
       }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -98,6 +98,7 @@ public class WatchTest {
     server.expect()
       .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
       .andReturn(410, outdatedEvent).once();
+    final boolean[] onCloseCalled = {false};
     try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
       @Override
       public void eventReceived(Action action, Pod resource) {
@@ -106,11 +107,12 @@ public class WatchTest {
 
       @Override
       public void onClose(KubernetesClientException cause) {
-        throw new AssertionFailedError();
+        onCloseCalled[0] =true;
       }
     })) {
 
     }
+    assertTrue(onCloseCalled[0]);
   }
 
   @Test


### PR DESCRIPTION
Avoid the thread leaking when `watch.waitUntilReady();` throws an exception when it can't establish a connection to k8
  