### PR TITLE
Fix some issues copying and reading directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   Bugs
 
     * Fix #1500: exec `redirectingInput` was not correctly setting the input pipe (since 4.2.0).
+    * Fix #1507: remove unnecessary OutputStream copying a directory and return the directory object instead the file object when a directory is copied or read
 
   Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
@@ -316,7 +316,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
         copyFile(getContext().getFile(), destination.toFile());
         return true;
       } else if (Utils.isNotNullOrEmpty(getContext().getDir())) {
-        copyDir(getContext().getFile(), destination.toFile());
+        copyDir(getContext().getDir(), destination.toFile());
         return true;
       }
       throw new IllegalStateException("No file or dir has been specified");
@@ -331,7 +331,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
       if (Utils.isNotNullOrEmpty(getContext().getFile())) {
         return readFile(getContext().getFile());
       } else if (Utils.isNotNullOrEmpty(getContext().getDir())) {
-        return readTar(getContext().getFile());
+        return readTar(getContext().getDir());
       }
       throw new IllegalStateException("No file or dir has been specified");
     } catch (Exception e) {
@@ -483,7 +483,6 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
         }
         try (
           InputStream is = readTar(source);
-          OutputStream os = new FileOutputStream(destination);
           org.apache.commons.compress.archivers.tar.TarArchiveInputStream tis = new org.apache.commons.compress.archivers.tar.TarArchiveInputStream(is))
 
         {


### PR DESCRIPTION
- Remove creation of unnecessary OutputStream copying a directory
- Return the dir and not the file when a directory is copied or read

Issue #1507
Changelog
Bug
Fix #1507: remove unnecessary OutputStream copying a directory and return the directory object instead the file object when a directory is copied or read