### PR TITLE
Support KUBECONFIG env var with multiple paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
   Improvements
 
+    * Fix #1306: Support `KUBECONFIG` env var with multiple paths
+
   Dependency Upgrade
 
   New Feature

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -436,8 +436,14 @@ public class Config {
   private static boolean tryKubeConfig(Config config, String context) {
     LOGGER.debug("Trying to configure client from Kubernetes config...");
     if (Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, true)) {
-      File kubeConfigFile = new File(
-          Utils.getSystemPropertyOrEnvVar(KUBERNETES_KUBECONFIG_FILE, new File(getHomeDir(), ".kube" + File.separator + "config").toString()));
+      String fileName = Utils.getSystemPropertyOrEnvVar(KUBERNETES_KUBECONFIG_FILE, new File(getHomeDir(), ".kube" + File.separator + "config").toString());
+      // if system property/env var contains multiple files take the first one
+      String[] fileNames = fileName.split(":");
+      if (fileNames.length > 1) {
+          LOGGER.debug("Found multiple Kubernetes config files ["+fileNames+"] using the first one: ["+fileNames[0]+"].");
+          fileName = fileNames[0];
+      }
+      File kubeConfigFile = new File(fileName);
       boolean kubeConfigFileExists = Files.isRegularFile(kubeConfigFile.toPath());
 
       if (kubeConfigFileExists) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -256,6 +256,19 @@ public class ConfigTest {
   }
 
   @Test
+  public void testWithMultipleKubeConfigAndOverrideContext() {
+    System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE + ":some-other-file");
+    Config config = Config.autoConfigure("production/172-28-128-4:8443/root");
+    assertNotNull(config);
+
+    assertEquals("https://172.28.128.4:8443/", config.getMasterUrl());
+    assertEquals("production", config.getNamespace());
+    assertEquals("supertoken", config.getOauthToken());
+    assertTrue(config.getCaCertFile().endsWith("testns/ca.pem".replace("/", File.separator)));
+    assertTrue(new File(config.getCaCertFile()).isAbsolute());
+  }
+
+  @Test
   public void testWithKubeConfigAndSystemProperties() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE);
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");


### PR DESCRIPTION
Pick the first kubeconfig file when env var has multiple ones

Example

```
/home/jdoe/.kube/config:/home/jdoe/.kube/config-something-else.yml
```

See https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable