### PR TITLE
Changed to use ExecConfig instead of additionalProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     * Fix #1218: CustomResourceDefinitions: cascading() causes NoSuchMethodError
     
     * Fix #1309: Can't get VersionInfo correctly
+    
+    * Fix #1332: Unable to use ExecCredentials
 
   Improvements
     

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang.SystemUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -438,7 +437,6 @@ public class ConfigTest {
   }
 
   @Test
-  @Ignore
   public void honorClientAuthenticatorCommands() throws Exception {
     if (SystemUtils.IS_OS_WINDOWS) {
       System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_WIN_FILE);

--- a/kubernetes-client/src/test/resources/test-kubeconfig-exec
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-exec
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiGroupVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - world
       command: ./token-generator

--- a/kubernetes-client/src/test/resources/test-kubeconfig-exec-win
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-exec-win
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiGroupVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - world
       command: ./token-generator-win.bat


### PR DESCRIPTION
Fixes https://github.com/fabric8io/kubernetes-client/issues/1332
Fix to use ExecConfig to retrieve credentials 

* using ExecConfig
* re-enabled test-case


