### PR TITLE
Issue 1468: Taking resource labels into consideration when comparing resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     * Fix #1297: wrong result produced when exec in used and params contains '&'. Url string not encoded properly.
     * Fix #1473: Use correct plural form in OpenshiftRole
     * Fix #1480: The kubernetes-client is not optionally depending on bouncycastle.
+    * Fix #1468: Taking labels into consideration when comparing resources for equality.
   
   Improvements
     * Fix #1455: Use SubjectAccessReview and LocalSubjectAccessReview in kubernetes client using subjectAccessReviewAuth()

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ResourceCompare.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ResourceCompare.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.collections.MapUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,12 +30,20 @@ public class ResourceCompare {
 
     private static final String METADATA = "metadata";
     private static final String STATUS = "status";
+    private static final String LABELS = "labels";
 
 
     public static <T>  boolean equals(T left, T right) {
-        HashMap<String, Object> leftMap = trim((Map<String, Object>) JSON_MAPPER.convertValue(left, TYPE_REF));
-        HashMap<String, Object> rightMap = trim((Map<String, Object>) JSON_MAPPER.convertValue(right, TYPE_REF));
-        return leftMap.equals(rightMap);
+        Map<String, Object> leftJson = (Map<String, Object>) JSON_MAPPER.convertValue(left, TYPE_REF);
+        Map<String, Object> rightJson = (Map<String, Object>) JSON_MAPPER.convertValue(right, TYPE_REF);
+
+        Map<String, Object> leftLabels = fetchLabels(leftJson);
+        Map<String, Object> rightLabels = fetchLabels(rightJson);
+
+        HashMap<String, Object> leftMap = trim(leftJson);
+        HashMap<String, Object> rightMap = trim(rightJson);
+
+        return leftMap.equals(rightMap) && leftLabels.equals(rightLabels);
     }
 
     private static HashMap<String, Object> trim(Map<String, Object> map) {
@@ -42,5 +51,12 @@ public class ResourceCompare {
         result.remove(STATUS);
         result.remove(METADATA);
         return result;
+    }
+
+    private static Map<String, Object> fetchLabels(Map<String, Object> map){
+        if (!map.containsKey(METADATA) || !((Map<Object, Object>)map.get(METADATA)).containsKey(LABELS)){
+            return MapUtils.EMPTY_MAP;
+        }
+        return (Map<String, Object>) ((Map<Object, Object>)map.get(METADATA)).get(LABELS);
     }
 }


### PR DESCRIPTION
Resource only equal if labels are also a match.

This restrictions prevented us from updating only the labels on the resources when calling `kubeClient.resource(resourceObj).createOrReplace();`