### PR TITLE
Fix list building for custom resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 3.1.13 (To be released)
   Bugs
    * Fix #1083 : Mock Kubernetes server only handles core and extensions API groups
+   * Fix #1087 : Mock server can't list custom resources
   
   New Feature
   

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
@@ -15,34 +15,16 @@
  */
 package io.fabric8.kubernetes.client.server.mock;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.crud.ResponseComposer;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 public class KubernetesResponseComposer implements ResponseComposer {
 
   @Override
   public String compose(Collection<String> collection) {
-    List<HasMetadata> items = new ArrayList<>();
-    for (String item : collection) {
-      try (InputStream stream = new ByteArrayInputStream(item.getBytes(StandardCharsets.UTF_8.name()))) {
-        HasMetadata h = Serialization.unmarshal(stream);
-        items.add(h);
-      } catch (Exception e) {
-        throw KubernetesClientException.launderThrowable(e);
-      }
-    }
-    KubernetesList list = new KubernetesListBuilder().withItems(items).build();
-    return Serialization.asJson(list);
+    return String.format(
+        "{\"apiVersion\":\"v1\",\"kind\":\"List\", \"items\": [%s]}",
+        String.join(",", collection));
   }
 }


### PR DESCRIPTION
This fixes issue #1087. Custom resources cannot be deserialized with the
standard Kubernetes JSON parser because it doesn't know about them.
Since all items are JSON anyway, we can just use text concatenation.