### PR TITLE
Endpoints should stay pluralized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.4-SNAPSHOT
   Bugs
+  * Fix #1690: Endpoints is always pluralized
 
   Improvements
 

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -160,7 +160,8 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
           kind.equalsIgnoreCase("NetworkPolicies")){
           kind = kind.substring(0,kind.length() - 3) + "y";
         }
-        else if (kind.equalsIgnoreCase("securityContextConstraints")){
+        else if (kind.equalsIgnoreCase("securityContextConstraints") ||
+          kind.equalsIgnoreCase("endpoints")){
           // do nothing
           // because its a case which is ending with s but its name is
           // like that, it is not plural

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
@@ -133,6 +133,17 @@ public class KubernetesAttributesExtractorTest {
   }
 
   @Test
+  public void shouldHandleEndpoints() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    AttributeSet attributes = extractor.extract("/api/v1/namespaces/myns/endpoints");
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("kind", "endpoints"));
+    expected = expected.add(new Attribute("namespace", "myns"));
+    Assert.assertTrue("Expected " + attributes + " to match " + expected, attributes.matches(expected));
+  }
+
+  @Test
   public void shouldHandleIngresses() {
     KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
     AttributeSet attributes = extractor.extract("/apis/extensions/v1beta1/namespaces/myns/ingresses");


### PR DESCRIPTION
Mock web server is currently removing the trailing s from endpoints when searching for objects in the API. This prevents it from finding created endpoints. Adding endpoints to the exception list of objects to be considered pluralized.