### PR TITLE
Fix tracking of watched resource versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,6 @@
 
 version: 2
 jobs:
-  TEST:
-    machine: true
-    steps:
-      - checkout
-      - run: mvn clean install
   OPENSHIFT_3.6.0:
     machine: true
     steps:
@@ -221,7 +216,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - TEST
       - OPENSHIFT_3.6.0
       - OPENSHIFT_3.6.1
       - OPENSHIFT_3.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 4.0.5
   Bugs
+  
+    * Fix #1214 : Watch resource versions not correctly tracked resulting in 410 errors on reconnect
 
   Improvements
     * Chore #1168 : Upgrade to Java 8

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -227,11 +227,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
             @SuppressWarnings("unchecked")
             T obj = (T) object;
             // Dirty cast - should always be valid though
-            String currentResourceVersion = resourceVersion.get();
-            String newResourceVersion = ((HasMetadata) obj).getMetadata().getResourceVersion();
-            if (currentResourceVersion == null || currentResourceVersion.compareTo(newResourceVersion) < 0) {
-              resourceVersion.compareAndSet(currentResourceVersion, newResourceVersion);
-            }
+            resourceVersion.set(((HasMetadata) obj).getMetadata().getResourceVersion());
             Watcher.Action action = Watcher.Action.valueOf(event.getType());
             watcher.eventReceived(action, obj);
           } else if (object instanceof KubernetesResourceList) {
@@ -239,11 +235,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
 
             KubernetesResourceList list = (KubernetesResourceList) object;
             // Dirty cast - should always be valid though
-            String currentResourceVersion = resourceVersion.get();
-            String newResourceVersion = list.getMetadata().getResourceVersion();
-            if (currentResourceVersion == null || currentResourceVersion.compareTo(newResourceVersion) < 0) {
-              resourceVersion.compareAndSet(currentResourceVersion, newResourceVersion);
-            }
+            resourceVersion.set(list.getMetadata().getResourceVersion());
             Watcher.Action action = Watcher.Action.valueOf(event.getType());
             List<HasMetadata> items = list.getItems();
             if (items != null) {


### PR DESCRIPTION
Fixes #1214

resourceVersions are Strings, so comparing them with compareTo leads to
unexpected results ("9".compareTo("10") is > 0.) Also since the versions
are supposed to be opaque we should not be trying to read any meaning
or ordering into them.

Since messages are processed in order we should just always store the
last processed resourceVersion.

I'm not sure this even needs to use an Atomic* type, but it seems safer
to just leave that in place.