### PR TITLE
Fixes #1178: Impersonate-Group may be specified multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   
     * Added Kubernetes/Openshift examples for client.getVersion()
     * Fix #1126 : Add new option `kubernetes.disable.hostname.verification` / `KUBERNETES_DISABLE_HOSTNAME_VERIFICATION` to disable hostname verification
+    * Fix #1178 : Impersonate-Group may be specified multiple times
 
   Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -157,6 +157,7 @@ public class Config {
   private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
   private int maxConcurrentRequestsPerHost = DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST;
   private String impersonateUsername;
+  @Deprecated
   private String impersonateGroup;
   private String[] impersonateGroups;
   private Map<String, String> impersonateExtras;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -158,6 +158,7 @@ public class Config {
   private int maxConcurrentRequestsPerHost = DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST;
   private String impersonateUsername;
   private String impersonateGroup;
+  private String[] impersonateGroups;
   private Map<String, String> impersonateExtras;
   /**
    * end of fields not used but needed for builder generation.
@@ -207,7 +208,7 @@ public class Config {
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
-  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String impersonateGroup, Map<String, String> impersonateExtras) {
+  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, String> impersonateExtras) {
     this.masterUrl = masterUrl;
     this.apiVersion = apiVersion;
     this.namespace = namespace;
@@ -224,7 +225,7 @@ public class Config {
 
     this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost);
     this.requestConfig.setImpersonateUsername(impersonateUsername);
-    this.requestConfig.setImpersonateGroup(impersonateGroup);
+    this.requestConfig.setImpersonateGroups(impersonateGroups);
     this.requestConfig.setImpersonateExtras(impersonateExtras);
 
 
@@ -277,7 +278,11 @@ public class Config {
     config.setPassword(Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_BASIC_PASSWORD_SYSTEM_PROPERTY, config.getPassword()));
 
     config.setImpersonateUsername(Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_USERNAME, config.getImpersonateUsername()));
-    config.setImpersonateGroup(Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_GROUP, config.getImpersonateGroup()));
+
+    String configuredImpersonateGroups = Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_GROUP, config.getImpersonateGroup());
+    if (configuredImpersonateGroups != null) {
+      config.setImpersonateGroups(configuredImpersonateGroups.split(","));
+    }
 
     String configuredWatchReconnectInterval = Utils.getSystemPropertyOrEnvVar(KUBERNETES_WATCH_RECONNECT_INTERVAL_SYSTEM_PROPERTY);
     if (configuredWatchReconnectInterval != null) {
@@ -585,13 +590,30 @@ public class Config {
     this.requestConfig.setImpersonateUsername(impersonateUsername);
   }
 
+  @JsonProperty("impersonateGroups")
+  public String[] getImpersonateGroups() {
+    return getRequestConfig().getImpersonateGroups();
+  }
+
+  public void setImpersonateGroups(String... impersonateGroup) {
+    this.requestConfig.setImpersonateGroups(impersonateGroup);
+  }
+
+  /**
+   * @deprecated Use {@link #getImpersonateGroups()} instead
+   */
+  @Deprecated
   @JsonProperty("impersonateGroup")
   public String getImpersonateGroup() {
     return getRequestConfig().getImpersonateGroup();
   }
 
+  /**
+   * @deprecated Use {@link #setImpersonateGroups(String...)} instead
+   */
+  @Deprecated
   public void setImpersonateGroup(String impersonateGroup) {
-    this.requestConfig.setImpersonateGroup(impersonateGroup);
+    this.requestConfig.setImpersonateGroups(impersonateGroup);
   }
 
   @JsonProperty("impersonateExtras")
@@ -867,7 +889,7 @@ public class Config {
   public void setMaxConcurrentRequests(int maxConcurrentRequests) {
     this.requestConfig.setMaxConcurrentRequests(maxConcurrentRequests);
   }
-  
+
   public int getMaxConcurrentRequestsPerHost() {
     return getRequestConfig().getMaxConcurrentRequestsPerHost();
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -157,6 +157,9 @@ public class Config {
   private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
   private int maxConcurrentRequestsPerHost = DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST;
   private String impersonateUsername;
+  /**
+  * @deprecated use impersonateGroups instead
+  */
   @Deprecated
   private String impersonateGroup;
   private String[] impersonateGroups;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client;
 
 import io.sundr.builder.annotations.Buildable;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +36,9 @@ public class RequestConfig {
   private String password;
   private String oauthToken;
   private String impersonateUsername;
-  private String impersonateGroup;
+
+  private String[] impersonateGroups = new String[0];
+
   private Map<String, String> impersonateExtras = new HashMap<>();
   private int watchReconnectInterval = 1000;
   private int watchReconnectLimit = -1;
@@ -177,7 +180,7 @@ public class RequestConfig {
   public void setMaxConcurrentRequests(int maxConcurrentRequests) {
     this.maxConcurrentRequests = maxConcurrentRequests;
   }
-  
+
   public int getMaxConcurrentRequestsPerHost() {
     return maxConcurrentRequestsPerHost;
   }
@@ -194,12 +197,28 @@ public class RequestConfig {
     return impersonateUsername;
   }
 
+  /**
+   * @deprecated Use {@link #setImpersonateGroups(String...)} instead
+   */
+  @Deprecated
   public void setImpersonateGroup(String impersonateGroup) {
-    this.impersonateGroup = impersonateGroup;
+    setImpersonateGroups(impersonateGroup);
   }
 
+  /**
+   * @deprecated Use {@link #getImpersonateGroups()} instead
+   */
+  @Deprecated
   public String getImpersonateGroup() {
-    return impersonateGroup;
+    return (impersonateGroups == null || impersonateGroups.length == 0) ? null : impersonateGroups[0];
+  }
+
+  public void setImpersonateGroups(String... impersonateGroups) {
+    this.impersonateGroups = impersonateGroups == null ? new String[0] : Arrays.copyOf(impersonateGroups, impersonateGroups.length);
+  }
+
+  public String[] getImpersonateGroups() {
+    return impersonateGroups;
   }
 
   public void setImpersonateExtras(Map<String, String> impersonateExtras) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ImpersonatorInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ImpersonatorInterceptor.java
@@ -41,8 +41,8 @@ public class ImpersonatorInterceptor implements Interceptor {
 
       requestBuilder.addHeader("Impersonate-User", requestConfig.getImpersonateUsername());
 
-      if (isNotNullOrEmpty(requestConfig.getImpersonateGroup())) {
-        requestBuilder.addHeader("Impersonate-Group", requestConfig.getImpersonateGroup());
+      for (String group : requestConfig.getImpersonateGroups()) {
+        requestBuilder.addHeader("Impersonate-Group", group);
       }
 
       if (isNotNullOrEmpty(requestConfig.getImpersonateExtras())) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -344,7 +344,7 @@ public class ConfigTest {
       .build();
 
     assertEquals("a", config.getImpersonateUsername());
-    assertEquals("group", config.getImpersonateGroup());
+    assertArrayEquals(new String[]{"group"}, config.getImpersonateGroups());
     assertEquals("d", config.getImpersonateExtras().get("c"));
 
   }
@@ -415,9 +415,8 @@ public class ConfigTest {
     final Config currentConfig = client.getConfiguration();
 
     assertEquals("a", currentConfig.getImpersonateUsername());
-    assertEquals("b", currentConfig.getImpersonateGroup());
+    assertArrayEquals(new String[]{"b"}, currentConfig.getImpersonateGroups());
     assertEquals("d", currentConfig.getImpersonateExtras().get("c"));
-
   }
 
   private void assertConfig(Config config) {

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/UserImpersonationIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/UserImpersonationIT.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.api.model.rbac.*;
+import io.fabric8.kubernetes.client.RequestConfig;
+import io.fabric8.openshift.api.model.ProjectRequest;
+import io.fabric8.openshift.api.model.User;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class UserImpersonationIT {
+
+  private static final String SERVICE_ACCOUNT = "serviceaccount1";
+  private static final String NEW_PROJECT = "impersonation" + System.nanoTime();
+
+  @ArquillianResource
+  OpenShiftClient client;
+
+  @ArquillianResource
+  Session session;
+
+  private ServiceAccount serviceAccount1;
+  private KubernetesClusterRole impersonatorRole;
+  private KubernetesClusterRoleBinding impersonatorRoleBinding;
+
+  private String currentNamespace;
+
+  @Before
+  public void init() {
+    currentNamespace = session.getNamespace();
+    // Create impersonator cluster role
+    impersonatorRole = new KubernetesClusterRoleBuilder()
+      .withNewMetadata()
+      .withName("impersonator")
+      .endMetadata()
+      .addToRules(new KubernetesPolicyRuleBuilder()
+        .addToApiGroups("")
+        .addToResources("users", "groups", "serviceaccounts")
+        .addToVerbs("impersonate")
+        .build()
+      )
+      .build();
+    client.rbac().kubernetesClusterRoles().inNamespace(currentNamespace).createOrReplace(impersonatorRole);
+
+    // Create Service Account
+    serviceAccount1 = new ServiceAccountBuilder()
+      .withNewMetadata().withName(SERVICE_ACCOUNT).endMetadata()
+      .build();
+    client.serviceAccounts().inNamespace(currentNamespace).create(serviceAccount1);
+
+    // Bind Impersonator Role to current user
+    impersonatorRoleBinding = new KubernetesClusterRoleBindingBuilder()
+      .withNewMetadata()
+      .withName("impersonate-role")
+      .endMetadata()
+      .addToSubjects(new KubernetesSubjectBuilder()
+        .withApiGroup("rbac.authorization.k8s.io")
+        .withKind("User")
+        .withName(client.currentUser().getMetadata().getName())
+        .withNamespace(currentNamespace)
+        .build()
+      )
+      .withRoleRef(new KubernetesRoleRefBuilder()
+        .withApiGroup("rbac.authorization.k8s.io")
+        .withKind("ClusterRole")
+        .withName("impersonator")
+        .build()
+      )
+      .build();
+
+    client.rbac().kubernetesClusterRoleBindings().inNamespace(currentNamespace).createOrReplace(impersonatorRoleBinding);
+  }
+
+
+  @Test
+  public void should_be_able_to_return_service_account_name_when_impersonating_current_user() {
+    RequestConfig requestConfig = client.getConfiguration().getRequestConfig();
+    requestConfig.setImpersonateUsername(SERVICE_ACCOUNT);
+    requestConfig.setImpersonateGroups("system:authenticated", "system:authenticated:oauth");
+
+    User user = client.currentUser();
+    assertThat(user.getMetadata().getName()).isEqualTo(SERVICE_ACCOUNT);
+  }
+
+
+  @Test
+  public void should_be_able_to_create_a_project_impersonating_service_account() {
+    RequestConfig requestConfig = client.getConfiguration().getRequestConfig();
+    requestConfig.setImpersonateUsername(SERVICE_ACCOUNT);
+    requestConfig.setImpersonateGroups("system:authenticated", "system:authenticated:oauth");
+    // Create a project
+    ProjectRequest projectRequest = client.projectrequests().createNew()
+      .withNewMetadata()
+      .withName(NEW_PROJECT)
+      .endMetadata()
+      .done();
+
+    // Grab the requester annotation
+    String requester = projectRequest.getMetadata().getAnnotations().get("openshift.io/requester");
+    assertThat(requester).isEqualTo(SERVICE_ACCOUNT);
+  }
+
+
+  @After
+  public void cleanup() {
+    // Reset original authentication
+    RequestConfig requestConfig = client.getConfiguration().getRequestConfig();
+    requestConfig.setImpersonateUsername(null);
+    requestConfig.setImpersonateGroups(null);
+
+    // Delete Cluster Role
+    client.rbac().kubernetesClusterRoles().inNamespace(currentNamespace).delete(impersonatorRole);
+    await().atMost(30, TimeUnit.SECONDS).until(kubernetesClusterRoleIsDeleted());
+
+    // Delete Cluster Role binding
+    client.rbac().kubernetesClusterRoleBindings().inNamespace(currentNamespace).delete(impersonatorRoleBinding);
+    await().atMost(30, TimeUnit.SECONDS).until(kubernetesClusterRoleBindingIsDeleted());
+
+    // Delete project
+    client.projects().withName(NEW_PROJECT).delete();
+    await().atMost(30, TimeUnit.SECONDS).until(projectIsDeleted());
+
+    // Delete ServiceAccounts
+    client.serviceAccounts().inNamespace(currentNamespace).delete(serviceAccount1);
+    await().atMost(30, TimeUnit.SECONDS).until(serviceAccountIsDeleted());
+  }
+
+  private Callable<Boolean> serviceAccountIsDeleted() {
+    return new Callable<Boolean>() {
+      @Override
+      public Boolean call() {
+        return client.serviceAccounts().inNamespace(currentNamespace).withName(serviceAccount1.getMetadata().getName()).get() == null;
+      }
+    };
+  }
+
+  private Callable<Boolean> projectIsDeleted() {
+    return new Callable<Boolean>() {
+      @Override
+      public Boolean call() {
+        return client.projects().withName(NEW_PROJECT).get() == null;
+      }
+    };
+  }
+
+  private Callable<Boolean> kubernetesClusterRoleBindingIsDeleted() {
+    return new Callable<Boolean>() {
+      @Override
+      public Boolean call() {
+        return client.rbac().kubernetesClusterRoleBindings().inNamespace(currentNamespace).withName("impersonator-role").get() == null;
+      }
+    };
+  }
+
+  private Callable<Boolean> kubernetesClusterRoleIsDeleted() {
+    return new Callable<Boolean>() {
+      @Override
+      public Boolean call() {
+        return client.rbac().kubernetesClusterRoles().inNamespace(currentNamespace).withName("impersonator").get() == null;
+      }
+    };
+  }
+
+
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.fabric8.openshift.client;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,12 +27,7 @@ import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true, allowGetters = true, allowSetters = true)
@@ -65,8 +62,8 @@ public class OpenShiftConfig extends Config {
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false, refs = {@BuildableReference(Config.class)})
-  public OpenShiftConfig(String openShiftUrl, String oapiVersion, String masterUrl, String apiVersion, String namespace, Boolean trustCerts, Boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, Integer maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long buildTimeout, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String impersonateGroup, Map<String, String> impersonateExtras) {
-    super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval,maxConcurrentRequestsPerHost, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions, websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroup, impersonateExtras);
+  public OpenShiftConfig(String openShiftUrl, String oapiVersion, String masterUrl, String apiVersion, String namespace, Boolean trustCerts, Boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, Integer maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long buildTimeout, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, String> impersonateExtras) {
+    super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequestsPerHost, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions, websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras);
     this.oapiVersion = oapiVersion;
     this.openShiftUrl = openShiftUrl;
     this.buildTimeout = buildTimeout;
@@ -107,7 +104,7 @@ public class OpenShiftConfig extends Config {
       kubernetesConfig.getKeyStoreFile(),
       kubernetesConfig.getKeyStorePassphrase(),
       kubernetesConfig.getImpersonateUsername(),
-      kubernetesConfig.getImpersonateGroup(),
+      kubernetesConfig.getImpersonateGroups(),
       kubernetesConfig.getImpersonateExtras()
       );
   }


### PR DESCRIPTION
#1178 According to https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation, the `Impersonate-Group` header may be specified multiple times