### PR TITLE
System.currentTimeMillis replaced with System.nanotime

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -925,8 +925,8 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
 
     long timeoutInMillis = timeUnit.toMillis(amount);
 
-    long end = System.currentTimeMillis() + timeoutInMillis;
-    while (System.currentTimeMillis() < end) {
+    long end = System.nanoTime() + timeoutInMillis;
+    while (System.nanoTime() < end) {
       T item = get();
       if (condition.test(item)) {
         return item;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -196,7 +196,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
         }
       }
 
-      long remaining =  (started + amount) - System.currentTimeMillis();
+      long remaining =  (started + amount) - System.nanoTime();
       long next = Math.max(0, Math.min(remaining, interval));
       return periodicWatchUntilReady(i - 1, started, next, amount);
     }
@@ -205,16 +205,16 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
   @Override
   public T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
     if (Readiness.isReadinessApplicable(getType())) {
-      long started = System.currentTimeMillis();
+      long started = System.nanoTime();
       waitUntilExists(amount, timeUnit);
-      long alreadySpent = System.currentTimeMillis() - started;
+      long alreadySpent = System.nanoTime() - started;
 
       long remaining = timeUnit.toMillis(amount) - alreadySpent;
       if (remaining <= 0) {
-        return periodicWatchUntilReady(0, System.currentTimeMillis(), 0, 0);
+        return periodicWatchUntilReady(0, System.nanoTime(), 0, 0);
       }
 
-      return periodicWatchUntilReady(10, System.currentTimeMillis(), Math.max(remaining / 10, 1000L), remaining);
+      return periodicWatchUntilReady(10, System.nanoTime(), Math.max(remaining / 10, 1000L), remaining);
     }
 
     return super.waitUntilReady(amount, timeUnit);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
@@ -82,9 +82,9 @@ public class ServiceOperationsImpl extends HasMetadataOperation<Service, Service
 
   @Override
   public Service waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
-    long started = System.currentTimeMillis();
+    long started = System.nanoTime();
     super.waitUntilReady(amount, timeUnit);
-    long alreadySpent = System.currentTimeMillis() - started;
+    long alreadySpent = System.nanoTime() - started;
 
     // if awaiting existence took very long, let's give at least 10 seconds to awaiting readiness
     long remaining = Math.max(10_000, timeUnit.toMillis(amount) - alreadySpent);


### PR DESCRIPTION
#1449 
System.currentTimeMillis replaced with System.nanotime  in HasMetadataOperation, ServiceOperationsImpl and BaseOperation for timeouts.