### PR TITLE
Fix #1765 Ability to upload files to a pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix #1838: Use the correct apiGroup for Knative in KnativeResourceMappingProvider
 
 #### Improvements
+* Fix #1765 Ability to upload files to a pod
 
 #### Dependency Upgrade
 * chore(deps): bump maven-jar-plugin from 3.1.2 to 3.2.0

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -163,6 +163,11 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
@@ -16,8 +16,8 @@
 package io.fabric8.kubernetes.client.dsl;
 
 
-public interface ContainerResource<S,W, I, PI, O, PO, X, T, B, IS>
+public interface ContainerResource<S,W, I, PI, O, PO, X, T, B, IS, UB>
         extends TtyExecInputOutputErrorable<X, O, PO, I, PI, T>,
-                FileSelector<CopyOrReadable<B, IS>>,
+                FileSelector<CopyOrReadable<B, IS, UB>>,
   TimestampBytesLimitTerminateTimeTailPrettyLoggable<S, W> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
@@ -27,7 +27,7 @@ import io.fabric8.kubernetes.client.PortForward;
 
 public interface PodResource<T, D> extends Resource<T, D>,
         Loggable<String, LogWatch>,
-        Containerable<String, ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream>>,
-        ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream>,
+        Containerable<String, ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream, Boolean>>,
+        ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream, Boolean>,
         PortForwardable<PortForward, LocalPortForward, ReadableByteChannel, WritableByteChannel> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Uploadable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Uploadable.java
@@ -15,6 +15,9 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface CopyOrReadable<B, I, UB> extends Copiable<B>, Readable<I>, Uploadable<UB> {
+import java.nio.file.Path;
 
+public interface Uploadable<T> {
+
+  T upload(Path path);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationsImpl.java
@@ -31,9 +31,6 @@ import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import io.fabric8.kubernetes.client.dsl.CopyOrReadable;
-import io.fabric8.kubernetes.client.utils.Utils;
-
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -42,29 +39,37 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.PortForward;
-import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.BytesLimitTerminateTimeTailPrettyLoggable;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
+import io.fabric8.kubernetes.client.dsl.CopyOrReadable;
 import io.fabric8.kubernetes.client.dsl.ExecListenable;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.Execable;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.Loggable;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.PrettyLoggable;
 import io.fabric8.kubernetes.client.dsl.TailPrettyLoggable;
 import io.fabric8.kubernetes.client.dsl.TimeTailPrettyLoggable;
 import io.fabric8.kubernetes.client.dsl.TtyExecErrorChannelable;
-import io.fabric8.kubernetes.client.dsl.BytesLimitTerminateTimeTailPrettyLoggable;
 import io.fabric8.kubernetes.client.dsl.TtyExecErrorable;
 import io.fabric8.kubernetes.client.dsl.TtyExecOutputErrorable;
 import io.fabric8.kubernetes.client.dsl.TtyExecable;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.dsl.internal.uploadable.PodUpload;
 import io.fabric8.kubernetes.client.utils.BlockingInputStreamPumper;
 import io.fabric8.kubernetes.client.utils.URLUtils;
-import okhttp3.*;
+import io.fabric8.kubernetes.client.utils.Utils;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
-public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> implements PodResource<Pod, DoneablePod>,CopyOrReadable<Boolean,InputStream> {
+import static io.fabric8.kubernetes.client.utils.OptionalDependencyWrapper.wrapRunWithOptionalDependency;
+
+public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> implements PodResource<Pod, DoneablePod>,CopyOrReadable<Boolean,InputStream, Boolean> {
 
     private static final String[] EMPTY_COMMAND = {"/bin/sh", "-i"};
 
@@ -183,7 +188,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
 
   /**
    * Returns an unclosed Reader. It's the caller responsibility to close it.
-   * @return Reader                                                                                                                                                             
+   * @return Reader
    */
   @Override
   public Reader getLogReader() {
@@ -243,7 +248,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
   }
 
   @Override
-    public ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream> inContainer(String containerId) {
+    public ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream, Boolean> inContainer(String containerId) {
         return new PodOperationsImpl(getContext().withContainerId(containerId));
     }
 
@@ -261,7 +266,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
             } else {
                 sb.append("&command=");
             }
-          
+
             try {
             	cmd = URLUtils.encodeToUTF(cmd);
             } catch (UnsupportedEncodingException encodEx) {
@@ -303,12 +308,12 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
 
 
     @Override
-    public CopyOrReadable<Boolean, InputStream> file(String file) {
+    public CopyOrReadable<Boolean, InputStream, Boolean> file(String file) {
       return new PodOperationsImpl(getContext().withFile(file));
     }
 
     @Override
-    public CopyOrReadable<Boolean, InputStream> dir(String dir) {
+    public CopyOrReadable<Boolean, InputStream, Boolean> dir(String dir) {
       return new PodOperationsImpl(getContext().withDir(dir));
     }
 
@@ -327,6 +332,18 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, Doneab
       throw KubernetesClientException.launderThrowable(e);
     }
    }
+
+  @Override
+  public Boolean upload(Path path) {
+    return wrapRunWithOptionalDependency(() -> {
+      try {
+        return PodUpload.upload(client, getContext(), this, path);
+      } catch (Exception ex) {
+        Thread.currentThread().interrupt();
+        throw KubernetesClientException.launderThrowable(ex);
+      }
+    }, "Base64InputStream class is provided by commons-codec, TarArchiveOutputStream is provided by commons-compress");
+  }
 
   @Override
   public InputStream read() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListener.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal.uploadable;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+public class PodUploadWebSocketListener extends WebSocketListener {
+
+  private static final byte FLAG_STDIN = (byte) 0;
+  private static final long MAX_QUEUE_SIZE = 16 * 1024 * 1024L;
+
+  private final AtomicReference<WebSocket> webSocketRef;
+  private final AtomicReference<String> error;
+  private final CountDownLatch readyLatch;
+  private final CountDownLatch completeLatch;
+
+  PodUploadWebSocketListener() {
+    this.webSocketRef = new AtomicReference<>();
+    this.error = new AtomicReference<>();
+    this.readyLatch = new CountDownLatch(1);
+    this.completeLatch = new CountDownLatch(1);
+  }
+
+  @Override
+  public void onOpen(WebSocket webSocket, Response response) {
+    webSocketRef.set(webSocket);
+  }
+
+  @Override
+  public void onMessage(WebSocket webSocket, ByteString bytes) {
+    if (readyLatch.getCount() > 0 && bytes.size() == 1) {
+      readyLatch.countDown();
+    } else if (bytes.size() > 1) {
+      error.set(bytes.substring(1).toString());
+    }
+  }
+
+  @Override
+  public void onClosed(WebSocket webSocket, int code, String reason) {
+    completeLatch.countDown();
+  }
+
+  @Override
+  public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+    final String responseBody = Optional.ofNullable(response.body())
+      .map(rb -> {
+        try {
+          return rb.string();
+        } catch (IOException e) {
+          return e.getMessage();
+        }
+      }).orElse("");
+    error.set(String.format("%s - %s%n%s", response.code(), response.message(), responseBody));
+
+    while (readyLatch.getCount() > 0) {
+      readyLatch.countDown();
+    }
+    while (completeLatch.getCount() > 0) {
+      completeLatch.countDown();
+    }
+  }
+
+  final void checkError() {
+    if (!isBlank(error.get())) {
+      throw new KubernetesClientException(error.get());
+    }
+  }
+
+  final void waitUntilReady(int timeoutSeconds) throws IOException, InterruptedException {
+    if (!readyLatch.await(timeoutSeconds, TimeUnit.SECONDS)) {
+      throw new IOException("Connection to server timed out");
+    }
+  }
+
+  final void waitUntilComplete(int timeoutSeconds) throws IOException, InterruptedException {
+    while (webSocketRef.get().queueSize() > 0 && completeLatch.getCount() > 0) {
+      checkError();
+      Thread.sleep(50);
+    }
+    webSocketRef.get().close(1000, "Operation completed");
+    if (!completeLatch.await(timeoutSeconds, TimeUnit.SECONDS)) {
+      throw new IOException("Upload operation timed out before completing");
+    }
+    checkError();
+  }
+
+  final void send(byte[] data, int length) {
+    checkError();
+    waitForQueue(length);
+    byte[] toSend = new byte[length + 1];
+    toSend[0] = FLAG_STDIN;
+    System.arraycopy(data, 0, toSend, 1, length);
+    webSocketRef.get().send(ByteString.of(toSend));
+  }
+
+  final void waitForQueue(int length) {
+    try {
+      while (webSocketRef.get().queueSize() + length > MAX_QUEUE_SIZE && !Thread.interrupted()) {
+        checkError();
+        Thread.sleep(50L);
+      }
+    } catch(InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/OptionalDependencyWrapper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/OptionalDependencyWrapper.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import java.util.function.Supplier;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
+public class OptionalDependencyWrapper {
+
+  private OptionalDependencyWrapper() {
+  }
+
+  /**
+   * Runs the provided {@link Supplier} implementation and catches any {@link NoClassDefFoundError}
+   *
+   * @param supplier implementation to safely run
+   * @param message to display for caught exceptions (e.g. "Base64InputStream class is provided by
+   * commons-codec"
+   */
+  public static <R> R wrapRunWithOptionalDependency(Supplier<R> supplier, String message) {
+
+    try {
+      return supplier.get();
+    } catch (NoClassDefFoundError ex) {
+      throw new KubernetesClientException(String.format(
+        "%s, an optional dependency. To use this functionality you must explicitly add this dependency to the classpath.",
+        message), ex);
+    }
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal.uploadable;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.function.ObjIntConsumer;
+
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
+import okhttp3.OkHttpClient;
+import okhttp3.WebSocket;
+import okio.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PodUploadTest {
+
+  private OkHttpClient mockClient;
+  private PodOperationContext mockContext;
+  private OperationSupport operationSupport;
+  private Path mockPathToUpload;
+  private WebSocket mockWebSocket;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    mockClient = Mockito.mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    mockContext = Mockito.mock(PodOperationContext.class, Mockito.RETURNS_DEEP_STUBS);
+    operationSupport = Mockito.mock(OperationSupport.class, Mockito.RETURNS_DEEP_STUBS);
+    mockPathToUpload = Mockito.mock(Path.class, Mockito.RETURNS_DEEP_STUBS);
+    mockWebSocket = Mockito.mock(WebSocket.class, Mockito.RETURNS_DEEP_STUBS);
+
+    when(mockClient.newBuilder().readTimeout(anyLong(), any(TimeUnit.class)).build()).thenReturn(mockClient);
+    when(operationSupport.getResourceUrl())
+      .thenReturn(new URL("https://openshift.com:8443/api/v1/namespaces/default/pods/mock-pod/"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    mockClient = null;
+    mockContext = null;
+    operationSupport = null;
+    mockPathToUpload = null;
+  }
+
+  @Test
+  void testUploadInvalidParametersShouldThrowException() throws Exception {
+    final IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
+      () -> PodUpload.upload(mockClient, mockContext, operationSupport, mockPathToUpload));
+
+    assertThat(result.getMessage(),
+      equalTo("Provided arguments are not valid (file, directory, path)"));
+  }
+
+  @Test
+  void testUploadFileHappyScenarioShouldUploadFile() throws Exception {
+    when(mockContext.getFile()).thenReturn("/mock/dir/file");
+    when(mockPathToUpload.toFile())
+      .thenReturn(new File(PodUpload.class.getResource("/upload/upload-sample.txt").getFile()));
+    when(mockClient.newWebSocket(any(), any())).thenAnswer(newWebSocket -> {
+      final PodUploadWebSocketListener wsl = newWebSocket.getArgument(1, PodUploadWebSocketListener.class);
+      // Set ready status
+      wsl.onOpen(mockWebSocket, null);
+      wsl.onMessage(mockWebSocket, ByteString.of((byte) 0));
+      // Set complete status
+      when(mockWebSocket.close(anyInt(), anyString())).thenAnswer(close -> {
+        wsl.onClosed(mockWebSocket, close.getArgument(0), close.getArgument(1));
+        return true;
+      });
+      return mockWebSocket;
+    });
+
+    final boolean result = PodUpload.upload(mockClient, mockContext, operationSupport, mockPathToUpload);
+
+    assertThat(result, equalTo(true));
+    verify(mockPathToUpload, atLeast(1)).toFile();
+    verify(mockClient, times(1)).newWebSocket(argThat(request -> {
+      assertThat(request.url().toString(), equalTo("https://openshift.com:8443/api/v1/namespaces/default/pods/mock-pod/exec?command=sh&command=-c&command=mkdir+-p+%2Fmock%2Fdir+%26%26+base64+-d+-+%3E+%2Fmock%2Fdir%2Ffile&stdin=true&stderr=true"));
+      return true;
+    }), any(PodUploadWebSocketListener.class));
+    verify(mockWebSocket, atLeast(1)).send(any(ByteString.class));
+    verify(mockWebSocket, times(0)).send(anyString());
+  }
+
+  @Test
+  void testUploadDirectoryHappyScenarioShouldUploadDirectory() throws Exception {
+    when(mockContext.getDir()).thenReturn("/mock/dir");
+    when(mockPathToUpload.toFile())
+      .thenReturn(new File(PodUpload.class.getResource("/upload").getFile()));
+    when(mockClient.newWebSocket(any(), any())).thenAnswer(newWebSocket -> {
+      final PodUploadWebSocketListener wsl = newWebSocket.getArgument(1, PodUploadWebSocketListener.class);
+      // Set ready status
+      wsl.onOpen(mockWebSocket, null);
+      wsl.onMessage(mockWebSocket, ByteString.of((byte) 0));
+      // Set complete status
+      when(mockWebSocket.close(anyInt(), anyString())).thenAnswer(close -> {
+        wsl.onClosed(mockWebSocket, close.getArgument(0), close.getArgument(1));
+        return true;
+      });
+      return mockWebSocket;
+    });
+
+    final boolean result = PodUpload.upload(mockClient, mockContext, operationSupport, mockPathToUpload);
+
+    assertThat(result, equalTo(true));
+    verify(mockPathToUpload, atLeast(1)).toFile();
+    verify(mockClient, times(1)).newWebSocket(argThat(request -> {
+      assertThat(request.url().toString(), equalTo("https://openshift.com:8443/api/v1/namespaces/default/pods/mock-pod/exec?command=sh&command=-c&command=mkdir+-p+%2Fmock%2Fdir+%26%26+base64+-d+-+%7C+tar+-C+%2Fmock%2Fdir+-xzf+-&stdin=true&stderr=true"));
+      return true;
+    }), any(PodUploadWebSocketListener.class));
+    verify(mockWebSocket, atLeast(1)).send(any(ByteString.class));
+    verify(mockWebSocket, times(0)).send(anyString());
+  }
+
+  @Test
+  void testCopy() throws Exception {
+    final ByteArrayInputStream input = new ByteArrayInputStream("I'LL BE COPIED".getBytes(Charset.defaultCharset()));
+    final ObjIntConsumer<byte[]> consumer = (bytes, length) -> {
+      assertThat(length, equalTo(14));
+      assertThat(new String(Arrays.copyOf(bytes, 14), Charset.defaultCharset()),
+        equalTo("I'LL BE COPIED"));
+    };
+
+    PodUpload.copy(input, consumer);
+  }
+
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListenerTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal.uploadable;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okio.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+class PodUploadWebSocketListenerTest {
+
+  private PodUploadWebSocketListener podUploadWebSocketListener;
+
+  @BeforeEach
+  void setUp() {
+    podUploadWebSocketListener = new PodUploadWebSocketListener();
+  }
+
+  @AfterEach
+  void tearDown() {
+    podUploadWebSocketListener = null;
+  }
+
+  @Test
+  void testSendShouldTruncateAndSendFlaggedWebSocketData() {
+    final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
+    podUploadWebSocketListener.onOpen(mockedWebSocket, null);
+    final byte[] toSend = new byte[]{1, 3, 3, 7, 0};
+
+    podUploadWebSocketListener.send(toSend, 4);
+
+    verify(mockedWebSocket, times(1))
+      .send(eq(ByteString.of((byte) 0, (byte) 1, (byte) 3, (byte) 3, (byte) 7)));
+  }
+
+  @Test()
+  void testCheckErrorHasErrorFromMessageShouldThrowException() {
+    podUploadWebSocketListener.onMessage(null, ByteString.encodeUtf8("ACK"));
+    podUploadWebSocketListener.onMessage(null, ByteString.encodeUtf8("![\"I'M AN ERROR\"]"));
+
+    assertThrows(KubernetesClientException.class, () -> podUploadWebSocketListener.checkError());
+  }
+
+  @Test()
+  void testCheckErrorHasErrorFromFailureShouldThrowException() {
+    final Response mockResponse = Mockito.mock(Response.class, Mockito.RETURNS_DEEP_STUBS);
+    when(mockResponse.code()).thenReturn(1337);
+    when(mockResponse.message()).thenReturn("Error");
+    when(mockResponse.body().toString()).thenReturn("Detailed error description");
+    podUploadWebSocketListener.onFailure(null, null, mockResponse);
+
+    assertThrows(KubernetesClientException.class, () -> podUploadWebSocketListener.checkError());
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/OptionalDependencyWrapperTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/OptionalDependencyWrapperTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.junit.jupiter.api.Test;
+
+import static io.fabric8.kubernetes.client.utils.OptionalDependencyWrapper.wrapRunWithOptionalDependency;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OptionalDependencyWrapperTest {
+
+  @Test
+  void testWrapRunWithOptionalDependencyHasAllDependenciesShouldNotThrowException() {
+    final boolean result = wrapRunWithOptionalDependency(() -> true,
+      "I have no optional dependencies");
+
+    assertThat(result, equalTo(true));
+  }
+
+  @Test
+  void testWrapRunWithOptionalDependencyUsesDependencyShouldThrowException() {
+    final KubernetesClientException exception = assertThrows(KubernetesClientException.class,
+      () -> wrapRunWithOptionalDependency(() -> {
+        throw new NoClassDefFoundError("com.1337.invalid.IDontExist");
+      }, "IDontExist class is provided by some optional package"));
+
+    assertThat(exception.getMessage(), equalTo(
+      "IDontExist class is provided by some optional package, an optional dependency. To use this functionality you must explicitly add this dependency to the classpath."));
+  }
+}

--- a/kubernetes-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/kubernetes-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/kubernetes-client/src/test/resources/upload/upload-sample.txt
+++ b/kubernetes-client/src/test/resources/upload/upload-sample.txt
@@ -1,0 +1,17 @@
+====
+    Copyright (C) 2015 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+====
+
+This is a file to test uploads

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -16,17 +16,8 @@
 
 package io.fabric8.kubernetes.client.mock;
 
-import io.fabric8.kubernetes.client.utils.Utils;
-import org.assertj.core.util.Files;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -38,12 +29,12 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.LocalPortForward;
@@ -52,17 +43,22 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
-
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.kubernetes.client.server.mock.OutputStreamMessage;
-
+import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.Response;
 import okio.ByteString;
+import org.assertj.core.util.Files;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableRuleMigrationSupport
 public class PodTest {
@@ -477,6 +473,13 @@ public class PodTest {
     assertEquals("Hello World!", got);
   }
 
+  @Test
+  public void testOptionalUpload() {
+    Assertions.assertThrows(KubernetesClientException.class, () -> {
+      KubernetesClient client = server.getClient();
+      client.pods().inNamespace("ns1").withName("pod2").dir("/etc/hosts/dir").upload(Files.temporaryFolder().toPath());
+    });
+  }
 
   @Test
   public void testOptionalCopy() {

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
     <zjsonpatch.version>0.3.0</zjsonpatch.version>
     <arquillian.cube.version>1.18.2</arquillian.cube.version>
     <slf4j.version>1.7.29</slf4j.version>
+    <mockito.version>3.1.0</mockito.version>
     <lombok.version>1.18.10</lombok.version>
     <snakeyaml.version>1.24</snakeyaml.version>
     <bouncycastle.version>1.62</bouncycastle.version>
@@ -276,6 +277,13 @@
         <groupId>org.skyscreamer</groupId>
         <artifactId>jsonassert</artifactId>
         <version>${jsonassert.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Scratch implementation to support directory and file uploads to a pod.

As stated here https://github.com/fabric8io/kubernetes-client/issues/1765#issuecomment-552891575, feature implementation using available methods (i.e. `exec`) is possible but performance is really bad.

Implemented WebSocket interaction from scratch for easier and better-controlled stream piping.

Implementation performed in helper classes so PodOperationsImpl class doesn't get cluttered and to allow very granular unit testing.

Closes #1765 