### PR TITLE
Fix #1859 - Pass caller's propagation-policy/cascade options to the underlying replicaset when deleting a deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.7-SNAPSHOT
 #### Bugs
 * Fix disabled Integration tests
+* Fix #1859 - Pass caller's propagation-policy/cascade options to the underlying replicaset when deleting a deployment
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/DeploymentOperationsImpl.java
@@ -290,10 +290,18 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
       if (selector == null || (selector.getMatchLabels() == null && selector.getMatchExpressions() == null)) {
         return;
       }
-      ReplicaSetOperationsImpl rsOper = new ReplicaSetOperationsImpl(new RollingOperationContext()
+      RollingOperationContext context = new RollingOperationContext()
         .withOkhttpClient(oper.client)
         .withConfig(oper.config)
-        .withNamespace(oper.getNamespace()));
+        .withNamespace(oper.getNamespace());
+
+      if (oper.getPropagationPolicy() != null) {
+        context = context.withPropagationPolicy(oper.getPropagationPolicy());
+      } else if (oper.isCascading()) {
+        context = context.withCascading(oper.isCascading());
+      }
+
+      ReplicaSetOperationsImpl rsOper = new ReplicaSetOperationsImpl(context);
       rsOper.inNamespace(oper.getNamespace()).withLabelSelector(selector).delete();
     }
   }


### PR DESCRIPTION
I tried and failed to write a unit test for this change.  The mock server allows you to set up expectations about a` server.expect().delete().withPath()`..., but there seem to be no way to actually set an expectation  about the request body (to validate the delete options).  I noticed the `server.getLastRequest()` exists, but this doesn't help me in this case.  `getLastRequest()` gives me the delete for the deployment, I need to access the penultimate which would be the DELETE for my replicaset.

