### PR TITLE
Avoid spurious print statement before invoking ResourceEventHandler.onAdd()

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorListener.java
@@ -63,7 +63,6 @@ public class ProcessorListener<T> implements Runnable {
           this.handler.onUpdate((T) notification.getOldObj(), (T) notification.getNewObj());
         } else if (obj instanceof AddNotification) {
           AddNotification notification = (AddNotification) obj;
-          System.out.println(this.handler.getClass().getName() + ".onAdd()");
           this.handler.onAdd((T) notification.getNewObj());
         } else if (obj instanceof DeleteNotification) {
           Object deletedObj = ((DeleteNotification) obj).getOldObj();


### PR DESCRIPTION
Users of the informer API shouldn't be seeing these debug statements. Since it isn't added to any other type of notification, I've just removed it for now.