### PR TITLE
Add support for Kubernetes RBAC ClusterRoles and ClusterRoleBindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   New Feature
   
     * Fix #1066 : Add support for Kubernetes RBAC Role and Role Binding
+    * Fix #1150: Add support for Kubernetes RBAC Cluster Role and Cluster Role Binding
     * Fix #770: Added Support for CronJob
 
 #### 4.0.0

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RbacAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RbacAPIGroupClient.java
@@ -19,6 +19,8 @@ import io.fabric8.kubernetes.api.model.rbac.*;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.RbacAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.internal.KubernetesClusterRoleBindingOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.KubernetesClusterRoleOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.KubernetesRoleOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.KubernetesRoleBindingOperationsImpl;
 import okhttp3.OkHttpClient;
@@ -41,5 +43,15 @@ public class RbacAPIGroupClient extends BaseClient implements RbacAPIGroupDSL {
   @Override
   public MixedOperation<KubernetesRoleBinding, KubernetesRoleBindingList, DoneableKubernetesRoleBinding, Resource<KubernetesRoleBinding, DoneableKubernetesRoleBinding>> kubernetesRoleBindings() {
     return new KubernetesRoleBindingOperationsImpl(httpClient, getConfiguration(), getNamespace());
+  }
+
+  @Override
+  public MixedOperation<KubernetesClusterRole, KubernetesClusterRoleList, DoneableKubernetesClusterRole, Resource<KubernetesClusterRole, DoneableKubernetesClusterRole>> kubernetesClusterRoles() {
+    return new KubernetesClusterRoleOperationsImpl(httpClient, getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<KubernetesClusterRoleBinding, KubernetesClusterRoleBindingList, DoneableKubernetesClusterRoleBinding, Resource<KubernetesClusterRoleBinding, DoneableKubernetesClusterRoleBinding>> kubernetesClusterRoleBindings() {
+    return new KubernetesClusterRoleBindingOperationsImpl(httpClient, getConfiguration());
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/RbacAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/RbacAPIGroupDSL.java
@@ -15,6 +15,12 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRole;
 import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleList;
 import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesRole;
@@ -28,5 +34,9 @@ public interface RbacAPIGroupDSL extends Client{
   MixedOperation<KubernetesRole, KubernetesRoleList, DoneableKubernetesRole, Resource<KubernetesRole, DoneableKubernetesRole>> kubernetesRoles();
 
   MixedOperation<KubernetesRoleBinding, KubernetesRoleBindingList, DoneableKubernetesRoleBinding, Resource<KubernetesRoleBinding, DoneableKubernetesRoleBinding>> kubernetesRoleBindings();
+
+  MixedOperation<KubernetesClusterRole, KubernetesClusterRoleList, DoneableKubernetesClusterRole, Resource<KubernetesClusterRole, DoneableKubernetesClusterRole>> kubernetesClusterRoles();
+
+  MixedOperation<KubernetesClusterRoleBinding, KubernetesClusterRoleBindingList, DoneableKubernetesClusterRoleBinding, Resource<KubernetesClusterRoleBinding, DoneableKubernetesClusterRoleBinding>> kubernetesClusterRoleBindings();
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesClusterRoleBindingOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesClusterRoleBindingOperationsImpl.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import okhttp3.OkHttpClient;
+
+public class KubernetesClusterRoleBindingOperationsImpl extends HasMetadataOperation<KubernetesClusterRoleBinding, KubernetesClusterRoleBindingList, DoneableKubernetesClusterRoleBinding, Resource<KubernetesClusterRoleBinding, DoneableKubernetesClusterRoleBinding>> {
+
+  public KubernetesClusterRoleBindingOperationsImpl(OkHttpClient client, Config config) {
+    this(client, config, "v1", null, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
+  }
+
+  public KubernetesClusterRoleBindingOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, KubernetesClusterRoleBinding item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
+    super(client, config, "rbac.authorization.k8s.io", apiVersion, "clusterrolebindings", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
+  }
+
+  @Override
+  public boolean isResourceNamespaced() {
+    return false;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesClusterRoleOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesClusterRoleOperationsImpl.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import io.fabric8.kubernetes.api.model.rbac.DoneableKubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import okhttp3.OkHttpClient;
+
+public class KubernetesClusterRoleOperationsImpl extends HasMetadataOperation<KubernetesClusterRole, KubernetesClusterRoleList, DoneableKubernetesClusterRole, Resource<KubernetesClusterRole, DoneableKubernetesClusterRole>> {
+
+  public KubernetesClusterRoleOperationsImpl(OkHttpClient client, Config config) {
+    this(client, config, "v1", null, null, true, null, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>());
+  }
+
+  public KubernetesClusterRoleOperationsImpl(OkHttpClient client, Config config, String apiVersion, String namespace, String name, Boolean cascading, KubernetesClusterRole item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields) {
+    super(client, config, "rbac.authorization.k8s.io", apiVersion, "clusterroles", namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
+  }
+
+  @Override
+  public boolean isResourceNamespaced() {
+    return false;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesClusterRoleBindingHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesClusterRoleBindingHandler.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.handlers;
+
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ResourceHandler;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.internal.KubernetesClusterRoleBindingOperationsImpl;
+import okhttp3.OkHttpClient;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+
+@Component
+@Service
+public class KubernetesClusterRoleBindingHandler implements ResourceHandler<KubernetesClusterRoleBinding, KubernetesClusterRoleBindingBuilder> {
+
+  @Override
+  public String getKind() {
+    return KubernetesClusterRoleBinding.class.getSimpleName();
+  }
+
+  @Override
+  public KubernetesClusterRoleBinding create(OkHttpClient client, Config config, String namespace, KubernetesClusterRoleBinding item) {
+    return new KubernetesClusterRoleBindingOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).create();
+  }
+
+  @Override
+  public KubernetesClusterRoleBinding replace(OkHttpClient client, Config config, String namespace, KubernetesClusterRoleBinding item) {
+    return new KubernetesClusterRoleBindingOperationsImpl(client, config, null, namespace, null, true, item, null, true, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).replace(item);
+  }
+
+  @Override
+  public KubernetesClusterRoleBinding reload(OkHttpClient client, Config config, String namespace, KubernetesClusterRoleBinding item) {
+    return new KubernetesClusterRoleBindingOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).fromServer().get();
+  }
+
+  @Override
+  public KubernetesClusterRoleBindingBuilder edit(KubernetesClusterRoleBinding item) {
+    return new KubernetesClusterRoleBindingBuilder(item);
+  }
+
+  @Override
+  public Boolean delete(OkHttpClient client, Config config, String namespace, KubernetesClusterRoleBinding item) {
+    return new KubernetesClusterRoleBindingOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).delete(item);
+  }
+
+  @Override
+  public Watch watch(OkHttpClient client, Config config, String namespace, KubernetesClusterRoleBinding item, Watcher<KubernetesClusterRoleBinding> watcher) {
+    return new KubernetesClusterRoleBindingOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).watch(watcher);
+  }
+
+  @Override
+  public Watch watch(OkHttpClient client, Config config, String namespace, KubernetesClusterRoleBinding item, String resourceVersion, Watcher<KubernetesClusterRoleBinding> watcher) {
+    return new KubernetesClusterRoleBindingOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).watch(resourceVersion, watcher);
+  }
+
+  @Override
+  public KubernetesClusterRoleBinding waitUntilReady(OkHttpClient client, Config config, String namespace, KubernetesClusterRoleBinding item, long amount, TimeUnit timeUnit) throws InterruptedException {
+    return new KubernetesClusterRoleBindingOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).waitUntilReady(amount, timeUnit);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesClusterRoleHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesClusterRoleHandler.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.handlers;
+
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ResourceHandler;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.internal.KubernetesClusterRoleOperationsImpl;
+import okhttp3.OkHttpClient;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+
+@Component
+@Service
+public class KubernetesClusterRoleHandler implements ResourceHandler<KubernetesClusterRole, KubernetesClusterRoleBuilder> {
+
+  @Override
+  public String getKind() {
+    return KubernetesClusterRole.class.getSimpleName();
+  }
+
+  @Override
+  public KubernetesClusterRole create(OkHttpClient client, Config config, String namespace, KubernetesClusterRole item) {
+    return new KubernetesClusterRoleOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).create();
+  }
+
+  @Override
+  public KubernetesClusterRole replace(OkHttpClient client, Config config, String namespace, KubernetesClusterRole item) {
+    return new KubernetesClusterRoleOperationsImpl(client, config, null, namespace, null, true, item, null, true, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).replace(item);
+  }
+
+  @Override
+  public KubernetesClusterRole reload(OkHttpClient client, Config config, String namespace, KubernetesClusterRole item) {
+    return new KubernetesClusterRoleOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).fromServer().get();
+  }
+
+  @Override
+  public KubernetesClusterRoleBuilder edit(KubernetesClusterRole item) {
+    return new KubernetesClusterRoleBuilder(item);
+  }
+
+  @Override
+  public Boolean delete(OkHttpClient client, Config config, String namespace, KubernetesClusterRole item) {
+    return new KubernetesClusterRoleOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).delete(item);
+  }
+
+  @Override
+  public Watch watch(OkHttpClient client, Config config, String namespace, KubernetesClusterRole item, Watcher<KubernetesClusterRole> watcher) {
+    return new KubernetesClusterRoleOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).watch(watcher);
+  }
+
+  @Override
+  public Watch watch(OkHttpClient client, Config config, String namespace, KubernetesClusterRole item, String resourceVersion, Watcher<KubernetesClusterRole> watcher) {
+    return new KubernetesClusterRoleOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).watch(resourceVersion, watcher);
+  }
+
+  @Override
+  public KubernetesClusterRole waitUntilReady(OkHttpClient client, Config config, String namespace, KubernetesClusterRole item, long amount, TimeUnit timeUnit) throws InterruptedException {
+    return new KubernetesClusterRoleOperationsImpl(client, config, null, namespace, null, true, item, null, false, -1, new TreeMap<String, String>(), new TreeMap<String, String>(), new TreeMap<String, String[]>(), new TreeMap<String, String[]>(), new TreeMap<String, String>()).waitUntilReady(amount, timeUnit);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
@@ -104,6 +104,8 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
       .put(new ResourceKey("Job", "jobs", "batch", "v1"), new ResourceKey("Job", "jobs", "extensions", "v1beta1"));
     notFoundTransformations.put(new ResourceKey("RoleBinding", "rolebindings", "rbac.authorization.k8s.io", "v1"), new ResourceKey("RoleBinding", "rolebindings", "rbac.authorization.k8s.io", "v1beta1"));
     notFoundTransformations.put(new ResourceKey("Role", "roles", "rbac.authorization.k8s.io", "v1"), new ResourceKey("Role", "roles", "rbac.authorization.k8s.io", "v1beta1"));
+    notFoundTransformations.put(new ResourceKey("ClusterRoleBinding", "clusterrolebindings", "rbac.authorization.k8s.io", "v1"), new ResourceKey("ClusterRoleBinding", "clusterrolebindings", "rbac.authorization.k8s.io", "v1beta1"));
+    notFoundTransformations.put(new ResourceKey("ClusterRole", "clusterroles", "rbac.authorization.k8s.io", "v1"), new ResourceKey("ClusterRole", "clusterroles", "rbac.authorization.k8s.io", "v1beta1"));
 
     badRequestTransformations.put(new ResourceKey("Deployment", "deployments", "apps", "v1beta1"), new ResourceKey("Deployment", "deployments", "extensions", "v1beta1"));
 

--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ResourceHandler
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ResourceHandler
@@ -25,6 +25,8 @@ io.fabric8.kubernetes.client.handlers.HorizontalPodAutoscalerHandler
 io.fabric8.kubernetes.client.handlers.IngressHandler
 io.fabric8.kubernetes.client.handlers.KubernetesRoleBindingHandler
 io.fabric8.kubernetes.client.handlers.KubernetesRoleHandler
+io.fabric8.kubernetes.client.handlers.KubernetesClusterRoleBindingHandler
+io.fabric8.kubernetes.client.handlers.KubernetesClusterRoleHandler
 io.fabric8.kubernetes.client.handlers.JobHandler
 io.fabric8.kubernetes.client.handlers.LimitRangeHandler
 io.fabric8.kubernetes.client.handlers.NamespaceHandler

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/KubernetesClusterRoleBindingIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/KubernetesClusterRoleBindingIT.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesSubjectBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class KubernetesClusterRoleBindingIT {
+
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  private KubernetesClusterRoleBinding kubernetesClusterRoleBinding;
+
+  @Before
+  public void init() {
+
+    // Do not run tests on opeshift 3.6.0 and 3.6.1
+    assumeFalse(client.getVersion().getMajor().equalsIgnoreCase("1")
+      && client.getVersion().getMinor().startsWith("6"));
+
+    kubernetesClusterRoleBinding = new KubernetesClusterRoleBindingBuilder()
+      .withNewMetadata()
+      .withName("read-nodes")
+      .endMetadata()
+      .addToSubjects(0, new KubernetesSubjectBuilder()
+        .withApiGroup("rbac.authorization.k8s.io")
+        .withKind("User")
+        .withName("jane")
+        .withNamespace("default")
+        .build()
+      )
+      .withRoleRef(new KubernetesRoleRefBuilder()
+        .withApiGroup("rbac.authorization.k8s.io")
+        .withKind("ClusterRole")
+        .withName("node-reader")
+        .build()
+      )
+      .build();
+
+    client.rbac().kubernetesClusterRoleBindings().createOrReplace(kubernetesClusterRoleBinding);
+  }
+
+  @Test
+  public void get() {
+
+    kubernetesClusterRoleBinding = client.rbac().kubernetesClusterRoleBindings().withName("read-nodes").get();
+
+    assertNotNull(kubernetesClusterRoleBinding);
+    assertEquals("ClusterRoleBinding", kubernetesClusterRoleBinding.getKind());
+    assertNotNull(kubernetesClusterRoleBinding.getMetadata());
+    assertEquals("read-nodes", kubernetesClusterRoleBinding.getMetadata().getName());
+    assertNotNull(kubernetesClusterRoleBinding.getSubjects());
+    assertEquals(1, kubernetesClusterRoleBinding.getSubjects().size());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getSubjects().get(0).getApiGroup());
+    assertEquals("User", kubernetesClusterRoleBinding.getSubjects().get(0).getKind());
+    assertEquals("jane", kubernetesClusterRoleBinding.getSubjects().get(0).getName());
+    assertEquals("default", kubernetesClusterRoleBinding.getSubjects().get(0).getNamespace());
+    assertNotNull(kubernetesClusterRoleBinding.getRoleRef());
+    assertEquals("ClusterRole", kubernetesClusterRoleBinding.getRoleRef().getKind());
+    assertEquals("node-reader", kubernetesClusterRoleBinding.getRoleRef().getName());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getRoleRef().getApiGroup());
+  }
+
+  @Test
+  public void load() {
+
+    KubernetesClusterRoleBinding aKubernetesClusterRoleBinding = client.rbac().kubernetesClusterRoleBindings()
+      .load(getClass().getResourceAsStream("/test-kubernetesclusterrolebinding.yml")).get();
+    assertNotNull(aKubernetesClusterRoleBinding);
+    assertEquals("ClusterRoleBinding", aKubernetesClusterRoleBinding.getKind());
+    assertNotNull(aKubernetesClusterRoleBinding.getMetadata());
+    assertEquals("read-nodes", aKubernetesClusterRoleBinding.getMetadata().getName());
+    assertNotNull(aKubernetesClusterRoleBinding.getSubjects());
+    assertEquals(1, aKubernetesClusterRoleBinding.getSubjects().size());
+    assertEquals("rbac.authorization.k8s.io", aKubernetesClusterRoleBinding.getSubjects().get(0).getApiGroup());
+    assertEquals("User", aKubernetesClusterRoleBinding.getSubjects().get(0).getKind());
+    assertEquals("jane", aKubernetesClusterRoleBinding.getSubjects().get(0).getName());
+    assertEquals("default", aKubernetesClusterRoleBinding.getSubjects().get(0).getNamespace());
+    assertNotNull(aKubernetesClusterRoleBinding.getRoleRef());
+    assertEquals("ClusterRole", aKubernetesClusterRoleBinding.getRoleRef().getKind());
+    assertEquals("node-reader", aKubernetesClusterRoleBinding.getRoleRef().getName());
+    assertEquals("rbac.authorization.k8s.io", aKubernetesClusterRoleBinding.getRoleRef().getApiGroup());
+  }
+
+  @Test
+  public void list() {
+
+    KubernetesClusterRoleBindingList kubernetesClusterRoleBindingList = client.rbac().kubernetesClusterRoleBindings().list();
+    boolean found = false;
+
+    assertNotNull(kubernetesClusterRoleBindingList);
+    assertNotNull(kubernetesClusterRoleBindingList.getItems());
+
+    for (KubernetesClusterRoleBinding kubernetesClusterRoleBinding : kubernetesClusterRoleBindingList.getItems())  {
+      if (kubernetesClusterRoleBinding.getMetadata().getName().equals("read-nodes"))  {
+        assertEquals("ClusterRoleBinding", kubernetesClusterRoleBinding.getKind());
+        assertNotNull(kubernetesClusterRoleBinding.getMetadata());
+        assertEquals("read-nodes", kubernetesClusterRoleBinding.getMetadata().getName());
+        assertNotNull(kubernetesClusterRoleBinding.getSubjects());
+        assertEquals(1, kubernetesClusterRoleBinding.getSubjects().size());
+        assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getSubjects().get(0).getApiGroup());
+        assertEquals("User", kubernetesClusterRoleBinding.getSubjects().get(0).getKind());
+        assertEquals("jane", kubernetesClusterRoleBinding.getSubjects().get(0).getName());
+        assertEquals("default", kubernetesClusterRoleBinding.getSubjects().get(0).getNamespace());
+        assertNotNull(kubernetesClusterRoleBinding.getRoleRef());
+        assertEquals("ClusterRole", kubernetesClusterRoleBinding.getRoleRef().getKind());
+        assertEquals("node-reader", kubernetesClusterRoleBinding.getRoleRef().getName());
+
+        found = true;
+      }
+    }
+
+    assertEquals(true, found);
+
+  }
+
+  @Test
+  public void update() {
+
+    kubernetesClusterRoleBinding = client.rbac().kubernetesClusterRoleBindings().withName("read-nodes").edit()
+      .editSubject(0).withName("jane-new").endSubject().done();
+
+    assertNotNull(kubernetesClusterRoleBinding);
+    assertEquals("ClusterRoleBinding", kubernetesClusterRoleBinding.getKind());
+    assertNotNull(kubernetesClusterRoleBinding.getMetadata());
+    assertEquals("read-nodes", kubernetesClusterRoleBinding.getMetadata().getName());
+    assertNotNull(kubernetesClusterRoleBinding.getSubjects());
+    assertEquals(1, kubernetesClusterRoleBinding.getSubjects().size());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getSubjects().get(0).getApiGroup());
+    assertEquals("User", kubernetesClusterRoleBinding.getSubjects().get(0).getKind());
+    assertEquals("jane-new", kubernetesClusterRoleBinding.getSubjects().get(0).getName());
+    assertEquals("default", kubernetesClusterRoleBinding.getSubjects().get(0).getNamespace());
+    assertNotNull(kubernetesClusterRoleBinding.getRoleRef());
+    assertEquals("ClusterRole", kubernetesClusterRoleBinding.getRoleRef().getKind());
+    assertEquals("node-reader", kubernetesClusterRoleBinding.getRoleRef().getName());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getRoleRef().getApiGroup());
+  }
+
+  @Test
+  public void delete() {
+
+    KubernetesClusterRoleBindingList kubernetesClusterRoleBindingListBefore = client.rbac().kubernetesClusterRoleBindings().list();
+
+    boolean deleted = client.rbac().kubernetesClusterRoleBindings().withName("read-nodes").delete();
+
+    assertTrue(deleted);
+    KubernetesClusterRoleBindingList kubernetesClusterRoleBindingListAfter = client.rbac().kubernetesClusterRoleBindings().list();
+    assertEquals(kubernetesClusterRoleBindingListBefore.getItems().size()-1,kubernetesClusterRoleBindingListAfter.getItems().size());
+
+  }
+
+  @After
+  public void cleanup() {
+    client.rbac().kubernetesClusterRoleBindings().withName("read-nodes").delete();
+  }
+
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/KubernetesClusterRoleIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/KubernetesClusterRoleIT.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesPolicyRuleBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.runner.RunWith;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.After;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class KubernetesClusterRoleIT {
+
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  private KubernetesClusterRole kubernetesClusterRole;
+
+  @Before
+  public void init() {
+    // Do not run tests on opeshift 3.6.0 and 3.6.1
+    assumeFalse(client.getVersion().getMajor().equalsIgnoreCase("1")
+      && client.getVersion().getMinor().startsWith("6"));
+
+    KubernetesClusterRole kubernetesclusterRole = new KubernetesClusterRoleBuilder()
+      .withNewMetadata()
+      .withName("node-reader")
+      .endMetadata()
+      .addToRules(0, new KubernetesPolicyRuleBuilder()
+        .addToApiGroups(0,"")
+        .addToResourceNames(0,"my-node")
+        .addToResources(0,"nodes")
+        .addToVerbs(0, "get")
+        .addToVerbs(1, "watch")
+        .addToVerbs(2, "list")
+        .build()
+      )
+      .build();
+
+    client.rbac().kubernetesClusterRoles().createOrReplace(kubernetesclusterRole);
+  }
+
+  @Test
+  public void get() {
+
+    kubernetesClusterRole = client.rbac().kubernetesClusterRoles().withName("node-reader").get();
+
+    assertNotNull(kubernetesClusterRole);
+    assertEquals("ClusterRole", kubernetesClusterRole.getKind());
+    assertNotNull(kubernetesClusterRole.getMetadata());
+    assertEquals("node-reader", kubernetesClusterRole.getMetadata().getName());
+    assertNotNull(kubernetesClusterRole.getRules());
+    assertEquals(1, kubernetesClusterRole.getRules().size());
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getApiGroups());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getApiGroups().size());
+    assertEquals("", kubernetesClusterRole.getRules().get(0).getApiGroups().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResourceNames());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResourceNames().size());
+    assertEquals("my-node", kubernetesClusterRole.getRules().get(0).getResourceNames().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResources());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResources().size());
+    assertEquals("nodes", kubernetesClusterRole.getRules().get(0).getResources().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getVerbs());
+    assertEquals(3, kubernetesClusterRole.getRules().get(0).getVerbs().size());
+    assertEquals("get", kubernetesClusterRole.getRules().get(0).getVerbs().get(0));
+    assertEquals("watch", kubernetesClusterRole.getRules().get(0).getVerbs().get(1));
+    assertEquals("list", kubernetesClusterRole.getRules().get(0).getVerbs().get(2));
+  }
+
+  @Test
+  public void load() {
+
+    KubernetesClusterRole aKubernetesClusterRole = client.rbac().kubernetesClusterRoles()
+      .load(getClass().getResourceAsStream("/test-kubernetesclusterrole.yml")).get();
+
+    assertNotNull(aKubernetesClusterRole);
+    assertEquals("ClusterRole", aKubernetesClusterRole.getKind());
+    assertNotNull(aKubernetesClusterRole.getMetadata());
+    assertEquals("node-reader", aKubernetesClusterRole.getMetadata().getName());
+    assertNotNull(aKubernetesClusterRole.getRules());
+    assertEquals(1, aKubernetesClusterRole.getRules().size());
+    assertNotNull(aKubernetesClusterRole.getRules().get(0).getApiGroups());
+    assertEquals(1, aKubernetesClusterRole.getRules().get(0).getApiGroups().size());
+    assertEquals("", aKubernetesClusterRole.getRules().get(0).getApiGroups().get(0));
+    assertNotNull(aKubernetesClusterRole.getRules().get(0).getNonResourceURLs());
+    assertEquals(1, aKubernetesClusterRole.getRules().get(0).getNonResourceURLs().size());
+    assertEquals("/healthz", aKubernetesClusterRole.getRules().get(0).getNonResourceURLs().get(0));
+    assertNotNull(aKubernetesClusterRole.getRules().get(0).getResourceNames());
+    assertEquals(1, aKubernetesClusterRole.getRules().get(0).getResourceNames().size());
+    assertEquals("my-node", aKubernetesClusterRole.getRules().get(0).getResourceNames().get(0));
+    assertNotNull(aKubernetesClusterRole.getRules().get(0).getResources());
+    assertEquals(1, aKubernetesClusterRole.getRules().get(0).getResources().size());
+    assertEquals("nodes", aKubernetesClusterRole.getRules().get(0).getResources().get(0));
+    assertNotNull(aKubernetesClusterRole.getRules().get(0).getVerbs());
+    assertEquals(3, aKubernetesClusterRole.getRules().get(0).getVerbs().size());
+    assertEquals("get", aKubernetesClusterRole.getRules().get(0).getVerbs().get(0));
+    assertEquals("watch", aKubernetesClusterRole.getRules().get(0).getVerbs().get(1));
+    assertEquals("list", aKubernetesClusterRole.getRules().get(0).getVerbs().get(2));
+  }
+
+  @Test
+  public void list() {
+
+    KubernetesClusterRoleList kubernetesClusterRoleList = client.rbac().kubernetesClusterRoles().list();
+    boolean found = false;
+
+    assertNotNull(kubernetesClusterRoleList);
+    assertNotNull(kubernetesClusterRoleList.getItems());
+
+    for (KubernetesClusterRole kubernetesClusterRole : kubernetesClusterRoleList.getItems())  {
+      if (kubernetesClusterRole.getMetadata().getName().equals("node-reader"))  {
+        assertEquals("ClusterRole", kubernetesClusterRole.getKind());
+        assertNotNull(kubernetesClusterRole.getMetadata());
+        assertEquals("node-reader", kubernetesClusterRole.getMetadata().getName());
+        assertNotNull(kubernetesClusterRole.getRules());
+        assertEquals(1, kubernetesClusterRole.getRules().size());
+        assertNotNull(kubernetesClusterRole.getRules().get(0).getApiGroups());
+        assertEquals(1, kubernetesClusterRole.getRules().get(0).getApiGroups().size());
+        assertEquals("", kubernetesClusterRole.getRules().get(0).getApiGroups().get(0));
+        assertNotNull(kubernetesClusterRole.getRules().get(0).getResourceNames());
+        assertEquals(1, kubernetesClusterRole.getRules().get(0).getResourceNames().size());
+        assertEquals("my-node", kubernetesClusterRole.getRules().get(0).getResourceNames().get(0));
+        assertNotNull(kubernetesClusterRole.getRules().get(0).getResources());
+        assertEquals(1, kubernetesClusterRole.getRules().get(0).getResources().size());
+        assertEquals("nodes", kubernetesClusterRole.getRules().get(0).getResources().get(0));
+        assertNotNull(kubernetesClusterRole.getRules().get(0).getVerbs());
+        assertEquals(3, kubernetesClusterRole.getRules().get(0).getVerbs().size());
+        assertEquals("get", kubernetesClusterRole.getRules().get(0).getVerbs().get(0));
+        assertEquals("watch", kubernetesClusterRole.getRules().get(0).getVerbs().get(1));
+        assertEquals("list", kubernetesClusterRole.getRules().get(0).getVerbs().get(2));
+        found = true;
+      }
+    }
+
+    assertEquals(true, found);
+  }
+
+  @Test
+  public void update() {
+
+    kubernetesClusterRole = client.rbac().kubernetesClusterRoles().withName("node-reader").edit()
+      .editRule(0).addToApiGroups(1, "extensions").endRule().done();
+
+    assertNotNull(kubernetesClusterRole);
+    assertEquals("ClusterRole", kubernetesClusterRole.getKind());
+    assertNotNull(kubernetesClusterRole.getMetadata());
+    assertEquals("node-reader", kubernetesClusterRole.getMetadata().getName());
+    assertNotNull(kubernetesClusterRole.getRules());
+    assertEquals(1, kubernetesClusterRole.getRules().size());
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getApiGroups());
+    assertEquals(2, kubernetesClusterRole.getRules().get(0).getApiGroups().size());
+    assertEquals("", kubernetesClusterRole.getRules().get(0).getApiGroups().get(0));
+    assertEquals("extensions", kubernetesClusterRole.getRules().get(0).getApiGroups().get(1));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResourceNames());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResourceNames().size());
+    assertEquals("my-node", kubernetesClusterRole.getRules().get(0).getResourceNames().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResources());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResources().size());
+    assertEquals("nodes", kubernetesClusterRole.getRules().get(0).getResources().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getVerbs());
+    assertEquals(3, kubernetesClusterRole.getRules().get(0).getVerbs().size());
+    assertEquals("get", kubernetesClusterRole.getRules().get(0).getVerbs().get(0));
+    assertEquals("watch", kubernetesClusterRole.getRules().get(0).getVerbs().get(1));
+    assertEquals("list", kubernetesClusterRole.getRules().get(0).getVerbs().get(2));
+  }
+
+  @Test
+  public void delete() {
+
+    KubernetesClusterRoleList kubernetesClusterRoleListBefore = client.rbac().kubernetesClusterRoles().list();
+
+    boolean deleted = client.rbac().kubernetesClusterRoles().withName("node-reader").delete();
+
+    assertTrue(deleted);
+    KubernetesClusterRoleList kubernetesClusterRoleListAfter = client.rbac().kubernetesClusterRoles().list();
+    assertEquals(kubernetesClusterRoleListBefore.getItems().size()-1,kubernetesClusterRoleListAfter.getItems().size());
+  }
+
+  @After
+  public void cleanup() {
+    client.rbac().kubernetesClusterRoles().withName("node-reader").delete();
+  }
+
+}

--- a/kubernetes-itests/src/test/resources/test-kubernetesclusterrole.yml
+++ b/kubernetes-itests/src/test/resources/test-kubernetesclusterrole.yml
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  resourceNames:
+  - my-node
+  nonResourceURLs:
+  - "/healthz"
+  verbs:
+  - get
+  - watch
+  - list

--- a/kubernetes-itests/src/test/resources/test-kubernetesclusterrolebinding.yml
+++ b/kubernetes-itests/src/test/resources/test-kubernetesclusterrolebinding.yml
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-nodes
+subjects:
+- kind: User
+  name: jane
+  namespace: default
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: node-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesClusterRoleBindingCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesClusterRoleBindingCrudTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBindingList;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesRoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesSubjectBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class KubernetesClusterRoleBindingCrudTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(KubernetesClusterRoleBindingCrudTest.class);
+
+  @Rule
+  public KubernetesServer kubernetesServer = new KubernetesServer(true,true);
+
+  @Test
+  public void crudTest() {
+
+    KubernetesClient client = kubernetesServer.getClient();
+
+    KubernetesClusterRoleBinding kubernetesClusterRoleBinding = new KubernetesClusterRoleBindingBuilder()
+      .withNewMetadata()
+        .withName("read-nodes")
+      .endMetadata()
+      .addToSubjects(0, new KubernetesSubjectBuilder()
+        .withApiGroup("rbac.authorization.k8s.io")
+        .withKind("User")
+        .withName("jane")
+        .withNamespace("default")
+        .build()
+      )
+      .withRoleRef(new KubernetesRoleRefBuilder()
+        .withApiGroup("rbac.authorization.k8s.io")
+        .withKind("ClusterRole")
+        .withName("node-reader")
+        .build()
+      )
+      .build();
+
+    //test of creation
+    kubernetesClusterRoleBinding = client.rbac().kubernetesClusterRoleBindings().create(kubernetesClusterRoleBinding);
+
+    assertNotNull(kubernetesClusterRoleBinding);
+    assertEquals("ClusterRoleBinding", kubernetesClusterRoleBinding.getKind());
+    assertEquals("rbac.authorization.k8s.io/v1", kubernetesClusterRoleBinding.getApiVersion());
+    assertNotNull(kubernetesClusterRoleBinding.getMetadata());
+    assertEquals("read-nodes", kubernetesClusterRoleBinding.getMetadata().getName());
+    assertNotNull(kubernetesClusterRoleBinding.getSubjects());
+    assertEquals(1, kubernetesClusterRoleBinding.getSubjects().size());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getSubjects().get(0).getApiGroup());
+    assertEquals("User", kubernetesClusterRoleBinding.getSubjects().get(0).getKind());
+    assertEquals("jane", kubernetesClusterRoleBinding.getSubjects().get(0).getName());
+    assertEquals("default", kubernetesClusterRoleBinding.getSubjects().get(0).getNamespace());
+    assertNotNull(kubernetesClusterRoleBinding.getRoleRef());
+    assertEquals("ClusterRole", kubernetesClusterRoleBinding.getRoleRef().getKind());
+    assertEquals("node-reader", kubernetesClusterRoleBinding.getRoleRef().getName());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getRoleRef().getApiGroup());
+
+    //test of list
+    KubernetesClusterRoleBindingList kubernetesClusterRoleBindingList = client.rbac().kubernetesClusterRoleBindings().list();
+
+    assertNotNull(kubernetesClusterRoleBindingList);
+    assertNotNull(kubernetesClusterRoleBindingList.getItems());
+    assertEquals(1, kubernetesClusterRoleBindingList.getItems().size());
+    assertNotNull(kubernetesClusterRoleBindingList.getItems().get(0));
+    assertEquals("ClusterRoleBinding", kubernetesClusterRoleBindingList.getItems().get(0).getKind());
+    assertEquals("rbac.authorization.k8s.io/v1", kubernetesClusterRoleBindingList.getItems().get(0).getApiVersion());
+    assertNotNull(kubernetesClusterRoleBindingList.getItems().get(0).getMetadata());
+    assertEquals("read-nodes", kubernetesClusterRoleBindingList.getItems().get(0).getMetadata().getName());
+    assertNotNull(kubernetesClusterRoleBindingList.getItems().get(0).getSubjects());
+    assertEquals(1, kubernetesClusterRoleBindingList.getItems().get(0).getSubjects().size());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBindingList.getItems().get(0).getSubjects().get(0).getApiGroup());
+    assertEquals("User", kubernetesClusterRoleBindingList.getItems().get(0).getSubjects().get(0).getKind());
+    assertEquals("jane", kubernetesClusterRoleBindingList.getItems().get(0).getSubjects().get(0).getName());
+    assertEquals("default", kubernetesClusterRoleBindingList.getItems().get(0).getSubjects().get(0).getNamespace());
+    assertNotNull(kubernetesClusterRoleBindingList.getItems().get(0).getRoleRef());
+    assertEquals("ClusterRole", kubernetesClusterRoleBindingList.getItems().get(0).getRoleRef().getKind());
+    assertEquals("node-reader", kubernetesClusterRoleBindingList.getItems().get(0).getRoleRef().getName());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBindingList.getItems().get(0).getRoleRef().getApiGroup());
+
+    //test of updation
+    kubernetesClusterRoleBinding = client.rbac().kubernetesClusterRoleBindings().withName("read-nodes").edit()
+      .editSubject(0).withName("jane-new").endSubject().done();
+
+    assertNotNull(kubernetesClusterRoleBinding);
+    assertEquals("ClusterRoleBinding", kubernetesClusterRoleBinding.getKind());
+    assertEquals("rbac.authorization.k8s.io/v1", kubernetesClusterRoleBinding.getApiVersion());
+    assertNotNull(kubernetesClusterRoleBinding.getMetadata());
+    assertEquals("read-nodes", kubernetesClusterRoleBinding.getMetadata().getName());
+    assertNotNull(kubernetesClusterRoleBinding.getSubjects());
+    assertEquals(1, kubernetesClusterRoleBinding.getSubjects().size());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getSubjects().get(0).getApiGroup());
+    assertEquals("User", kubernetesClusterRoleBinding.getSubjects().get(0).getKind());
+    assertEquals("jane-new", kubernetesClusterRoleBinding.getSubjects().get(0).getName());
+    assertEquals("default", kubernetesClusterRoleBinding.getSubjects().get(0).getNamespace());
+    assertNotNull(kubernetesClusterRoleBinding.getRoleRef());
+    assertEquals("ClusterRole", kubernetesClusterRoleBinding.getRoleRef().getKind());
+    assertEquals("node-reader", kubernetesClusterRoleBinding.getRoleRef().getName());
+    assertEquals("rbac.authorization.k8s.io", kubernetesClusterRoleBinding.getRoleRef().getApiGroup());
+
+    //test of deletion
+    boolean deleted = client.rbac().kubernetesClusterRoleBindings().delete();
+
+    assertTrue(deleted);
+    kubernetesClusterRoleBindingList = client.rbac().kubernetesClusterRoleBindings().list();
+    assertEquals(0,kubernetesClusterRoleBindingList.getItems().size());
+
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesClusterRoleCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesClusterRoleCrudTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesClusterRoleList;
+import io.fabric8.kubernetes.api.model.rbac.KubernetesPolicyRuleBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class KubernetesClusterRoleCrudTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(KubernetesClusterRoleCrudTest.class);
+
+  @Rule
+  public KubernetesServer kubernetesServer = new KubernetesServer(true,true);
+
+  @Test
+  public void crudTest(){
+
+    KubernetesClient client = kubernetesServer.getClient();
+
+    KubernetesClusterRole kubernetesClusterRole = new KubernetesClusterRoleBuilder()
+      .withNewMetadata()
+        .withName("node-reader")
+      .endMetadata()
+      .addToRules(0, new KubernetesPolicyRuleBuilder()
+        .addToApiGroups(0,"")
+        .addToNonResourceURLs(0,"/healthz")
+        .addToResourceNames(0,"my-node")
+        .addToResources(0,"nodes")
+        .addToVerbs(0, "get")
+        .addToVerbs(1, "watch")
+        .addToVerbs(2, "list")
+        .build()
+      )
+      .build();
+
+    //test of creation
+    kubernetesClusterRole = client.rbac().kubernetesClusterRoles().create(kubernetesClusterRole);
+
+    assertNotNull(kubernetesClusterRole);
+    assertEquals("ClusterRole", kubernetesClusterRole.getKind());
+    assertEquals("rbac.authorization.k8s.io/v1", kubernetesClusterRole.getApiVersion());
+    assertNotNull(kubernetesClusterRole.getMetadata());
+    assertEquals("node-reader", kubernetesClusterRole.getMetadata().getName());
+    assertNotNull(kubernetesClusterRole.getRules());
+    assertEquals(1, kubernetesClusterRole.getRules().size());
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getApiGroups());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getApiGroups().size());
+    assertEquals("", kubernetesClusterRole.getRules().get(0).getApiGroups().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getNonResourceURLs());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getNonResourceURLs().size());
+    assertEquals("/healthz", kubernetesClusterRole.getRules().get(0).getNonResourceURLs().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResourceNames());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResourceNames().size());
+    assertEquals("my-node", kubernetesClusterRole.getRules().get(0).getResourceNames().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResources());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResources().size());
+    assertEquals("nodes", kubernetesClusterRole.getRules().get(0).getResources().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getVerbs());
+    assertEquals(3, kubernetesClusterRole.getRules().get(0).getVerbs().size());
+    assertEquals("get", kubernetesClusterRole.getRules().get(0).getVerbs().get(0));
+    assertEquals("watch", kubernetesClusterRole.getRules().get(0).getVerbs().get(1));
+    assertEquals("list", kubernetesClusterRole.getRules().get(0).getVerbs().get(2));
+
+    //test of list
+    KubernetesClusterRoleList kubernetesClusterRoleList = client.rbac().kubernetesClusterRoles().list();
+
+    assertNotNull(kubernetesClusterRoleList);
+    assertNotNull(kubernetesClusterRoleList.getItems());
+    assertEquals(1, kubernetesClusterRoleList.getItems().size());
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0));
+    assertEquals("ClusterRole", kubernetesClusterRoleList.getItems().get(0).getKind());
+    assertEquals("rbac.authorization.k8s.io/v1", kubernetesClusterRoleList.getItems().get(0).getApiVersion());
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0).getMetadata());
+    assertEquals("node-reader", kubernetesClusterRoleList.getItems().get(0).getMetadata().getName());
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0).getRules());
+    assertEquals(1, kubernetesClusterRoleList.getItems().get(0).getRules().size());
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getApiGroups());
+    assertEquals(1, kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getApiGroups().size());
+    assertEquals("", kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getApiGroups().get(0));
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getNonResourceURLs());
+    assertEquals(1, kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getNonResourceURLs().size());
+    assertEquals("/healthz", kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getNonResourceURLs().get(0));
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getResourceNames());
+    assertEquals(1, kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getResourceNames().size());
+    assertEquals("my-node", kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getResourceNames().get(0));
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getResources());
+    assertEquals(1, kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getResources().size());
+    assertEquals("nodes", kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getResources().get(0));
+    assertNotNull(kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getVerbs());
+    assertEquals(3, kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getVerbs().size());
+    assertEquals("get", kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getVerbs().get(0));
+    assertEquals("watch", kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getVerbs().get(1));
+    assertEquals("list", kubernetesClusterRoleList.getItems().get(0).getRules().get(0).getVerbs().get(2));
+
+    //test of updation
+
+    kubernetesClusterRole = client.rbac().kubernetesClusterRoles().withName("node-reader").edit()
+      .editRule(0).addToApiGroups(1, "extensions").endRule().done();
+
+    assertNotNull(kubernetesClusterRole);
+    assertEquals("ClusterRole", kubernetesClusterRole.getKind());
+    assertEquals("rbac.authorization.k8s.io/v1", kubernetesClusterRole.getApiVersion());
+    assertNotNull(kubernetesClusterRole.getMetadata());
+    assertEquals("node-reader", kubernetesClusterRole.getMetadata().getName());
+    assertNotNull(kubernetesClusterRole.getRules());
+    assertEquals(1, kubernetesClusterRole.getRules().size());
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getApiGroups());
+    assertEquals(2, kubernetesClusterRole.getRules().get(0).getApiGroups().size());
+    assertEquals("", kubernetesClusterRole.getRules().get(0).getApiGroups().get(0));
+    assertEquals("extensions", kubernetesClusterRole.getRules().get(0).getApiGroups().get(1));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getNonResourceURLs());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getNonResourceURLs().size());
+    assertEquals("/healthz", kubernetesClusterRole.getRules().get(0).getNonResourceURLs().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResourceNames());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResourceNames().size());
+    assertEquals("my-node", kubernetesClusterRole.getRules().get(0).getResourceNames().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getResources());
+    assertEquals(1, kubernetesClusterRole.getRules().get(0).getResources().size());
+    assertEquals("nodes", kubernetesClusterRole.getRules().get(0).getResources().get(0));
+    assertNotNull(kubernetesClusterRole.getRules().get(0).getVerbs());
+    assertEquals(3, kubernetesClusterRole.getRules().get(0).getVerbs().size());
+    assertEquals("get", kubernetesClusterRole.getRules().get(0).getVerbs().get(0));
+    assertEquals("watch", kubernetesClusterRole.getRules().get(0).getVerbs().get(1));
+    assertEquals("list", kubernetesClusterRole.getRules().get(0).getVerbs().get(2));
+
+    //test of deletion
+    boolean deleted = client.rbac().kubernetesClusterRoles().delete();
+
+    assertTrue(deleted);
+    kubernetesClusterRoleList = client.rbac().kubernetesClusterRoles().list();
+    assertEquals(0,kubernetesClusterRoleList.getItems().size());
+  }
+}


### PR DESCRIPTION
Thsi PR adds support for ClusterRole and ClusterRoleBinding from Kubernetes API. The code changes should be very similar to #1111 - the main difference being that Cluster Role and Cluster Role Binding are not namespaced resources.

This PR should fix issue #1150 