### PR TITLE
oAuth token rotation support

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.kubernetes.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,7 +33,6 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
 import okhttp3.TlsVersion;
-import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -165,6 +165,8 @@ public class Config {
   private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
   private int maxConcurrentRequestsPerHost = DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST;
   private String impersonateUsername;
+  private OAuthTokenProvider oauthTokenProvider;
+
   /**
   * @deprecated use impersonateGroups instead
   */
@@ -219,8 +221,13 @@ public class Config {
     return config;
   }
 
-  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
+  @Deprecated
   public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras) {
+    this(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequestsPerHost, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions,  websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras, null);
+  }
+
+  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
+  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider) {
     this.masterUrl = masterUrl;
     this.apiVersion = apiVersion;
     this.namespace = namespace;
@@ -235,7 +242,7 @@ public class Config {
     this.clientKeyAlgo = clientKeyAlgo;
     this.clientKeyPassphrase = clientKeyPassphrase;
 
-    this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost);
+    this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, oauthTokenProvider);
     this.requestConfig.setImpersonateUsername(impersonateUsername);
     this.requestConfig.setImpersonateGroups(impersonateGroups);
     this.requestConfig.setImpersonateExtras(impersonateExtras);
@@ -262,6 +269,7 @@ public class Config {
     this.trustStorePassphrase = trustStorePassphrase;
     this.keyStoreFile = keyStoreFile;
     this.keyStorePassphrase = keyStorePassphrase;
+    this.oauthTokenProvider = oauthTokenProvider;
   }
 
   public static void configFromSysPropsOrEnvVars(Config config) {
@@ -509,7 +517,7 @@ public class Config {
 
           if (Utils.isNullOrEmpty(config.getOauthToken()) && currentAuthInfo.getAuthProvider() != null && !Utils.isNullOrEmpty(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN))) {
             config.setOauthToken(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN));
-          } else { // https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
+          } else if (config.getOauthTokenProvider() == null) {  // https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
             ExecConfig exec = currentAuthInfo.getExec();
             if (exec != null) {
               String apiVersion = exec.getApiVersion();
@@ -1033,4 +1041,12 @@ public class Config {
     return keyStoreFile;
   }
 
+  @JsonIgnore
+  public OAuthTokenProvider getOauthTokenProvider() {
+    return oauthTokenProvider;
+  }
+
+  public void setOauthTokenProvider(OAuthTokenProvider oauthTokenProvider) {
+    this.oauthTokenProvider = oauthTokenProvider;
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/OAuthTokenProvider.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/OAuthTokenProvider.java
@@ -1,0 +1,13 @@
+package io.fabric8.kubernetes.client;
+
+public interface OAuthTokenProvider {
+
+  /**
+   * Returns a Bearer token used for authorization between a client
+   * and a kubernetes cluster. The token will be injected into an Authorization header.
+   *
+   * @return oauth token
+   */
+  String getToken();
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -36,6 +36,7 @@ public class RequestConfig {
   private String username;
   private String password;
   private String oauthToken;
+  private OAuthTokenProvider oauthTokenProvider;
   private String impersonateUsername;
 
   private String[] impersonateGroups = new String[0];
@@ -56,12 +57,26 @@ public class RequestConfig {
   RequestConfig() {
   }
 
-  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
+  /**
+   * For backward compatibility
+   * Use {@link RequestConfigBuilder} instead
+   */
+  @Deprecated
   public RequestConfig(String username, String password, String oauthToken,
                        int watchReconnectLimit, int watchReconnectInterval,
                        int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
                        long websocketTimeout, long websocketPingInterval,
                        int maxConcurrentRequests, int maxConcurrentRequestsPerHost) {
+    this(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval,
+         websocketTimeout,  websocketPingInterval,maxConcurrentRequests, maxConcurrentRequestsPerHost, null);
+  }
+
+  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
+  public RequestConfig(String username, String password, String oauthToken,
+                       int watchReconnectLimit, int watchReconnectInterval,
+                       int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
+                       long websocketTimeout, long websocketPingInterval,
+                       int maxConcurrentRequests, int maxConcurrentRequestsPerHost, OAuthTokenProvider oauthTokenProvider) {
     this.username = username;
     this.oauthToken = oauthToken;
     this.password = password;
@@ -76,6 +91,7 @@ public class RequestConfig {
     this.websocketPingInterval = websocketPingInterval;
     this.maxConcurrentRequests = maxConcurrentRequests;
     this.maxConcurrentRequestsPerHost = maxConcurrentRequestsPerHost;
+    this.oauthTokenProvider = oauthTokenProvider;
   }
 
   public String getUsername() {
@@ -103,11 +119,22 @@ public class RequestConfig {
   }
 
   public String getOauthToken() {
+    if (oauthTokenProvider != null) {
+      return oauthTokenProvider.getToken();
+    }
     return oauthToken;
   }
 
   public void setOauthToken(String oauthToken) {
     this.oauthToken = oauthToken;
+  }
+
+  public OAuthTokenProvider getOauthTokenProvider() {
+    return oauthTokenProvider;
+  }
+
+  public void setOauthTokenProvider(OAuthTokenProvider oauthTokenProvider) {
+    this.oauthTokenProvider = oauthTokenProvider;
   }
 
   public int getWatchReconnectLimit() {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -450,7 +450,6 @@ public class ConfigTest {
     assertEquals("HELLO WORLD", config.getOauthToken());
   }
 
-
   @Test
   public void shouldBeUsedTokenSuppliedByProvider() throws Exception {
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -450,6 +450,22 @@ public class ConfigTest {
     assertEquals("HELLO WORLD", config.getOauthToken());
   }
 
+
+  @Test
+  public void shouldBeUsedTokenSuppliedByProvider() throws Exception {
+
+    Config config = new ConfigBuilder().withOauthToken("oauthToken")
+                                       .withOauthTokenProvider(new OAuthTokenProvider() {
+                                          @Override
+                                          public String getToken() {
+                                            return "PROVIDER_TOKEN";
+                                          }
+                                       })
+                                       .build();
+
+    assertEquals("PROVIDER_TOKEN", config.getOauthToken());
+  }
+
   private void assertConfig(Config config) {
     assertNotNull(config);
     assertTrue(config.isTrustCerts());

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
@@ -96,7 +96,6 @@ public class RequestConfigTest {
     assertAuthorizationHeader("Bearer token2");
   }
 
-
   private void sendRequest(RequestConfig requestConfig) {
     NamespacedKubernetesClient client = server.getClient();
     client.withRequestConfig(requestConfig)


### PR DESCRIPTION
Added support for an oAuth token roration. 

### Usage
A user can implement `OAuthTokenProvider` interface, method getToken.  
In `HttpClientUtils` will be called `config.getOauthToken()` which will delegate a call to the provider. 

```java
class RotatingOAuthTokenProvider implements OAuthTokenProvider {
    
    public String getToken() {
        // ...
    }
}
```

The implementation can be then supplied to a `ConfigBuilder` as bellow.

```java
new ConfigBuilder().withOauthTokenProvider(rotatingOAuthTokenProvider)
                   .build()
```

If the `OAuthTokenProvider` is supplied, takes precedence over token autoconfiguration, or static token.