### PR TITLE
Make sure http2 is not tried

### DIFF
--- a/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeMockServer.java
+++ b/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeMockServer.java
@@ -29,6 +29,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import java.util.Map;
 import java.util.Queue;
 
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static okhttp3.TlsVersion.TLS_1_0;
 
 public class KnativeMockServer extends KubernetesMockServer {
@@ -58,6 +59,6 @@ public class KnativeMockServer extends KubernetesMockServer {
       .withTrustCerts(true)
       .withTlsVersions(TLS_1_0)
       .build();
-    return new DefaultKnativeClient(config);
+    return new DefaultKnativeClient(createHttpClientForMockServer(config), config);
   }
 }

--- a/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonMockServer.java
+++ b/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonMockServer.java
@@ -29,6 +29,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import java.util.Map;
 import java.util.Queue;
 
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static okhttp3.TlsVersion.TLS_1_0;
 
 public class TektonMockServer extends KubernetesMockServer {
@@ -58,6 +59,6 @@ public class TektonMockServer extends KubernetesMockServer {
       .withTrustCerts(true)
       .withTlsVersions(TLS_1_0)
       .build();
-    return new DefaultTektonClient(config);
+    return new DefaultTektonClient(createHttpClientForMockServer(config), config);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -107,6 +107,7 @@ public class Config {
   public static final String KUBERNETES_SERVICE_PORT_PROPERTY = "KUBERNETES_SERVICE_PORT";
   public static final String KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
   public static final String KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+  public static final String KUBERNETES_HTTP2_DISABLE = "http2.disable";
   public static final String KUBERNETES_HTTP_PROXY = "http.proxy";
   public static final String KUBERNETES_HTTPS_PROXY = "https.proxy";
   public static final String KUBERNETES_ALL_PROXY = "all.proxy";
@@ -182,6 +183,7 @@ public class Config {
    * end of fields not used but needed for builder generation.
    */
 
+  private boolean http2Disable;
   private String httpProxy;
   private String httpsProxy;
   private String proxyUsername;
@@ -230,11 +232,11 @@ public class Config {
 
   @Deprecated
   public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras) {
-    this(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequestsPerHost, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions,  websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras, null);
+    this(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequestsPerHost, false, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions,  websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras, null);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
-  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider) {
+  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequestsPerHost, boolean http2Disable, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider) {
     this.masterUrl = masterUrl;
     this.apiVersion = apiVersion;
     this.namespace = namespace;
@@ -254,7 +256,7 @@ public class Config {
     this.requestConfig.setImpersonateGroups(impersonateGroups);
     this.requestConfig.setImpersonateExtras(impersonateExtras);
 
-
+    this.http2Disable = http2Disable;
     this.httpProxy= httpProxy;
     this.httpsProxy= httpsProxy;
     this.noProxy= noProxy;
@@ -354,6 +356,8 @@ public class Config {
     if (configuredMaxConcurrentReqeustsPerHost != null) {
       config.setMaxConcurrentRequestsPerHost(Integer.parseInt(configuredMaxConcurrentReqeustsPerHost));
     }
+
+    config.setHttp2Disable(Utils.getSystemPropertyOrEnvVar(KUBERNETES_HTTP2_DISABLE, config.isHttp2Disable()));
 
     config.setHttpProxy(Utils.getSystemPropertyOrEnvVar(KUBERNETES_ALL_PROXY, config.getHttpProxy()));
     config.setHttpsProxy(Utils.getSystemPropertyOrEnvVar(KUBERNETES_ALL_PROXY, config.getHttpsProxy()));
@@ -935,6 +939,14 @@ public class Config {
     this.requestConfig.setLoggingInterval(loggingInterval);
   }
 
+  @JsonProperty("http2Disable")
+  public boolean isHttp2Disable() {
+    return http2Disable;
+  }
+
+  public void setHttp2Disable(boolean http2Disable) {
+    this.http2Disable = http2Disable;
+  }
 
   public void setHttpProxy(String httpProxy) {
     this.httpProxy= httpProxy;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -38,6 +38,7 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -59,6 +60,14 @@ public class HttpClientUtils {
   }
 
   public static OkHttpClient createHttpClient(final Config config) {
+      return createHttpClient(config, (b) -> {});
+  }
+
+  public static OkHttpClient createHttpClientForMockServer(final Config config) {
+      return createHttpClient(config, b -> b.protocols(Collections.singletonList(Protocol.HTTP_1_1)));
+  }
+
+  private static OkHttpClient createHttpClient(final Config config, final Consumer<OkHttpClient.Builder> additionalConfig) {
         try {
             OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
 
@@ -167,6 +176,10 @@ public class HttpClientUtils {
 
             if (config.isHttp2Disable()) {
                 httpClientBuilder.protocols(Collections.singletonList(Protocol.HTTP_1_1));
+            }
+
+            if(additionalConfig != null) {
+                additionalConfig.accept(httpClientBuilder);
             }
 
             return httpClientBuilder.build();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -36,6 +36,7 @@ import java.net.Proxy;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -162,6 +163,10 @@ public class HttpClientUtils {
                 .tlsVersions(config.getTlsVersions())
                 .build();
               httpClientBuilder.connectionSpecs(Arrays.asList(spec, CLEARTEXT));
+            }
+
+            if (config.isHttp2Disable()) {
+                httpClientBuilder.protocols(Collections.singletonList(Protocol.HTTP_1_1));
             }
 
             return httpClientBuilder.build();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/server/mock/KubernetesMockServer.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/server/mock/KubernetesMockServer.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
 
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static okhttp3.TlsVersion.TLS_1_0;
 
 @Deprecated
@@ -80,7 +81,7 @@ public class KubernetesMockServer extends DefaultMockServer {
                 .withTlsVersions(TLS_1_0)
                 .withNamespace("test")
                 .build();
-        return new DefaultKubernetesClient(config);
+        return new DefaultKubernetesClient(createHttpClientForMockServer(config), config);
     }
 
 

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
 
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static okhttp3.TlsVersion.TLS_1_0;
 
 public class KubernetesMockServer extends DefaultMockServer {
@@ -82,7 +83,7 @@ public class KubernetesMockServer extends DefaultMockServer {
                 .withTlsVersions(TLS_1_0)
                 .withNamespace("test")
                 .build();
-        return new DefaultKubernetesClient(config);
+        return new DefaultKubernetesClient(createHttpClientForMockServer(config), config);
     }
 
 

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
@@ -21,7 +21,9 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfig;
 
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static okhttp3.TlsVersion.TLS_1_0;
 
 @Deprecated
@@ -48,6 +50,6 @@ public class OpenShiftMockServer extends KubernetesMockServer {
       .withTrustCerts(true)
       .withTlsVersions(TLS_1_0)
       .build();
-    return new DefaultOpenShiftClient(config);
+    return new DefaultOpenShiftClient(createHttpClientForMockServer(config), new OpenShiftConfig(config));
   }
 }

--- a/openshift-client/src/test/java/io/fabric8/openshift/server/mock/OpenShiftMockServer.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/server/mock/OpenShiftMockServer.java
@@ -21,7 +21,9 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfig;
 
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static okhttp3.TlsVersion.TLS_1_0;
 
 @Deprecated
@@ -48,6 +50,6 @@ public class OpenShiftMockServer extends KubernetesMockServer {
       .withTrustCerts(true)
       .withTlsVersions(TLS_1_0)
       .build();
-    return new DefaultOpenShiftClient(config);
+    return new DefaultOpenShiftClient(createHttpClientForMockServer(config), new OpenShiftConfig(config));
   }
 }

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
@@ -30,6 +30,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import java.util.Map;
 import java.util.Queue;
 
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
 import static okhttp3.TlsVersion.TLS_1_0;
 
 public class OpenShiftMockServer extends KubernetesMockServer {
@@ -60,7 +61,7 @@ public class OpenShiftMockServer extends KubernetesMockServer {
       .withTlsVersions(TLS_1_0)
       .withDisableApiGroupCheck(disableApiGroupCheck)
       .build();
-    return new DefaultOpenShiftClient(config);
+    return new DefaultOpenShiftClient(createHttpClientForMockServer(config), config);
   }
 
   public boolean isDisableApiGroupCheck() {


### PR DESCRIPTION
This is prevented because it breaks the mock-webserver in Java 11

The actual problem with mock-webserver seems to be an okhttp issue, but we can easily work around it here by ensuring that http2 is never tried (kubernetes-api server isn't http2 anyway so there no point in even attempting to use http2).

This is not a problem in Java 8 because the default installations of Java 8 don't support http2 