### PR TITLE
Preserve labels and fields when using CRD's withResourceVersion()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   Bugs
    
   Improvements
+
+    * Fix #1425: Preserve labels and fields when using CRD's withResourceVersion()
   
   Dependency Upgrade
     * Upgrade Sundrio to 0.16.5

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -109,8 +109,26 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
     this.fields = fields;
   }
 
-  protected BaseOperation(OkHttpClient client, Config config, String apiGroupName, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
-    super(client, config, apiGroup(item, apiGroupName), apiVersion(item, apiVersion), resourceT, namespace, name(item, name));
+  protected BaseOperation(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Class<T> type, Class<L> listType, Class<D> doneableType) {
+    super(client, config, apiGroup, apiVersion(item, apiVersion), resourceT, namespace, name(item, name));
+    this.cascading = cascading;
+    this.item = item;
+    this.resourceVersion = resourceVersion;
+    this.reloadingFromServer = reloadingFromServer;
+    this.type = type;
+    this.listType = listType;
+    this.doneableType = doneableType;
+    this.reaper = null;
+    this.gracePeriodSeconds = gracePeriodSeconds;
+    this.labels = labels;
+    this.labelsNot = labelsNot;
+    this.labelsIn = labelsIn;
+    this.labelsNotIn = labelsNotIn;
+    this.fields = fields;
+  }
+
+  protected BaseOperation(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
+    super(client, config, apiGroup, apiVersion(item, apiVersion), resourceT, namespace, name(item, name));
     this.cascading = cascading;
     this.item = item;
     this.resourceVersion = resourceVersion;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -40,6 +40,10 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
     super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields);
   }
 
+  protected HasMetadataOperation(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Class<T> type, Class<L> listType, Class<D> doneableType) {
+    super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields, type, listType, doneableType);
+  }
+
   public HasMetadataOperation(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
     super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, type, listType, doneableType);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -36,6 +36,7 @@ import okhttp3.OkHttpClient;
 
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 
 /**
  */
@@ -50,6 +51,17 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
 
   public CustomResourceOperationsImpl(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, boolean resouceNamespaced, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, Class<T> type, Class<L> listType, Class<D> doneableType) {
     super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, type, listType, doneableType);
+    this.resourceNamespaced = resouceNamespaced;
+    this.apiVersion = getAPIGroup() + "/" + getAPIVersion();
+
+    KubernetesDeserializer.registerCustomKind(type.getSimpleName(), type);
+    if (KubernetesResource.class.isAssignableFrom(listType)) {
+      KubernetesDeserializer.registerCustomKind(listType.getSimpleName(), (Class<? extends KubernetesResource>) listType);
+    }
+  }
+
+  protected CustomResourceOperationsImpl(OkHttpClient client, Config config, String apiGroup, String apiVersion, String resourceT, boolean resouceNamespaced, String namespace, String name, Boolean cascading, T item, String resourceVersion, Boolean reloadingFromServer, long gracePeriodSeconds, Map<String, String> labels, Map<String, String> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Class<T> type, Class<L> listType, Class<D> doneableType) {
+    super(client, config, apiGroup, apiVersion, resourceT, namespace, name, cascading, item, resourceVersion, reloadingFromServer, gracePeriodSeconds, labels, labelsNot, labelsIn, labelsNotIn, fields, type, listType, doneableType);
     this.resourceNamespaced = resouceNamespaced;
     this.apiVersion = getAPIGroup() + "/" + getAPIVersion();
 
@@ -124,7 +136,7 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
 
   @Override
   public Watchable<Watch, Watcher<T>> withResourceVersion(String resourceVersion) {
-    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), resourceNamespaced, getNamespace(), getName(), isCascading(), getItem(), resourceVersion, isReloadingFromServer(), getType(), getListType(), getDoneableType());
+    return new CustomResourceOperationsImpl<>(client, getConfig(), getAPIGroup(), getAPIVersion(), getResourceT(), resourceNamespaced, getNamespace(), getName(), isCascading(), getItem(), resourceVersion, isReloadingFromServer(), getGracePeriodSeconds(), getLabels(), getLabelsNot(), getLabelsIn(), getLabelsNotIn(), getFields(), getType(), getListType(), getDoneableType());
   }
 
   @Override


### PR DESCRIPTION
The original implementation of `CustomResourceOperationsImpl::withResourceVersion()` uses a constructor that discards any previous alterations made with operations such as `withLabel`.

This patch adds the necessary constructors in `BaseOperation`, `HasMetadataOperation` and `CustomResourceOperationsImpl` to allow `withResourceVersion()` to preserve these fields.