### PR TITLE
Add admissionregistration to Packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ####  Bugs
   * Fix #1690: Endpoints is always pluralized
   * Fix #1684: Fixed URL resolution algorithm for OpenShift resources without API Group name
+  * FIX #1706: Fixed Add admissionregistration to Packages.
 
 #### Improvements
   * Fix #1650: Introduced `kubernetes.disable.autoConfig` system property to disable auto configuration in Config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.4-SNAPSHOT
 #### Bugs
+  * Fix #1706: admissionregistration resources are now parsed correctly
 
 #### Improvements
 
@@ -14,7 +15,6 @@
 ####  Bugs
   * Fix #1690: Endpoints is always pluralized
   * Fix #1684: Fixed URL resolution algorithm for OpenShift resources without API Group name
-  * FIX #1706: Fixed Add admissionregistration to Packages.
 
 #### Improvements
   * Fix #1650: Introduced `kubernetes.disable.autoConfig` system property to disable auto configuration in Config

--- a/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -55,6 +55,7 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
 
         PACKAGES = new ArrayList<String>(){{
             add("io.fabric8.kubernetes.api.model.");
+            add("io.fabric8.kubernetes.api.model.admissionregistration.");
             add("io.fabric8.kubernetes.api.model.apiextensions.");
             add("io.fabric8.kubernetes.api.model.apps.");
             add("io.fabric8.kubernetes.api.model.authentication.");

--- a/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/MutatingWebhookConfigurationTest.java
+++ b/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/MutatingWebhookConfigurationTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model;
+
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.fabric8.kubernetes.api.model.admissionregistration.MutatingWebhookConfiguration;
+
+public class MutatingWebhookConfigurationTest {
+ 
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void kubernetesMutatingWebhookConfigurationTest() throws Exception {
+        // given
+        final String originalJson = Helper.loadJson("/valid-mutating-webhook-configuration.json");
+
+        // when
+        final MutatingWebhookConfiguration kubernetesMutatingWebhookConfiguration = mapper.readValue(originalJson, MutatingWebhookConfiguration.class);
+        final String serializedJson = mapper.writeValueAsString(kubernetesMutatingWebhookConfiguration);
+
+        // then
+        assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
+                .isEqualTo(originalJson);
+    }
+}

--- a/kubernetes-model/kubernetes-model/src/test/resources/valid-mutating-webhook-configuration.json
+++ b/kubernetes-model/kubernetes-model/src/test/resources/valid-mutating-webhook-configuration.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": "admissionregistration.k8s.io/v1beta1",
+  "kind": "MutatingWebhookConfiguration",
+  "metadata": {
+    "name": "istio-sidecar-injector",
+    "namespace": "istio-system",
+    "labels": {
+      "app": "sidecarInjectorWebhook",
+      "chart": "sidecarInjectorWebhook",
+      "heritage": "Tiller",
+      "release": "istio"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "sidecar-injector.istio.io",
+      "clientConfig": {
+        "service": {
+          "name": "istio-sidecar-injector",
+          "namespace": "istio-system",
+          "path": "/inject"
+        },
+        "caBundle": ""
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE"
+          ],
+          "apiGroups": [
+            ""
+          ],
+          "apiVersions": [
+            "v1"
+          ],
+          "resources": [
+            "pods"
+          ]
+        }
+      ],
+      "failurePolicy": "Fail",
+      "namespaceSelector": {
+        "matchLabels": {
+          "istio-injection": "enabled"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When trying to parse this file:

```yaml
apiVersion: admissionregistration.k8s.io/v1beta1
kind: MutatingWebhookConfiguration
metadata:
  name: istio-sidecar-injector
  namespace: istio-system
  labels:
    app: sidecarInjectorWebhook
    chart: sidecarInjectorWebhook
    heritage: Tiller
    release: istio
webhooks:
  - name: sidecar-injector.istio.io
    clientConfig:
      service:
        name: istio-sidecar-injector
        namespace: istio-system
        path: "/inject"
      caBundle: ""
    rules:
      - operations: [ "CREATE" ]
        apiGroups: [""]
        apiVersions: ["v1"]
        resources: ["pods"]
    failurePolicy: Fail
    namespaceSelector:
      matchLabels:
        istio-injection: enabled
```

We get the following error:

```
com.fasterxml.jackson.databind.JsonMappingException: No resource type found for:admissionregistration.k8s.io/v1beta1#MutatingWebhookConfiguration
 at [Source: (BufferedInputStream); line: 30, column: 1]
```
