### PR TITLE
Ignore unknown properties when deserializing ExecCredential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Fix #579: Add Timestampable interface to PodOperationsImpl/BuildOperationsImpl and set timestamps parameter
   * Fix #1273: customResources can't be used with Cluster scoped CRDs
   * Fix #1228: Closed InputStream in OperationSupport's handleResponse to avoid leak
+  * Fix ExecCredential deserialization in kubeconfig auth
 
   Improvements
     * Fix #1226 : Extend and move integrations tests

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -554,13 +554,16 @@ public class Config {
 
     return false;
   }
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private static final class ExecCredential {
     public String kind;
     public String apiVersion;
     public ExecCredentialSpec spec;
     public ExecCredentialStatus status;
   }
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private static final class ExecCredentialSpec {}
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private static final class ExecCredentialStatus {
     public String token;
     // TODO clientCertificateData, clientKeyData, expirationTimestamp


### PR DESCRIPTION
`aws-iam-authenticator token --cluster-id <cluster-id>` returns a JSON blob of the form
```
{
  "kind": "ExecCredential",
  "apiVersion": "client.authentication.k8s.io/v1alpha1",
  "spec": {},
  "status": {
    "expirationTimestamp": "2018-11-28T02:24:39Z",
    "token": "<some token>"
  }
}
```
This fails to deserialize in `ExecCredentialStatus`. There is a TODO to add some fields, including `expirationTimestamp`, but this is a temporary stopgap to avoid requiring those fields.