### PR TITLE
fix: Fixed URL resolution algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.4-SNAPSHOT
   Bugs
   * Fix #1690: Endpoints is always pluralized
+  * Fix #1684: Fixed URL resolution algorithm for OpenShift resources without API Group name
 
   Improvements
 

--- a/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/openshift/api/model/Template.java
+++ b/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/openshift/api/model/Template.java
@@ -77,7 +77,7 @@ public class Template implements HasMetadata {
      */
     @JsonProperty("apiVersion")
     @NotNull
-    private String apiVersion = "v1";
+    private String apiVersion = "template.openshift.io/v1";
     /**
      * (Required)
      */

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
@@ -51,7 +51,7 @@ public class BuildConfigTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/namespaces/test/buildconfigs").andReturn(200, new BuildConfigListBuilder().build()).once();
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/buildconfigs").andReturn(200, new BuildConfigListBuilder().build()).once();
 
    server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
       .addNewGroup()
@@ -64,7 +64,7 @@ public class BuildConfigTest {
       .endGroup()
       .build()).always();
 
-   server.expect().withPath("/oapi/v1/namespaces/ns1/buildconfigs").andReturn(200, new BuildConfigListBuilder()
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs").andReturn(200, new BuildConfigListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).once();
 
@@ -92,11 +92,11 @@ public class BuildConfigTest {
 
   @Test
   public void testGet() {
-   server.expect().withPath("/oapi/v1/namespaces/test/buildconfigs/bc1").andReturn(200, new BuildConfigBuilder()
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/buildconfigs/bc1").andReturn(200, new BuildConfigBuilder()
       .withNewMetadata().withName("bc1").endMetadata()
       .build()).once();
 
-   server.expect().withPath("/oapi/v1/namespaces/ns1/buildconfigs/bc2").andReturn(200, new BuildConfigBuilder()
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2").andReturn(200, new BuildConfigBuilder()
       .withNewMetadata().withName("bc2").endMetadata()
       .build()).once();
 
@@ -117,7 +117,7 @@ public class BuildConfigTest {
   @Test
   @Ignore //Seems that in this version of mockwebserver, posting using an inputstream doesn't work that well, so we'll have to ignore.
   public void testBinaryBuildFromInputStream() {
-   server.expect().post().withPath("/oapi/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?commit=some%20commit&revision.authorName=author%20name&revision.authorEmail=author@someorg.com&revision.committerName=committer%20name&revision.committerEmail=committer@someorg.com")
+   server.expect().post().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?commit=some%20commit&revision.authorName=author%20name&revision.authorEmail=author@someorg.com&revision.committerName=committer%20name&revision.committerEmail=committer@someorg.com")
       .andReturn(201, new BuildBuilder()
       .withNewMetadata().withName("bc2").endMetadata().build()).once();
 
@@ -141,7 +141,7 @@ public class BuildConfigTest {
     File warFile = new File("target/test.war");
     warFile.createNewFile();
 
-    server.expect().post().withPath("/oapi/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?commit=&asFile=" + warFile.getName())
+    server.expect().post().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?commit=&asFile=" + warFile.getName())
       .andReturn(201, new BuildBuilder()
       .withNewMetadata().withName("bc2").endMetadata().build()).once();
 
@@ -158,7 +158,7 @@ public class BuildConfigTest {
   // TODO Add delay to mockwebserver. Disabled as too dependent on timing issues right now.
   //@Test
   public void testBinaryBuildWithTimeout() {
-   server.expect().post().delay(200).withPath("/oapi/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?commit=")
+   server.expect().post().delay(200).withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?commit=")
       .andReturn(201, new BuildBuilder()
       .withNewMetadata().withName("bc2").endMetadata().build()).once();
 
@@ -179,10 +179,10 @@ public class BuildConfigTest {
 
   @Test
   public void testDelete() {
-   server.expect().withPath("/oapi/v1/namespaces/test/buildconfigs/bc1").andReturn(200, new BuildConfigBuilder().withNewMetadata().withName("bc1").and().build()).once();
-   server.expect().withPath("/oapi/v1/namespaces/test/builds?labelSelector=openshift.io%2Fbuild-config.name%3Dbc1").andReturn( 200, new BuildListBuilder().build()).once();
-   server.expect().withPath("/oapi/v1/namespaces/ns1/buildconfigs/bc2").andReturn( 200, new BuildConfigBuilder().withNewMetadata().withName("bc2").and().build()).once();
-   server.expect().withPath("/oapi/v1/namespaces/ns1/builds?labelSelector=openshift.io%2Fbuild-config.name%3Dbc2").andReturn( 200, new BuildListBuilder().build()).once();
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/buildconfigs/bc1").andReturn(200, new BuildConfigBuilder().withNewMetadata().withName("bc1").and().build()).once();
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/builds?labelSelector=openshift.io%2Fbuild-config.name%3Dbc1").andReturn( 200, new BuildListBuilder().build()).once();
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2").andReturn( 200, new BuildConfigBuilder().withNewMetadata().withName("bc2").and().build()).once();
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/builds?labelSelector=openshift.io%2Fbuild-config.name%3Dbc2").andReturn( 200, new BuildListBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -43,7 +43,7 @@ public class DeploymentConfigTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/namespaces/test/deploymentconfigs").andReturn(200, new DeploymentConfigListBuilder().build()).once();
+   server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs").andReturn(200, new DeploymentConfigListBuilder().build()).once();
    server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
       .addNewGroup()
       .withApiVersion("v1")
@@ -54,7 +54,7 @@ public class DeploymentConfigTest {
       .withName("security.openshift.io")
       .endGroup()
       .build()).always();
-   server.expect().withPath("/oapi/v1/namespaces/ns1/deploymentconfigs").andReturn(200, new DeploymentConfigListBuilder()
+   server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs").andReturn(200, new DeploymentConfigListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).once();
 
@@ -81,11 +81,11 @@ public class DeploymentConfigTest {
 
   @Test
   public void testGet() {
-   server.expect().withPath("/oapi/v1/namespaces/test/deploymentconfigs/dc1").andReturn(200, new DeploymentConfigBuilder()
+   server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1").andReturn(200, new DeploymentConfigBuilder()
       .withNewMetadata().withName("dc1").endMetadata()
       .build()).once();
 
-   server.expect().withPath("/oapi/v1/namespaces/ns1/deploymentconfigs/dc2").andReturn(200, new DeploymentConfigBuilder()
+   server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs/dc2").andReturn(200, new DeploymentConfigBuilder()
       .withNewMetadata().withName("dc2").endMetadata()
       .build()).once();
 
@@ -144,8 +144,8 @@ public class DeploymentConfigTest {
       .endStatus()
       .build();
 
-   server.expect().withPath("/oapi/v1/namespaces/test/deploymentconfigs/dc1").andReturn(200, dc1).times(2);
-   server.expect().withPath("/oapi/v1/namespaces/ns1/deploymentconfigs/dc2").andReturn( 200, dc2).times(5);
+   server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1").andReturn(200, dc1).times(2);
+   server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs/dc2").andReturn( 200, dc2).times(5);
 
     OpenShiftClient client = server.getOpenshiftClient();
 
@@ -161,12 +161,12 @@ public class DeploymentConfigTest {
 
 	@Test
 	public void testDeployingLatest() {
-		server.expect().withPath("/oapi/v1/namespaces/test/deploymentconfigs/dc1")
+		server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1")
 				.andReturn(200, new DeploymentConfigBuilder().withNewMetadata().withName("dc1").endMetadata()
 						.withNewStatus().withLatestVersion(1L).endStatus().build())
 				.always();
 
-		server.expect().patch().withPath("/oapi/v1/namespaces/test/deploymentconfigs/dc1")
+		server.expect().patch().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1")
 				.andReturn(200, new DeploymentConfigBuilder().withNewMetadata().withName("dc1").endMetadata()
 						.withNewStatus().withLatestVersion(2L).endStatus().build())
 				.once();
@@ -180,12 +180,12 @@ public class DeploymentConfigTest {
 
   @Test
   public void testDeployingLatestHandlesMissingLatestVersion() {
-    server.expect().withPath("/oapi/v1/namespaces/test/deploymentconfigs/dc1")
+    server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1")
       .andReturn(200, new DeploymentConfigBuilder().withNewMetadata().withName("dc1").endMetadata()
         .withNewStatus().endStatus().build())
       .always();
 
-    server.expect().patch().withPath("/oapi/v1/namespaces/test/deploymentconfigs/dc1")
+    server.expect().patch().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1")
       .andReturn(200, new DeploymentConfigBuilder().withNewMetadata().withName("dc1").endMetadata()
         .withNewStatus().withLatestVersion(1L).endStatus().build())
       .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
@@ -39,7 +39,7 @@ public class GroupTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/groups").andReturn(200, new GroupListBuilder()
+   server.expect().withPath("/apis/user.openshift.io/v1/groups").andReturn(200, new GroupListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).always();
 
@@ -53,10 +53,6 @@ public class GroupTest {
       .withName("security.openshift.io")
       .endGroup()
       .build()).always();
-
-    server.expect().withPath("/apis/user.openshift.io/v1/groups").andReturn(200, new GroupListBuilder()
-      .addNewItem().and()
-      .addNewItem().and().build()).always();
 
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
@@ -74,11 +70,11 @@ public class GroupTest {
 
   @Test
   public void testGet() {
-   server.expect().withPath("/oapi/v1/groups/group1").andReturn(200, new GroupBuilder()
+   server.expect().withPath("/apis/user.openshift.io/v1/groups/group1").andReturn(200, new GroupBuilder()
       .withNewMetadata().withName("group1").endMetadata()
       .build()).once();
 
-   server.expect().withPath("/oapi/v1/groups/Group2").andReturn(200, new GroupBuilder()
+   server.expect().withPath("/apis/user.openshift.io/v1/groups/Group2").andReturn(200, new GroupBuilder()
       .withNewMetadata().withName("Group2").endMetadata()
       .build()).once();
 
@@ -99,8 +95,8 @@ public class GroupTest {
 
   @Test
   public void testDelete() {
-   server.expect().withPath("/oapi/v1/groups/group1").andReturn(200, new GroupBuilder().build()).once();
-   server.expect().withPath("/oapi/v1/groups/Group2").andReturn( 200, new GroupBuilder().build()).once();
+   server.expect().withPath("/apis/user.openshift.io/v1/groups/group1").andReturn(200, new GroupBuilder().build()).once();
+   server.expect().withPath("/apis/user.openshift.io/v1/groups/Group2").andReturn( 200, new GroupBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubernetesOperationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubernetesOperationTest.java
@@ -60,7 +60,7 @@ public class KubernetesOperationTest {
       .withName("security.openshift.io")
       .endGroup()
       .build()).once();
-   server.expect().withPath("/oapi/v1/namespaces/test/buildconfigs/bc1").andReturn(200, new BuildConfigBuilder().build()).once();
+   server.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/buildconfigs/bc1").andReturn(200, new BuildConfigBuilder().build()).once();
    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder().build()).once();
 
     try (KubernetesClient client = server.getKubernetesClient()) {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientTest.java
@@ -37,7 +37,7 @@ public class OAuthClientTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/oauthclients").andReturn(200, new OAuthClientListBuilder()
+   server.expect().withPath("/apis/oauth.openshift.io/v1/oauthclients").andReturn(200, new OAuthClientListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).once();
 
@@ -52,11 +52,11 @@ public class OAuthClientTest {
 
   @Test
   public void testGet() {
-   server.expect().withPath("/oapi/v1/oauthclients/client1").andReturn(200, new OAuthClientBuilder()
+   server.expect().withPath("/apis/oauth.openshift.io/v1/oauthclients/client1").andReturn(200, new OAuthClientBuilder()
       .withNewMetadata().withName("client1").endMetadata()
       .build()).once();
 
-   server.expect().withPath("/oapi/v1/oauthclients/client2").andReturn(200, new OAuthClientBuilder()
+   server.expect().withPath("/apis/oauth.openshift.io/v1/oauthclients/client2").andReturn(200, new OAuthClientBuilder()
       .withNewMetadata().withName("client2").endMetadata()
       .build()).once();
 
@@ -77,8 +77,8 @@ public class OAuthClientTest {
 
   @Test
   public void testDelete() {
-   server.expect().withPath("/oapi/v1/oauthclients/client1").andReturn(200, new OAuthClientBuilder().build()).once();
-   server.expect().withPath("/oapi/v1/oauthclients/client2").andReturn(200, new OAuthClientBuilder().build()).once();
+   server.expect().withPath("/apis/oauth.openshift.io/v1/oauthclients/client1").andReturn(200, new OAuthClientBuilder().build()).once();
+   server.expect().withPath("/apis/oauth.openshift.io/v1/oauthclients/client2").andReturn(200, new OAuthClientBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
@@ -41,7 +41,7 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testCreateWithOnlySubjects() throws Exception {
-    server.expect().post().withPath("/oapi/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
+    server.expect().post().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -62,7 +62,7 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testCreateWithUserNamesAndGroupsAndNoSubjects() throws Exception {
-    server.expect().post().withPath("/oapi/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
+    server.expect().post().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -81,7 +81,7 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testCreateWithUserNamesAndGroupsAndOverwriteSubjects() throws Exception {
-    server.expect().post().withPath("/oapi/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
+    server.expect().post().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -101,8 +101,8 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testReplaceWithOnlySubjects() throws Exception {
-    server.expect().get().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
-    server.expect().put().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().get().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().put().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -123,8 +123,8 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testReplaceWithUserNamesAndGroupsAndNoSubjects() throws Exception {
-    server.expect().get().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
-    server.expect().put().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().get().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().put().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -144,8 +144,8 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testReplaceWithUserNamesAndGroupsAndOverwriteSubjects() throws Exception {
-    server.expect().get().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
-    server.expect().put().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().get().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().put().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -165,8 +165,8 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testPatchWithOnlySubjects() throws Exception {
-    server.expect().get().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, new OpenshiftRoleBindingBuilder().addToUserNames("unexpected").build()).once();
-    server.expect().patch().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().get().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, new OpenshiftRoleBindingBuilder().addToUserNames("unexpected").build()).once();
+    server.expect().patch().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -190,8 +190,8 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testPatchWithUserNamesAndGroupsAndNoSubjects() throws Exception {
-    server.expect().get().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, new OpenshiftRoleBindingBuilder().addToUserNames("unexpected").build()).once();
-    server.expect().patch().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().get().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, new OpenshiftRoleBindingBuilder().addToUserNames("unexpected").build()).once();
+    server.expect().patch().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -213,8 +213,8 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testPatchWithUserNamesAndGroupsAndOverwriteSubjects() throws Exception {
-    server.expect().get().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, new OpenshiftRoleBindingBuilder().addToUserNames("unexpected").build()).once();
-    server.expect().patch().withPath("/oapi/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
+    server.expect().get().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, new OpenshiftRoleBindingBuilder().addToUserNames("unexpected").build()).once();
+    server.expect().patch().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings/testrb").andReturn(200, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -237,7 +237,7 @@ public class OpenshiftRoleBindingTest {
 
   @Test
   public void testCreateInline() throws Exception {
-    server.expect().post().withPath("/oapi/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
+    server.expect().post().withPath("/apis/authorization.openshift.io/v1/namespaces/test/rolebindings").andReturn(201, expectedOpenshiftRoleBinding).once();
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleTest.java
@@ -36,8 +36,8 @@ public class OpenshiftRoleTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/namespaces/test/roles").andReturn(200, new OpenshiftRoleListBuilder().build()).once();
-   server.expect().withPath("/oapi/v1/namespaces/ns1/roles").andReturn(200, new OpenshiftRoleListBuilder()
+   server.expect().withPath("/apis/authorization.openshift.io/v1/namespaces/test/roles").andReturn(200, new OpenshiftRoleListBuilder().build()).once();
+   server.expect().withPath("/apis/authorization.openshift.io/v1/namespaces/ns1/roles").andReturn(200, new OpenshiftRoleListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).once();
    server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
@@ -74,11 +74,11 @@ public class OpenshiftRoleTest {
 
   @Test
   public void testGet() {
-   server.expect().withPath("/oapi/v1/namespaces/test/roles/role1").andReturn(200, new OpenshiftRoleBuilder()
+   server.expect().withPath("/apis/authorization.openshift.io/v1/namespaces/test/roles/role1").andReturn(200, new OpenshiftRoleBuilder()
       .withNewMetadata().withName("role1").endMetadata()
       .build()).once();
 
-   server.expect().withPath("/oapi/v1/namespaces/ns1/roles/role2").andReturn(200, new OpenshiftRoleBuilder()
+   server.expect().withPath("/apis/authorization.openshift.io/v1/namespaces/ns1/roles/role2").andReturn(200, new OpenshiftRoleBuilder()
       .withNewMetadata().withName("role2").endMetadata()
       .build()).once();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectRequestTest.java
@@ -34,7 +34,7 @@ public class ProjectRequestTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/projectrequests").andReturn(200, new StatusBuilder().withMessage("success").build()).once();
+   server.expect().withPath("/apis/project.openshift.io/v1/projectrequests").andReturn(200, new StatusBuilder().withMessage("success").build()).once();
     OpenShiftClient client = server.getOpenshiftClient();
 
     Status status = client.projectrequests().list();
@@ -48,7 +48,7 @@ public class ProjectRequestTest {
   public void testCreate() {
     ProjectRequest req1 = new ProjectRequestBuilder().withApiVersion("v1").withNewMetadata().withName("req1").and().build();
 
-   server.expect().withPath("/oapi/v1/projectrequests").andReturn(201, req1).once();
+   server.expect().withPath("/apis/project.openshift.io/v1/projectrequests").andReturn(201, req1).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectTest.java
@@ -37,7 +37,7 @@ public class ProjectTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/projects").andReturn(200, new ProjectListBuilder()
+   server.expect().withPath("/apis/project.openshift.io/v1/projects").andReturn(200, new ProjectListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).once();
 
@@ -52,11 +52,11 @@ public class ProjectTest {
 
   @Test
   public void testGet() {
-   server.expect().withPath("/oapi/v1/projects/project1").andReturn(200, new ProjectBuilder()
+   server.expect().withPath("/apis/project.openshift.io/v1/projects/project1").andReturn(200, new ProjectBuilder()
       .withNewMetadata().withName("project1").endMetadata()
       .build()).once();
 
-   server.expect().withPath("/oapi/v1/projects/project2").andReturn(200, new ProjectBuilder()
+   server.expect().withPath("/apis/project.openshift.io/v1/projects/project2").andReturn(200, new ProjectBuilder()
       .withNewMetadata().withName("project2").endMetadata()
       .build()).once();
 
@@ -77,8 +77,8 @@ public class ProjectTest {
 
   @Test
   public void testDelete() {
-   server.expect().withPath("/oapi/v1/projects/project1").andReturn(200, new ProjectBuilder().build()).once();
-   server.expect().withPath("/oapi/v1/projects/project2").andReturn( 200, new ProjectBuilder().build()).once();
+   server.expect().withPath("/apis/project.openshift.io/v1/projects/project1").andReturn(200, new ProjectBuilder().build()).once();
+   server.expect().withPath("/apis/project.openshift.io/v1/projects/project2").andReturn( 200, new ProjectBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
@@ -37,7 +37,7 @@ public class SecurityContextConstraintsTest {
 
   @Test
   public void testList() {
-   server.expect().withPath("/oapi/v1/securitycontextconstraints").andReturn(200, new SecurityContextConstraintsListBuilder()
+   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints").andReturn(200, new SecurityContextConstraintsListBuilder()
             .addNewItem().endItem()
             .build()).once();
 
@@ -50,8 +50,8 @@ public class SecurityContextConstraintsTest {
 
   @Test
   public void testDelete() {
-   server.expect().withPath("/oapi/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().build()).once();
-   server.expect().withPath("/oapi/v1/securitycontextconstraints/scc2").andReturn(200, new SecurityContextConstraintsBuilder().build()).once();
+   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().build()).once();
+   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc2").andReturn(200, new SecurityContextConstraintsBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 
@@ -67,8 +67,8 @@ public class SecurityContextConstraintsTest {
 
   @Test
   public void testEdit() {
-   server.expect().withPath("/oapi/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().build()).times(2);
-   server.expect().withPath("/oapi/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().addToAllowedCapabilities("allowed").build()).once();
+   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().build()).times(2);
+   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().addToAllowedCapabilities("allowed").build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
     SecurityContextConstraints scc = client.securityContextConstraints().withName("scc1").edit().addToAllowedCapabilities("allowed").done();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
@@ -36,17 +36,6 @@ public class SubjectAccessReviewTest {
 
   @Test
   public void testCreate() {
-    server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
-      .addNewGroup()
-      .withApiVersion("v1")
-      .withName("autoscaling.k8s.io")
-      .endGroup()
-      .addNewGroup()
-      .withApiVersion("v1")
-      .withName("security.openshift.io")
-      .endGroup()
-      .build()).always();
-
     server.expect().withPath("/apis/authorization.openshift.io/v1/subjectaccessreviews").andReturn(201, new SubjectAccessReviewResponseBuilder()
       .withReason("r1")
       .build()).once();
@@ -61,17 +50,6 @@ public class SubjectAccessReviewTest {
 
   @Test
   public void testCreateInLine() {
-    server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
-      .addNewGroup()
-      .withApiVersion("v1")
-      .withName("autoscaling.k8s.io")
-      .endGroup()
-      .addNewGroup()
-      .withApiVersion("v1")
-      .withName("security.openshift.io")
-      .endGroup()
-      .build()).always();
-
     server.expect().withPath("/apis/authorization.openshift.io/v1/subjectaccessreviews").andReturn(201, new SubjectAccessReviewResponseBuilder()
       .withReason("r2")
       .build()).once();
@@ -101,7 +79,7 @@ public class SubjectAccessReviewTest {
 
   @Test
   public void testCreateLocalInLine() {
-   server.expect().withPath("/oapi/v1/namespaces/test/subjectaccessreviews").andReturn( 201, new SubjectAccessReviewResponseBuilder()
+   server.expect().withPath("/apis/authorization.openshift.io/v1/namespaces/test/subjectaccessreviews").andReturn( 201, new SubjectAccessReviewResponseBuilder()
       .withReason("r2")
       .build()).once();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
@@ -65,7 +65,7 @@ public class SubjectAccessReviewTest {
 
   @Test
   public void testCreateLocal() {
-   server.expect().withPath("/oapi/v1/namespaces/test/subjectaccessreviews").andReturn(201, new SubjectAccessReviewResponseBuilder()
+   server.expect().withPath("/apis/authorization.openshift.io/v1/namespaces/test/subjectaccessreviews").andReturn(201, new SubjectAccessReviewResponseBuilder()
       .withReason("r1")
       .build()).once();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -54,8 +54,8 @@ public class TemplateTest {
 
   @Test
   public void testList() {
-    server.expect().withPath("/oapi/v1/namespaces/test/templates").andReturn(200, new TemplateListBuilder().build()).once();
-    server.expect().withPath("/oapi/v1/namespaces/ns1/templates").andReturn(200, new TemplateListBuilder()
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates").andReturn(200, new TemplateListBuilder().build()).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/ns1/templates").andReturn(200, new TemplateListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).once();
     server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
@@ -94,7 +94,7 @@ public class TemplateTest {
   public void testListWithParams() throws IOException {
     String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-list-with-number-params.json"));
 
-    server.expect().withPath("/oapi/v1/namespaces/test/templates").andReturn(200, json).always();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates").andReturn(200, json).always();
 
     OpenShiftClient client = server.getOpenshiftClient();
 
@@ -109,11 +109,11 @@ public class TemplateTest {
 
   @Test
   public void testGet() {
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
       .withNewMetadata().withName("tmpl1").endMetadata()
       .build()).once();
 
-    server.expect().withPath("/oapi/v1/namespaces/ns1/templates/tmpl2").andReturn(200, new TemplateBuilder()
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/ns1/templates/tmpl2").andReturn(200, new TemplateBuilder()
       .withNewMetadata().withName("tmpl2").endMetadata()
       .build()).once();
 
@@ -134,8 +134,8 @@ public class TemplateTest {
 
   @Test
   public void testDelete() {
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder().build()).once();
-    server.expect().withPath("/oapi/v1/namespaces/ns1/templates/tmpl2").andReturn(200, new TemplateBuilder().build()).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder().build()).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/ns1/templates/tmpl2").andReturn(200, new TemplateBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 
@@ -158,8 +158,8 @@ public class TemplateTest {
       .endMetadata()
       .build();
 
-    server.expect().withPath("/oapi/v1/namespaces/test/templates").andReturn(200, template).once();
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl3").andReturn(404, new StatusBuilder().withCode(404).build()).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates").andReturn(200, template).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl3").andReturn(404, new StatusBuilder().withCode(404).build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 
@@ -170,8 +170,8 @@ public class TemplateTest {
 
   @Test
   public void testProcess() {
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder().build()).once();
-    server.expect().withPath("/oapi/v1/namespaces/test/processedtemplates").andReturn(201, new KubernetesListBuilder().build()).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder().build()).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/processedtemplates").andReturn(201, new KubernetesListBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
     KubernetesList list = client.templates().withName("tmpl1").process(new ParameterValue("name1", "value1"));
@@ -209,7 +209,7 @@ public class TemplateTest {
   @Test
   public void testLoadParameterizedNumberTemplate() throws IOException {
     String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-with-number-params.json"));
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
 
     Map<String, String> map = new HashMap<>();
     map.put("PORT", "8080");
@@ -223,7 +223,7 @@ public class TemplateTest {
   @Test
   public void testProcessParameterizedNumberTemplate() throws IOException {
     String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-with-number-params.json"));
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
 
     Map<String, String> map = new HashMap<>();
     map.put("PORT", "8080");
@@ -235,7 +235,7 @@ public class TemplateTest {
 
   @Test
   public void testNullParameterMapValueShouldNotThrowNullPointerException() {
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
       .withNewMetadata().withName("tmpl1").endMetadata()
       .withParameters(new ParameterBuilder().withName("key").build())
       .build()).once();
@@ -247,7 +247,7 @@ public class TemplateTest {
 
   @Test
   public void testEmptyParameterMapValueShouldNotThrowNullPointerException() {
-    server.expect().withPath("/oapi/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
+    server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
       .withNewMetadata().withName("tmpl1").endMetadata()
       .withParameters(new ParameterBuilder().withName("key").build())
       .build()).once();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserTest.java
@@ -42,20 +42,6 @@ public class UserTest {
    server.expect().withPath("/apis/user.openshift.io/v1/users").andReturn(200, new UserListBuilder()
       .addNewItem().and()
       .addNewItem().and().build()).always();
-   server.expect().withPath("/oapi/v1/users").andReturn(200, new UserListBuilder()
-      .addNewItem().and()
-      .addNewItem().and().build()).always();
-   server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
-      .addNewGroup()
-      .withApiVersion("v1")
-      .withName("autoscaling.k8s.io")
-      .endGroup()
-      .addNewGroup()
-      .withApiVersion("v1")
-      .withName("security.openshift.io")
-      .endGroup()
-      .build()).always();
-
 
     NamespacedOpenShiftClient client = server.getOpenshiftClient();
 
@@ -72,11 +58,11 @@ public class UserTest {
 
   @Test
   public void testGet() {
-   server.expect().withPath("/oapi/v1/users/user1").andReturn(200, new UserBuilder()
+   server.expect().withPath("/apis/user.openshift.io/v1/users/user1").andReturn(200, new UserBuilder()
       .withNewMetadata().withName("user1").endMetadata()
       .build()).once();
 
-   server.expect().withPath("/oapi/v1/users/User2").andReturn(200, new UserBuilder()
+   server.expect().withPath("/apis/user.openshift.io/v1/users/User2").andReturn(200, new UserBuilder()
       .withNewMetadata().withName("User2").endMetadata()
       .build()).once();
 
@@ -97,8 +83,8 @@ public class UserTest {
 
   @Test
   public void testDelete() {
-   server.expect().withPath("/oapi/v1/users/user1").andReturn(200, new UserBuilder().build()).once();
-   server.expect().withPath("/oapi/v1/users/User2").andReturn( 200, new UserBuilder().build()).once();
+   server.expect().withPath("/apis/user.openshift.io/v1/users/user1").andReturn(200, new UserBuilder().build()).once();
+   server.expect().withPath("/apis/user.openshift.io/v1/users/User2").andReturn( 200, new UserBuilder().build()).once();
 
     OpenShiftClient client = server.getOpenshiftClient();
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -63,18 +63,15 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
 
   @Override
   public URL getRootUrl() {
-    OpenShiftConfig config = OpenShiftConfig.wrap(context.getConfig());
-    OpenShiftClient oc = new DefaultOpenShiftClient(context.getClient(), config);
-    if (config.isOpenShiftAPIGroups(oc)) {
-      oc.close();
-      return super.getRootUrl();
-    } else {
-      oc.close();
+    // This is an OpenShift resource. If no API Group Name is specified, use /oapi endpoint
+    if (Utils.isNullOrEmpty(context.getApiGroupName())) {
       try {
         return new URL(OpenShiftConfig.wrap(getConfig()).getOpenShiftUrl());
       } catch (MalformedURLException e) {
         throw KubernetesClientException.launderThrowable(e);
       }
+    } else {
+      return super.getRootUrl();
     }
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ProjectRequestsOperationImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ProjectRequestsOperationImpl.java
@@ -17,12 +17,9 @@ package io.fabric8.openshift.client.dsl.internal;
 
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.utils.URLUtils;
-import io.fabric8.openshift.client.DefaultOpenShiftClient;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.OpenshiftAdapterSupport;
+import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import io.fabric8.kubernetes.api.builder.Function;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
@@ -38,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 
 import static io.fabric8.openshift.client.OpenShiftAPIGroups.PROJECT;
 
+// TODO: Check why this class does not extend OpenshiftOperation, then the getRoot method can be removed
 public class ProjectRequestsOperationImpl extends OperationSupport implements ProjectRequestOperation {
 
   public ProjectRequestsOperationImpl(OkHttpClient client, OpenShiftConfig config) {
@@ -56,18 +54,15 @@ public class ProjectRequestsOperationImpl extends OperationSupport implements Pr
 
   @Override
   public URL getRootUrl() {
-    OpenShiftConfig config = OpenShiftConfig.wrap(context.getConfig());
-    OpenShiftClient oc = new DefaultOpenShiftClient(context.getClient(), config);
-    if (config.isOpenShiftAPIGroups(oc)) {
-      oc.close();
-      return super.getRootUrl();
-    } else {
-      oc.close();
+    // This is an OpenShift resource. If no API Group Name is specified, use /oapi endpoint
+    if (Utils.isNullOrEmpty(context.getApiGroupName())) {
       try {
         return new URL(OpenShiftConfig.wrap(getConfig()).getOpenShiftUrl());
       } catch (MalformedURLException e) {
         throw KubernetesClientException.launderThrowable(e);
       }
+    } else {
+      return super.getRootUrl();
     }
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/SubjectAccessReviewOperationImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/SubjectAccessReviewOperationImpl.java
@@ -24,8 +24,6 @@ import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.openshift.api.model.*;
 import io.fabric8.openshift.api.model.LocalSubjectAccessReviewBuilder;
 import io.fabric8.openshift.api.model.SubjectAccessReviewBuilder;
-import io.fabric8.openshift.client.DefaultOpenShiftClient;
-import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.*;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -41,6 +39,7 @@ import java.util.concurrent.ExecutionException;
 
 import static io.fabric8.openshift.client.OpenShiftAPIGroups.AUTHORIZATION;
 
+// TODO: Check why this class does not extend OpenshiftOperation, then the getRoot method can be removed
 public class SubjectAccessReviewOperationImpl extends OperationSupport implements SubjectAccessReviewOperation<CreateableSubjectAccessReview, CreateableLocalSubjectAccessReview, CreateableSelfSubjectAccessReview, CreateableSelfSubjectRulesReview> {
 
   public SubjectAccessReviewOperationImpl(OkHttpClient client, OpenShiftConfig config) {
@@ -69,18 +68,15 @@ public class SubjectAccessReviewOperationImpl extends OperationSupport implement
 
   @Override
   public URL getRootUrl() {
-    OpenShiftConfig config = OpenShiftConfig.wrap(context.getConfig());
-    OpenShiftClient oc = new DefaultOpenShiftClient(context.getClient(), config);
-    if (config.isOpenShiftAPIGroups(oc)) {
-      oc.close();
-      return super.getRootUrl();
-    } else {
-      oc.close();
+    // This is an OpenShift resource. If no API Group Name is specified, use /oapi endpoint
+    if (Utils.isNullOrEmpty(context.getApiGroupName())) {
       try {
         return new URL(OpenShiftConfig.wrap(getConfig()).getOpenShiftUrl());
       } catch (MalformedURLException e) {
         throw KubernetesClientException.launderThrowable(e);
       }
+    } else {
+      return super.getRootUrl();
     }
   }
 


### PR DESCRIPTION
Template and other openshift-related resource operations may use the /apis endpoint if and only if the API Group name is specified. If for some reason the API Group Name is not declared (for example, a Template object with apiVersion:v1), then the /oapi endpoint is used.

Fixes #1684