### PR TITLE
Parsing kube config file without reflection. Fixes #1591

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.kubernetes.client.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.AuthInfo;
 import io.fabric8.kubernetes.api.model.Cluster;
 import io.fabric8.kubernetes.api.model.Config;
@@ -24,25 +22,31 @@ import io.fabric8.kubernetes.api.model.Context;
 import io.fabric8.kubernetes.api.model.NamedAuthInfo;
 import io.fabric8.kubernetes.api.model.NamedCluster;
 import io.fabric8.kubernetes.api.model.NamedContext;
+import io.fabric8.kubernetes.client.internal.mappers.ConfigMapper;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
 
 /**
  * Helper class for working with the YAML config file thats located in
  * <code>~/.kube/config</code> which is updated when you use commands
- * like <code>osc login</code> and <code>osc project myproject</code>
+ * like <code>oc login</code> and <code>oc project myproject</code>
  */
 public class KubeConfigUtils {
+    
   public static Config parseConfig(File file) throws IOException {
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    return mapper.readValue(file, Config.class);
+    final Yaml yamlMapper = new Yaml();
+    final ConfigMapper configMapper = new ConfigMapper();  
+    return configMapper.map(yamlMapper.load(new FileInputStream(file)));
   }
 
   public static Config parseConfigFromString(String contents) throws IOException {
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    return mapper.readValue(contents, Config.class);
+    final Yaml yamlMapper = new Yaml();
+    final ConfigMapper configMapper = new ConfigMapper();
+    return configMapper.map(yamlMapper.load(contents));
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/AuthInfoMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/AuthInfoMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.AuthInfo;
+
+public class AuthInfoMapper extends PropertyMapper<AuthInfo> {
+
+    private final NamedExtensionsMapper namedExtensionsMapper = new NamedExtensionsMapper();
+    private final AuthProviderMapper authProviderConfigMapper = new AuthProviderMapper();
+    private final ExecConfigMapper execConfigMapper = new ExecConfigMapper();
+    
+    @SuppressWarnings("unchecked")
+    @Override
+    public AuthInfo map(Map<String, Object> mappedBean) {
+        final AuthInfo authInfo = new AuthInfo();
+        authInfo.setAs(get("as", mappedBean));
+        authInfo.setAsGroups(getList("as-groups", mappedBean));
+        authInfo.setAsUserExtra(get("as-user-extra", mappedBean, Map.class));
+        authInfo.setAuthProvider(get("auth-provider", mappedBean, authProviderConfigMapper));
+        authInfo.setClientCertificate(get("client-certificate", mappedBean));
+        authInfo.setClientCertificateData(get("client-certificate-data", mappedBean));
+        authInfo.setClientKey(get("client-key", mappedBean));
+        authInfo.setClientKeyData(get("client-key-data", mappedBean));
+        authInfo.setExec(get("exec", mappedBean, execConfigMapper));
+        authInfo.setExtensions(getList("extensions", mappedBean, namedExtensionsMapper));
+        authInfo.setPassword(get("password", mappedBean));
+        authInfo.setToken(get("token", mappedBean));
+        authInfo.setTokenFile(get("tokenFile", mappedBean));
+        authInfo.setUsername(get("username", mappedBean));
+        return authInfo;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/AuthProviderMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/AuthProviderMapper.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.AuthProviderConfig;
+
+@SuppressWarnings("unchecked")
+public class AuthProviderMapper extends PropertyMapper<AuthProviderConfig> {
+
+    @Override
+    public AuthProviderConfig map(Map<String, Object> mappedBean) {
+        final AuthProviderConfig bean = new AuthProviderConfig();
+        bean.setConfig(get("config", mappedBean, Map.class));
+        bean.setName(get("name", mappedBean));
+        return bean;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ClusterMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ClusterMapper.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Cluster;
+
+public class ClusterMapper extends PropertyMapper<Cluster> {
+
+    private final NamedExtensionsMapper namedExtensionsMapper = new NamedExtensionsMapper();
+
+    @Override
+    public Cluster map(Map<String, Object> mappedBean) {
+        final Cluster cluster = new Cluster();
+        cluster.setCertificateAuthority(get("certificate-authority", mappedBean, String.class));
+        cluster.setCertificateAuthorityData(get("certificate-authority-data", mappedBean, String.class));
+        cluster.setExtensions(getList("extensions", mappedBean, namedExtensionsMapper));
+        cluster.setInsecureSkipTlsVerify(get("insecure-skip-tls-verify", mappedBean, Boolean.class));
+        cluster.setServer(get("server", mappedBean, String.class));
+        return cluster;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ConfigMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ConfigMapper.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Config;
+
+public class ConfigMapper extends PropertyMapper<Config> {
+
+    private final NamedClusterMapper namedClusterMapper = new NamedClusterMapper();
+    private final NamedContextMapper namedContextMapper = new NamedContextMapper();
+    private final NamedExtensionsMapper namedExtensionsMapper = new NamedExtensionsMapper();
+    private final PreferencesMapper preferencesMapper = new PreferencesMapper();
+    private final NamedAuthInfoMapper namedAuthInfoMapper = new NamedAuthInfoMapper();
+
+    @Override
+    public Config map(Map<String, Object> mappedBean) {
+        final Config config = new Config();
+        config.setApiVersion(get("apiVersion", mappedBean, String.class));
+        config.setClusters(getList("clusters", mappedBean, namedClusterMapper));
+        config.setContexts(getList("contexts", mappedBean, namedContextMapper));
+        config.setCurrentContext(get("current-context", mappedBean, String.class));
+        config.setExtensions(getList("extensions", mappedBean, namedExtensionsMapper));
+        config.setKind(get("kind", mappedBean, String.class));
+        config.setPreferences(get("preferences", mappedBean, preferencesMapper));
+        config.setUsers(getList("users", mappedBean, namedAuthInfoMapper));
+        return config;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ContextMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ContextMapper.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Context;
+
+public class ContextMapper extends PropertyMapper<Context> {
+
+    private final NamedExtensionsMapper namedExtensionsMapper = new NamedExtensionsMapper();
+
+    @Override
+    public Context map(Map<String, Object> mappedBean) {
+        final Context bean = new Context();
+        bean.setCluster(get("cluster", mappedBean, String.class));
+        bean.setUser(get("user", mappedBean, String.class));
+        bean.setNamespace(get("namespace", mappedBean, String.class));
+        bean.setExtensions(getList("extensions", mappedBean, namedExtensionsMapper));
+        return bean;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ExecConfigMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ExecConfigMapper.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.ExecConfig;
+
+public class ExecConfigMapper extends PropertyMapper<ExecConfig> {
+
+    private final ExecEnvVarMapper execEnvVarMapper = new ExecEnvVarMapper();
+
+    @Override
+    public ExecConfig map(Map<String, Object> mappedBean) {
+        final ExecConfig bean = new ExecConfig();
+        bean.setApiVersion(get("apiVersion", mappedBean));
+        bean.setArgs(getList("args", mappedBean));
+        bean.setCommand(get("command", mappedBean));
+        bean.setEnv(getList("env", mappedBean, execEnvVarMapper));
+        return bean;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ExecEnvVarMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/ExecEnvVarMapper.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.ExecEnvVar;
+
+public class ExecEnvVarMapper extends PropertyMapper<ExecEnvVar> {
+
+    @Override
+    public ExecEnvVar map(Map<String, Object> mappedBean) {
+        final ExecEnvVar bean = new ExecEnvVar();
+        bean.setName(get("name", mappedBean));
+        bean.setValue(get("value", mappedBean));
+        return bean;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedAuthInfoMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedAuthInfoMapper.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.NamedAuthInfo;
+
+public class NamedAuthInfoMapper extends PropertyMapper<NamedAuthInfo> {
+    
+    private final AuthInfoMapper authInfoMapper = new AuthInfoMapper();
+
+    @Override
+    public NamedAuthInfo map(Map<String, Object> mappedBean) {
+        final NamedAuthInfo bean = new NamedAuthInfo();
+        bean.setName(get("name", mappedBean, String.class));
+        bean.setUser(get("user", mappedBean, authInfoMapper));
+        return bean;
+    }
+    
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedClusterMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedClusterMapper.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.NamedCluster;
+
+public class NamedClusterMapper extends PropertyMapper<NamedCluster> {
+
+    private final ClusterMapper clusterMapper = new ClusterMapper();
+
+    @Override
+    public NamedCluster map(Map<String, Object> mappedBean) {
+        final NamedCluster bean = new NamedCluster();
+        bean.setName(get("name", mappedBean, String.class));
+        bean.setCluster(get("cluster", mappedBean, clusterMapper));
+        return bean;
+    }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedContextMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedContextMapper.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.NamedContext;
+
+public class NamedContextMapper extends PropertyMapper<NamedContext> {
+
+    private final ContextMapper contextMapper = new ContextMapper();
+
+    @Override
+    public NamedContext map(Map<String, Object> mappedBean) {
+        final NamedContext bean = new NamedContext();
+        bean.setName(get("name", mappedBean));
+        bean.setContext(get("context", mappedBean, contextMapper));
+        return bean;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedExtensionsMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/NamedExtensionsMapper.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.NamedExtension;
+
+public class NamedExtensionsMapper extends PropertyMapper<NamedExtension> {
+
+    @Override
+    public NamedExtension map(Map<String, Object> mappedBean) {
+        final NamedExtension bean = new NamedExtension();
+        bean.setName(get("name", mappedBean));
+        return bean;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/PreferencesMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/PreferencesMapper.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Preferences;
+
+public class PreferencesMapper extends PropertyMapper<Preferences> {
+
+    private final NamedExtensionsMapper namedExtensionsMapper = new NamedExtensionsMapper();
+
+    @Override
+    public Preferences map(Map<String, Object> mappedBean) {
+        final Preferences bean = new Preferences();
+        bean.setColors(get("colors", mappedBean, Boolean.class));
+        bean.setExtensions(getList("extensions", mappedBean, namedExtensionsMapper));
+        return bean;
+    }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/PropertyMapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/mappers/PropertyMapper.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.internal.mappers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unchecked")
+public abstract class PropertyMapper<T> {
+
+    public abstract T map(Map<String, Object> mappedBean);
+
+    protected String get(final String prop, final Map<String, Object> mappedBean) {
+        final Object value = mappedBean.get(prop);
+        if (value instanceof String && value != null) {
+            return (String) value;
+        }
+        return null;
+    }
+
+    protected <V> V get(final String prop, final Map<String, Object> mappedBean, final Class<V> clazz) {
+        final Object value = mappedBean.get(prop);
+        if (clazz.isInstance(value) && value != null) {
+            return (V) value;
+        }
+        return null;
+    }
+
+    protected <V> V get(final String prop, final Map<String, Object> mappedBean, final PropertyMapper<?> mapper) {
+        final Object value = mappedBean.get(prop);
+        if (value instanceof Map<?, ?>) {
+            return (V) mapper.map((Map<String, Object>) value);
+        }
+        return null;
+    }
+
+    protected <V> List<V> getList(final String prop, final Map<String, Object> mappedBean) {
+        final Object value = mappedBean.get(prop);
+        if (value instanceof List<?> && value != null) {
+            return (List<V>) value;
+        }
+        return null;
+    }
+
+    protected <V> List<V> getList(final String prop, final Map<String, Object> mappedBean, final PropertyMapper<V> mapper) {
+        final Object value = mappedBean.get(prop);
+        List<V> mappedList = new ArrayList<>();
+        if (value instanceof List<?> && value != null) {
+            ((List<V>) value).forEach(v -> {
+                if (v instanceof Map<?, ?> && v != null) {
+                    mappedList.add(mapper.map((Map<String, Object>) v));
+                }
+            });
+        }
+        return mappedList;
+    }
+
+}


### PR DESCRIPTION
Fixes #1591 

**Work in Progress: this PR has been opened to discuss the implementation details with manteiners**

Hi @geoand and @iocanel! As promised, here's the PR with an implementation suggestion to remove reflection completely from the configuration use case. 

I've tested this feature across your unit tests, IT and inside the native image. Seems solid, but I intend to write some more tests. 

Before keep going, I'd like to hear from you if this approach seems fine or if you'd like to take another one. With this new approach I was able to run the authentication and config features from kubernetes client inside a native image without registering any class for reflection.

I understand that's not the ideal world and in the future we could auto-generate those "mappers" with a maven plugin during build time.

Let me know your thoughts.

Cheers!
