### PR TITLE
Added CRUD Test and Regression Test for SecurityContextConstraints

### DIFF
--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/SecurityContexConstraintsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/SecurityContexConstraintsIT.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift;
+
+
+import io.fabric8.openshift.api.model.SecurityContextConstraints;
+import io.fabric8.openshift.api.model.SecurityContextConstraintsBuilder;
+import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class SecurityContexConstraintsIT {
+
+  @ArquillianResource
+  OpenShiftClient client;
+
+  @ArquillianResource
+  Session session;
+
+  private SecurityContextConstraints scc;
+
+  @Before
+  public void init(){
+
+    scc = new SecurityContextConstraintsBuilder()
+      .withNewMetadata().withName("test-scc").endMetadata()
+      .withAllowPrivilegedContainer(true)
+      .withNewRunAsUser()
+      .withType("RunAsAny")
+      .endRunAsUser()
+      .withNewSeLinuxContext()
+      .withType("RunAsAny")
+      .endSeLinuxContext()
+      .withNewFsGroup()
+      .withType("RunAsAny")
+      .endFsGroup()
+      .withNewSupplementalGroups()
+      .withType("RunAsAny")
+      .endSupplementalGroups()
+      .addToUsers("admin")
+      .addToGroups("admin-group")
+      .build();
+
+    scc = client.securityContextConstraints().create(scc);
+  }
+
+  @Test
+  public void load() {
+      
+    SecurityContextConstraints loadedSCC = client.securityContextConstraints()
+      .load(getClass().getResourceAsStream("/test-scc.yml")).get();
+
+    assertNotNull(loadedSCC);
+    assertEquals("test-scc",loadedSCC.getMetadata().getName());
+    assertTrue(loadedSCC.getAllowPrivilegedContainer());
+    assertEquals("RunAsAny",loadedSCC.getRunAsUser().getType());
+    assertEquals("RunAsAny",loadedSCC.getSeLinuxContext().getType());
+    assertEquals(1,loadedSCC.getUsers().size());
+    assertEquals("admin", loadedSCC.getUsers().get(0));
+    assertEquals(1,loadedSCC.getGroups().size());
+    assertEquals("admin-group", loadedSCC.getGroups().get(0));
+  }
+
+  @Test
+  public void get() {
+
+    SecurityContextConstraints getSCC = client.securityContextConstraints()
+      .withName("test-scc").get();
+    assertNotNull(getSCC);
+    assertEquals("test-scc",getSCC.getMetadata().getName());
+    assertTrue(getSCC.getAllowPrivilegedContainer());
+    assertEquals("RunAsAny",getSCC.getRunAsUser().getType());
+    assertEquals("RunAsAny",getSCC.getFsGroup().getType());
+    assertEquals("RunAsAny",getSCC.getSeLinuxContext().getType());
+    assertEquals("RunAsAny",getSCC.getSupplementalGroups().getType());
+    assertEquals(1,getSCC.getUsers().size());
+    assertEquals("admin", getSCC.getUsers().get(0));
+    assertEquals(1,getSCC.getGroups().size());
+    assertEquals("admin-group", getSCC.getGroups().get(0));
+  }
+
+  @Test
+  public void list() {
+
+    SecurityContextConstraintsList sccList = client.securityContextConstraints().list();
+
+    assertNotNull(sccList);
+    assertEquals(1,sccList.getItems().size());
+    assertEquals("test-scc",sccList.getItems().get(0).getMetadata().getName());
+    assertTrue(sccList.getItems().get(0).getAllowPrivilegedContainer());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getRunAsUser().getType());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getFsGroup().getType());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getSeLinuxContext().getType());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getSupplementalGroups().getType());
+    assertEquals(1,sccList.getItems().get(0).getUsers().size());
+    assertEquals("admin", sccList.getItems().get(0).getUsers().get(0));
+    assertEquals(1,sccList.getItems().get(0).getGroups().size());
+    assertEquals("admin-group", sccList.getItems().get(0).getGroups().get(0));
+  }
+
+  @Test
+  public void update(){
+
+    scc = client.securityContextConstraints().withName("test-scc").edit()
+      .withAllowPrivilegedContainer(false)
+      .done();
+
+    assertNotNull(scc);
+    assertEquals("test-scc",scc.getMetadata().getName());
+    assertFalse(scc.getAllowPrivilegedContainer());
+    assertEquals("RunAsAny",scc.getRunAsUser().getType());
+    assertEquals("RunAsAny",scc.getFsGroup().getType());
+    assertEquals("RunAsAny",scc.getSeLinuxContext().getType());
+    assertEquals("RunAsAny",scc.getSupplementalGroups().getType());
+    assertEquals(1,scc.getUsers().size());
+    assertEquals("admin", scc.getUsers().get(0));
+    assertEquals(1,scc.getGroups().size());
+    assertEquals("admin-group", scc.getGroups().get(0));
+  }
+
+  @Test
+  public void delete(){
+
+    boolean deleted = client.securityContextConstraints().delete(scc);
+    assertTrue(deleted);
+    SecurityContextConstraintsList sccList = client.securityContextConstraints().list();
+    assertFalse(sccList.getItems().contains(scc));
+  }
+
+
+  @After
+  public void cleanup() {
+
+    client.securityContextConstraints().delete();
+  }
+
+}

--- a/kubernetes-itests/src/test/resources/test-scc.yml
+++ b/kubernetes-itests/src/test/resources/test-scc.yml
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: test-scc
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- admin
+groups:
+- admin-group

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -137,6 +137,11 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
           kind.equalsIgnoreCase("NetworkPolicies")){
           kind = kind.substring(0,kind.length() - 3) + "y";
         }
+        else if (kind.equalsIgnoreCase("securityContextConstraints")){
+          // do nothing
+          // because its a case which is ending with s but its name is
+          // like that, it is not plural
+        }
         else if (kind.endsWith("s")) {
           kind = kind.substring(0, kind.length() - 1);
         }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsCrudTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.api.model.SecurityContextConstraints;
+import io.fabric8.openshift.api.model.SecurityContextConstraintsBuilder;
+import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SecurityContextConstraintsCrudTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(SecurityContextConstraintsCrudTest.class);
+
+  @Rule
+  public OpenShiftServer openshiftServer = new OpenShiftServer(true,true);
+
+  @Test
+  public void crudTest(){
+    OpenShiftClient client = openshiftServer.getOpenshiftClient();
+
+    logger.info("Current User " + client.currentUser());
+
+    SecurityContextConstraints scc = new SecurityContextConstraintsBuilder()
+      .withNewMetadata().withName("test-scc").endMetadata()
+      .withAllowPrivilegedContainer(true)
+      .withNewRunAsUser()
+      .withType("RunAsAny")
+      .endRunAsUser()
+      .withNewSeLinuxContext()
+      .withType("RunAsAny")
+      .endSeLinuxContext()
+      .withNewFsGroup()
+      .withType("RunAsAny")
+      .endFsGroup()
+      .withNewSupplementalGroups()
+      .withType("RunAsAny")
+      .endSupplementalGroups()
+      .addToUsers("admin")
+      .addToGroups("admin-group")
+      .build();
+
+    //test of Creation
+
+    scc = client.securityContextConstraints().create(scc);
+    assertNotNull(scc);
+    assertEquals("test-scc",scc.getMetadata().getName());
+    assertTrue(scc.getAllowPrivilegedContainer());
+    assertEquals("RunAsAny",scc.getRunAsUser().getType());
+    assertEquals("RunAsAny",scc.getFsGroup().getType());
+    assertEquals("RunAsAny",scc.getSeLinuxContext().getType());
+    assertEquals("RunAsAny",scc.getSupplementalGroups().getType());
+    assertEquals(1,scc.getUsers().size());
+    assertEquals("admin", scc.getUsers().get(0));
+    assertEquals(1,scc.getGroups().size());
+    assertEquals("admin-group", scc.getGroups().get(0));
+
+
+
+    //test of list
+    SecurityContextConstraintsList sccList = client.securityContextConstraints().list();
+
+    logger.info(sccList.toString());
+
+    assertNotNull(sccList);
+    assertEquals(1,sccList.getItems().size());
+    assertEquals("test-scc",sccList.getItems().get(0).getMetadata().getName());
+    assertTrue(sccList.getItems().get(0).getAllowPrivilegedContainer());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getRunAsUser().getType());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getFsGroup().getType());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getSeLinuxContext().getType());
+    assertEquals("RunAsAny",sccList.getItems().get(0).getSupplementalGroups().getType());
+    assertEquals(1,sccList.getItems().get(0).getUsers().size());
+    assertEquals("admin", sccList.getItems().get(0).getUsers().get(0));
+    assertEquals(1,sccList.getItems().get(0).getGroups().size());
+    assertEquals("admin-group", sccList.getItems().get(0).getGroups().get(0));
+
+    //test of updation
+    scc = client.securityContextConstraints().withName("test-scc").edit()
+      .withAllowPrivilegedContainer(false)
+      .done();
+
+    logger.info("Updated PodSecurityPolicy : " + scc.toString());
+
+    assertNotNull(scc);
+    assertEquals("test-scc",scc.getMetadata().getName());
+    assertFalse(scc.getAllowPrivilegedContainer());
+    assertEquals("RunAsAny",scc.getRunAsUser().getType());
+    assertEquals("RunAsAny",scc.getFsGroup().getType());
+    assertEquals("RunAsAny",scc.getSeLinuxContext().getType());
+    assertEquals("RunAsAny",scc.getSupplementalGroups().getType());
+    assertEquals(1,scc.getUsers().size());
+    assertEquals("admin", scc.getUsers().get(0));
+    assertEquals(1,scc.getGroups().size());
+    assertEquals("admin-group", scc.getGroups().get(0));
+
+    //test of deletion
+    boolean deleted = client.securityContextConstraints().delete(scc);
+    assertTrue(deleted);
+    sccList = client.securityContextConstraints().list();
+    assertEquals(0,sccList.getItems().size());
+
+  }
+}


### PR DESCRIPTION
Added CRUD Test and Regression Test for SecurityContextConstraints
After adding tests, they were failing so fixed the SCC.
It was not working for get, update and list operations.
#996