### PR TITLE
Fix #1347: the JSON property is apiVersion, not apiGroupVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Service myservice = client.services().inNamespace("default").createNew()
                      .done();
 ```
 
-You can also set the apiGroupVersion of the resource like in the case of SecurityContextConstraints :
+You can also set the apiVersion of the resource like in the case of SecurityContextConstraints :
 
 ```java
 SecurityContextConstraints scc = new SecurityContextConstraintsBuilder()

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -546,7 +546,7 @@ public class Config {
                 }
                 ExecCredential ec = Serialization.unmarshal(p.getInputStream(), ExecCredential.class);
                 if (!apiVersion.equals(ec.apiVersion)) {
-                  LOGGER.warn("Wrong apiGroupVersion {} vs. {}", ec.apiVersion, apiVersion);
+                  LOGGER.warn("Wrong apiVersion {} vs. {}", ec.apiVersion, apiVersion);
                 }
                 if (ec.status != null && ec.status.token != null) {
                   config.setOauthToken(ec.status.token);
@@ -554,7 +554,7 @@ public class Config {
                   LOGGER.warn("No token returned");
                 }
               } else { // TODO v1beta1?
-                LOGGER.warn("Unsupported apiGroupVersion: {}", apiVersion);
+                LOGGER.warn("Unsupported apiVersion: {}", apiVersion);
               }
             }
           }
@@ -781,7 +781,7 @@ public class Config {
     this.caCertFile = caCertFile;
   }
 
-  @JsonProperty("apiGroupVersion")
+  @JsonProperty("apiVersion")
   public String getApiVersion() {
     return apiVersion;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -43,7 +43,7 @@ public abstract class CustomResource implements HasMetadata {
   public String toString() {
     return "CustomResourceSupport{" +
         "kind='" + kind + '\'' +
-        ", apiGroupVersion='" + apiVersion + '\'' +
+        ", apiVersion='" + apiVersion + '\'' +
         ", metadata=" + metadata +
         '}';
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -33,7 +33,7 @@ import java.util.List;
 public class CustomResourceList<T extends HasMetadata> implements KubernetesResource, KubernetesResourceList {
 
   @NotNull
-  @JsonProperty("apiGroupVersion")
+  @JsonProperty("apiVersion")
   private String apiVersion;
   @JsonProperty("items")
   @Valid

--- a/kubernetes-client/src/test/resources/test-kubeconfig
+++ b/kubernetes-client/src/test/resources/test-kubeconfig
@@ -1,4 +1,4 @@
-apiGroupVersion: v1
+apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: testns/ca.pem

--- a/kubernetes-client/src/test/resources/test-kubeconfig-exec
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-exec
@@ -1,4 +1,4 @@
-apiGroupVersion: v1
+apiVersion: v1
 kind: Config
 clusters:
 - cluster:

--- a/kubernetes-client/src/test/resources/test-kubeconfig-exec-win
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-exec-win
@@ -1,4 +1,4 @@
-apiGroupVersion: v1
+apiVersion: v1
 kind: Config
 clusters:
 - cluster:

--- a/kubernetes-client/src/test/resources/token-generator-win.bat
+++ b/kubernetes-client/src/test/resources/token-generator-win.bat
@@ -20,7 +20,7 @@ CALL :upper token
 
 echo {
 echo   "kind": "ExecCredential",
-echo   "apiGroupVersion": "client.authentication.k8s.io/v1alpha1",
+echo   "apiVersion": "client.authentication.k8s.io/v1alpha1",
 echo   "spec": {},
 echo   "status": {
 echo     "token": "%token%"

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/Dummy.java
@@ -26,7 +26,7 @@ public class Dummy extends CustomResource {
   @Override
   public String toString() {
     return "Dummy{" +
-        "apiGroupVersion='" + getApiVersion() + '\'' +
+        "apiVersion='" + getApiVersion() + '\'' +
         ", metadata=" + getMetadata() +
         ", spec=" + spec +
         '}';

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
@@ -39,7 +39,7 @@ public class KubernetesResponseComposer implements ResponseComposer {
   @Override
   public String compose(Collection<String> collection) {
     return String.format(
-        "{\"apiGroupVersion\":\"v1\",\"kind\":\"List\", \"items\": [%s]}",
+        "{\"apiVersion\":\"v1\",\"kind\":\"List\", \"items\": [%s]}",
         join(",", collection));
   }
 }


### PR DESCRIPTION
Reverts some bits of #1322 by @iocanel to try to fix #1347. I am not all that confident I understand the code I am touching so please review carefully.

(No changelog entry needed, since #1322 is not yet released either.)