### PR TITLE
Added NO_PROXY support for IP address range value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   Bugs
    * Impersonation parameters not set in withRequestConfig - https://github.com/fabric8io/kubernetes-client/pull/1037
 
+  Improvements
+   * NO_PROXY setting now supports IP ranges so you can specify whole subnet to be excluded from proxy traffic eg. 192.168.0.1/8
+   
 #### 3.1.10 
 
   Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IpAddressMatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IpAddressMatcher.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+/*
+* Excerpt of code by @author Luke Taylor from
+* https://github.com/spring-projects/spring-security/blob/master/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+*
+*
+* Matches a request based on IP Address or subnet mask matching against the remote
+* address.
+* <p>
+* Both IPv6 and IPv4 addresses are supported, but a matcher which is configured with an
+* IPv4 address will never match a request which returns an IPv6 address, and vice-versa.
+*
+* */
+public final class IpAddressMatcher {
+
+  private final InetAddress ipAddress;
+  private final int bitMask;
+
+  /**
+   * Takes a specific IP address or a range specified using the IP/Netmask (e.g.
+   * 192.168.1.0/24 or 202.24.0.0/14).
+   *
+   * @param ipAddress the address or range of addresses from which the request must
+   * come.
+   */
+  public IpAddressMatcher(String ipAddress) {
+    if (ipAddress.indexOf('/') > 0) {
+      String[] addressWithMask = ipAddress.split("\\/");
+      ipAddress = addressWithMask[0];
+      this.bitMask = Integer.parseInt(addressWithMask[1]);
+    } else {
+      bitMask = -1;
+    }
+    this.ipAddress = parseAddress(ipAddress);
+  }
+
+  public boolean matches(String addressToCheck) {
+    InetAddress checkAddress = parseAddress(addressToCheck);
+
+    if (!ipAddress.getClass().equals(checkAddress.getClass())) {
+      return false;
+    }
+
+    if (bitMask < 0) {
+      return checkAddress.equals(ipAddress);
+    }
+
+    byte[] checkAddrBytes = checkAddress.getAddress();
+    byte[] ipAddrBytes = ipAddress.getAddress();
+
+    int oddBits = bitMask % 8;
+    int maskBytes = bitMask / 8 + (oddBits == 0 ? 0 : 1);
+    byte[] mask = new byte[maskBytes];
+
+    Arrays.fill(mask, 0, oddBits == 0 ? mask.length : mask.length - 1, (byte) 0xFF);
+
+    if (oddBits != 0) {
+      int lastByte = (1 << oddBits) - 1;
+      lastByte <<= 8 - oddBits;
+      mask[mask.length - 1] = (byte) lastByte;
+    }
+
+    for (int i = 0; i < mask.length; i++) {
+      if ((checkAddrBytes[i] & mask[i]) != (ipAddrBytes[i] & mask[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private InetAddress parseAddress(String address) {
+    try {
+      return InetAddress.getByName(address);
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("Failed to parse ipAddress" + address, e);
+    }
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/IpAddressMatcherTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/IpAddressMatcherTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class IpAddressMatcherTest {
+
+  @Test
+  public void testIpRangeMatcher() {
+    Assert.assertTrue(new IpAddressMatcher("192.168.10.110").matches("192.168.10.110"));
+    Assert.assertTrue(new IpAddressMatcher("192.168.1.0/8").matches("192.168.10.110"));
+    Assert.assertTrue(new IpAddressMatcher("192.168.1.0/24").matches("192.168.1.100"));
+    Assert.assertFalse(new IpAddressMatcher("192.168.1.0/24").matches("193.168.1.10"));
+    Assert.assertFalse(new IpAddressMatcher("192.168.1.0/24").matches("192.168.2.10"));
+    Assert.assertFalse(new IpAddressMatcher("192.168.1.0/24").matches("192.168.2.10"));
+    Assert.assertFalse(new IpAddressMatcher("192.168.1.0/8").matches("193.168.1.10"));
+  }
+
+  @Test
+  public void testIpAddressRegexp() {
+    try {
+      Pattern pattern = Pattern.compile(HttpClientUtils.ipv4Pattern, Pattern.CASE_INSENSITIVE);
+      Matcher matcherPlain = pattern.matcher("192.168.0.1");
+      Assert.assertTrue(matcherPlain.matches());
+
+      Matcher matcherPlainProtocol = pattern.matcher("http://192.168.0.1");
+      Assert.assertTrue(matcherPlainProtocol.matches());
+
+      Matcher matcherPlainProtocol2 = pattern.matcher("https://192.168.0.1");
+      Assert.assertTrue(matcherPlainProtocol2.matches());
+
+      Matcher matcherRange = pattern.matcher("192.168.0.1/24");
+      Assert.assertTrue(matcherRange.matches());
+
+      Matcher matcherRangeProtocol = pattern.matcher("http://192.168.0.1/24");
+      Assert.assertTrue(matcherRangeProtocol.matches());
+
+      Matcher matcherRangeProtocol2 = pattern.matcher("https://192.168.0.1/24");
+      Assert.assertTrue(matcherRangeProtocol2.matches());
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to compile pattern.");
+    }
+  }
+}


### PR DESCRIPTION
NO_PROXY value can contain ip range values. In such case proxy shouldn't be used but currently is. This PR implements check whether NO_PROXY contains ip value or ip range value such as 192.168.0.1/8 and correctly matches such range against requested URL ignoring proxy for given ranges.