### PR TITLE
Added vCommander to Used By

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,9 @@ All the resource objects used here will be according to OpenShift 3.9.0  and Kub
   - [Strimzi](https://github.com/strimzi/)
   - [Syndesis](https://syndesis.io/)
   
+  Proprietary Platforms:
+  - [vCommander](https://www.embotics.com/hybrid-cloud-management-platform)
+  
 As our community grows, we would like to track keep track of our users. Please send a PR with your organization/community name.   
 
 ## Tests we run for every new Pull Request


### PR DESCRIPTION
Closed the previous PR due to some invalid configuration issues I had.  As per the result of the discussion from that PR, added vCommander under "Properitary Platforms" list.