### PR TITLE
Check for port before setting Origin header for watch requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### CHANGELOG
 
 ### 4.3-SNAPSHOT
-  Bugs  
+  Bugs
   * Fixed user/password authentication bug in OpenShift 4
   * Fix #1667: Origin header for watch requests had a port of -1 when no port specified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.3-SNAPSHOT
   Bugs
+   * Fix #1667: Origin header for watch requests had a port of -1 when no port specified
 
   Improvements
    * Test coverage for PersistentVolumeClaim

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -144,10 +144,15 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
 
     httpUrlBuilder.addQueryParameter("watch", "true");
 
+    String origin = requestUrl.getProtocol() + "://" + requestUrl.getHost();
+    if (requestUrl.getPort() != -1) {
+        origin += ":" + requestUrl.getPort();
+    }
+
     Request request = new Request.Builder()
       .get()
       .url(httpUrlBuilder.build())
-      .addHeader("Origin", requestUrl.getProtocol() + "://" + requestUrl.getHost() + ":" + requestUrl.getPort())
+      .addHeader("Origin", origin)
       .build();
 
     webSocket = clonedClient.newWebSocket(request, new WebSocketListener() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -146,10 +146,15 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
 
     httpUrlBuilder.addQueryParameter("watch", "true");
 
+    String origin = requestUrl.getProtocol() + "://" + requestUrl.getHost();
+    if (requestUrl.getPort() != -1) {
+        origin += ":" + requestUrl.getPort();
+    }
+
     final Request request = new Request.Builder()
       .get()
       .url(httpUrlBuilder.build())
-      .addHeader("Origin", requestUrl.getProtocol() + "://" + requestUrl.getHost() + ":" + requestUrl.getPort())
+      .addHeader("Origin", origin)
       .build();
 
     clonedClient.newCall(request).enqueue(new Callback() {


### PR DESCRIPTION
 When the Kubernetes URL used doesn't specify a port
(e.g., https://example.com/api/v1/...), the origin header for
watch requests ends up with a port of -1 (e.g., https://example.com:-1).
This happens because calling `getPort()` on a java.net.URL object that
does not have a port explicitly specified will always return -1. The
return value was always just inserted into the origin header.

Now, we check for this and only append a port to the origin header if
`getPort()` returns something other than -1. We make this change in both
the WatchConnectionManager and WatchHTTPManager classes.

I wasn't able to come up with a way to make a test for this, because the 
mock Kubernetes server support specifying the port, and especially not 
the defaults of 80/443. 

Fixes issue #1667 