### PR TITLE
Fix #1013 : Kubernetes connection is not getting closed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Change Log
 
 #### 3.1.11 (To be released)
+  Bugs
+  * Fix #1013 : Kubernetes connection is not getting closed.
 
   Bugs
    * Impersonation parameters not set in withRequestConfig - https://github.com/fabric8io/kubernetes-client/pull/1037


### PR DESCRIPTION
#1013  Using clonedClient seems to be creating connection leaks(as seen in
OkHttp's platform logs when using client). Therefore create a new client
instead of cloning it from previous one.