### PR TITLE
chore: use Jandex 2.1.1 in jandex-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,13 @@
             <inherited>true</inherited>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <version>2.1.1.Final</version>
+          </dependency>
+        </dependencies>
       </plugin>      
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This is necessary for Quarkus 0.13.1+ and fixes warnings as:

```
[WARNING] [io.quarkus.deployment.index.ApplicationArchiveBuildStep] Re-indexing /home/ggastald/.m2/repository/io/fabric8/openshift-client/4.2.0/openshift-client-4.2.0.jar - at least Jandex 2.1 must be used to index an application dependency
[WARNING] [io.quarkus.deployment.index.ApplicationArchiveBuildStep] Re-indexing /home/ggastald/.m2/repository/io/fabric8/kubernetes-model/4.2.0/kubernetes-model-4.2.0.jar - at least Jandex 2.1 must be used to index an application dependency
[WARNING] [io.quarkus.deployment.index.ApplicationArchiveBuildStep] Re-indexing /home/ggastald/.m2/repository/io/fabric8/kubernetes-client/4.2.0/kubernetes-client-4.2.0.jar - at least Jandex 2.1 must be used to index an application dependency
[WARNING] [io.quarkus.deployment.index.ApplicationArchiveBuildStep] Re-indexing /home/ggastald/.m2/repository/io/fabric8/kubernetes-model-common/4.2.0/kubernetes-model-common-4.2.0.jar - at least Jandex 2.1 must be used to index an application dependency
```