### PR TITLE
chore: Switch reconnect backoff message in wach manager to debug level

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -381,7 +381,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
     if (exponentOfTwo > maxIntervalExponent)
       exponentOfTwo = maxIntervalExponent;
     long ret = reconnectInterval * (1 << exponentOfTwo);
-    logger.info("Current reconnect backoff is " + ret + " milliseconds (T" + exponentOfTwo + ")");
+    logger.debug("Current reconnect backoff is " + ret + " milliseconds (T" + exponentOfTwo + ")");
     return ret;
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -311,7 +311,7 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
     if (exponentOfTwo > maxIntervalExponent)
       exponentOfTwo = maxIntervalExponent;
     long ret = reconnectInterval * (1 << exponentOfTwo);
-    logger.info("Current reconnect backoff is " + ret + " milliseconds (T" + exponentOfTwo + ")");
+    logger.debug("Current reconnect backoff is " + ret + " milliseconds (T" + exponentOfTwo + ")");
     return ret;
   }
 


### PR DESCRIPTION
info level seems to be inappropriate for this internal processing message as this regularly happens and does not really add much information, looks more like random noise.

Its valuable for debugging though, so I suggest to move this from "info" to "debug" level.