### PR TITLE
config: support loading from kubeconfig string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    * Added support for StorageClass - https://github.com/fabric8io/kubernetes-client/pull/978
    * Added support for PodSecurityPolicy - https://github.com/fabric8io/kubernetes-client/pull/992
    * The client now warns when using Kubernetes alpha or beta resources - https://github.com/fabric8io/kubernetes-client/pull/1010
+   * A Config can now be built from `Config.fromKubeconfig(kubeconfigFileContents)`: https://github.com/fabric8io/kubernetes-client/pull/1029
   
   Improvements
    * Fixed issue of SecurityContextConstraints not working - https://github.com/fabric8io/kubernetes-client/pull/982

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
@@ -40,6 +40,11 @@ public class KubeConfigUtils {
     return mapper.readValue(file, Config.class);
   }
 
+  public static Config parseConfigFromString(String contents) throws IOException {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    return mapper.readValue(contents, Config.class);
+  }
+
   /**
    * Returns the current context in the given config
    */


### PR DESCRIPTION
Fixes #1028.

I've manually verified this by building the `kubernetes-plugin` for Jenkins with my modified library and was able to connect to a cluster via a `kubeconfig` provided as a `secretText` by utilizing the `fromKubeconfig` static method added here.

My intent was to reduce code duplication, while still preserving the existing code path with `tryKubeConfig` and with the relative->absolute path rewriting in kubeconfig.