### PR TITLE
Respect the termination grace period from the Kubernetes resource as a default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.7-SNAPSHOT
 #### Bugs
+* Fix #1833: Respect the termination grace period from the Kubernetes resource by default
 * Fix #1827: Fix `withGracePeriod` and `withPropagationPolicy` return type to safely chain further DSL methods and default GracePeriod to 30s
 * Fix #1828: VersionInfo date parsing of year
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationContext.java
@@ -39,8 +39,8 @@ public class OperationContext {
   protected boolean cascading;
   protected boolean reloadingFromServer;
 
-  // Default to k8s 30s value: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
-  protected long gracePeriodSeconds = 30L;
+  // Default to -1 to respect the value set in the resource or the Kubernetes default (30 seconds)
+  protected long gracePeriodSeconds = -1L;
   protected String propagationPolicy;
 
   protected Map<String, String> labels;

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
@@ -74,7 +74,7 @@ public class BaseOperationTest {
   public void testDefaultGracePeriod() {
     final BaseOperation operation = new BaseOperation(new OperationContext());
 
-    assertThat(operation.getGracePeriodSeconds(), is(30L));
+    assertThat(operation.getGracePeriodSeconds(), is(-1L));
   }
 
   @Test


### PR DESCRIPTION
As discussed in #1827, this PR sets the default grace period to `-1` seconds as default. That should make the client not specify any grace period when deleting resources and this respect the grace period configured in the resource it self (e.g. `terminationGracePeriod` field in PodSpec) or the Kubernetes default which is IMHO the most natural default behavior. When you test it for example with Pod, you should see that:
* If the Pod specifies its own grace period it is respected by default
* If the Pod doesn't specify any grace period, the Kubernetes default 30 seconds are used
* If the client specifies the grace period using `withGracePeriod(...)`, the value from client is used.