### PR TITLE
Fix #1162: delete RC after fully deleting DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 
     * Fix #1144 : Get Request with OpenShift Mock Server Not Working
 
-    * Fix #1147: Cluster context was being ignored when loading the Config from a kubeconfig file
+    * Fix #1147 : Cluster context was being ignored when loading the Config from a kubeconfig file
+    
+    * Fix #1162 : Deletion of DeploymentConfig now does not fail randomly because of issues related to owner references of the ReplicationController
 
   Improvements
   

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/DeploymentConfigOperationsImpl.java
@@ -125,6 +125,9 @@ public class DeploymentConfigOperationsImpl extends OpenShiftOperation<Deploymen
       //We are deleting the DC before reaping the replication controller, because the RC's won't go otherwise.
       Boolean reaped = operation.cascading(false).delete();
 
+      // Waiting for the DC to be completely deleted before removing the replication controller (error in Openshift 3.9)
+      waitForDeletion();
+
       Map<String, String> selector = new HashMap<>();
       selector.put(DEPLOYMENT_CONFIG_REF, deployment.getMetadata().getName());
       if (selector != null && !selector.isEmpty()) {
@@ -159,6 +162,31 @@ public class DeploymentConfigOperationsImpl extends OpenShiftOperation<Deploymen
         throw KubernetesClientException.launderThrowable(e);
       }
     }
+
+    private void waitForDeletion() {
+      final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+      final Runnable deploymentPoller = new Runnable() {
+        public void run() {
+          DeploymentConfig deployment = operation.get();
+          if (deployment == null) {
+            countDownLatch.countDown();
+          }
+        }
+      };
+
+      ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+      ScheduledFuture poller = executor.scheduleWithFixedDelay(deploymentPoller, 0, 10, TimeUnit.MILLISECONDS);
+      try {
+        countDownLatch.await(1, TimeUnit.MINUTES);
+        executor.shutdown();
+      } catch (InterruptedException e) {
+        poller.cancel(true);
+        executor.shutdown();
+        throw KubernetesClientException.launderThrowable(e);
+      }
+    }
+
   }
 
   @Override


### PR DESCRIPTION
#1162 This should fix the issue that prevent deleting deploymentconfigs in Openshift 3.9.

Something should have changed in Openshift, so that after the call to "delete" the DC returns, the resource is in a temporary state and a immediate call to "delete" the associated RC fails. With this change, the RC is deleted only *after* the DC is completely gone.

I've verified that without this change, the error happens 1 out of 3 attempts, while with the change I've executed more than 10 deletes without errors (it's a heisenbug, cannot do a deterministic test).