### PR TITLE
Fix #1856: Prevent NPE loop when deleting locally loaded scaleable resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.7-SNAPSHOT
 #### Bugs
 * Fix #1838: Use the correct apiGroup for Knative in KnativeResourceMappingProvider
+* Fix #1856: Prevent NPE loop when deleting locally loaded scaleable resource (e.g. statefulset).
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -641,7 +641,7 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
   public Boolean delete() {
     if (item != null || (name != null && !name.isEmpty())) {
       try {
-        if (cascading && !isReaping()) {
+        if (reloadingFromServer && cascading && !isReaping()) {
           if (reaper != null) {
             setReaping(true);
             //If the reaper also removes the target resource, we can return asap.

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Deletable;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.Rule;
@@ -139,6 +140,17 @@ public class StatefulSetTest {
 
     deleted = client.apps().statefulSets().inNamespace("ns1").withName("repl2").delete();
     assertTrue(deleted);
+  }
+
+  @Test
+  public void testDeleteLoadedResource() {
+    StatefulSet response = server.getClient().apps().statefulSets().load(getClass().getResourceAsStream("/test-statefulset.yml")).get();
+    server.expect().delete().withPath("/apis/apps/v1beta1/namespaces/test/statefulsets/example").andReturn(200, response).once();
+
+    KubernetesClient client = server.getClient();
+
+    Deletable<Boolean> items = client.load(getClass().getResourceAsStream("/test-statefulset.yml"));
+    assertTrue(items.delete());
   }
 
   @Test

--- a/kubernetes-tests/src/test/resources/test-statefulset.yml
+++ b/kubernetes-tests/src/test/resources/test-statefulset.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: example
+spec:
+  replicas: 1
+  serviceName: example-server-headless
+  selector:
+    matchLabels:
+      name: example
+      app: example
+  template:
+    metadata:
+      labels:
+        name: example
+        app: example
+      name: example
+    spec:
+      serviceAccount: example
+      containers:
+        - image: myimage
+          name: example-server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+      terminationGracePeriodSeconds: 120


### PR DESCRIPTION
I've added a test that expose my issue.   I've also included a simple change that resolves the problem on the code path we are using.   It is possible other code paths that may be susceptible to this issue too. HTH