### PR TITLE
Remove reference to missing dependency StringUtils (commons-lang)

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListener.java
@@ -27,8 +27,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
-
 public class PodUploadWebSocketListener extends WebSocketListener {
 
   private static final byte FLAG_STDIN = (byte) 0;
@@ -86,7 +84,7 @@ public class PodUploadWebSocketListener extends WebSocketListener {
   }
 
   final void checkError() {
-    if (!isBlank(error.get())) {
+    if (error.get() != null && !error.get().trim().isEmpty()) {
       throw new KubernetesClientException(error.get());
     }
   }


### PR DESCRIPTION
Remove reference to `StringUtils` included in non-required dependency added by accident in the previous pull request (https://github.com/fabric8io/kubernetes-client/pull/1865).