### PR TITLE
fix(kubernetes-model): META-INF/services is now added back to resulting JAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
   Bugs
     * Fix #1387: ValidatingWebhookConfigurationOperationsImpl should be a NonNamespaceOperation
+    * Fix #1429: Fixes JsonMappingException: No resource type found for:v1#List when reading a Kubernetes List YAML
    
   Improvements
   

--- a/kubernetes-model/kubernetes-model/pom.xml
+++ b/kubernetes-model/kubernetes-model/pom.xml
@@ -178,6 +178,7 @@
               io.fabric8.openshift.api.model**
             </Export-Package>
             <Include-Resource>
+              {maven-resources},
               /kubernetes.properties=target/classes/kubernetes.properties,
               /openshift.properties=target/classes/openshift.properties
             </Include-Resource>


### PR DESCRIPTION
Adds a missing {maven-resources} to Include-Resource
More information: http://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#include-resource

Fixes #1429