### PR TITLE
fixes portforwarding when there are more services with the same name in multiple namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.4-SNAPSHOT
 #### Bugs
   * Fix #1706: admissionregistration resources are now parsed correctly
+  * Fix #1722: Service port forward are now done in the correct namespace
 
 #### Improvements
   * Test coverage for HorizontalPodAutoscaler

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
@@ -132,7 +132,7 @@ public class ServiceOperationsImpl extends HasMetadataOperation<Service, Service
   private Pod matchingPod() {
     Service item = fromServer().get();
     Map<String, String> labels = item.getSpec().getSelector();
-    PodList list = new PodOperationsImpl(client, config).withLabels(labels).list();
+    PodList list = new PodOperationsImpl(client, config).inNamespace(item.getMetadata().getNamespace()).withLabels(labels).list();
     return list.getItems().stream().findFirst().orElseThrow(() -> new IllegalStateException("Could not find matching pod for service:" + item + "."));
   }
 


### PR DESCRIPTION
I encountered an incorrect port forwarding (on service) when I had more than one namespace. In each namespace there were services with the same name. When I called portForward on service it randomly chose one of these services instead of the service with current namespace.
This pull request should remedy this behaviour.