### PR TITLE
Fixed LoadMultipleDocumentsFromFileExample

### DIFF
--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
@@ -35,18 +35,11 @@ public class LoadMultipleDocumentsFromFileExample {
       master = args[0];
     }
 
-    Config config = new ConfigBuilder().build();
+    Config config = new ConfigBuilder().withMasterUrl(master).build();
     KubernetesClient client = new DefaultKubernetesClient(config);
 
     List<HasMetadata> list = client.load(LoadMultipleDocumentsFromFileExample.class.getResourceAsStream("/multiple-document-template.yml")).get();
     System.out.println("Found in file:" + list.size() + " items.");
-    for (HasMetadata meta : list) {
-      System.out.println(display(meta));
-    }
-
-    list = client.load(LoadMultipleDocumentsFromFileExample.class.getResourceAsStream("/multiple-document-template.yml")).accept((Visitor<ObjectMetaBuilder>) item -> item.addToLabels("visitorkey", "visitorvalue")).get();
-
-    System.out.println("Visited:" + list.size() + " items.");
     for (HasMetadata meta : list) {
       System.out.println(display(meta));
     }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LoadMultipleDocumentsFromFileExample.java
@@ -43,6 +43,19 @@ public class LoadMultipleDocumentsFromFileExample {
     for (HasMetadata meta : list) {
       System.out.println(display(meta));
     }
+
+    list = client.load(LoadMultipleDocumentsFromFileExample.class.getResourceAsStream("/multiple-document-template.yml"))
+      .accept(new Visitor<ObjectMetaBuilder>() {
+        @Override
+        public void visit(ObjectMetaBuilder item) {
+          item.addToLabels("visitorkey", "visitorvalue");
+        }
+      }).get();
+
+    System.out.println("Visited:" + list.size() + " items.");
+    for (HasMetadata meta : list) {
+      System.out.println(display(meta));
+    }
   }
 
   private static String display(HasMetadata item) {


### PR DESCRIPTION
Fixes #1603
No exception in thread after removing the use of accept() method. 
It's only being used in 2 files (this one and LoadExample) and the multiple documents are loading with no issues without it.