### PR TITLE
Fix #1674: Cascade delete can't be overriden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.4-SNAPSHOT
 #### Bugs
   * Fix #1730: Fix failing build on jdk11
+  * Fix #1634: Cascade delete can't be overriden
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -112,13 +112,13 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
 
   @Override
   public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), is, null, false) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), is, null, true) {
     };
   }
 
   @Override
   public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(KubernetesResourceList item) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, null, null, -1, false) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, null, null, -1, true) {
     };
   }
 
@@ -134,20 +134,20 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
 
   @Override
   public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), s, null, null, -1, false) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), s, null, null, -1, true) {
     };
   }
 
 
   @Override
   public NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<HasMetadata, Boolean> resource(HasMetadata item) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, -1, false) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), item, -1, true) {
     };
   }
 
   @Override
   public NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<HasMetadata, Boolean> resource(String s) {
-    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), s, -1, false) {
+    return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<Visitor>(), s, -1, true) {
     };
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterRoleBindingOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterRoleBindingOperationsImpl.java
@@ -27,7 +27,11 @@ import okhttp3.OkHttpClient;
 public class ClusterRoleBindingOperationsImpl extends HasMetadataOperation<ClusterRoleBinding, ClusterRoleBindingList, DoneableClusterRoleBinding, Resource<ClusterRoleBinding, DoneableClusterRoleBinding>> {
 
   public ClusterRoleBindingOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public ClusterRoleBindingOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public ClusterRoleBindingOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterRoleOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterRoleOperationsImpl.java
@@ -28,7 +28,11 @@ import okhttp3.OkHttpClient;
 public class ClusterRoleOperationsImpl extends HasMetadataOperation<ClusterRole, ClusterRoleList, DoneableClusterRole, Resource<ClusterRole, DoneableClusterRole>> {
 
   public ClusterRoleOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public ClusterRoleOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public ClusterRoleOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ComponentStatusOperationsImpl.java
@@ -32,7 +32,11 @@ public class ComponentStatusOperationsImpl extends HasMetadataOperation<Componen
   Resource<ComponentStatus, DoneableComponentStatus>> {
 
   public ComponentStatusOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public ComponentStatusOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public ComponentStatusOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CronJobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CronJobOperationsImpl.java
@@ -33,7 +33,11 @@ import java.util.TreeMap;
 public class CronJobOperationsImpl extends HasMetadataOperation<CronJob, CronJobList, DoneableCronJob, Resource<CronJob, DoneableCronJob>> {
 
   public CronJobOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public CronJobOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public CronJobOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceDefinitionOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceDefinitionOperationsImpl.java
@@ -31,7 +31,11 @@ public class CustomResourceDefinitionOperationsImpl extends HasMetadataOperation
 
 
   public CustomResourceDefinitionOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public CustomResourceDefinitionOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public CustomResourceDefinitionOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
@@ -48,7 +48,11 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   static final transient Logger LOG = LoggerFactory.getLogger(DeploymentOperationsImpl.class);
 
   public DeploymentOperationsImpl(OkHttpClient client, Config config) {
-    this(new RollingOperationContext().withOkhttpClient(client).withConfig(config).withCascading(true));
+    this(client, config, null);
+  }
+
+  public DeploymentOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new RollingOperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace).withCascading(true));
     if (config.getNamespace() != null) {
       this.namespace = config.getNamespace();
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/JobOperationsImpl.java
@@ -43,7 +43,11 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Doneab
   static final transient Logger LOG = LoggerFactory.getLogger(JobOperationsImpl.class);
 
   public JobOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config).withCascading(true));
+    this(client, config, null);
+  }
+
+  public JobOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace).withCascading(true));
   }
 
   public JobOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/MutatingWebhookConfigurationOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/MutatingWebhookConfigurationOperationsImpl.java
@@ -31,6 +31,10 @@ public class MutatingWebhookConfigurationOperationsImpl extends HasMetadataOpera
     this(new OperationContext().withOkhttpClient(client).withConfig(config));
   }
 
+  public MutatingWebhookConfigurationOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
+  }
+
   public MutatingWebhookConfigurationOperationsImpl(OperationContext context) {
     super(context.withApiGroupName("admissionregistration.k8s.io")
       .withApiGroupVersion("v1beta1")

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceOperationsImpl.java
@@ -27,7 +27,11 @@ import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 public class NamespaceOperationsImpl  extends HasMetadataOperation<Namespace, NamespaceList, DoneableNamespace, Resource<Namespace, DoneableNamespace>> {
 
   public NamespaceOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public NamespaceOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(null));
   }
 
   public NamespaceOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NodeOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NodeOperationsImpl.java
@@ -27,7 +27,11 @@ import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 public class NodeOperationsImpl extends HasMetadataOperation<Node, NodeList, DoneableNode, Resource<Node, DoneableNode>> {
 
   public NodeOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public NodeOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public NodeOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PersistentVolumeOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PersistentVolumeOperationsImpl.java
@@ -28,7 +28,11 @@ public class PersistentVolumeOperationsImpl
   extends HasMetadataOperation<PersistentVolume, PersistentVolumeList, DoneablePersistentVolume, Resource<PersistentVolume, DoneablePersistentVolume>> {
 
   public PersistentVolumeOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public PersistentVolumeOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public PersistentVolumeOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
@@ -91,7 +91,11 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
     private final Integer bufferSize;
 
   public PodOperationsImpl(OkHttpClient client, Config config) {
-    this(new PodOperationContext().withOkhttpClient(client).withConfig(config).withCascading(true));
+    this(client, config, null);
+  }
+
+  public PodOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new PodOperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace).withCascading(true));
   }
 
   public PodOperationsImpl(PodOperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodSecurityPolicyOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodSecurityPolicyOperationsImpl.java
@@ -27,7 +27,11 @@ import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 public class PodSecurityPolicyOperationsImpl extends HasMetadataOperation<PodSecurityPolicy, PodSecurityPolicyList, DoneablePodSecurityPolicy, Resource<PodSecurityPolicy, DoneablePodSecurityPolicy>>{
 
   public PodSecurityPolicyOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public PodSecurityPolicyOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public PodSecurityPolicyOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PriorityClassOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PriorityClassOperationsImpl.java
@@ -28,7 +28,11 @@ import okhttp3.OkHttpClient;
 public class PriorityClassOperationsImpl extends HasMetadataOperation<PriorityClass, PriorityClassList, DoneablePriorityClass, Resource<PriorityClass, DoneablePriorityClass>> {
 
   public PriorityClassOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public PriorityClassOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public PriorityClassOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicaSetOperationsImpl.java
@@ -36,7 +36,11 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
   implements TimeoutImageEditReplacePatchable<ReplicaSet, ReplicaSet, DoneableReplicaSet> {
 
   public ReplicaSetOperationsImpl(OkHttpClient client, Config config) {
-    this(new RollingOperationContext().withOkhttpClient(client).withConfig(config).withCascading(true));
+    this(client, config, null);
+  }
+
+  public ReplicaSetOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new RollingOperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace).withCascading(true));
   }
 
   public ReplicaSetOperationsImpl(RollingOperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ReplicationControllerOperationsImpl.java
@@ -37,6 +37,10 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   implements TimeoutImageEditReplacePatchable<ReplicationController, ReplicationController, DoneableReplicationController> {
 
   public ReplicationControllerOperationsImpl(OkHttpClient client, Config config) {
+    this(client, config, null);
+  }
+
+  public ReplicationControllerOperationsImpl(OkHttpClient client, Config config, String namespace) {
     this(new RollingOperationContext().withOkhttpClient(client).withConfig(config).withCascading(true));
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
@@ -40,7 +40,11 @@ import java.util.concurrent.TimeUnit;
 public class ServiceOperationsImpl extends HasMetadataOperation<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> implements ServiceResource<Service, DoneableService> {
 
   public ServiceOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public ServiceOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public ServiceOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StatefulSetOperationsImpl.java
@@ -36,7 +36,11 @@ public class StatefulSetOperationsImpl extends RollableScalableResourceOperation
   implements TimeoutImageEditReplacePatchable<StatefulSet, StatefulSet, DoneableStatefulSet>
 {
   public StatefulSetOperationsImpl(OkHttpClient client, Config config) {
-    this(new RollingOperationContext().withOkhttpClient(client).withConfig(config).withCascading(true));
+    this(client, config, null);
+  }
+
+  public StatefulSetOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new RollingOperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace).withCascading(true));
   }
 
   public StatefulSetOperationsImpl(RollingOperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StorageClassOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/StorageClassOperationsImpl.java
@@ -27,7 +27,11 @@ import okhttp3.OkHttpClient;
 public class StorageClassOperationsImpl extends HasMetadataOperation<StorageClass, StorageClassList, DoneableStorageClass, Resource<StorageClass, DoneableStorageClass>> {
 
   public StorageClassOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public StorageClassOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public StorageClassOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ValidatingWebhookConfigurationOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ValidatingWebhookConfigurationOperationsImpl.java
@@ -36,7 +36,11 @@ import java.util.TreeMap;
 public class ValidatingWebhookConfigurationOperationsImpl extends HasMetadataOperation<ValidatingWebhookConfiguration, ValidatingWebhookConfigurationList, DoneableValidatingWebhookConfiguration, Resource<ValidatingWebhookConfiguration, DoneableValidatingWebhookConfiguration>> {
 
   public ValidatingWebhookConfigurationOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public ValidatingWebhookConfigurationOperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public ValidatingWebhookConfigurationOperationsImpl(OperationContext context) {

--- a/kubernetes-client/src/main/resources/resource-handler.vm
+++ b/kubernetes-client/src/main/resources/resource-handler.vm
@@ -98,11 +98,7 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
 
   @Override
   public Boolean delete(OkHttpClient client, Config config, String namespace, Boolean cascading, ${model.name} item) {
-    if(cascading) {
-      return new ${model.name}OperationsImpl(client, config).withItem(item).cascading(cascading).delete();
-    } else {
-      return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).delete(item);
-    }
+    return new ${model.name}OperationsImpl(client, config, namespace).withItem(item).cascading(cascading).delete();
   }
 
   @Override

--- a/kubernetes-client/src/main/resources/resource-operation.vm
+++ b/kubernetes-client/src/main/resources/resource-operation.vm
@@ -65,7 +65,11 @@ import java.util.TreeMap;
 public class ${model.name}OperationsImpl extends HasMetadataOperation<${model.name}, ${model.name}List, Doneable${model.name}, Resource<${model.name}, Doneable${model.name}>> {
 
   public ${model.name}OperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this(client, config, null);
+  }
+
+  public ${model.name}OperationsImpl(OkHttpClient client, Config config, String namespace) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace));
   }
 
   public ${model.name}OperationsImpl(OperationContext context) {


### PR DESCRIPTION
Fix #1674 

@dsimansk : I've tested this on the following scenarios

1.
```
      client.resource(aResource).withGracePeriod(0).cascading(true).delete();
```
Cascade deletion is performed since it's explicitly specified

2.
```
      client.resource(nginxDeployment).withGracePeriod(0).cascading(false).delete();
```
Cascade deletion is not performed 
3.
```
      client.resource(nginxDeployment).withGracePeriod(0).delete();
```
Cascade deletion is performed since it's default behavior in `kubectl ` also

4.
```
      client.apps().deployments().inNamespace("default").withName("nginx").cascading(false).delete();
```
Cascade deletion is not performed since it's overriden by dsl

5.
```
      client.apps().deployments().inNamespace("default").withName("nginx").delete();
```
Cascade deletion is performed since it's like that in `kubectl` also

6.
```
      client.apps().deployments().inNamespace("default").withName("nginx").cascading(true).delete();
```
Cascade deletion is perfomed.