### PR TITLE
Updated regression test as they were not working with Kubernetes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,9 @@ jobs:
             echo "Configured OpenShift cluster : v3.6.0"
 
       - run:
-          command: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B install -P itests
+          command: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B install -P itests-openshift
           no_output_timeout: 3600
+
   OPENSHIFT_3.6.1:
     machine: true
     steps:
@@ -78,8 +79,9 @@ jobs:
             echo "Configured OpenShift cluster : v3.6.1"
 
       - run:
-          command: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B install -P itests
+          command: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B install -P itests-openshift
           no_output_timeout: 3600
+
   OPENSHIFT_3.7.0:
     machine: true
     steps:
@@ -142,8 +144,9 @@ jobs:
             echo "Configured OpenShift cluster : v3.7.0"
 
       - run:
-          command: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B install -P itests
+          command: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B install -P itests-openshift
           no_output_timeout: 3600
+
 workflows:
   version: 2
   build_and_test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,31 @@ Do all your development or fixing work here.
 
 After all your development/fixing work is done, do not forget to add `Unit Test` and `Regression Test` around that. It will be nice if you can add an example of the new feature you have added.
 
+#### * Check your work after running all Unit and Regression Tests
+
+You should run all the unit tests by hitting the following command
+
+```
+mvn clean install
+```
+
+To run regression tests, you need to run a OpenShift/Kubernetes Cluster and after that
+
+For Kubernetes,
+
+```
+mvn clean verify -Pitests-kubernetes
+```
+
+For OpenShift (Login as Admin),
+
+```
+mvn clean verify -Pitests-openshift
+```
+
 #### * Other Requirements
  * If adding a new feature or fixing some bug please update the [CHANGELOG.md](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md),
- * Make sure you add the license headers at top of every new source file you add while implementing the feature.
+ * Make sure you add the license headers at top of every new source file you add while implementing the feature. You can do so by hitting `mvn -N license:format` command.
 
 #### * Commit your work
 After all your work is done, you need to commit the changes.

--- a/kubernetes-itests/pom.xml
+++ b/kubernetes-itests/pom.xml
@@ -62,24 +62,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <version>${arquillian.core.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-kubernetes</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.fabric8</groupId>
-          <artifactId>kubernetes-openshift-uberjar</artifactId>
-        </exclusion>
-      </exclusions>
-      <version>${arquillian.cube.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-openshift</artifactId>
       <version>${arquillian.cube.version}</version>
@@ -92,4 +74,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
 </project>

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildConfigIT.java
@@ -16,7 +16,9 @@
 
 package io.fabric8.openshift;
 
-import io.fabric8.openshift.api.model.*;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
+import io.fabric8.openshift.api.model.BuildConfigList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
@@ -16,7 +16,9 @@
 
 package io.fabric8.openshift;
 
-import io.fabric8.openshift.api.model.*;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfigList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/ImageStreamIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/ImageStreamIT.java
@@ -16,7 +16,9 @@
 
 package io.fabric8.openshift;
 
-import io.fabric8.openshift.api.model.*;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import io.fabric8.openshift.api.model.ImageStreamList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/RouteIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/RouteIT.java
@@ -16,7 +16,9 @@
 
 package io.fabric8.openshift;
 
-import io.fabric8.openshift.api.model.*;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.api.model.RouteList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/SecurityContextConstraintsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/SecurityContextConstraintsIT.java
@@ -21,7 +21,7 @@ import io.fabric8.openshift.api.model.SecurityContextConstraintsBuilder;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Session;
-import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.After;
@@ -34,8 +34,8 @@ import java.util.Collections;
 import static org.junit.Assert.*;
 
 @RunWith(ArquillianConditionalRunner.class)
-@RequiresKubernetes
-public class SecurityContexConstraintsIT {
+@RequiresOpenshift
+public class SecurityContextConstraintsIT {
 
   @ArquillianResource
   OpenShiftClient client;

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/TemplateIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/TemplateIT.java
@@ -18,7 +18,6 @@ package io.fabric8.openshift;
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.openshift.api.model.Parameter;
 import io.fabric8.openshift.api.model.Template;
 import io.fabric8.openshift.api.model.TemplateBuilder;
 import io.fabric8.openshift.api.model.TemplateList;

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.sonatype.oss</groupId>
@@ -89,7 +90,7 @@
     <kubernetes.model.version>2.0.8</kubernetes.model.version>
     <log4j.version>2.5</log4j.version>
     <zjsonpatch.version>0.3.0</zjsonpatch.version>
-    <arquillian.cube.version>1.11.0</arquillian.cube.version>
+    <arquillian.cube.version>1.15.2</arquillian.cube.version>
     <assertj.core.version>3.8.0</assertj.core.version>
     <arquillian.core.version>1.2.0.Final</arquillian.core.version>
 
@@ -348,10 +349,49 @@
       </build>
     </profile>
     <profile>
-      <id>itests</id>
+      <id>itests-kubernetes</id>
       <modules>
         <module>kubernetes-itests</module>
       </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>2.20.1</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.arquillian.cube</groupId>
+          <artifactId>arquillian-cube-kubernetes-starter</artifactId>
+          <version>${arquillian.cube.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>itests-openshift</id>
+      <modules>
+        <module>kubernetes-itests</module>
+      </modules>
+      <dependencies>
+        <dependency>
+          <groupId>org.arquillian.cube</groupId>
+          <artifactId>arquillian-cube-openshift-starter</artifactId>
+          <version>${arquillian.cube.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
This was because of dependency issue of arquillian
Created two different profile one for Kubernetes and one for Openshift
Changed the Requirement According to Object
If `@RequiresKubernetes` it will run in both profile
If `@RequireOpenshift` it will run in only Openshift profile and will be skipped in Kubernetes
If the user is running the test on Kubernetes, it should hit -P itests-kubernetes profile
and for openshift it should hit -P itests-openshift profile
#1024

Thanks @dipak-pawar for helping.