### PR TITLE
Fix #1005: Loading a template from file and processing it locally by passing parameters map is broken.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   Bugs
    
    * Fix #1008: Use a reasonable buffer size for exec stdin
+   * Fix #1005: Loading a template from file and processing it locally by passing parameters map is broken
   
   Improvements
   

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -115,7 +115,8 @@ public class Serialization {
    * @throws KubernetesClientException
    */
   public static <T> T unmarshal(InputStream is, ObjectMapper mapper, Map<String, String> parameters) {
-    try (BufferedInputStream bis = new BufferedInputStream(is)) {
+    InputStream wrapped = parameters != null && !parameters.isEmpty() ? new ReplaceValueStream(parameters).createInputStream(is) : is;
+    try (BufferedInputStream bis = new BufferedInputStream(wrapped)) {
       bis.mark(-1);
       int intch;
       do {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -40,7 +40,6 @@ import io.fabric8.openshift.client.ParameterValue;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static io.fabric8.kubernetes.client.utils.ReplaceValueStream.replaceValues;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -173,7 +172,7 @@ public class TemplateTest {
     OpenShiftClient client = new DefaultOpenShiftClient(new OpenShiftConfigBuilder().withDisableApiGroupCheck(true).build());
     Map<String, String> map = new HashMap<>();
     map.put("PORT", "8080");
-    KubernetesList list = client.templates().load(replaceValues(getClass().getResourceAsStream("/template-with-number-params.yml"), map)).processLocally(map);
+    KubernetesList list = client.templates().withParameters(map).load(getClass().getResourceAsStream("/template-with-number-params.yml")).processLocally(map);
     assertListIsServiceWithPort8080(list);
   }
 


### PR DESCRIPTION
Fix #1005

Actually, I'm not sure how it used to work before. Right now I've added a small fix so this operation works:
```
    KubernetesList list = client.templates().withParameters(map).load(getClass().getResourceAsStream("/template-with-number-params.yml")).processLocally(map);
```
So basically we're passing parameters in `withParameters` method, hashmap passed in `processLocally` is of no use. Was client able to parse yaml correctly with parameters earlier?