### PR TITLE
Fix #1548: Unable to update status on Custom Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #1872: Support for kubernetes 1.17
 
 #### New Features
+* Fix #1548: Allow user to update the status on CustomResources
 
 ### 4.6.4 (20-11-2019)
 #### Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
@@ -15,5 +15,5 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface EditReplacePatchable<I, T, D> extends Editable<D>, Replaceable<I, T>, Patchable<I, T> {
+public interface EditReplacePatchable<I, T, D> extends Editable<D>, Replaceable<I, T>, Patchable<I, T>, StatusUpdatable<T> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusUpdatable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusUpdatable.java
@@ -15,12 +15,14 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.client.GracePeriodConfigurable;
-import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
-
-public interface WatchListDeletable<T, L, B, H, W> extends VersionWatchable<H, W>, Listable<L>, Deletable<B>,
-                                                           GracePeriodConfigurable<Deletable<B>>,
-                                                           StatusUpdatable<T>,
-                                                           PropagationPolicyConfigurable<Deletable<B>>
-{
+public interface StatusUpdatable<T> {
+  /**
+   * When the status subresource is enabled, the /status subresource for the custom resource is exposed.
+   * It does a PUT requests to the /status subresource take a resource object and ignore changes
+   * to anything except the status stanza.
+   *
+   * @param item kubernetes object
+   * @return updated object
+   */
+  T updateStatus(T item);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -694,6 +694,15 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
     return deleted;
   }
 
+  @Override
+  public T updateStatus(T item) throws KubernetesClientException {
+    try {
+      return handleStatusUpdate(item, getType());
+    } catch (InterruptedException | ExecutionException | IOException e) {
+      throw KubernetesClientException.launderThrowable(forOperationType("statusUpdate"), e);
+    }
+  }
+
   public BaseOperation<T,L,D,R> withItem(T item) {
     return newInstance(context.withItem(item));
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -279,6 +279,12 @@ public class OperationSupport {
     return handleResponse(requestBuilder, type, parameters);
   }
 
+  protected <T> T handleStatusUpdate(T updated, Class<T> type) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+    RequestBody body = RequestBody.create(JSON, JSON_MAPPER.writeValueAsString(updated));
+    Request.Builder requestBuilder = new Request.Builder().put(body).url(getResourceUrl(checkNamespace(updated), checkName(updated)) + "/status");
+    return handleResponse(requestBuilder, type);
+  }
+
   /**
    * Send an http patch and handle the response.
    *

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -310,6 +310,93 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
   }
 
   /**
+   * Update status related to a CustomResource, this method does a PUT request on /status endpoint related
+   * to the CustomResource
+   *
+   * @param name name of custom resource
+   * @param objectAsMap custom resource as a HashMap
+   * @return updated CustomResource as HashMap
+   * @throws IOException in case any failure to parse Map
+   * @throws KubernetesClientException in case any failure from Kubernetes APIs
+   */
+  public Map<String, Object> updateStatus(String name, Map<String, Object> objectAsMap) throws IOException, KubernetesClientException {
+    return validateAndSubmitRequest(fetchUrl(null, null) + (name != null ? name : "") + "/status", objectMapper.writeValueAsString(objectAsMap), HttpCallMethod.PUT);
+  }
+
+  /**
+   * Update status related to a CustomResource, this method does a PUT request on /status endpoint related
+   * to the CustomResource
+   *
+   * @param name name of CustomResource
+   * @param objectAsJsonString CustomResource as a JSON string
+   * @return updated CustomResource as a HashMap
+   * @throws IOException in case any failure to parse Map
+   * @throws KubernetesClientException in case any failure from Kubernetes APIs
+   */
+  public Map<String, Object> updateStatus(String name, String objectAsJsonString) throws IOException, KubernetesClientException {
+    return validateAndSubmitRequest(fetchUrl(null, null) + (name != null ? name : "") + "/status", objectAsJsonString, HttpCallMethod.PUT);
+  }
+
+  /**
+   * Update status related to a CustomResource, this method does a PUT request on /status endpoint related
+   * to the CustomResource
+   *
+   * @param namespace namespace of CustomResource
+   * @param name name of CustomResource
+   * @param objectAsMap CustomResource as a HashMap
+   * @return updated CustomResource as a HashMap
+   * @throws IOException in case any failure to parse Map
+   * @throws KubernetesClientException in case any failure from Kubernetes APIs
+   */
+  public Map<String, Object> updateStatus(String namespace, String name, Map<String, Object> objectAsMap) throws IOException, KubernetesClientException {
+    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : "") + "/status", objectMapper.writeValueAsString(objectAsMap), HttpCallMethod.PUT);
+  }
+
+  /**
+   * Update status related to a CustomResource, this method does a PUT request on /status endpoint related
+   * to the CustomResource
+   *
+   * @param name name of CustomResource
+   * @param objectAsStream stream pointing to CustomResource
+   * @return updated CustomResource as a HashMap
+   * @throws IOException in case any failure to parse Map
+   * @throws KubernetesClientException in case any failure from Kubernetes APIs
+   */
+  public Map<String, Object> updateStatus(String name, InputStream objectAsStream) throws IOException, KubernetesClientException {
+    return validateAndSubmitRequest(fetchUrl(null, null) + (name != null ? name : "") + "/status", IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
+  }
+
+  /**
+   * Update status related to a CustomResource, this method does a PUT request on /status endpoint related
+   * to the CustomResource
+   *
+   * @param namespace namespace of CustomResource
+   * @param name name of CustomResource
+   * @param objectAsStream CustomResource object as a stream
+   * @return updated CustomResource as a HashMap
+   * @throws IOException in case any failure to parse Map
+   * @throws KubernetesClientException in case any failure from Kubernetes APIs
+   */
+  public Map<String, Object> updateStatus(String namespace, String name, InputStream objectAsStream) throws IOException, KubernetesClientException {
+    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : "") + "/status", IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
+  }
+
+  /**
+   * Update status related to a CustomResource, this method does a PUT request on /status endpoint related
+   * to the CustomResource
+   *
+   * @param namespace namespace of CustomResource
+   * @param name name of CustomResource
+   * @param objectAsJsonString CustomResource object as a JSON string
+   * @return updated CustomResource as a HashMap
+   * @throws IOException in case any failure to parse Map
+   * @throws KubernetesClientException in case any failure from Kubernetes APIs
+   */
+  public Map<String, Object> updateStatus(String namespace, String name, String objectAsJsonString) throws IOException, KubernetesClientException {
+    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : "") + "/status", objectAsJsonString, HttpCallMethod.PUT);
+  }
+
+  /**
    * Get a custom resource from the cluster which is non-namespaced.
    *
    * @param name name of custom resource
@@ -667,10 +754,14 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
   }
 
   private Map<String, Object> validateAndSubmitRequest(String namespace, String name, String objectAsString, HttpCallMethod httpCallMethod) throws IOException {
+    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : ""), objectAsString, httpCallMethod);
+  }
+
+  private Map<String, Object> validateAndSubmitRequest(String resourceUrl, String objectAsString, HttpCallMethod httpCallMethod) throws IOException {
     if (IOHelpers.isJSONValid(objectAsString)) {
-      return makeCall(fetchUrl(namespace, null) + (name != null ? name : ""), objectAsString, httpCallMethod);
+      return makeCall(resourceUrl, objectAsString, httpCallMethod);
     } else {
-      return makeCall(fetchUrl(namespace, null) + (name != null ? name : ""), IOHelpers.convertYamlToJson(objectAsString), httpCallMethod);
+      return makeCall(resourceUrl, IOHelpers.convertYamlToJson(objectAsString), httpCallMethod);
     }
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -236,4 +236,14 @@ public class CustomResourceTest {
       client.customResource(customResourceDefinitionContext).delete("ns2", "example-hello");
     });
   }
+
+  @Test
+  public void testStatusUpdate() throws IOException {
+    String objectAsJsonString = "{\"metadata\":{},\"apiVersion\":\"v1\",\"kind\":\"Status\",\"details\":{\"name\":\"prometheus-example-rules\",\"group\":\"monitoring.coreos.com\",\"kind\":\"prometheusrules\",\"uid\":\"b3d085bd-6a5c-11e9-8787-525400b18c1d\"},\"status\":\"Success\"}";
+    server.expect().put().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello/status").andReturn(HttpURLConnection.HTTP_OK, objectAsJsonString).once();
+
+    KubernetesClient client = server.getClient();
+    Map<String, Object> result = client.customResource(customResourceDefinitionContext).updateStatus("ns1", "example-hello", objectAsJsonString);
+    assertEquals("Success", result.get("status"));
+  }
 }


### PR DESCRIPTION
Fix #1548 

`/status` is one of the supported subresources in Kubernetes API
https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource