### PR TITLE
Get Request with OpenShift Mock Server Not Working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 4.0.4 (To be released)
   Bugs
+    * Fix #1144 : Get Request with OpenShift Mock Server Not Working
 
   Improvements
   

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -38,7 +38,7 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
   public static final String NAME = "name";
   public static final String NAMESPACE = "namespace";
 
-  private static final String API_GROUP = "/api(s/[a-zA-Z0-9-_.]+)?";
+  private static final String API_GROUP = "/o?api(s/[a-zA-Z0-9-_.]+)?";
   private static final String VERSION_GROUP = "(/(?<version>[a-zA-Z0-9-_]+))?";
   private static final String KIND_GROUP = "/(?<kind>[^/?]+)";
   private static final String NAME_GROUP = "(/(?<name>[^/?]+))?";

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
+import io.fabric8.openshift.api.model.BuildConfigList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuildConfigCrudTest {
+
+  @Rule
+  public OpenShiftServer server = new OpenShiftServer(true, true);
+
+  @Test
+  public void testCrud() {
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    BuildConfig buildConfig = new BuildConfigBuilder()
+      .withNewMetadata()
+        .withName("bc2")
+        .withLabels(Collections.singletonMap("key","value"))
+      .endMetadata()
+      .build();
+
+    client.buildConfigs().create(buildConfig);
+
+    BuildConfig buildConfig1 = client.buildConfigs().withName("bc2").get();
+    assertEquals("value", buildConfig1.getMetadata().getLabels().get("key"));
+
+    BuildConfigList buildConfigList = client.buildConfigs().list();
+    assertEquals(1, buildConfigList.getItems().size());
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigCrudTest.java
@@ -63,7 +63,7 @@ public class DeploymentConfigCrudTest {
 
     DeploymentConfigList aDeploymentConfigList = client.deploymentConfigs().list();
     assertNotNull(aDeploymentConfigList);
-    assertEquals(3, aDeploymentConfigList.getItems().size());
+    assertEquals(0, aDeploymentConfigList.getItems().size());
 
     aDeploymentConfigList = client.deploymentConfigs().inAnyNamespace().list();
     assertNotNull(aDeploymentConfigList);
@@ -71,22 +71,21 @@ public class DeploymentConfigCrudTest {
 
     aDeploymentConfigList = client.deploymentConfigs().inNamespace("ns1").list();
     assertNotNull(aDeploymentConfigList);
-    // ! Doesn't work expected 2, but gives 3.
-//    assertEquals(2, aDeploymentConfigList.getItems().size());
+    assertEquals(2, aDeploymentConfigList.getItems().size());
 
     aDeploymentConfigList = client.deploymentConfigs().inNamespace("ns1")
       .withLabels(Collections.singletonMap("testKey", "testValue")).list();
     assertNotNull(aDeploymentConfigList);
-    assertEquals(3, aDeploymentConfigList.getItems().size());
+    assertEquals(2, aDeploymentConfigList.getItems().size());
+
+    deploymentConfig3 = client.deploymentConfigs().inNamespace("ns2").withName("deploymentConfig3").edit()
+      .editMetadata().addToLabels("testkey1","testvalue2").endMetadata()
+      .done();
+    assertNotNull(deploymentConfig3);
+    assertEquals(2, deploymentConfig3.getMetadata().getLabels().size());
 
     // ! Doesn't work
-//    boolean bDeleted = client.deploymentConfigs().inNamespace("ns1").withName("deploymentConfig2").delete();
-//    assertTrue(bDeleted);
-
-//    deploymentConfig3 = client.deploymentConfigs().inNamespace("ns1").withName("deploymentConfig3").edit()
-//      .editMetadata().withName("DEPLOYMENTCONFIG3").endMetadata()
-//      .done();
-//    assertNotNull(deploymentConfig3);
-//    assertEquals("DEPLOYMENTCONFIG3", deploymentConfig3.getMetadata().getName());
+    // boolean bDeleted = client.deploymentConfigs().inNamespace("ns1").withName("deploymentConfig2").delete();
+    // assertTrue(bDeleted);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
@@ -53,7 +53,7 @@ public class RouteCrudTest {
 
     RouteList aRouteList = client.routes().list();
     assertNotNull(aRouteList);
-    assertEquals(3, aRouteList.getItems().size());
+    assertEquals(0, aRouteList.getItems().size());
 
     aRouteList = client.routes().inAnyNamespace().list();
     assertNotNull(aRouteList);
@@ -61,14 +61,14 @@ public class RouteCrudTest {
 
     aRouteList = client.routes().inNamespace("ns1").list();
     assertNotNull(aRouteList);
-    //assertEquals(2, aRouteList.getItems().size()); //! expected 2 but gives 3
+    assertEquals(2, aRouteList.getItems().size());
 
     aRouteList = client.routes().inAnyNamespace().withLabels(Collections.singletonMap("foo", "bar")).list();
     assertNotNull(aRouteList);
     assertEquals(3, aRouteList.getItems().size());
 
-    boolean bDeleted = client.routes().delete();
-    aRouteList = client.routes().list();
+    boolean bDeleted = client.routes().inNamespace("ns1").delete();
+    aRouteList = client.routes().inNamespace("ns1").list();
     assertTrue(bDeleted);
     assertEquals(0, aRouteList.getItems().size());
   }


### PR DESCRIPTION
Adds the case of openshift url also when doing the path URL match
to work fine with openshift resouce in openshift mock server crud Mode
Fix #1144