### PR TITLE
Utils.waitUntilReady should record the stack trace of the caller before rethrowing an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #1782: Informer Deadlock; Fix lock typo in SharedProcessor
 
 #### Improvements
+* Fix #1797: Utils.waitUntilReady should record the stack trace of the caller before rethrowing an exception
 * Add support for filtering labels by EXISTS/NOT_EXISTS via the single argument versions of `.withLabel` and `.withoutLabel`
 * Schedule reconnect in case of HTTP_GONE when watching; the rescheduled connect will start from beginning of history by not specifying resourceVersion
 #### Dependency Upgrade

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -130,7 +130,9 @@ public class Utils {
       if (obj instanceof Boolean) {
         return (Boolean) obj;
       } else if (obj instanceof Throwable) {
-        throw (Throwable) obj;
+        Throwable t = (Throwable) obj;
+        t.addSuppressed(new Throwable("waiting here"));
+        throw t;
       }
       return false;
     } catch (Throwable t) {


### PR DESCRIPTION
I had a situation where one method in my code called a second, which called a third, which called `Watchable.watch`, and I _think_ `watch` threw up an exception (in this case due to an RBAC mistake) which was caught ultimately in my first method (according to the method name recorded by `java.util.logging`)…but it was hard to tell for sure since the stack trace including `watch` was nowhere to be seen:

```
io.fabric8.kubernetes.client.KubernetesClientException: deployments.apps "etc" is forbidden: User "system:serviceaccount:somens:someacct" cannot watch resource "deployments" in API group "apps" in the namespace "somens"
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onFailure(WatchConnectionManager.java:206)
	at okhttp3.internal.ws.RealWebSocket.failWebSocket(RealWebSocket.java:571)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:198)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Poking around, my guess is that the problem is that `Utils.waitUntilReady` is taking this exception thrown and caught in some thread pool and rethrowing it to its caller. Somehow the caller’s stack trace needs to be included.

(Another idiom is to wrap the original exception in a new exception using `cause`, but that forces you to pick a type for the wrapper; using `addSuppressed` avoids that issue.)

----

I had hoped to test this change against the original reproduced problem; unfortunately I did not manage to compile this project, getting seemingly different puzzling errors from Maven or javac each time, like

```
Generating: …/fabric8io/kubernetes-client/kubernetes-model/kubernetes-model/target/classes/kubernetes.properties
Generating: …/fabric8io/kubernetes-client/kubernetes-model/kubernetes-model/target/classes/openshift.properties
An exception has occurred in the compiler (1.8.0_222). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program and the following diagnostic in your report. Thank you.
java.lang.IllegalStateException: endPosTable already set
	at com.sun.tools.javac.util.DiagnosticSource.setEndPosTable(DiagnosticSource.java:136)
	at com.sun.tools.javac.util.Log.setEndPosTable(Log.java:350)
	at com.sun.tools.javac.main.JavaCompiler.parse(JavaCompiler.java:667)
	at com.sun.tools.javac.main.JavaCompiler.parseFiles(JavaCompiler.java:950)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.<init>(JavacProcessingEnvironment.java:900)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.next(JavacProcessingEnvironment.java:929)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1195)
	at com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1170)
	at com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:856)
	at com.sun.tools.javac.main.Main.compile(Main.java:523)
	at com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:129)
	at com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:138)
	at org.codehaus.plexus.compiler.javac.JavaxToolsCompiler.compileInProcess(JavaxToolsCompiler.java:126)
	at org.codehaus.plexus.compiler.javac.JavacCompiler.performCompile(JavacCompiler.java:174)
	at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:1134)
	at org.apache.maven.plugin.compiler.CompilerMojo.execute(CompilerMojo.java:187)
	at …
```

or

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project kubernetes-model: Compilation failure: Compilation failure: 
[ERROR] …/fabric8io/kubernetes-client/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/openshift/api/model/Template.java:[105,18] cannot find symbol
[ERROR]   symbol:   class Parameter
[ERROR]   location: class io.fabric8.openshift.api.model.Template
```

or

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project kubernetes-client: Fatal error compiling: java.lang.RuntimeException: java.io.FileNotFoundException: resource-handler-services.vm -> [Help 1]
```