### PR TITLE
chore: change deprecated basedir maven property

### DIFF
--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -109,13 +109,13 @@
         <artifactId>jsonschema2pojo-maven-plugin</artifactId>
         <version>${jsonschema2pojo.version}</version>
         <configuration>
-          <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
+          <sourceDirectory>${project.basedir}/src/main/resources/schema</sourceDirectory>
           <targetPackage>io.fabric8.knative.api.model</targetPackage>
           <includeConstructors>true</includeConstructors>
           <includeJsr303Annotations>false</includeJsr303Annotations>
           <includeToString>false</includeToString>
           <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
-          <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
           <customAnnotator>io.fabric8.knative.KnativeTypeAnnotator</customAnnotator>
         </configuration>
         <executions>

--- a/extensions/service-catalog/model/servicecatalog-model/pom.xml
+++ b/extensions/service-catalog/model/servicecatalog-model/pom.xml
@@ -43,7 +43,6 @@
     </osgi.include.resources>
 
     <clone-kube>true</clone-kube>
-    <kube.dir>${basedir}/src/main/resources</kube.dir>
   </properties>
 
   <dependencies>
@@ -103,7 +102,7 @@
               <goal>process</goal>
             </goals>
             <configuration>
-              <outputDirectory>target/generated-sources</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
               <processor>io.sundr.builder.internal.processor.BuildableProcessor</processor>
             </configuration>
           </execution>
@@ -114,13 +113,13 @@
         <artifactId>jsonschema2pojo-maven-plugin</artifactId>
         <version>${jsonschema2pojo.version}</version>
         <configuration>
-          <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
+          <sourceDirectory>${project.basedir}/src/main/resources/schema</sourceDirectory>
           <targetPackage>io.fabric8.servicecatalog.api.model</targetPackage>
           <includeConstructors>true</includeConstructors>
           <includeJsr303Annotations>false</includeJsr303Annotations>
           <includeToString>false</includeToString>
           <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
-          <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
           <customAnnotator>io.fabric8.servicecatalog.annotator.ServiceCatalogTypeAnnotator</customAnnotator>
         </configuration>
         <executions>

--- a/extensions/tekton/model/pom.xml
+++ b/extensions/tekton/model/pom.xml
@@ -94,13 +94,13 @@
           <artifactId>jsonschema2pojo-maven-plugin</artifactId>
           <version>${jsonschema2pojo.version}</version>
           <configuration>
-            <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
+            <sourceDirectory>${project.basedir}/src/main/resources/schema</sourceDirectory>
             <targetPackage>io.fabric8.tekton.api.model</targetPackage>
             <includeConstructors>true</includeConstructors>
             <includeJsr303Annotations>false</includeJsr303Annotations>
             <includeToString>false</includeToString>
             <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
-            <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
+            <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
             <customAnnotator>io.fabric8.tekton.TektonTypeAnnotator</customAnnotator>
           </configuration>
           <executions>
@@ -128,9 +128,9 @@
               <configuration>
                 <target>
                   <echo>removing the duplicate generated calss</echo>
-                  <delete file="${basedir}/target/generated-sources/io/fabric8/tekton/pipeline/v1alpha1/ArrayOrString.java" verbose="true" />
+                  <delete file="${project.build.directory}/generated-sources/io/fabric8/tekton/pipeline/v1alpha1/ArrayOrString.java" verbose="true" />
                   <delete verbose="true">
-                    <fileset dir="${basedir}/target/generated-sources">
+                    <fileset dir="${project.build.directory}/generated-sources">
                       <include name="*.java" />
                     </fileset>
                   </delete>

--- a/kubernetes-model/kubernetes-model/pom.xml
+++ b/kubernetes-model/kubernetes-model/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <clone-kube>true</clone-kube>
-    <kube.dir>${basedir}/src/main/resources</kube.dir>
   </properties>
 
   <dependencies>
@@ -89,14 +88,14 @@
         <version>${jsonschema2pojo.version}</version>
         <configuration>
           <sourcePaths>
-            <sourcePath>${kube.dir}/schema/kube-schema.json</sourcePath>
+            <sourcePath>${project.basedir}/src/main/resources/schema/kube-schema.json</sourcePath>
           </sourcePaths>
           <targetPackage>io.fabric8.kubernetes.api.model</targetPackage>
           <includeConstructors>true</includeConstructors>
           <includeJsr303Annotations>false</includeJsr303Annotations>
           <includeToString>false</includeToString>
           <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
-          <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
           <customAnnotator>io.fabric8.kubernetes.annotator.KubernetesTypeAnnotator</customAnnotator>
           <annotationStyle>none</annotationStyle>
         </configuration>
@@ -123,13 +122,13 @@
             <configuration>
               <target>
                 <echo>removing the duplicate generated calss</echo>
-                <delete file="${basedir}/target/generated-sources/io/fabric8/kubernetes/api/model/IntOrString.java" verbose="true" />
-                <delete file="${basedir}/target/generated-sources/io/fabric8/kubernetes/api/model/Quantity.java" verbose="true" />
-                <delete file="${basedir}/target/generated-sources/io/fabric8/openshift/api/model/Template.java" verbose="true" />
-                <delete file="${basedir}/target/generated-sources/io/fabric8/kubernetes/api/model/HasMetadata.java" verbose="true" />
-                <delete file="${basedir}/target/generated-sources/io/fabric8/kubernetes/api/model/WatchEvent.java" verbose="true" />
+                <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/IntOrString.java" verbose="true" />
+                <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/Quantity.java" verbose="true" />
+                <delete file="${project.build.directory}/generated-sources/io/fabric8/openshift/api/model/Template.java" verbose="true" />
+                <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/HasMetadata.java" verbose="true" />
+                <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/WatchEvent.java" verbose="true" />
                 <delete verbose="true">
-                  <fileset dir="${basedir}/target/generated-sources">
+                  <fileset dir="${project.build.directory}/generated-sources">
                     <include name="*.java" />
                   </fileset>
                 </delete>
@@ -217,14 +216,14 @@
             <version>${jsonschema2pojo.version}</version>
             <configuration>
               <sourcePaths>
-                <sourcePath>${kube.dir}/schema/kube-schema.json</sourcePath>
+                <sourcePath>${project.basedir}/src/main/resources/schema/kube-schema.json</sourcePath>
               </sourcePaths>
               <targetPackage>io.fabric8.kubernetes.api.model</targetPackage>
               <includeConstructors>true</includeConstructors>
               <includeJsr303Annotations>false</includeJsr303Annotations>
               <includeToString>false</includeToString>
               <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
-              <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
               <customAnnotator>io.fabric8.kubernetes.annotator.KubernetesTypeAnnotator</customAnnotator>
               <annotationStyle>none</annotationStyle>
             </configuration>


### PR DESCRIPTION
`${basedir}` is a deprecated maven property, change it for `${project.basedir}`

* https://maven.apache.org/ref/3.2.5/maven-model-builder/index.html
* https://github.com/cko/predefined_maven_properties/blob/master/README.md