### PR TITLE
Fixed deserialize of `IntOrString` with correct `Kind` instead of `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.4-SNAPSHOT
 #### Bugs
   * Fix #1706: admissionregistration resources are now parsed correctly
+  * Fixed deserialize of `IntOrString` with correct `Kind` instead of `null`
 
 #### Improvements
 

--- a/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/IntOrString.java
+++ b/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/IntOrString.java
@@ -159,16 +159,24 @@ public class IntOrString implements Serializable {
         @Override
         public void serialize(IntOrString value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
             if (value != null) {
-                Integer intValue = value.getIntVal();
-                if (intValue != null) {
-                    jgen.writeNumber(intValue);
-                } else {
-                    String stringValue = value.getStrVal();
-                    if (stringValue != null) {
-                        jgen.writeString(stringValue);
+                if (value.getKind() == null) {
+                    Integer intValue = value.getIntVal();
+                    if (intValue != null) {
+                        jgen.writeNumber(intValue);
                     } else {
-                        jgen.writeNull();
+                        String stringValue = value.getStrVal();
+                        if (stringValue != null) {
+                            jgen.writeString(stringValue);
+                        } else {
+                            jgen.writeNull();
+                        }
                     }
+                } else if (value.getKind() == 0) {
+                    jgen.writeNumber(value.getIntVal());
+                } else if (value.getKind() == 1) {
+                    jgen.writeString(value.getStrVal());
+                } else {
+                    jgen.writeNull();
                 }
             } else {
                 jgen.writeNull();
@@ -183,11 +191,11 @@ public class IntOrString implements Serializable {
         public IntOrString deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JsonProcessingException {
             ObjectCodec oc = jsonParser.getCodec();
             JsonNode node = oc.readTree(jsonParser);
-            IntOrString intOrString = new IntOrString();
+            IntOrString intOrString;
             if (node.isInt()) {
-                intOrString.setIntVal(node.asInt());
+                intOrString = new IntOrString(node.asInt());
             } else {
-                intOrString.setStrVal(node.asText());
+                intOrString = new IntOrString(node.asText());
             }
             return intOrString;
         }

--- a/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/IntOrStringTest.java
+++ b/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/IntOrStringTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IntOrStringTest {
+
+    @Test
+    public void testIntOrStringJson() throws IOException {
+        IntOrString is = new IntOrString(3000);
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(is);
+        IntOrString is2 = mapper.readValue(json, IntOrString.class);
+        assertEquals(is, is2);
+
+        is = new IntOrString("3000");
+        json = mapper.writeValueAsString(is);
+        is2 = mapper.readValue(json, IntOrString.class);
+        assertEquals(is, is2);
+    }
+}


### PR DESCRIPTION
when I use `kubernetes-client` to fetch some resource in kubernetes, especially for `Ingress` or `Service`, the port in that is with type `IntOrString`, and with field `Kind` value `null`. This bring on many troubles.
