### PR TITLE
Add support for EXISTS/NOT_EXISTS filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 #### Bugs
 
 #### Improvements
-
+* Add support for filtering labels by EXISTS/NOT_EXISTS via the single argument versions of `.withLabel` and `.withoutLabel`
 #### Dependency Upgrade
 
 #### New Feature

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
     <jackson.version>2.9.9</jackson.version>
     <jackson.version.databind>2.9.9.3</jackson.version.databind>
-    <mockwebserver.version>0.1.6</mockwebserver.version>
+    <mockwebserver.version>0.1.7</mockwebserver.version>
 
     <!-- API versions -->
     <jsr305.version>3.0.2</jsr305.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
     <jackson.version>2.9.9</jackson.version>
     <jackson.version.databind>2.9.9.3</jackson.version.databind>
-    <mockwebserver.version>0.1.4</mockwebserver.version>
+    <mockwebserver.version>0.1.5-SNAPSHOT</mockwebserver.version>
 
     <!-- API versions -->
     <jsr305.version>3.0.2</jsr305.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
     <jackson.version>2.9.9</jackson.version>
     <jackson.version.databind>2.9.9.3</jackson.version.databind>
-    <mockwebserver.version>0.1.5-SNAPSHOT</mockwebserver.version>
+    <mockwebserver.version>0.1.6</mockwebserver.version>
 
     <!-- API versions -->
     <jsr305.version>3.0.2</jsr305.version>


### PR DESCRIPTION
This uses the types exposed in https://github.com/fabric8io/mockwebserver/pull/45 to implement EXISTS/NOT_EXISTS filtering of labels via the single argument overloads of the `.withLabel` and `.withoutLabel` methods.