### PR TITLE
Fix deployment examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### 4.0.4 (To be released)
   Bugs
 
+    * Fix #1180 : DeploymentExamples requires the definition of a selector with match labels
+
     * Fix #1156 : Watcher does not have correct authentication information in Openshift environment.
     
     * Fix #1125 : ConfigMap labels are ignored when using mock KubernetesServer

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/DeploymentExamples.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/DeploymentExamples.java
@@ -67,6 +67,9 @@ public class DeploymentExamples {
           .endContainer()
           .endSpec()
           .endTemplate()
+          .withNewSelector()
+          .addToMatchLabels("app", "nginx")
+          .endSelector()
           .endSpec()
           .build();
 


### PR DESCRIPTION
After move from extensions/v1beta1 to apps/v1 , deployments made
 mandatory the definition of a selector with match labels.