### PR TITLE
Add support for API groups to attribute extractor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 3.1.13 (To be released)
   Bugs
+   * Fix #1083 : Mock Kubernetes server only handles core and extensions API groups
   
   New Feature
   

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -38,8 +38,8 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
   public static final String NAME = "name";
   public static final String NAMESPACE = "namespace";
 
-  private static final String API_GROUP = "/api[s]?(/extensions)?";
-  private static final String VERSION_GROUP = "(/(?<version>[a-zA-z0-9-_]+))?";
+  private static final String API_GROUP = "/api(s/[a-zA-Z0-9-_.]+)?";
+  private static final String VERSION_GROUP = "(/(?<version>[a-zA-Z0-9-_]+))?";
   private static final String KIND_GROUP = "/(?<kind>[^/?]+)";
   private static final String NAME_GROUP = "(/(?<name>[^/?]+))?";
   private static final String NAMESPACE_GROUP = "(/namespaces/(?<namespace>[^/]+))?";

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
@@ -126,4 +126,29 @@ public class KubernetesAttributesExtractorTest {
     expected = expected.add(new Attribute("namespace", "myns"));
     Assert.assertTrue("Expected " + attributes + " to match " + expected, attributes.matches(expected));
   }
+
+  @Test
+  public void shouldHandleApiGroups() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    AttributeSet attributes = extractor.extract("/apis/autoscaling/v1/namespaces/myns/horizontalpodautoscalers/myhpa");
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("kind", "horizontalpodautoscaler"));
+    expected = expected.add(new Attribute("namespace", "myns"));
+    expected = expected.add(new Attribute("name", "myhpa"));
+    Assert.assertTrue("Expected " + attributes + " to match " + expected, attributes.matches(expected));
+  }
+
+  @Test
+  public void shouldHandleCrds() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    AttributeSet attributes = extractor.extract("/apis/test.com/v1/namespaces/myns/crds/mycrd");
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("kind", "crd"));
+    expected = expected.add(new Attribute("namespace", "myns"));
+    expected = expected.add(new Attribute("name", "mycrd"));
+    Assert.assertTrue("Expected " + attributes + " to match " + expected, attributes.matches(expected));
+  }
+
 }


### PR DESCRIPTION
Custom resource definitions and many APIs live in API groups other than
"extensions". The current regex doesn't accept these groups and leads to
silent failures in the mock behavior because the path can't be parsed.

Technically, these API groups should be part of the attributes, but they
can't be extracted from a HasMetadata interface and I suspect we'd be
introducing matching failures if we added them for URL-generated
attributes but not object-generated attributes.

While there, fix typo in the VERSION_GROUP.