### PR TITLE
add type parameter to custom resource list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     * assertNotNull replaced with assertTrue for boolean statements in unit tests
     * Test coverage for PodPreset
     * Added test coverage for PersistentVolume
+    * Add type parameter to make CustomResourceList.getItems() return a typed List.
 
   Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
-public class CustomResourceList<T extends HasMetadata> implements KubernetesResource, KubernetesResourceList {
+public class CustomResourceList<T extends HasMetadata> implements KubernetesResource, KubernetesResourceList<T> {
 
   @NotNull
   @JsonProperty("apiVersion")


### PR DESCRIPTION
Without the type parameter, `list.getItems()` returns a `List<Object>`. It should return `List<T>`. Built-in types implement this correctly, for example `PodList` extends `KubernetesResourceList<Pod>`, so `PodList.getItems()` returns a `List<Pod>`. Adding the type parameter makes this work for custom resources.