### PR TITLE
Optimize watch to avoid missing events

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -197,7 +197,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
     }
 
     ReadinessWatcher<T> watcher = new ReadinessWatcher<>(item);
-    try (Watch watch = watch(watcher)) {
+    try (Watch watch = watch(item.getMetadata().getResourceVersion(), watcher)) {
       try {
         return watcher.await(interval, TimeUnit.MILLISECONDS);
       } catch (KubernetesClientTimeoutException e) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -149,7 +149,7 @@ public class ResourceTest {
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, noReady).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
       .open()
       .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
       .done()
@@ -190,7 +190,7 @@ public class ResourceTest {
     // and again so that "periodicWatchUntilReady" successfully begins
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, noReady).times(2);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
       .open()
       .waitFor(100).andEmit(new WatchEvent(ready, "MODIFIED"))
       .done()
@@ -230,7 +230,7 @@ public class ResourceTest {
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, noReady).times(2);
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, noReady).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
       .open()
       .waitFor(100).andEmit(new WatchEvent(ready, "MODIFIED"))
       .done()


### PR DESCRIPTION
This Fixes #997 (that is a PR). Watchers did not specify the starting `resourceVersion`, so they started from "latest" and they could miss the readiness event.. relying on a timeout and a subsequent retry..

With this change, the watcher starts from latest observed "resourceVersion", so the readiness event is not missed and it is much faster.