### PR TITLE
fix: skip karaf itests when using the release profile.

### DIFF
--- a/platforms/karaf/itests/pom.xml
+++ b/platforms/karaf/itests/pom.xml
@@ -162,6 +162,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skip>${karaf.itest.skip}</skip>
                     <systemPropertyVariables>
                         <features.xml>${project.build.directory}/features.xml</features.xml>
                         <features.repo>${project.build.directory}/features-repo</features.repo>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <osgi.bundles />
     <osgi.activator />
     <osgi.export.service />
+    <karaf.itest.skip>false</karaf.itest.skip>
   </properties>
 
   <modules>
@@ -273,6 +274,9 @@
   <profiles>
     <profile>
       <id>release</id>
+      <properties>
+        <karaf.itest.skip>true</karaf.itest.skip>
+      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
I want to cut a 4.0.1 and karaf itests are blocking the release, for reasons not clear to me (they seem to work great on circleci, maybe port related reasons).

Let's skip them when using the release profile.