### PR TITLE
Cleanup log4j dependency from project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ buildNumber.properties
 .project
 .settings/
 .classpath
+.factorypath
 
 ### Java template
 *.class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #1828: VersionInfo date parsing of year
 
 #### Improvements
+* Cleanup log4j dependency from project
 
 #### Dependency Upgrade
 
@@ -66,7 +67,7 @@
 
 #### Improvements
   * Removed Bean Validation integration
-  
+
 ### 4.5.0 (10-09-2019)
 
 #### Bugs
@@ -119,7 +120,7 @@
 
 ### 4.4.0 (05-08-2019)
   Bugs
-  * Fix #1592: Corrected type returned by Config.builder() 
+  * Fix #1592: Corrected type returned by Config.builder()
   * Fix #1565: CRD's Enums are prefixed with Raw keyword
   * Fixed user/password authentication bug in OpenShift 4
   * Fix #1667: Origin header for watch requests had a port of -1 when no port specified
@@ -132,7 +133,7 @@
    * Removed deprecated KubernetesKind enum
 
   Dependency Upgrade
-    
+
   New Feature
   * Knative extension
   * Tekton extension
@@ -140,7 +141,7 @@
 
 ### 4.3.1 (19-07-2019)
   Bugs
-   * Fix #1592: Corrected type returned by Config.builder() 
+   * Fix #1592: Corrected type returned by Config.builder()
    * Set cascade deletion to true in case of list operations
    * Fix #1617: Multiple CA certificates with non-unique Subject DN not loaded
    * Fix #1634: Make map backing KubernetesDeserializer thread-safe
@@ -179,7 +180,7 @@
   Improvements
 
     * Added example for raw custom resources.
-    
+
   Dependency Upgrade
 
   New Feature

--- a/extensions/knative/tests/pom.xml
+++ b/extensions/knative/tests/pom.xml
@@ -63,18 +63,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
-      <optional>true</optional>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions/service-catalog/model/pom.xml
+++ b/extensions/service-catalog/model/pom.xml
@@ -56,10 +56,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <felix.scr.annotations.version>1.9.8</felix.scr.annotations.version>
-    <log4j.version>2.3</log4j.version>
     <mockwebserver.version>0.1.4</mockwebserver.version>
-
-    <slf4j.version>1.7.12</slf4j.version>
 
     <scr.annotations.version>1.9.2</scr.annotations.version>
     <sundrio.version>0.17.2</sundrio.version>

--- a/extensions/service-catalog/tests/pom.xml
+++ b/extensions/service-catalog/tests/pom.xml
@@ -64,18 +64,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
-      <optional>true</optional>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions/tekton/tests/pom.xml
+++ b/extensions/tekton/tests/pom.xml
@@ -65,18 +65,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
-      <optional>true</optional>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -175,11 +175,6 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
@@ -282,7 +277,6 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/kubernetes-examples/pom.xml
+++ b/kubernetes-examples/pom.xml
@@ -42,14 +42,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/PodSecurityPolicyExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/PodSecurityPolicyExample.java
@@ -22,8 +22,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import java.io.FileInputStream;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PodSecurityPolicyExample {
 
@@ -31,7 +31,7 @@ public class PodSecurityPolicyExample {
     //command for that is
     //oc login -u system:admin
 
-    private static final Logger logger = Logger.getLogger(PodSecurityPolicyExample.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(PodSecurityPolicyExample.class);
 
     public static void main(String args[]) throws InterruptedException {
 
@@ -42,15 +42,14 @@ public class PodSecurityPolicyExample {
 
             //Creating PodSecurityPolicy from Yaml file
 
-            logger.log(Level.INFO, "Loading File : " + sample);
+            logger.info("Loading File : {}", sample);
             PodSecurityPolicy podSecurityPolicy = client.extensions().podSecurityPolicies().load(new FileInputStream(sample)).get();
             client.extensions().podSecurityPolicies().create(podSecurityPolicy);
-            logger.log(Level.INFO, "PodSecurityPolicy created with Name : "
-                  + podSecurityPolicy.getMetadata().getName());
+            logger.info("PodSecurityPolicy created with Name : {}", podSecurityPolicy.getMetadata().getName());
 
             //Creating PodSecurityPolicy from Builder
 
-            logger.log(Level.INFO, "Starting creating PodSecurityPolicy from Builder ");
+            logger.info("Starting creating PodSecurityPolicy from Builder ");
 
             PodSecurityPolicy podSecurityPolicy1 = new PodSecurityPolicyBuilder().withNewMetadata()
                     .withName("example2")
@@ -65,17 +64,16 @@ public class PodSecurityPolicyExample {
                     .build();
 
             client.extensions().podSecurityPolicies().create(podSecurityPolicy1);
-            logger.log(Level.INFO, "PodSecurityPolicy created with Name : "
-                    + podSecurityPolicy1.getMetadata().getName());
+            logger.info("PodSecurityPolicy created with Name : {}",
+                    podSecurityPolicy1.getMetadata().getName());
 
             client.close();
 
         } catch (KubernetesClientException ClientException) {
-            logger.log(Level.SEVERE, "Problem encountered with Kubernetes client!!");
-            ClientException.printStackTrace();
+            logger.error("Problem encountered with Kubernetes client!!", ClientException);
 
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Exception encountered : " + e.getMessage());
+            logger.error("Exception encountered : {}", e.getMessage());
         }
 
 

--- a/kubernetes-tests/pom.xml
+++ b/kubernetes-tests/pom.xml
@@ -82,20 +82,10 @@
       </exclusions>
     </dependency>
 
-
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
-      <optional>true</optional>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -200,7 +200,6 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
     <automaton.bundle.version>1.11-8_1</automaton.bundle.version>
     <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
     <junit.version>5.5.2</junit.version>
-    <log4j.version>2.12.1</log4j.version>
     <zjsonpatch.version>0.3.0</zjsonpatch.version>
     <arquillian.cube.version>1.18.2</arquillian.cube.version>
     <slf4j.version>1.7.26</slf4j.version>


### PR DESCRIPTION
The SLF4J is used as logging dependency, log4j is used only on tests, so this replaces the log4j declaration for slf4j-simple in the test scope.

This cleanup helps to reduce the dependencies used in the project and keep a single implementation in place.

This also removes the unnecessary dependency on jul-to-slf4j, which ends up being transitively included in projects that use kubernetes-client.