### PR TITLE
Fix #1004: Multiple document handling breaks if "---" found anywhere in the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 3.1.11 (To be released)
   Bugs
   * Fix #1013 : Kubernetes connection is not getting closed.
+  * Fix #1004: Multiple document handling breaks if "---" found anywhere in the document
 
   Bugs
    * Impersonation parameters not set in withRequestConfig - https://github.com/fabric8io/kubernetes-client/pull/1037

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
@@ -63,14 +63,14 @@ public class LoadMultipleDocumentsFromFileExample {
     StringBuilder sb = new StringBuilder();
     sb.append("[ ");
     if (Utils.isNotNullOrEmpty(item.getKind())) {
-      sb.append("Kind:").append(item.getKind());
+      sb.append(" Kind:").append(item.getKind());
     }
     if (Utils.isNotNullOrEmpty(item.getMetadata().getName())) {
-      sb.append("Name:").append(item.getMetadata().getName());
+      sb.append(" Name:").append(item.getMetadata().getName());
     }
 
     if (item.getMetadata().getLabels() != null && !item.getMetadata().getLabels().isEmpty()) {
-      sb.append("Lables: [ ");
+      sb.append(" Lables: [ ");
       for (Map.Entry<String, String> entry : item.getMetadata().getLabels().entrySet()) {
         sb.append(entry.getKey()).append(":").append(entry.getValue()).append(" ");
       }

--- a/kubernetes-examples/src/main/resources/multiple-document-template.yml
+++ b/kubernetes-examples/src/main/resources/multiple-document-template.yml
@@ -34,7 +34,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: redis-master
+  name: redis---master---
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
Don't use --- as a delimiter to split documents. Instead, split document by '\n', process
line by line and only split when a single '---' found in the document. #1004 