### PR TITLE
Add support for label selectors in the mock server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
     * Fix #1156 : Watcher does not have correct authentication information in Openshift environment.
     
+    * Fix #1125 : ConfigMap labels are ignored when using mock KubernetesServer
+
     * Fix #1144 : Get Request with OpenShift Mock Server Not Working
 
     * Fix #1147: Cluster context was being ignored when loading the Config from a kubeconfig file

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -58,8 +58,16 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
   private static final String VALUE_GROUP = "(?<value>[a-zA-Z0-9-_.]+)";
   private static final Pattern LABEL_REQUIREMENT_EQUALITY = Pattern.compile(KEY_GROUP + EQUALITY_GROUP + VALUE_GROUP);
 
+  // These elements are added to the path/query fragment so that it can be parsed by HttpUrl. Their
+  // values are not important, HttpUrl expects the scheme to be http or https.
+  private static final String SCHEME = "http";
+  private static final String HOST = "localhost";
+
   private HttpUrl parseUrlFromPathAndQuery(String s) {
-    return HttpUrl.parse("http://localhost" + s);
+    if (!s.startsWith("/")) {
+      s = "/" + s;
+    }
+    return HttpUrl.parse(String.format("%s://%s%s", SCHEME, HOST, s));
   }
 
   @Override

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
@@ -67,6 +67,10 @@ public class ConfigMapCrudTest {
     assertNotNull(aConfigMapList);
     assertEquals(3, aConfigMapList.getItems().size());
 
+    aConfigMapList = client.configMaps().inAnyNamespace().withLabels(Collections.singletonMap("foo", "bar")).list();
+    assertNotNull(aConfigMapList);
+    assertEquals(2, aConfigMapList.getItems().size());
+
     aConfigMapList = client.configMaps().inNamespace("ns1").list();
     assertNotNull(aConfigMapList);
     assertEquals(2, aConfigMapList.getItems().size());
@@ -75,10 +79,6 @@ public class ConfigMapCrudTest {
     aConfigMapList = client.configMaps().inNamespace("ns1").list();
     assertNotNull(aConfigMapList);
     assertEquals(1, aConfigMapList.getItems().size());
-
-    aConfigMapList = client.configMaps().inAnyNamespace().withLabels(Collections.singletonMap("foo", "bar")).list();
-    assertNotNull(aConfigMapList);
-    assertEquals(2, aConfigMapList.getItems().size());
 
     configmap2 = client.configMaps().inNamespace("ns1").withName("configmap2").edit().addToData("II", "TWO").done();
     assertNotNull(configmap2);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -51,6 +51,11 @@ public class PodCrudTest {
     assertNotNull(podList);
     assertEquals(0, podList.getItems().size());
 
+    // test listing with labels
+    podList = client.pods().inAnyNamespace().withLabels(Collections.singletonMap("testKey", "testValue")).list();
+    assertNotNull(podList);
+    assertEquals(2, podList.getItems().size());
+
     podList = client.pods().inNamespace("ns1").list();
     assertNotNull(podList);
     assertEquals(2, podList.getItems().size());
@@ -65,11 +70,6 @@ public class PodCrudTest {
     assertEquals(1, podList.getItems().size());
 
     podList = client.pods().inAnyNamespace().list();
-    assertNotNull(podList);
-    assertEquals(2, podList.getItems().size());
-
-    // test listing with labels
-    podList = client.pods().inAnyNamespace().withLabels(Collections.singletonMap("testKey", "testValue")).list();
     assertNotNull(podList);
     assertEquals(2, podList.getItems().size());
 


### PR DESCRIPTION
This supports simple label selectors (eg foo=bar). The != operator would
go beyond the limits of the AttributeSet-based matching in
CrudDispatcher.

There was a test using labels in ConfigMapCrudTest, but it was only
passing because, at the point of execution, all resources match the
label selector. This change moves changes the order of assertions so
that the effect of the label selector is observable.

This should fix #1125, although I haven't tested that code directly.