### PR TITLE
Issue 1228: InputStream not closing correctly during unmarshal action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Fix #1238: Renamed files with invalid Windows characters
   * Fix #1260: Added Windows support in ConfigTest.honorClientAuthenticatorCommands
   * Fix #579: Add Timestampable interface to PodOperationsImpl/BuildOperationsImpl and set timestamps parameter
+  * Fix #1228: Closed InputStream in OperationSupport's handleResponse to avoid leak
 
   Improvements
   * Fix #1226 : Extend and move integrations tests

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -380,7 +380,9 @@ public class OperationSupport {
     try (ResponseBody body = response.body()) {
       assertResponseCode(request, response);
       if (type != null) {
-        return Serialization.unmarshal(body.byteStream(), type, parameters);
+        try (InputStream bodyInputStream = body.byteStream()) {
+          return Serialization.unmarshal(bodyInputStream, type, parameters);
+        }
       } else {
         return null;
       }


### PR DESCRIPTION
Looks like the InputStream not being closed was the source of the leakage for me.  Referencing https://github.com/fabric8io/kubernetes-client/issues/1228 since that was the base of discussion around the issue.

Mixed with the okhttp WebSocket fix, this should get most of the leakages.