### PR TITLE
fixes(#1089): Appends query params at the end of the URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### 3.2.1 (To be released)
 
+  Bugs
+    * Fix #1089 : Query parameters are not correctly processed if set in `masterUrl`
+
 #### 3.2.0
   Bugs
    * Fix #1083 : Mock Kubernetes server only handles core and extensions API groups

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/URLUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/URLUtils.java
@@ -15,17 +15,39 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 public class URLUtils {
     private URLUtils() {}
 
     public static String join(String... parts) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < parts.length; i++) {
+
+        String queryParams = "";
+        if (parts.length > 0) {
+          String urlWithoutQuery = parts[0];
+          try {
+            URI uri = new URI(parts[0]);
+            if (uri.getQuery() != null) {
+              queryParams = "?" + uri.getQuery();
+              urlWithoutQuery = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, uri.getFragment())
+                .toString();
+            }
+          } catch (URISyntaxException e) {
+            // Not all first parameters are URL
+          }
+          sb.append(urlWithoutQuery).append("/");
+        }
+
+        for (int i = 1; i < parts.length; i++) {
             sb.append(parts[i]);
             if (i < parts.length - 1) {
                 sb.append("/");
             }
         }
+
+        sb.append(queryParams);
         String joined = sb.toString();
 
         // And normalize it...

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/URLUtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/URLUtilsTest.java
@@ -42,5 +42,22 @@ public class URLUtilsTest {
 
   }
 
+  @Test
+  public void shouldJoinNoneUrl() {
+
+    // Given
+
+    String masterUrl = "images.openshift.io";
+
+    // When
+
+    final String fullUrl = URLUtils.join(masterUrl, "api");
+
+    // Then
+
+    assertThat(fullUrl, is("images.openshift.io/api"));
+
+  }
+
 
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/URLUtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/URLUtilsTest.java
@@ -1,0 +1,46 @@
+package io.fabric8.kubernetes.client.utils;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class URLUtilsTest {
+
+
+  @Test
+  public void shouldJoinUrlWithoutQueryParams() {
+
+    // Given
+
+    String masterUrl = "https://oso-master-url:8888/kubernetes";
+
+    // When
+
+    final String fullUrl = URLUtils.join(masterUrl, "api");
+
+    // Then
+
+    assertThat(fullUrl, is("https://oso-master-url:8888/kubernetes/api"));
+
+  }
+
+  @Test
+  public void shouldJoinUrlWithQueryParams() {
+
+    // Given
+
+    String masterUrl = "https://oso-master-url:8888/kubernetes?key=value";
+
+    // When
+
+    final String fullUrl = URLUtils.join(masterUrl, "api");
+
+    // Then
+
+    assertThat(fullUrl, is("https://oso-master-url:8888/kubernetes/api?key=value"));
+
+  }
+
+
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/URLUtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/URLUtilsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.client.utils;
 
 import org.junit.Test;


### PR DESCRIPTION
This PR appends query params at the end of the URL so in case of master URL has parameters they are appended correctly at the end.