### PR TITLE
Test showing pauses in pod waitUntilReady

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/WaitTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/WaitTest.java
@@ -1,0 +1,78 @@
+package io.fabric8.kubernetes.client;
+
+import static org.junit.Assert.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+
+public class WaitTest {
+
+    private DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+
+    private KubernetesClient client;
+    private Pod pod;
+
+    @Before
+    public void configure() throws Exception {
+        client = new DefaultKubernetesClient();
+
+        String image = "busybox";
+        Container c = new ContainerBuilder().withName(image).withImagePullPolicy("IfNotPresent").withImage(image)
+                .withCommand("cat").withTty(true).build();
+        String podName = "test-waiting-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        pod = client.pods().create(new PodBuilder().withNewMetadata().withName(podName).endMetadata().withNewSpec()
+                .withContainers(c).endSpec().build());
+
+        System.out.println("Created pod: " + pod.getMetadata().getName());
+    }
+
+    @Test(timeout = 100000)
+    public void testWaitForPod() throws Exception {
+        Thread[] t = new Thread[20];
+        List<Boolean> results = Collections.synchronizedList(new ArrayList<Boolean>(t.length));
+        for (int i = 0; i < t.length; i++) {
+            t[i] = newThread(i, results);
+        }
+        for (int i = 0; i < t.length; i++) {
+            t[i].start();
+        }
+        for (int i = 0; i < t.length; i++) {
+            t[i].join();
+        }
+        assertEquals("Not all threads finished successfully", t.length, results.size());
+        for (Boolean r : results) {
+            assertTrue(r);
+        }
+    }
+
+    private Thread newThread(final int i, final List<Boolean> results) {
+        return new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    client.pods().inNamespace(pod.getMetadata().getNamespace()).withName(pod.getMetadata().getName())
+                            .waitUntilReady(5, TimeUnit.MINUTES);
+                    results.add(Boolean.TRUE);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    System.out.println(dtf.format(LocalDateTime.now()) + " Thread " + i + " finished");
+                }
+            }
+        }, "test-" + i);
+    }
+
+}


### PR DESCRIPTION
Minimal test from https://github.com/jenkinsci/kubernetes-plugin/pull/271

Running this test shows 30 second waits when running multiple concurrent threads using waitUntilReady

```
mvn clean test -Dtest=WaitTest
...
Running io.fabric8.kubernetes.client.WaitTest
Created pod: test-waiting-2g74l
2018/01/30 20:54:49 Thread 1 finished
2018/01/30 20:54:49 Thread 8 finished
2018/01/30 20:54:49 Thread 19 finished
2018/01/30 20:54:49 Thread 4 finished
2018/01/30 20:54:49 Thread 7 finished
2018/01/30 20:55:19 Thread 10 finished
2018/01/30 20:55:19 Thread 17 finished
2018/01/30 20:55:19 Thread 12 finished
2018/01/30 20:55:19 Thread 0 finished
2018/01/30 20:55:19 Thread 18 finished
2018/01/30 20:55:28 Thread 14 finished
2018/01/30 20:55:28 Thread 11 finished
2018/01/30 20:55:28 Thread 6 finished
2018/01/30 20:55:28 Thread 9 finished
2018/01/30 20:55:28 Thread 3 finished
2018/01/30 20:55:28 Thread 2 finished
2018/01/30 20:55:28 Thread 13 finished
2018/01/30 20:55:28 Thread 16 finished
2018/01/30 20:55:28 Thread 5 finished
2018/01/30 20:55:28 Thread 15 finished
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 44.234 sec - in io.fabric8.kubernetes.client.WaitTest
```