### PR TITLE
fix(#1099): CustomResourceDefinitions: withResourceVersion() causes NoSuchMethodError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
     * Fix #1180 : DeploymentExamples requires the definition of a selector with match labels
 
+    * Fix #1099 : CustomResourceDefinitions: withResourceVersion() causes NoSuchMethodError
+
     * Fix #1156 : Watcher does not have correct authentication information in Openshift environment.
     
     * Fix #1125 : ConfigMap labels are ignored when using mock KubernetesServer

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -21,11 +21,14 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.Watchable;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import okhttp3.OkHttpClient;
@@ -104,5 +107,10 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
   @Override
   public Gettable<T> fromServer() {
     return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), getName(), isCascading(), getItem(), getResourceVersion(), true, getType(), getListType(), getDoneableType());
+  }
+
+  @Override
+  public Watchable<Watch, Watcher<T>> withResourceVersion(String resourceVersion) {
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), getNamespace(), getName(), isCascading(), getItem(), resourceVersion, isReloadingFromServer(), getType(), getListType(), getDoneableType());
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -21,6 +21,9 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -270,4 +273,13 @@ public class Utils {
     }
     return sb.toString();
   }
+
+  public static String filePath(URL path) {
+    try {
+      return Paths.get(path.toURI()).toString();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -17,20 +17,20 @@
 package io.fabric8.kubernetes.client;
 
 import io.fabric8.kubernetes.client.utils.Serialization;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URLDecoder;
-import java.util.HashMap;
-import java.util.Map;
+import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static okhttp3.TlsVersion.TLS_1_1;
 import static okhttp3.TlsVersion.TLS_1_2;
@@ -41,10 +41,10 @@ import static org.junit.Assert.assertTrue;
 
 public class ConfigTest {
 
-  private static final String TEST_KUBECONFIG_FILE = decodeUrl(ConfigTest.class.getResource("/test-kubeconfig").getFile());
-  private static final String TEST_NAMESPACE_FILE = decodeUrl(ConfigTest.class.getResource("/test-namespace").getFile());
+  private static final String TEST_KUBECONFIG_FILE = Utils.filePath(ConfigTest.class.getResource("/test-kubeconfig"));
+  private static final String TEST_NAMESPACE_FILE = Utils.filePath(ConfigTest.class.getResource("/test-namespace"));
 
-  private static final String TEST_CONFIG_YML_FILE = decodeUrl(ConfigTest.class.getResource("/test-config.yml").getFile());
+  private static final String TEST_CONFIG_YML_FILE = Utils.filePath(ConfigTest.class.getResource("/test-config.yml"));
 
   @Before
   public void setUp() {
@@ -197,14 +197,6 @@ public class ConfigTest {
     assertConfig(config);
   }
 
-  private static String decodeUrl(String url) {
-    try {
-      return URLDecoder.decode(url, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   @Test
   public void testMasterUrlWithServiceAccount() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, "/dev/null");
@@ -234,7 +226,7 @@ public class ConfigTest {
     assertEquals("https://172.28.128.4:8443/", config.getMasterUrl());
     assertEquals("testns", config.getNamespace());
     assertEquals("token", config.getOauthToken());
-    assertTrue(config.getCaCertFile().endsWith("testns/ca.pem"));
+    assertTrue(config.getCaCertFile().endsWith("testns/ca.pem".replace("/", File.separator)));
     assertTrue(new File(config.getCaCertFile()).isAbsolute());
   }
 
@@ -247,7 +239,7 @@ public class ConfigTest {
     assertEquals("https://172.28.128.4:8443/", config.getMasterUrl());
     assertEquals("production", config.getNamespace());
     assertEquals("supertoken", config.getOauthToken());
-    assertTrue(config.getCaCertFile().endsWith("testns/ca.pem"));
+    assertTrue(config.getCaCertFile().endsWith("testns/ca.pem".replace("/", File.separator)));
     assertTrue(new File(config.getCaCertFile()).isAbsolute());
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/CertUtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/CertUtilsTest.java
@@ -19,10 +19,14 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.Utils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
+import java.net.URISyntaxException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -30,10 +34,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Properties;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertTrue;
 
 public class CertUtilsTest {
 
-  private static String FABRIC8_STORE_PATH = decodeUrl(CertUtilsTest.class.getResource("/ssl/fabric8-store").getPath());
+  private static String FABRIC8_STORE_PATH = Utils.filePath(CertUtilsTest.class.getResource("/ssl/fabric8-store"));
   private static char[] FABRIC8_STORE_PASSPHRASE = "fabric8".toCharArray();
   private Properties systemProperties;
 
@@ -125,13 +125,13 @@ public class CertUtilsTest {
 
   @Test
   public void testLoadKeyStoreFromFileUsingSystemProperties()
-    throws InvalidKeySpecException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+    throws InvalidKeySpecException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, URISyntaxException {
 
     System.setProperty(CertUtils.KEY_STORE_SYSTEM_PROPERTY, FABRIC8_STORE_PATH);
     System.setProperty(CertUtils.KEY_STORE_PASSWORD_SYSTEM_PROPERTY, String.valueOf(FABRIC8_STORE_PASSPHRASE));
 
-    String privateKeyPath = decodeUrl(getClass().getResource("/ssl/fabric8").getPath());
-    String multipleCertsPath = decodeUrl(getClass().getResource("/ssl/multiple-certs.pem").getPath());
+    String privateKeyPath = Utils.filePath(getClass().getResource("/ssl/fabric8"));
+    String multipleCertsPath = Utils.filePath(getClass().getResource("/ssl/multiple-certs.pem"));
 
     KeyStore trustStore =
       CertUtils.createKeyStore(null, multipleCertsPath, null, privateKeyPath, "RSA", "changeit", null, null);
@@ -156,11 +156,4 @@ public class CertUtilsTest {
     return CertUtils.getInputStreamFromDataOrFile(null, "src/test/resources/ssl/multiple-certs.pem");
   }
 
-  private static String decodeUrl(String url) {
-    try {
-      return URLDecoder.decode(url, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
@@ -123,12 +123,12 @@ public class CRDExample {
       dummySpec.setFoo("cheese: " + now);
       dummy.setSpec(dummySpec);
 
-      dummyClient.createOrReplace(dummy);
+      Dummy created = dummyClient.createOrReplace(dummy);
 
       System.out.println("Upserted " + dummy);
 
       System.out.println("Watching for changes to Dummies");
-      dummyClient.watch(new Watcher<Dummy>() {
+      dummyClient.withResourceVersion(created.getMetadata().getResourceVersion()).watch(new Watcher<Dummy>() {
         @Override
         public void eventReceived(Action action, Dummy resource) {
           System.out.println("==> " + action + " for " + resource);


### PR DESCRIPTION
Fixes issue [#1099](https://github.com/fabric8io/kubernetes-client/issues/1099).

+ changes how file paths to resources are resolved in tests (to work also Windows).