### PR TITLE
Fix #1173 : Send response to Callback for exec commands that have no textual feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     
     * Fix #1165 : Null parameter values when processing a template are now handled properly
 
+    * Fix #1173 : Send response to Callback for exec commands that have no textual feedback
+
   Improvements
   
     * Added Kubernetes/Openshift examples for client.getVersion()

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -249,8 +249,8 @@ public class ExecWebSocketListener extends WebSocketListener implements ExecWatc
                         }
                         break;
                     case 2:
-                        if (err != null) {
-                            err.write(byteString.toByteArray());
+                        if (out != null) {
+                            out.write(byteString.toByteArray());
                         }
                         break;
                     case 3:


### PR DESCRIPTION
Bug Fix: #1173

After a command is sent through the ExecWatch object to be executed in a pod, the response is labeled with a StreamID. Previously, StreamID 1 would write to the output stream, and StreamIDs 2 and 3 would write to the error stream. However, these error streams were unreachable by the ExecWatch object (.redirectingError() could not do it). 

The messages that were given StreamID2 were -- error messages from bash (ie. if i try to exec "asdfjadsf", bash should return /bin/sh: 15: asdfjadsf: not found), and protocol for terminated messages. The protocol for a terminated command execution is one or two copies of "# ". With the updated writing to output stream instead of error stream, the user can now recognize this sequence as their command finishing execution. 

I tried to filter out the protocol sequence before writing out output stream, but this resulted in nothing being sent through the stream at all, which defeats the purpose of the bug fix as we want something to be sent (null/empty strings cannot be sent).

Also, is it possible for this bug fix to be added to version 3.1.1?