### PR TITLE
Support client.authentication.k8s.io/v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
     * Updated compatability matrix after model upgrade in README.md 
 
     * Fix #1306: Support `KUBECONFIG` env var with multiple paths
- 
+
+    * Fix #1348: support `v1beta1` version for `ExecCredentials`
+
   Dependency Upgrade
 
   New Feature

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -521,7 +521,7 @@ public class Config {
             ExecConfig exec = currentAuthInfo.getExec();
             if (exec != null) {
               String apiVersion = exec.getApiVersion();
-              if ("client.authentication.k8s.io/v1alpha1".equals(apiVersion)) {
+              if ("client.authentication.k8s.io/v1alpha1".equals(apiVersion) || "client.authentication.k8s.io/v1beta1".equals(apiVersion)) {
                 List<String> argv = new ArrayList<String>();
                 String command = exec.getCommand();
                 if (command.contains("/") && !command.startsWith("/") && kubeconfigPath != null && !kubeconfigPath.isEmpty()) {


### PR DESCRIPTION
Amends #1224 to support the current `apiVersion` documented [here](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). With #1347 worked around, this has been successfully tested on a GKE cluster using

```yaml
users:
- name: gcp
  user:
    exec:
      apiVersion: "client.authentication.k8s.io/v1beta1"
      command: "sh"
      args:
        - "-c"
        - |
            gcloud config config-helper --format=json | jq '{"apiVersion": "client.authentication.k8s.io/v1beta1", "kind": "ExecCredential", "status": {"token": .credential.access_token, "expirationTimestamp": .credential.token_expiry}}'
```

(The `gcloud container clusters get-credentials` command recommended by Google rewrites your `~/.kube/config` to use

```yaml
users:
- name: …
  user:
   auth-provider:
     name: gcp
     config:
       access-token: …
       cmd-args: config config-helper --format=json
       cmd-path: gcloud
       expiry: …
       expiry-key: '{.credential.token_expiry}'
       token-key: '{.credential.access_token}'
```

which `Config` does not support, and which I think is semi-deprecated.)