### PR TITLE
Remove lexicographic resource version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   * Fix #1730: Fix failing build on jdk11
   * Fix #1634: Cascade delete can't be overriden
   * Fixed Knative model so that it recognizes Container and Volume types as Buildable.
+  * Remove lexicographic resource version check in WatchHTTPManager
 
 #### Improvements
   * Added in kubernetes-server-mock (CRUD) the withoutLabel filter and respective tests


### PR DESCRIPTION
Also makes the handling of resourceVersion in WatchHTTPManager identical to that of WatchConnectionManager.