### PR TITLE
fix(tekton): Fixed build warnings

### DIFF
--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -147,7 +147,7 @@
                         <configuration>
                             <artifacts>
                                 <artifact>
-                                    <file>${build.outputDirectory}/schema/knative-schema.json</file>
+                                    <file>${project.build.outputDirectory}/schema/knative-schema.json</file>
                                     <type>json</type>
                                     <classifier>schema</classifier>
                                 </artifact>

--- a/extensions/tekton/model/pom.xml
+++ b/extensions/tekton/model/pom.xml
@@ -147,7 +147,7 @@
               <configuration>
                 <artifacts>
                   <artifact>
-                    <file>${build.outputDirectory}/schema/tekton-schema.json</file>
+                    <file>${project.build.outputDirectory}/schema/tekton-schema.json</file>
                     <type>json</type>
                     <classifier>schema</classifier>
                   </artifact>


### PR DESCRIPTION
This removes the build warnings seen when building the project:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.fabric8:knative-model:bundle:4.3-SNAPSHOT
[WARNING] The expression ${build.outputDirectory} is deprecated. Please use ${project.build.outputDirectory} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.fabric8:tekton-model:bundle:4.3-SNAPSHOT
[WARNING] The expression ${build.outputDirectory} is deprecated. Please use ${project.build.outputDirectory} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```