### PR TITLE
fix #1495: avoid runtime dependency on Commons Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 #### 4.2-SNAPSHOT
 
   Bugs
+
+    * Fix #1495: avoid runtime dependency on Commons Collections
+
+#### 4.2.1
+
+  Bugs
     
     * Fix #1297: wrong result produced when exec in used and params contains '&'. Url string not encoded properly.
     * Fix #1473: Use correct plural form in OpenshiftRole
@@ -22,7 +28,7 @@
     * First Draft of Custom Resource Improvements (#1472)
 
 
-#### 4.1-SNAPSHOT
+#### 4.2.0
 
   Bugs
   

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ResourceCompare.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ResourceCompare.java
@@ -18,8 +18,8 @@ package io.fabric8.kubernetes.client.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.collections.MapUtils;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,7 +55,7 @@ public class ResourceCompare {
 
     private static Map<String, Object> fetchLabels(Map<String, Object> map){
         if (!map.containsKey(METADATA) || !((Map<Object, Object>)map.get(METADATA)).containsKey(LABELS)){
-            return MapUtils.EMPTY_MAP;
+            return Collections.emptyMap();
         }
         return (Map<String, Object>) ((Map<Object, Object>)map.get(METADATA)).get(LABELS);
     }


### PR DESCRIPTION
The fix for issue #1468 introduced a runtime dependency
on Commons Collections just for `MapUtils.EMPTY_MAP`.
However, depending on Fabric8 Kubernetes Client doesn't
transitively bring in Commons Collections, so invoking
the respective codepath results in `NoClassDefFoundError`.

This commit replaces the usage of `MapUtils.EMPTY_MAP`
by `Collections.emptyMap()`, which does the same and
is available in the Java Collections Framework.