### PR TITLE
Upgrade sundrio version to 0.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 ### CHANGELOG
 
+
 #### 4.1-SNAPSHOT
+
+  Bugs
+   
+  Improvements
+  
+  Dependency Upgrade
+    * Upgrade Sundrio to 0.16.5
+  
+  New Feature
+
+#### 4.1.3
 
   Bugs
    

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <snakeyaml.version>1.24</snakeyaml.version>
 
     <scr.annotations.version>1.9.12</scr.annotations.version>
-    <sundrio.version>0.14.6</sundrio.version>
+    <sundrio.version>0.16.5</sundrio.version>
     <validation.api.version>2.0.1.Final</validation.api.version>
     <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
     <maven.buildhelper.plugin.version>1.10</maven.buildhelper.plugin.version>


### PR DESCRIPTION
Fixes #1359

I do not write the `CHANGELOG` for I found the released version tag `v4.1.3` is not sync with `master`
and the master `CHANGELOG` do not contain the v4.1.3 