### PR TITLE
Check if BouncyCastle provider is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.6-SNAPSHOT
 #### Bugs
+* Fix #1796: Check if BouncyCastle provider is set
 * Fix #1724: createOrReplace function does not work properly for Custom defined resources
 * Fix #1789: Create or replace on operation seems broken
 * Fix #1782: Informer Deadlock; Fix lock typo in SharedProcessor

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
@@ -143,7 +143,9 @@ public class CertUtils {
         @Override
         public PrivateKey call() {
           try {
-            Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+            if (Security.getProvider("BC") == null) {
+              Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+            }
             PEMKeyPair keys = (PEMKeyPair) new PEMParser(new InputStreamReader(keyInputStream)).readObject();
             return new
               JcaPEMKeyConverter().


### PR DESCRIPTION
bcpkix-jdk15on have only 400kb instead of 4.5MB from bcprov-ext-jdk15on

With this check we can take advantage of a BouncyCastleProvider that is already set (for example by the jenkins plugin bouncycastle-api)