### PR TITLE
assertNotNull replaced with assertTrue for booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ### 4.3-SNAPSHOT
   Bugs
-
+  
   Improvements
+
+    * assertNotNull replaced with assertTrue for boolean statements in unit tests
 
   Dependency Upgrade
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobTest.java
@@ -216,7 +216,7 @@ public class CronJobTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.batch().cronjobs().inAnyNamespace().delete(cronjob1, cronjob2);
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.batch().cronjobs().inAnyNamespace().delete(cronjob3);
     assertFalse(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -195,7 +195,7 @@ public class DeploymentTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.apps().deployments().withName("deployment1").delete();
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.apps().deployments().withName("deployment2").delete();
     assertFalse(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/IngressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/IngressTest.java
@@ -121,7 +121,7 @@ public class IngressTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.extensions().ingress().withName("ingress1").delete();
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.extensions().ingress().withName("ingress2").delete();
     assertFalse(deleted);
@@ -143,7 +143,7 @@ public class IngressTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.extensions().ingress().inAnyNamespace().delete(ingress1, ingress2);
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.extensions().ingress().inAnyNamespace().delete(ingress3);
     assertFalse(deleted);
@@ -156,7 +156,7 @@ public class IngressTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.extensions().ingress().inNamespace("test1").delete(ingress1);
-    assertNotNull(deleted);
+    assertTrue(deleted);
   }
 
   @Test(expected = KubernetesClientException.class)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/JobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/JobTest.java
@@ -164,7 +164,7 @@ public class JobTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.batch().jobs().withName("job1").delete();
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.batch().jobs().withName("job2").delete();
     assertTrue(deleted);
@@ -209,7 +209,7 @@ public class JobTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.batch().jobs().inAnyNamespace().delete(job1, job2);
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.batch().jobs().inAnyNamespace().delete(job3);
     assertFalse(deleted);
@@ -221,7 +221,7 @@ public class JobTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.batch().jobs().inNamespace("test1").delete(job1);
-    assertNotNull(deleted);
+    assertTrue(deleted);
   }
 
   @Test(expected = KubernetesClientException.class)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -140,7 +140,7 @@ public class PodTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.pods().withName("pod1").delete();
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.pods().withName("pod2").delete();
     assertFalse(deleted);
@@ -162,7 +162,7 @@ public class PodTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.pods().inAnyNamespace().delete(pod1, pod2);
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.pods().inAnyNamespace().delete(pod3);
     assertFalse(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
@@ -130,7 +130,7 @@ public class ReplicaSetTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.apps().replicaSets().withName("repl1").delete();
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.apps().replicaSets().withName("repl2").delete();
     assertFalse(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
@@ -130,7 +130,7 @@ public class ReplicationControllerTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.replicationControllers().withName("repl1").delete();
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.replicationControllers().withName("repl2").delete();
     assertFalse(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -130,7 +130,7 @@ public class StatefulSetTest {
     KubernetesClient client = server.getClient();
 
     Boolean deleted = client.apps().statefulSets().withName("repl1").delete();
-    assertNotNull(deleted);
+    assertTrue(deleted);
 
     deleted = client.apps().statefulSets().withName("repl2").delete();
     assertFalse(deleted);


### PR DESCRIPTION
assertNotNull replaced with assertTrue for boolean statements in unit tests. 