### PR TITLE
Readd missing inPipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
   Bugs
 
+    * Fix #1500: exec `redirectingInput` was not correctly setting the input pipe (since 4.2.0).
+
   Improvements
 
   Dependency Upgrade

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
@@ -549,7 +549,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
 
     @Override
     public TtyExecOutputErrorable<String, OutputStream, PipedInputStream, ExecWatch> redirectingInput(Integer bufferSize) {
-        return new PodOperationsImpl(getContext().withBufferSize(bufferSize));
+        return new PodOperationsImpl(getContext().withInPipe(new PipedOutputStream()).withBufferSize(bufferSize));
     }
 
     @Override


### PR DESCRIPTION
Was inadvertently removed in ded7e13e

https://github.com/fabric8io/kubernetes-client/commit/ded7e13e50e307d3144b246b2052d451a10fde0c#diff-f97f7e5381172790f1294e7696201bacL298