### PR TITLE
Fix #1156 : Watcher does not have correct authentication information …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### 4.0.4 (To be released)
   Bugs
+
+    * Fix #1156 : Watcher does not have correct authentication information in Openshift environment.
+    
     * Fix #1144 : Get Request with OpenShift Mock Server Not Working
 
     * Fix #1147: Cluster context was being ignored when loading the Config from a kubeconfig file


### PR DESCRIPTION
#1156 
OpenShift authentication information disappears when httpClient is created using `HttpClientUtils.createHttpClient()`. So I reverted the code to use clonedClient.