### PR TITLE
Close the initial request before discarding it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 4.1.1
   Bugs
+  
+    * Fix #1239: Fix one case of OkHttp connection leaks
 
   Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
@@ -123,6 +123,7 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
       ResourceKey key = getKey(matcher);
       ResourceKey target = responseCodeToTransformations.get(response.code()).get(key);
       if (target != null) {
+        response.close(); // At this point, we know we won't reuse or return the response; so close it to avoid a connection leak.
         String newUrl = new StringBuilder(url)
             .replace(matcher.start(API_VERSION), matcher.end(API_VERSION), target.version) // Order matters: We need to substitute right to left, so that former substitution don't affect the indexes of later.
             .replace(matcher.start(API_GROUP), matcher.end(API_GROUP), target.group)


### PR DESCRIPTION
Plugs a connection leak. 

This is the same symptom as #1198 addresses in several other places. In this case, once you get to line 121, you _know_ you're not going to need to use `response` or `request` for anything other than getting the response status code. The 'response` needs to be closed in order not to leak a connection. Getting its status code still works after closure.