### PR TITLE
Suppress warning about CRDs being beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
     * Fix #1348: support `v1beta1` version for `ExecCredentials`
 
+    * Fix #1354: suppress log warnings that `CustomResourceDefinition`s are still in beta
+
   Dependency Upgrade
     
     * Updated jackson to 2.9.8

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/VersionUsageUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/VersionUsageUtils.java
@@ -39,6 +39,10 @@ public final class VersionUsageUtils {
       return;
     }
 
+    if (type.equals("customresourcedefinitions") && version.equals("v1beta1")) {
+      return;
+    }
+
     if (isUnstable(version)) {
       if (LOG_EACH_USAGE || UNSTABLE_TYPES.putIfAbsent(type + "-" + version, true) == null) {
         alert(type, version);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/VersionUsageUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/VersionUsageUtils.java
@@ -39,10 +39,6 @@ public final class VersionUsageUtils {
       return;
     }
 
-    if (type.equals("customresourcedefinitions") && version.equals("v1beta1")) {
-      return;
-    }
-
     if (isUnstable(version)) {
       if (LOG_EACH_USAGE || UNSTABLE_TYPES.putIfAbsent(type + "-" + version, true) == null) {
         alert(type, version);
@@ -56,7 +52,12 @@ public final class VersionUsageUtils {
   }
 
   private static void alert(String type, String version) {
-    LOG.warn("The client is using resource type '{}' with unstable version '{}'", type, version);
+    String message = "The client is using resource type '{}' with unstable version '{}'";
+    if (type.equals("customresourcedefinitions") && version.equals("v1beta1")) {
+      LOG.debug(message, type, version);
+    } else {
+      LOG.warn(message, type, version);
+    }
   }
 
 }


### PR DESCRIPTION
If you are using custom resources, there is nothing you can do about the fact that [this system is still officially in beta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#customresourcedefinition-v1beta1-apiextensions-k8s-io) so it is just annoying to get a warning about it in every JVM session. This is particularly noxious in the case of [Jenkins X serverless builds](https://jenkins-x.io/architecture/cloud-native-jenkins/) which print a message like

```
  18.333 [id=39]	WARNING	i.f.k.c.i.VersionUsageUtils#alert: The client is using resource type 'customresourcedefinitions' with unstable version 'v1beta1'
```

near the start of every build, as the `jx-resources` plugin (which uses `kubernetes-client` via `jx-java-client`) is initialized and begins updating a `PipelineActivity` CR.