### PR TITLE
Remove Test

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -199,14 +199,6 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithServiceAccount() {
-    System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, "/dev/null");
-    Config config = Config.autoConfigure(null);
-    assertNotNull(config);
-    assertEquals("https://kubernetes.default.svc/", config.getMasterUrl());
-  }
-
-  @Test
   public void testMasterUrlWithServiceAccount() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, "/dev/null");
     System.setProperty(Config.KUBERNETES_SERVICE_HOST_PROPERTY, "10.0.0.1");


### PR DESCRIPTION
If we keep that test, it will return different URl for
every other CI. If we do some changes in test, it will
be similar to other tests like setting masterUrl and all.
This started happening after PR #1086
Asserting not null and is URL is the only solution
but does not make any difference as we have another tests for this func.