### PR TITLE
Fixes premature call to watcher onClose

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -231,7 +231,10 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
               }
             }, nextReconnectInterval(), TimeUnit.MILLISECONDS);
           } catch (RejectedExecutionException e) {
-            logger.error("Exception in reconnect", e);
+            // This is a standard exception if we close the scheduler. We should not print it
+            if (!forceClosed.get()) {
+              logger.error("Exception in reconnect", e);
+            }
             reconnectPending.set(false);
           }
         }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/WatcherToggle.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/WatcherToggle.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+
+import java.util.Objects;
+
+/**
+ * A utility class to enable and disable callbacks to a watcher instance.
+ */
+public class WatcherToggle<T> implements Watcher<T> {
+
+  private Watcher<T> delegate;
+
+  private boolean enabled;
+
+  public WatcherToggle(Watcher<T> delegate, boolean enabled) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate watcher cannot be null");
+    this.enabled = enabled;
+  }
+
+  public void disable() {
+    this.enabled = false;
+  }
+
+  public void enable() {
+    this.enabled = true;
+  }
+
+  @Override
+  public void eventReceived(Action action, T resource) {
+    if (enabled) {
+      delegate.eventReceived(action, resource);
+    }
+  }
+
+  @Override
+  public void onClose(KubernetesClientException cause) {
+    if (enabled) {
+      delegate.onClose(cause);
+    }
+  }
+}


### PR DESCRIPTION
This is related to https://github.com/fabric8io/fabric8-maven-plugin/issues/1263

The client tries to create a standard watch, then falls back to a http watch in some cases (to be understood why it always do so in f-m-p). The problem is that when it cleans up the standard watch, it closes the websocket but it also calls the "onClose" method on the user watcher, and it shouldn't, because the user watcher is going to be used by the fallback http watch.

This avoids the call to the user onClose callback if the watcher is going to be reused.