### PR TITLE
chore(deps): use Jackson BOM 2.9.10

### DIFF
--- a/extensions/service-catalog/client/pom.xml
+++ b/extensions/service-catalog/client/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.6.3</version>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/service-catalog/model/pom.xml
+++ b/extensions/service-catalog/model/pom.xml
@@ -56,7 +56,6 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <felix.scr.annotations.version>1.9.8</felix.scr.annotations.version>
-    <jackson.version>2.6.3</jackson.version>
     <log4j.version>2.3</log4j.version>
     <mockwebserver.version>0.1.4</mockwebserver.version>
 
@@ -120,11 +119,6 @@
             <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-jaxb-annotations</artifactId>
-        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>io.sundr</groupId>

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -182,17 +182,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version.databind}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>

--- a/kubernetes-model/pom.xml
+++ b/kubernetes-model/pom.xml
@@ -61,11 +61,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-jaxb-annotations</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
         <groupId>io.sundr</groupId>
         <artifactId>builder-annotations</artifactId>
         <version>${sundrio.version}</version>

--- a/platforms/karaf/features/src/main/resources/feature.xml
+++ b/platforms/karaf/features/src/main/resources/feature.xml
@@ -19,9 +19,9 @@
 
   <feature name="kubernetes-client" description="Fabric8 Kubernetes Client" version="${project.version}">
     <bundle dependency='true'>mvn:com.google.code.findbugs/jsr305/${jsr305.version}</bundle>
-    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson.bundle.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.bundle.version}</bundle>
-    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version.databind}</bundle>
+    <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.bundle.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.generex/${generex.bundle.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,7 @@
     <okhttp.bundle.version>3.12.0_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
-    <jackson.version>2.9.9</jackson.version>
-    <jackson.version.databind>2.9.9.3</jackson.version.databind>
+    <jackson.version>2.9.10</jackson.version>
     <mockwebserver.version>0.1.7</mockwebserver.version>
 
     <!-- API versions -->
@@ -225,13 +224,16 @@
         <version>${project.version}</version>
        </dependency>
 
-
-       <!-- Dependencies -->
-       <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <!-- Jackson dependencies, imported as a BOM -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
+
+      <!-- Dependencies -->
       <dependency>
         <groupId>io.sundr</groupId>
         <artifactId>builder-annotations</artifactId>

--- a/uberjar/pom.xml
+++ b/uberjar/pom.xml
@@ -166,17 +166,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version.databind}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Allow the use of the Jackson BOM to define the versions of the dependencies of Jackson and clean up the definitions of the dependencies in child poms.

This also updates Jackson to 2.9.10 which is backward compatible.