### PR TITLE
Fix Disabled integration tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.7-SNAPSHOT
 #### Bugs
+* Fix disabled Integration tests
 
 #### Improvements
 

--- a/kubernetes-itests/pom.xml
+++ b/kubernetes-itests/pom.xml
@@ -31,14 +31,10 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <!-- Arquillian is still not compatible with Junit 5, so using Junit 4 here -->
+      <version>${junit.compatible-with-arquillian.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
   <url>http://fabric8.io/</url>
   <inceptionYear>2015</inceptionYear>
+  <description>Java client for Kubernetes and OpenShift</description>
 
   <organization>
     <name>Red Hat</name>
@@ -104,6 +105,7 @@
     <automaton.bundle.version>1.11-8_1</automaton.bundle.version>
     <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
     <junit.version>5.5.2</junit.version>
+    <junit.compatible-with-arquillian.version>4.12</junit.compatible-with-arquillian.version>
     <zjsonpatch.version>0.3.0</zjsonpatch.version>
     <arquillian.cube.version>1.18.2</arquillian.cube.version>
     <slf4j.version>1.7.29</slf4j.version>


### PR DESCRIPTION
During his testing @manusa found out that integration tests are
not getting executed during their run on CircleCI. The reason was due
to incompatibility of Junit 5 with Arquillian. I've reverted to Junit 4
in kubernetes-itests/ module for now.

We can update this whenever this gets resolved:
    https://github.com/arquillian/arquillian-core/issues/137