### PR TITLE
First draft of custom resources improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
   
 
   New Feature
+    * First Draft of Custom Resource Improvements (#1472)
 
-#### 4.2.0
+
+#### 4.1-SNAPSHOT
 
   Bugs
   

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -282,12 +282,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20180813</version>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -281,6 +281,13 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20180813</version>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -69,6 +69,7 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
 import io.fabric8.kubernetes.client.dsl.*;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.internal.*;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import okhttp3.OkHttpClient;
@@ -242,6 +243,11 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
       .withType(resourceType)
       .withListType(listClass)
       .withDoneableType(doneClass));
+  }
+
+  @Override
+  public RawCustomResourceOperationsImpl customResource(CustomResourceDefinitionContext customResourceDefinition) {
+    return new RawCustomResourceOperationsImpl(httpClient, getConfiguration(), customResourceDefinition);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -68,6 +68,8 @@ import io.fabric8.kubernetes.client.dsl.*;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefinition;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 
 import java.io.InputStream;
 import java.util.Collection;
@@ -86,6 +88,8 @@ public interface KubernetesClient extends Client {
   ExtensionsAPIGroupDSL extensions();
 
   VersionInfo getVersion();
+
+  RawCustomResourceOperationsImpl customResource(CustomResourceDefinitionContext customResourceDefinition);
 
   AppsAPIGroupDSL apps();
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
@@ -1,0 +1,66 @@
+package io.fabric8.kubernetes.client.dsl.base;
+
+public class CustomResourceDefinitionContext {
+  private String name;
+  private String group;
+  private String scope;
+  private String plural;
+  private String version;
+
+  public String getName() { return name; }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public String getPlural() {
+    return plural;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public static class Builder {
+    private CustomResourceDefinitionContext customResourceDefinitionContext;
+
+    public Builder() {
+      this.customResourceDefinitionContext = new CustomResourceDefinitionContext();
+    }
+
+    public Builder withName(String name) {
+      this.customResourceDefinitionContext.name = name;
+      return this;
+    }
+
+    public Builder withGroup(String group) {
+      this.customResourceDefinitionContext.group = group;
+      return this;
+    }
+
+    public Builder withScope(String scope) {
+      this.customResourceDefinitionContext.scope = scope;
+      return this;
+    }
+
+    public Builder withPlural(String plural) {
+      this.customResourceDefinitionContext.plural = plural;
+      return this;
+    }
+
+    public Builder withVersion(String version) {
+      this.customResourceDefinitionContext.version = version;
+      return this;
+    }
+
+    public CustomResourceDefinitionContext build() {
+      return this.customResourceDefinitionContext;
+    }
+  }
+
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.client.dsl.base;
 
 public class CustomResourceDefinitionContext {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceDefinitionOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceDefinitionOperationsImpl.java
@@ -23,10 +23,6 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import okhttp3.OkHttpClient;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  */
@@ -46,6 +42,7 @@ public class CustomResourceDefinitionOperationsImpl extends HasMetadataOperation
     this.listType = CustomResourceDefinitionList.class;
     this.doneableType = DoneableCustomResourceDefinition.class;
   }
+
   @Override
   public CustomResourceDefinitionOperationsImpl newInstance(OperationContext context) {
     return new CustomResourceDefinitionOperationsImpl(context);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionVersion;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.utils.IOHelpers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
+
+public class RawCustomResourceOperationsImpl extends OperationSupport {
+  private OkHttpClient client;
+  private Config config;
+  private CustomResourceDefinitionContext customResourceDefinition;
+
+  private enum HttpCallMethod { GET, POST, PUT, DELETE };
+
+  public RawCustomResourceOperationsImpl(OkHttpClient client, Config config, CustomResourceDefinitionContext customResourceDefinition) {
+    this.client = client;
+    this.config = config;
+    this.customResourceDefinition = customResourceDefinition;
+  }
+
+  public JSONObject create(String objectAsString) throws IOException {
+    return validateAndSubmitRequest(null, null, objectAsString, HttpCallMethod.POST);
+  }
+
+  public JSONObject create(String namespace, String objectAsString) throws KubernetesClientException, IOException {
+    return validateAndSubmitRequest(namespace, null, objectAsString, HttpCallMethod.POST);
+  }
+
+  public JSONObject create(InputStream objectAsStream) throws KubernetesClientException, IOException {
+    return validateAndSubmitRequest(null, null, IOHelpers.readFully(objectAsStream), HttpCallMethod.POST);
+  }
+
+  public JSONObject create(String namespace, InputStream objectAsStream) throws KubernetesClientException, IOException {
+    return validateAndSubmitRequest(namespace, null, IOHelpers.readFully(objectAsStream), HttpCallMethod.POST);
+  }
+
+  public JSONObject edit(String name, String objectAsString) throws IOException {
+    return validateAndSubmitRequest(null, name, objectAsString, HttpCallMethod.PUT);
+  }
+
+  public JSONObject edit(String namespace, String name, String objectAsString) throws IOException {
+    return validateAndSubmitRequest(namespace, name, objectAsString, HttpCallMethod.PUT);
+  }
+
+  public JSONObject edit(String namespace, String name, InputStream objectAsStream) throws IOException, KubernetesClientException {
+    return validateAndSubmitRequest(namespace, name, IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
+  }
+
+  public JSONObject get(String name) {
+    return makeCall(fetchUrl(null, null) + name, null, HttpCallMethod.GET);
+  }
+
+  public JSONObject get(String namespace, String name) {
+      return makeCall(fetchUrl(namespace, null) + name, null, HttpCallMethod.GET);
+  }
+
+  public JSONObject list() {
+    return makeCall(fetchUrl(null, null), null, HttpCallMethod.GET);
+  }
+
+  public JSONObject list(String namespace) {
+    return makeCall(fetchUrl(namespace, null), null, HttpCallMethod.GET);
+  }
+
+  public JSONObject list(String namespace, Map<String, String> labels) {
+    return makeCall(fetchUrl(namespace, labels), null, HttpCallMethod.GET);
+  }
+
+  public JSONObject delete(String namespace) {
+    return makeCall(fetchUrl(namespace, null), null, HttpCallMethod.DELETE);
+  }
+
+  public JSONObject delete(String namespace, String name) {
+    return makeCall(fetchUrl(namespace, null) + name, null, HttpCallMethod.DELETE);
+  }
+
+  private String fetchUrl(String namespace, Map<String, String> labels) {
+    StringBuilder urlBuilder = new StringBuilder(config.getMasterUrl());
+    urlBuilder.append("apis/")
+      .append(customResourceDefinition.getGroup())
+      .append("/")
+      .append(customResourceDefinition.getVersion())
+      .append("/");
+
+    if(customResourceDefinition.getScope().equals("Namespaced") && namespace != null) {
+      urlBuilder.append("namespaces/").append(namespace).append("/");
+    }
+    urlBuilder.append(customResourceDefinition.getPlural()).append("/");
+    if(labels != null) {
+      urlBuilder.append("?labelSelector").append("=").append(getLabelsQueryParam(labels));
+    }
+    return urlBuilder.toString();
+  }
+
+  private String getLabelsQueryParam(Map<String, String> labels) {
+    StringBuilder labelQueryBuilder = new StringBuilder();
+    for(Map.Entry<String, String> entry : labels.entrySet()) {
+      if(labelQueryBuilder.length() > 0) {
+        labelQueryBuilder.append(",");
+      }
+      labelQueryBuilder.append(entry.getKey()).append("=").append(entry.getValue());
+    }
+    return labelQueryBuilder.toString();
+  }
+
+  private JSONObject makeCall(String url, String body, HttpCallMethod callMethod) throws RuntimeException {
+    try {
+      Response response;
+      if(body == null) {
+        response = client.newCall(getRequest(url, callMethod)).execute();
+      }
+      else {
+        response = client.newCall(getRequest(url, body, callMethod)).execute();
+      }
+      if(response.code() != HttpURLConnection.HTTP_NOT_FOUND &&
+         response.code() != HttpURLConnection.HTTP_SERVER_ERROR &&
+         response.code() != HttpURLConnection.HTTP_BAD_REQUEST) {
+        return new JSONObject(response.body().string());
+      } else {
+        response.close();
+        throw new IllegalStateException(response.message());
+      }
+    } catch(Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  private JSONObject validateAndSubmitRequest(String namespace, String name, String objectAsString, HttpCallMethod httpCallMethod) throws IOException {
+    if (IOHelpers.isJSONValid(objectAsString)) {
+      return makeCall(fetchUrl(namespace, null) + (name != null ? name : ""), objectAsString, httpCallMethod);
+    } else {
+      return makeCall(fetchUrl(namespace, null) + (name != null ? name : ""), IOHelpers.convertYamlToJson(objectAsString), httpCallMethod);
+    }
+  }
+
+  private Request getRequest(String url, HttpCallMethod httpCallMethod) {
+    Request.Builder requestBuilder = new Request.Builder();
+    switch(httpCallMethod) {
+      case GET:
+        requestBuilder.get().url(url);
+        break;
+      case DELETE:
+        requestBuilder.delete().url(url);
+        break;
+    }
+
+    return requestBuilder.build();
+  }
+
+  private Request getRequest(String url, String body, HttpCallMethod httpCallMethod) {
+    Request.Builder requestBuilder = new Request.Builder();
+    RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), body);
+    switch(httpCallMethod) {
+      case POST:
+        return requestBuilder.post(requestBody).url(url).build();
+      case PUT:
+        return requestBuilder.put(requestBody).url(url).build();
+    }
+    return requestBuilder.build();
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -100,6 +100,8 @@ import io.fabric8.kubernetes.client.dsl.SchedulingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.kubernetes.client.dsl.SettingsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.StorageAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
@@ -381,6 +383,11 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResource(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return customResources(crd, resourceType, listClass, doneClass);
+  }
+
+  @Override
+  public RawCustomResourceOperationsImpl customResource(CustomResourceDefinitionContext customResourceDefinition) {
+    return delegate.customResource(customResourceDefinition);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
@@ -15,6 +15,12 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,5 +59,28 @@ public class IOHelpers {
             }
         }
     }
+
+  public static boolean isJSONValid(String test) {
+    try {
+      new JSONObject(test);
+    } catch (JSONException ex) {
+      // edited, to include @Arthur's comment
+      // e.g. in case JSONArray is valid as well...
+      try {
+        new JSONArray(test);
+      } catch (JSONException ex1) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static String convertYamlToJson(String yaml) throws IOException {
+    ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+    Object obj = yamlReader.readValue(yaml, Object.class);
+
+    ObjectMapper jsonWriter = new ObjectMapper();
+    return jsonWriter.writeValueAsString(obj);
+  }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
@@ -15,11 +15,9 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,19 +58,15 @@ public class IOHelpers {
         }
     }
 
-  public static boolean isJSONValid(String test) {
-    try {
-      new JSONObject(test);
-    } catch (JSONException ex) {
-      // edited, to include @Arthur's comment
-      // e.g. in case JSONArray is valid as well...
-      try {
-        new JSONArray(test);
-      } catch (JSONException ex1) {
-        return false;
-      }
+  public static boolean isJSONValid(String json) throws IOException {
+    boolean valid = true;
+    try{
+      ObjectMapper objectMapper = new ObjectMapper();
+      objectMapper.readTree(json);
+    } catch(JsonProcessingException e){
+      valid = false;
     }
-    return true;
+    return valid;
   }
 
   public static String convertYamlToJson(String yaml) throws IOException {

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDLoadExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDLoadExample.java
@@ -22,10 +22,12 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+
 public class CRDLoadExample {
   private static Logger logger = LoggerFactory.getLogger(CRDLoadExample.class);
 
-  public static void main(String args[]) {
+  public static void main(String args[]) throws IOException {
     try (final KubernetesClient client = new DefaultKubernetesClient()) {
       // List all Custom resources.
       log("Listing all current Custom Resource Definitions :");
@@ -34,11 +36,12 @@ public class CRDLoadExample {
 
       // Creating a custom resource from yaml
       CustomResourceDefinition aCustomResourceDefinition = client.customResourceDefinitions().load(CRDLoadExample.class.getResourceAsStream("/crd.yml")).get();
+      log("Creating CRD...");
       client.customResourceDefinitions().create(aCustomResourceDefinition);
 
-      log("Created CRD");
       log("Updated Custom Resource Definitions: ");
       client.customResourceDefinitions().list().getItems().forEach(crd -> log(crd.getMetadata().getName()));
+
     }
   }
 

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDLoadExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDLoadExample.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.examples;
+
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CRDLoadExample {
+  private static Logger logger = LoggerFactory.getLogger(CRDLoadExample.class);
+
+  public static void main(String args[]) {
+    try (final KubernetesClient client = new DefaultKubernetesClient()) {
+      // List all Custom resources.
+      log("Listing all current Custom Resource Definitions :");
+      CustomResourceDefinitionList crdList = client.customResourceDefinitions().list();
+      crdList.getItems().forEach(crd -> log(crd.getMetadata().getName()));
+
+      // Creating a custom resource from yaml
+      CustomResourceDefinition aCustomResourceDefinition = client.customResourceDefinitions().load(CRDLoadExample.class.getResourceAsStream("/crd.yml")).get();
+      client.customResourceDefinitions().create(aCustomResourceDefinition);
+
+      log("Created CRD");
+      log("Updated Custom Resource Definitions: ");
+      client.customResourceDefinitions().list().getItems().forEach(crd -> log(crd.getMetadata().getName()));
+    }
+  }
+
+  private static void log(String action, Object obj) {
+    logger.info("{}: {}", action, obj);
+  }
+
+  private static void log(String action) {
+    logger.info(action);
+  }
+}

--- a/kubernetes-examples/src/main/resources/crd.yml
+++ b/kubernetes-examples/src/main/resources/crd.yml
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "apiextensions.k8s.io/v1beta1"
+kind: "CustomResourceDefinition"
+metadata:
+  name: "projects.example.fabric8.io"
+spec:
+  group: "example.fabric8.io"
+  version: "v1alpha1"
+  scope: "Namespaced"
+  names:
+    plural: "projects"
+    singular: "project"
+    kind: "Project"
+  validation:
+    openAPIV3Schema:
+      required: ["spec"]
+      properties:
+        spec:
+          required: ["replicas"]
+          properties:
+            replicas:
+              type: "integer"
+              minimum: 1

--- a/kubernetes-examples/src/main/resources/crd.yml
+++ b/kubernetes-examples/src/main/resources/crd.yml
@@ -14,25 +14,30 @@
 # limitations under the License.
 #
 
-apiVersion: "apiextensions.k8s.io/v1beta1"
-kind: "CustomResourceDefinition"
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: "projects.example.fabric8.io"
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
 spec:
-  group: "example.fabric8.io"
-  version: "v1alpha1"
-  scope: "Namespaced"
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+  # either Namespaced or Cluster
+  scope: Namespaced
   names:
-    plural: "projects"
-    singular: "project"
-    kind: "Project"
-  validation:
-    openAPIV3Schema:
-      required: ["spec"]
-      properties:
-        spec:
-          required: ["replicas"]
-          properties:
-            replicas:
-              type: "integer"
-              minimum: 1
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct

--- a/kubernetes-examples/src/main/resources/custom-resource.yml
+++ b/kubernetes-examples/src/main/resources/custom-resource.yml
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "stable.example.com/v1"
+kind: CronTab
+metadata:
+  name: my-fourth-cron-object
+spec:
+  cronSpec: "* * * * */9"
+  image: my-awesome-cron-image

--- a/kubernetes-itests/src/test/java/io/fabric8/commons/DeleteEntity.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/commons/DeleteEntity.java
@@ -71,6 +71,8 @@ public class DeleteEntity<T> implements Callable<Boolean> {
         return this.client.rbac().clusterRoleBindings().withName(this.name).get() == null;
       case "ClusterRole":
         return this.client.rbac().clusterRoles().withName(this.name).get() == null;
+      case "CustomResourceDefinition":
+        return this.client.customResourceDefinitions().withName(this.name).get() == null;
       case "RoleBinding":
         return this.client.rbac().roleBindings().inNamespace(this.namespace).withName(this.name).get() == null;
       case "Role":

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import io.fabric8.commons.DeleteEntity;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionList;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionVersionBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class CustomResourceDefinitionIT {
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  private CustomResourceDefinition crd1;
+
+  @Before
+  public void init() {
+    crd1 = new CustomResourceDefinitionBuilder()
+      .withApiVersion("apiextensions.k8s.io/v1beta1")
+      .withNewMetadata()
+      .withName("itests.examples.fabric8.io")
+      .endMetadata()
+      .withNewSpec()
+      .withGroup("examples.fabric8.io")
+      .addAllToVersions(Collections.singletonList(new CustomResourceDefinitionVersionBuilder()
+        .withName("v1")
+        .withServed(true)
+        .withStorage(true)
+        .build()))
+      .withScope("Namespaced")
+      .withNewNames()
+      .withPlural("itests")
+      .withSingular("itest")
+      .withKind("Itest")
+      .withShortNames("it")
+      .endNames()
+      .endSpec()
+      .build();
+
+    client.customResourceDefinitions().create(crd1);
+  }
+
+  @Test
+  public void load() {
+    CustomResourceDefinition aCustomResourceDefinition = client.customResourceDefinitions().load(getClass().getResourceAsStream("/test-crd.yml")).get();
+    assertThat(aCustomResourceDefinition).isNotNull();
+  }
+
+  @Test
+  public void get() {
+    crd1 = client.customResourceDefinitions().withName(crd1.getMetadata().getName()).get();
+    assertThat(crd1).isNotNull();
+  }
+
+  @Test
+  public void list() {
+    CustomResourceDefinitionList crdList = client.customResourceDefinitions().list();
+    assertThat(crdList).isNotNull();
+    assertThat(crdList.getItems().size()).isGreaterThan(0);
+  }
+
+  @Test
+  public void update() {
+    CustomResourceDefinition updatedCrd = client.customResourceDefinitions().withName(crd1.getMetadata().getName()).edit().editSpec().editOrNewNames().addNewShortName("its").endNames().endSpec().done();
+    assertThat(updatedCrd.getSpec().getNames().getShortNames().size()).isEqualTo(2);
+  }
+
+  @Test
+  public void delete() {
+    boolean bDeleted = client.customResourceDefinitions().withName(crd1.getMetadata().getName()).delete();
+    assertThat(bDeleted).isTrue();
+  }
+
+  @After
+  public void cleanup() {
+    if(client.customResourceDefinitions().withName(crd1.getMetadata().getName()).get() != null) {
+      client.customResourceDefinitions().withName(crd1.getMetadata().getName()).delete();
+    }
+
+    DeleteEntity<CustomResourceDefinition> configMapDelete = new DeleteEntity<>(CustomResourceDefinition.class, client, "configmap1", null);
+    await().atMost(30, TimeUnit.SECONDS).until(configMapDelete);
+  }
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawCustomResourceIT.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class RawCustomResourceIT {
+  @ArquillianResource
+  public KubernetesClient client;
+
+  @ArquillianResource
+  public Session session;
+
+  private String currentNamespace;
+
+  private CustomResourceDefinitionContext customResourceDefinitionContext;
+
+  @Before
+  public void initCustomResourceDefinition() {
+    currentNamespace = session.getNamespace();
+
+    // Create a Custom Resource Definition Animals:
+    CustomResourceDefinition animalCrd = client.customResourceDefinitions().load(getClass().getResourceAsStream("/test-rawcustomresource-definition.yml")).get();
+    client.customResourceDefinitions().create(animalCrd);
+
+    customResourceDefinitionContext = new CustomResourceDefinitionContext.Builder()
+      .withName("animals.jungle.example.com")
+      .withGroup("jungle.example.com")
+      .withVersion("v1")
+      .withPlural("animals")
+      .withScope("Namespaced")
+      .build();
+  }
+
+  @Test
+  public void testCrud() throws IOException {
+    // Test Create via file
+    JSONObject object = client.customResource(customResourceDefinitionContext).create(currentNamespace, getClass().getResourceAsStream("/test-rawcustomresource.yml"));
+    assertThat(object.getJSONObject("metadata").get("name")).isEqualTo("otter");
+    // Test Create via raw json string
+    String rawJsonCustomResourceObj = "{\"apiVersion\":\"jungle.example.com/v1\"," +
+      "\"kind\":\"Animal\",\"metadata\": {\"name\": \"walrus\"}," +
+      "\"spec\": {\"image\": \"my-awesome-walrus-image\"}}";
+    object = client.customResource(customResourceDefinitionContext).create(currentNamespace, rawJsonCustomResourceObj);
+    assertThat(object.getJSONObject("metadata").get("name")).isEqualTo("walrus");
+
+    // Test Get:
+    object = client.customResource(customResourceDefinitionContext).get(currentNamespace, "otter");
+    assertThat(object.getJSONObject("metadata").get("name")).isEqualTo("otter");
+
+    // Test List:
+    JSONObject list = client.customResource(customResourceDefinitionContext).list(currentNamespace);
+    assertThat(list.getJSONArray("items").length()).isEqualTo(2);
+
+    // List with labels:
+    list = client.customResource(customResourceDefinitionContext).list(currentNamespace, Collections.singletonMap("foo", "bar"));
+    assertThat(list.getJSONArray("items").length()).isEqualTo(1);
+
+    // Test Update
+    object = client.customResource(customResourceDefinitionContext).get(currentNamespace, "walrus");
+    object.getJSONObject("spec").put("image", "my-updated-awesome-walrus-image");
+    object = client.customResource(customResourceDefinitionContext).edit(currentNamespace, "walrus", object.toString());
+    assertThat(object.getJSONObject("spec").get("image")).isEqualTo("my-updated-awesome-walrus-image");
+
+    // Test Delete:
+    client.customResource(customResourceDefinitionContext).delete(currentNamespace, "otter");
+    client.customResource(customResourceDefinitionContext).delete(currentNamespace);
+  }
+
+  @After
+  public void cleanup() {
+    // Delete Custom Resource Definition Animals:
+    client.customResourceDefinitions().withName(customResourceDefinitionContext.getName()).delete();
+  }
+}

--- a/kubernetes-itests/src/test/resources/test-crd.yml
+++ b/kubernetes-itests/src/test/resources/test-crd.yml
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "apiextensions.k8s.io/v1beta1"
+kind: "CustomResourceDefinition"
+metadata:
+  name: "projects.example.fabric8.io"
+spec:
+  group: "example.fabric8.io"
+  version: "v1alpha1"
+  scope: "Namespaced"
+  names:
+    plural: "projects"
+    singular: "project"
+    kind: "Project"
+  validation:
+    openAPIV3Schema:
+      required: ["spec"]
+      properties:
+        spec:
+          required: ["replicas"]
+          properties:
+            replicas:
+              type: "integer"
+              minimum: 1

--- a/kubernetes-itests/src/test/resources/test-rawcustomresource-definition.yml
+++ b/kubernetes-itests/src/test/resources/test-rawcustomresource-definition.yml
@@ -20,6 +20,7 @@ metadata:
   name: animals.jungle.example.com
 spec:
   group: jungle.example.com
+  version: v1
   versions:
     - name: v1
       served: true

--- a/kubernetes-itests/src/test/resources/test-rawcustomresource-definition.yml
+++ b/kubernetes-itests/src/test/resources/test-rawcustomresource-definition.yml
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: animals.jungle.example.com
+spec:
+  group: jungle.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: animals
+    singular: animals
+    kind: Animal
+    shortNames:
+    - al

--- a/kubernetes-itests/src/test/resources/test-rawcustomresource.yml
+++ b/kubernetes-itests/src/test/resources/test-rawcustomresource.yml
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "jungle.example.com/v1"
+kind: Animal
+metadata:
+  name: otter
+  labels:
+    foo: bar
+spec:
+  image: my-awesome-otter-image

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -37,6 +37,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.DoneableCustomResourceDefin
 import io.fabric8.kubernetes.client.*;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.*;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.internal.*;
 import io.fabric8.kubernetes.client.utils.BackwardsCompatibilityInterceptor;
 import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
@@ -262,6 +263,10 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> customResourceDefinitions() {
     return new CustomResourceDefinitionOperationsImpl(httpClient, getConfiguration());
+  }
+
+  public RawCustomResourceOperationsImpl customResource(CustomResourceDefinitionContext customResourceDefinition) {
+    return new RawCustomResourceOperationsImpl(httpClient, getConfiguration(), customResourceDefinition);
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -25,6 +25,8 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.VersionInfo;
 import io.fabric8.kubernetes.client.dsl.*;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
@@ -388,6 +390,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> customResourceDefinitions() {
     return delegate.customResourceDefinitions();
+  }
+
+  @Override
+  public RawCustomResourceOperationsImpl customResource(CustomResourceDefinitionContext customResourceDefinition) {
+    return delegate.customResource(customResourceDefinition);
   }
 
   @Override


### PR DESCRIPTION
Introduce a rawCustomResource() in client dsl 

rawCustomResource() would allow client to create, delete, list, update custom
resources without having to require Pojos of custom resources. Now the client would only
deal with JSONObjects.