### PR TITLE
Fix #1246: Separate stderr and stdout streams in ExecWebSocketListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     * Fix #1266: Not setting optional Impersonate-Group results in NPE in ImpersonatorInterceptor
     * Fix #1238: Renamed files with invalid Windows characters
 	  * Fix #1260: Added Windows support in ConfigTest.honorClientAuthenticatorCommands
+    * Fix #1246: Fix bug causing stderr to be written to the stdout stream in ExecWebSocketListener
 
   Improvements
     * Fix #1226 : Extend and move integrations tests

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -249,8 +249,8 @@ public class ExecWebSocketListener extends WebSocketListener implements ExecWatc
                         }
                         break;
                     case 2:
-                        if (out != null) {
-                            out.write(byteString.toByteArray());
+                        if (err != null) {
+                            err.write(byteString.toByteArray());
                         }
                         break;
                     case 3:


### PR DESCRIPTION
Fixes #1246 - brief summary of issue: the exec listener was changed to combine stderr with stdout

This PR just reverts those changes so that stderr is properly written to the stderr stream and kept separate from stdout. 

If adding a simple way for people to use the exec api through the client would be useful, @PaulFurtado described what we've written to do this in [this comment](https://github.com/fabric8io/kubernetes-client/issues/1246#issuecomment-436899940). We'd be happy to take a look at adding something similar to the client.