### PR TITLE
Modified Config and ConfigTest to use File.pathSeparator to allow for multi-platform support

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -19,11 +19,9 @@ package io.fabric8.kubernetes.client;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import io.fabric8.kubernetes.api.model.ConfigBuilder;
-import okhttp3.TlsVersion;
 import io.fabric8.kubernetes.api.model.AuthInfo;
 import io.fabric8.kubernetes.api.model.Cluster;
+import io.fabric8.kubernetes.api.model.ConfigBuilder;
 import io.fabric8.kubernetes.api.model.Context;
 import io.fabric8.kubernetes.client.internal.KubeConfigUtils;
 import io.fabric8.kubernetes.client.internal.SSLUtils;
@@ -31,13 +29,15 @@ import io.fabric8.kubernetes.client.utils.IOHelpers;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
+import okhttp3.TlsVersion;
+import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -437,12 +437,16 @@ public class Config {
     LOGGER.debug("Trying to configure client from Kubernetes config...");
     if (Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, true)) {
       String fileName = Utils.getSystemPropertyOrEnvVar(KUBERNETES_KUBECONFIG_FILE, new File(getHomeDir(), ".kube" + File.separator + "config").toString());
-      // if system property/env var contains multiple files take the first one
-      String[] fileNames = fileName.split(":");
+
+      // if system property/env var contains multiple files take the first one based on the environment
+      // we are running in (eg. : for Linux, ; for Windows)
+      String[] fileNames = fileName.split(File.pathSeparator);
+
       if (fileNames.length > 1) {
-          LOGGER.debug("Found multiple Kubernetes config files ["+fileNames+"] using the first one: ["+fileNames[0]+"].");
-          fileName = fileNames[0];
+        LOGGER.debug("Found multiple Kubernetes config files [{}], using the first one: [{}].", fileNames, fileNames[0]);
+        fileName = fileNames[0];
       }
+
       File kubeConfigFile = new File(fileName);
       boolean kubeConfigFileExists = Files.isRegularFile(kubeConfigFile.toPath());
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -257,7 +257,8 @@ public class ConfigTest {
 
   @Test
   public void testWithMultipleKubeConfigAndOverrideContext() {
-    System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE + ":some-other-file");
+    System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE + File.pathSeparator + "some-other-file");
+
     Config config = Config.autoConfigure("production/172-28-128-4:8443/root");
     assertNotNull(config);
 


### PR DESCRIPTION
Realized today the tests were failing locally for me - took me longer then I would like to admit to realize it was due to the multi-file support added recently.