### PR TITLE
OpenShiftOAuthInterceptor.authorize() should only throw IOException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   Improvements
     * Fix #1226 : Extend and move integrations tests
     * Fix #989  : Add support for waitForCondition
+    * Fix #1293 : OpenShiftOAuthInterceptor.authorize() should only throw IOException
 
   Dependency Upgrade
     * Fix #1223: jackson-dataformat-yaml dependency (2.7.7) ageing

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
@@ -104,7 +104,7 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
         }
     }
 
-    private String acquireNewToken() {
+    private String acquireNewToken() throws IOException {
       synchronized (client) {
         // current token (if exists) is broken, don't resend
         oauthToken.set(null);
@@ -116,29 +116,24 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
       return oauthToken.get();
     }
 
-    private String authorize() {
-        try {
-            OkHttpClient.Builder builder = client.newBuilder();
-            builder.interceptors().remove(this);
-            OkHttpClient clone = builder.build();
+    private  String authorize() throws IOException {
+        OkHttpClient.Builder builder = client.newBuilder();
+        builder.interceptors().remove(this);
+        OkHttpClient clone = builder.build();
 
-            String credential = Credentials.basic(config.getUsername(), new String(config.getPassword()));
-            URL url = new URL(URLUtils.join(config.getMasterUrl(), AUTHORIZE_PATH));
-            Response response = clone.newCall(new Request.Builder().get().url(url).header(AUTHORIZATION, credential).build()).execute();
+        String credential = Credentials.basic(config.getUsername(), new String(config.getPassword()));
+        URL url = new URL(URLUtils.join(config.getMasterUrl(), AUTHORIZE_PATH));
+        Response response = clone.newCall(new Request.Builder().get().url(url).header(AUTHORIZATION, credential).build()).execute();
 
-            response.body().close();
-            response = response.priorResponse() != null ? response.priorResponse() : response;
-            response = response.networkResponse() != null ? response.networkResponse() : response;
-            String token = response.header(LOCATION);
-            if (token == null || token.isEmpty()) {
-              throw new KubernetesClientException("Unexpected response (" + response.code() + " " + response.message() + "), to the authorization request. Missing header:[" + LOCATION + "]!");
-            }
-            token = token.substring(token.indexOf(BEFORE_TOKEN) + BEFORE_TOKEN.length());
-            token = token.substring(0, token.indexOf(AFTER_TOKEN));
-            return token;
-        } catch (Exception e) {
-            throw KubernetesClientException.launderThrowable(e);
+        response.body().close();
+        response = response.priorResponse() != null ? response.priorResponse() : response;
+        response = response.networkResponse() != null ? response.networkResponse() : response;
+        String token = response.header(LOCATION);
+        if (token == null || token.isEmpty()) {
+          throw new IOException("Unexpected response(" + response.code() + " " + response.message() + "), to the authorization request. Missing header:[" + LOCATION + "]!");
         }
+        token = token.substring(token.indexOf(BEFORE_TOKEN) + BEFORE_TOKEN.length());
+        token = token.substring(0, token.indexOf(AFTER_TOKEN));
+        return token;
     }
 }
-


### PR DESCRIPTION
The authorize method should never wrap an underlying checked IOException
into an unchecked KubernetesClientException. The IOException is declared
in the calling method (intercept()) and is handled by okhttp's RealCall$
AsyncCall as part of the Interceptor contract. But a RuntimeException is
not handled and okhttp's Dispatcher thread simply exits in this case,
instead of notifying the listener through the onFailure() callback.

Specific scenario that fails without this fix:
A watch is connected via websocket and the authorization token times
out, so the server closes the connection. When the watch first tries to
reconnect, a socket read timeout occurs during the authorization phase.
- Without the fix. this timeout kills the Dispatcher thread and the
  WatchConnectionManager is never notified via the onFailure() callback.
- With the fix, RealCall$AsyncCall properly catches the IOException and
  calls onFailure(), allowing WatchConnectionManager to retry.

For other exceptions that may occur: KCE.launderThrowable() only wraps
checked exception; RuntimeException-s and Error-s simply passed through
the catch clause anyway. All checked exceptions thrown in the method are
IOExceptions now, which we are supposed to throw anyway.