### PR TITLE
Fix #1282: Add Support for fetching Kubernetes Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 #### New Features
 * Fix #1548: Allow user to update the status on CustomResources
+* Fix #1282: Add Support for fetching Kubernetes metrics
 
 ### 4.6.4 (20-11-2019)
 #### Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -317,6 +317,9 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   public BatchAPIGroupDSL batch() { return adapt(BatchAPIGroupClient.class); }
 
   @Override
+  public MetricAPIGroupDSL top() { return adapt(MetricAPIGroupClient.class); }
+
+  @Override
   public PolicyAPIGroupDSL policy() { return adapt(PolicyAPIGroupClient.class); }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -189,6 +189,13 @@ public interface KubernetesClient extends Client {
   BatchAPIGroupDSL batch();
 
   /**
+   * API entrypoint for kubernetes metrics
+   *
+   * @return MetricAPIGroupDSL which offers for fetching metrics
+   */
+  MetricAPIGroupDSL top();
+
+  /**
    * API entrypoint for kubernetes resources with APIGroup policy/v1beta1
    *
    * @return PolicyAPIGroupDSL which offers entrypoint to specific resources in this APIGroup

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/MetricAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/MetricAPIGroupClient.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.client.dsl.MetricAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.internal.NodeMetricOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.PodMetricOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class MetricAPIGroupClient extends BaseClient implements MetricAPIGroupDSL {
+  public MetricAPIGroupClient() throws KubernetesClientException {
+    super();
+  }
+
+  public MetricAPIGroupClient(OkHttpClient httpClient, final Config config) throws KubernetesClientException {
+    super(httpClient, config);
+  }
+
+  @Override
+  public PodMetricOperationsImpl pods() {
+    return new PodMetricOperationsImpl(httpClient, getConfiguration());
+  }
+
+  @Override
+  public NodeMetricOperationsImpl nodes() {
+    return new NodeMetricOperationsImpl(httpClient, getConfiguration());
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/MetricAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/MetricAPIGroupExtensionAdapter.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+
+public class MetricAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<MetricAPIGroupClient> {
+
+  @Override
+  protected String getAPIGroupName() {
+    return "batch";
+  }
+
+  @Override
+  public Class<MetricAPIGroupClient> getExtensionType() {
+    return MetricAPIGroupClient.class;
+  }
+
+  @Override
+  protected MetricAPIGroupClient newInstance(Client client) {
+    return new MetricAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/MetricAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/MetricAPIGroupDSL.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.dsl.internal.NodeMetricOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.PodMetricOperationsImpl;
+
+public interface MetricAPIGroupDSL extends Client {
+  PodMetricOperationsImpl pods();
+  NodeMetricOperationsImpl nodes();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.DeleteOptions;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.internal.VersionUsageUtils;
@@ -196,6 +197,12 @@ public class OperationSupport {
     throw new KubernetesClientException("Name mismatch. Item name:" + itemName + ". Operation name:" + operationName + ".");
   }
 
+  protected <T> T handleMetric(String resourceUrl, Class<T> type) throws InterruptedException, IOException, ExecutionException {
+      Request.Builder requestBuilder = new Request.Builder()
+        .get()
+        .url(resourceUrl);
+      return handleResponse(requestBuilder, type);
+  }
 
   protected <T> void handleDelete(T resource, long gracePeriodSeconds, String propagationPolicy, boolean cascading) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
     handleDelete(getResourceUrl(checkNamespace(resource), checkName(resource)), gracePeriodSeconds, propagationPolicy, cascading);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NodeMetricOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NodeMetricOperationsImpl.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.utils.URLUtils;
+import okhttp3.OkHttpClient;
+
+public class NodeMetricOperationsImpl extends OperationSupport {
+  private static String METRIC_ENDPOINT_URL = "apis/metrics.k8s.io/v1beta1/nodes";
+
+  public NodeMetricOperationsImpl(OkHttpClient client, Config config) {
+    super(new OperationContext().withOkhttpClient(client).withConfig(config));
+  }
+
+  public NodeMetricsList metrics() {
+    try {
+      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL);
+      return handleMetric(resourceUrl, NodeMetricsList.class);
+    } catch(Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  public NodeMetrics metrics(String nodeName) {
+    try {
+      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL, nodeName);
+      return handleMetric(resourceUrl, NodeMetrics.class);
+    } catch(Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodMetricOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodMetricOperationsImpl.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.utils.URLUtils;
+import io.fabric8.kubernetes.client.utils.Utils;
+import okhttp3.OkHttpClient;
+
+public class PodMetricOperationsImpl extends OperationSupport {
+  private static String METRIC_ENDPOINT_URL = "apis/metrics.k8s.io/v1beta1";
+
+  public PodMetricOperationsImpl(OkHttpClient client, Config config) {
+    super(new OperationContext().withOkhttpClient(client).withConfig(config));
+  }
+
+  public PodMetrics metrics(String namespace, String podName) {
+    try {
+      Utils.checkNotNull(namespace, "Namespace not provided");
+      Utils.checkNotNull(podName, "Name not provided");
+
+      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL,
+        "namespaces", namespace, "pods", podName);
+      return handleMetric(resourceUrl, PodMetrics.class);
+    } catch(Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  public PodMetricsList metrics() {
+    try {
+      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL, "pods");
+      return handleMetric(resourceUrl, PodMetricsList.class);
+    } catch(Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  public PodMetricsList metrics(String namespace) {
+    try {
+      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL,
+        "namespaces", namespace, "pods");
+      return handleMetric(resourceUrl, PodMetricsList.class);
+    } catch(Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -87,6 +87,7 @@ import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
+import io.fabric8.kubernetes.client.dsl.MetricAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
@@ -377,6 +378,9 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
 
   @Override
   public BatchAPIGroupDSL batch() { return delegate.batch(); }
+
+  @Override
+  public MetricAPIGroupDSL top() { return delegate.top(); }
 
   @Override
   public PolicyAPIGroupDSL policy() { return delegate.policy(); }

--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
@@ -18,6 +18,7 @@ io.fabric8.kubernetes.client.AppsAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.AutoscalingAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.BatchAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.ExtensionsAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.MetricAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.NetworkAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.PolicyAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.RbacAPIGroupExtensionAdapter

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/TopExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/TopExample.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.examples;
+
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class TopExample {
+
+  private static final Logger logger = LoggerFactory.getLogger(TopExample.class);
+
+  public static void main(String[] args) {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      NodeMetricsList nodeMetricList = client.top().nodes().metrics();
+
+      log("name CPU(cores) CPU(%) Memory(Bytes) Memory(%)");
+      for (NodeMetrics nodeMetrics : nodeMetricList.getItems()) {
+        log(nodeMetrics.getMetadata().getName() +
+          " " + nodeMetrics.getUsage().get("cpu") +
+          " " + nodeMetrics.getUsage().get("memory"));
+      }
+
+      log("==== Pod Metrics ====");
+      log("name CPU(cores) CPU(%) Memory(Bytes) Memory(%)");
+      PodMetricsList podMetricsList = client.top().pods().metrics("default");
+      for (PodMetrics podMetrics : podMetricsList.getItems()) {
+        log(podMetrics.getMetadata().getName());
+
+        List<ContainerMetrics> containerMetricsList = podMetrics.getContainers();
+        for(ContainerMetrics containerMetric :  containerMetricsList) {
+          log(podMetrics.getMetadata().getName() +
+            " " + containerMetric.getUsage().get("cpu") +
+            " " + containerMetric.getUsage().get("memory"));
+        }
+      }
+
+      PodMetrics podMetrics = client.top().pods().metrics("default", "nginx-deployment-54f57cf6bf-gcvzx");
+      log(" ===== Individual Pod Metrics =====");
+      log("Pod Name: " + podMetrics.getMetadata().getName());
+      List<ContainerMetrics> containerMetricsList = podMetrics.getContainers();
+      for(ContainerMetrics containerMetric :  containerMetricsList) {
+        log(podMetrics.getMetadata().getName() +
+          " " + containerMetric.getUsage().get("cpu") +
+          " " + containerMetric.getUsage().get("memory"));
+      }
+
+    } catch (KubernetesClientException e) {
+      logger.error(e.getMessage(), e);
+    } finally {
+    }
+  }
+
+  private static void log(String action, Object obj) {
+    logger.info("{}: {}", action, obj);
+  }
+
+  private static void log(String action) {
+    logger.info(action);
+  }
+}

--- a/kubernetes-model/Gopkg.lock
+++ b/kubernetes-model/Gopkg.lock
@@ -197,6 +197,17 @@
   version = "v1.17.0"
 
 [[projects]]
+  digest = "1:7814e7cc39cdcb500eafc02de1ec5ca87a5fd69c117f5225eb93ad79a83a7ff8"
+  name = "k8s.io/metrics"
+  packages = [
+    "pkg/apis/metrics",
+    "pkg/apis/metrics/v1beta1",
+  ]
+  pruneopts = "UT"
+  revision = ""
+  version = "kubernetes-1.17.0"
+
+[[projects]]
   branch = "master"
   digest = "1:533745b9452e27599b73ffa11c5248d44116e6d92b325fd7f400abab761187b9"
   name = "k8s.io/utils"
@@ -247,6 +258,7 @@
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/client-go/tools/clientcmd/api/v1",
     "k8s.io/kubernetes/pkg/watch/json",
+    "k8s.io/metrics/pkg/apis/metrics/v1beta1",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/kubernetes-model/Gopkg.toml
+++ b/kubernetes-model/Gopkg.toml
@@ -52,6 +52,10 @@ required = [
   name = "k8s.io/client-go"
   version = "kubernetes-1.17.0"
 
+[[constraint]]
+  name = "k8s.io/metrics"
+  version = "kubernetes-1.17.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/kubernetes-model/cmd/generate/generate.go
+++ b/kubernetes-model/cmd/generate/generate.go
@@ -53,8 +53,8 @@ import (
   storageclassapiv1beta1 "k8s.io/api/storage/v1beta1"
   apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
   "k8s.io/apimachinery/pkg/api/resource"
-  apimachineryapis "k8s.io/apimachinery/pkg/apis/meta/v1"
   metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  metrics "k8s.io/metrics/pkg/apis/metrics/v1beta1"
   apimachineryversion "k8s.io/apimachinery/pkg/version"
   configapi "k8s.io/client-go/tools/clientcmd/api/v1"
   watch "k8s.io/kubernetes/pkg/watch/json"
@@ -70,8 +70,8 @@ import (
 
 type Schema struct {
   Info                              apimachineryversion.Info
-  APIGroup                          apimachineryapis.APIGroup
-  APIGroupList                      apimachineryapis.APIGroupList
+  APIGroup                          metav1.APIGroup
+  APIGroupList                      metav1.APIGroupList
   BaseKubernetesList                metav1.List
   ObjectMeta                        metav1.ObjectMeta
   TypeMeta                          metav1.TypeMeta
@@ -249,6 +249,10 @@ type Schema struct {
   CSINodeList                        storageclassapiv1beta1.CSINodeList
   Lease                              coordination.Lease
   LeaseList                          coordination.LeaseList
+  PodMetrics                         metrics.PodMetrics
+  PodMetricsList                     metrics.PodMetricsList
+  NodeMetrics                        metrics.NodeMetrics
+  NodeMetricsList                    metrics.NodeMetricsList
 }
 
 func main() {
@@ -298,6 +302,7 @@ func main() {
     {"k8s.io/api/admissionregistration/v1beta1", "admissionregistration.k8s.io", "io.fabric8.kubernetes.api.model.admissionregistration", "kubernetes_admissionregistration_"},
     {"k8s.io/api/certificates/v1beta1", "certificates.k8s.io", "io.fabric8.kubernetes.api.model.certificates", "kubernetes_certificates_"},
     {"k8s.io/api/coordination/v1beta1", "coordination.k8s.io", "io.fabric8.kubernetes.api.model.coordination.v1beta1", "kubernetes_certificates_v1beta1_"},
+    {"k8s.io/metrics/pkg/apis/metrics/v1beta1", "metrics.k8s.io", "io.fabric8.kubernetes.api.model.metrics.v1beta1", "kubernetes_metrics_v1beta1_"},
   }
 
   typeMap := map[reflect.Type]reflect.Type{

--- a/kubernetes-model/kubernetes-model/pom.xml
+++ b/kubernetes-model/kubernetes-model/pom.xml
@@ -124,6 +124,7 @@
                 <echo>removing the duplicate generated calss</echo>
                 <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/IntOrString.java" verbose="true" />
                 <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/Quantity.java" verbose="true" />
+                <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/Duration.java" verbose="true" />
                 <delete file="${project.build.directory}/generated-sources/io/fabric8/openshift/api/model/Template.java" verbose="true" />
                 <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/HasMetadata.java" verbose="true" />
                 <delete file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/WatchEvent.java" verbose="true" />

--- a/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Duration.java
+++ b/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Duration.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.api.model;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Inline;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Duration is wrapper around duration variable which just stores the
+ * amount of time in seconds. It supports correct marshaling to YAML
+ * and JSON. In particular, it marshals into strings, which can be used
+ * as map keys in json.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = Duration.Deserializer.class)
+@JsonSerialize(using = Duration.Serializer.class)
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+public class Duration implements Serializable
+{
+
+    /**
+     * 
+     * 
+     */
+    @JsonProperty("Duration")
+    private Long duration;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public Duration() {
+    }
+
+    /**
+     * 
+     * @param duration
+     */
+    public Duration(Long duration) {
+        this.duration = duration;
+    }
+
+    public Duration(String duration) {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher(duration);
+      long totalSeconds = 0;
+
+      while (m.find()) {
+        String digit = m.group();
+        int digitIndex = duration.indexOf(digit);
+        if (digitIndex + 1 < duration.length()) {
+          char unit = duration.charAt(digitIndex + 1);
+          if (unit == 'h') {
+            totalSeconds += (3600 * Integer.parseInt(digit));
+          } else if (unit == 'm') {
+            totalSeconds += (60 * Integer.parseInt(digit));
+          } else if (unit == 's') {
+            totalSeconds += (Integer.parseInt(digit));
+          }
+        }
+      }
+      this.duration = totalSeconds;
+    }
+
+    /**
+     * 
+     * 
+     * @return
+     *     The duration
+     */
+    @JsonProperty("Duration")
+    public Long getDuration() {
+        return duration;
+    }
+
+    /**
+     * 
+     * 
+     * @param duration
+     *     The Duration
+     */
+    @JsonProperty("Duration")
+    public void setDuration(Long duration) {
+        this.duration = duration;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+  public static class Serializer extends JsonSerializer<Duration> {
+
+    @Override
+    public void serialize(Duration value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+      if (value != null && value.getDuration() != null) {
+        jgen.writeString(value.getDuration().toString());
+      } else {
+        jgen.writeNull();
+      }
+    }
+  }
+
+  public static class Deserializer extends JsonDeserializer<Duration> {
+
+    @Override
+    public Duration deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+      ObjectCodec oc = jsonParser.getCodec();
+      JsonNode node = oc.readTree(jsonParser);
+      Duration duration = new Duration(node.asText());
+      return duration;
+    }
+
+  }
+
+}

--- a/kubernetes-model/kubernetes-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/kubernetes-model/src/main/resources/schema/kube-schema.json
@@ -1516,6 +1516,22 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_Duration": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "Duration": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.Duration",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_FieldsV1": {
       "type": "object",
       "description": "",
@@ -13062,6 +13078,189 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_metrics_v1beta1_ContainerMetrics": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "usage": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "$ref": "#/definitions/kubernetes_resource_Quantity",
+            "javaType": "io.fabric8.kubernetes.api.model.Quantity"
+          },
+          "javaType": "java.util.Map\u003cString,io.fabric8.kubernetes.api.model.Quantity\u003e"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_NodeMetrics": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "NodeMetrics",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "usage": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "$ref": "#/definitions/kubernetes_resource_Quantity",
+            "javaType": "io.fabric8.kubernetes.api.model.Quantity"
+          },
+          "javaType": "java.util.Map\u003cString,io.fabric8.kubernetes.api.model.Quantity\u003e"
+        },
+        "window": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Duration",
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_NodeMetricsList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_NodeMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "NodeMetricsList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics\u003e"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_PodMetrics": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "containers": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_ContainerMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PodMetrics",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "window": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Duration",
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_PodMetricsList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_PodMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PodMetricsList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics\u003e"
+      ]
+    },
     "kubernetes_networking_IPBlock": {
       "type": "object",
       "description": "",
@@ -20300,6 +20499,14 @@
       "$ref": "#/definitions/kubernetes_core_NodeList",
       "javaType": "io.fabric8.kubernetes.api.model.NodeList"
     },
+    "NodeMetrics": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_NodeMetrics",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics"
+    },
+    "NodeMetricsList": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_NodeMetricsList",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList"
+    },
     "OAuthAccessToken": {
       "$ref": "#/definitions/os_oauth_OAuthAccessToken",
       "javaType": "io.fabric8.openshift.api.model.OAuthAccessToken"
@@ -20411,6 +20618,14 @@
     "PodList": {
       "$ref": "#/definitions/kubernetes_core_PodList",
       "javaType": "io.fabric8.kubernetes.api.model.PodList"
+    },
+    "PodMetrics": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_PodMetrics",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics"
+    },
+    "PodMetricsList": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_PodMetricsList",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList"
     },
     "PodPreset": {
       "$ref": "#/definitions/kubernetes_settings_PodPreset",

--- a/kubernetes-model/kubernetes-model/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model/kubernetes-model/src/main/resources/schema/validation-schema.json
@@ -1516,6 +1516,22 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_Duration": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "Duration": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.Duration",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_FieldsV1": {
       "type": "object",
       "description": "",
@@ -13062,6 +13078,189 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_metrics_v1beta1_ContainerMetrics": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "usage": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "$ref": "#/definitions/kubernetes_resource_Quantity",
+            "javaType": "io.fabric8.kubernetes.api.model.Quantity"
+          },
+          "javaType": "java.util.Map\u003cString,io.fabric8.kubernetes.api.model.Quantity\u003e"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_NodeMetrics": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "NodeMetrics",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "usage": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "$ref": "#/definitions/kubernetes_resource_Quantity",
+            "javaType": "io.fabric8.kubernetes.api.model.Quantity"
+          },
+          "javaType": "java.util.Map\u003cString,io.fabric8.kubernetes.api.model.Quantity\u003e"
+        },
+        "window": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Duration",
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_NodeMetricsList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_NodeMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "NodeMetricsList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics\u003e"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_PodMetrics": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "containers": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_ContainerMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PodMetrics",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "window": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Duration",
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "kubernetes_metrics_v1beta1_PodMetricsList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_PodMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PodMetricsList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics\u003e"
+      ]
+    },
     "kubernetes_networking_IPBlock": {
       "type": "object",
       "description": "",
@@ -20300,6 +20499,14 @@
       "$ref": "#/definitions/kubernetes_core_NodeList",
       "javaType": "io.fabric8.kubernetes.api.model.NodeList"
     },
+    "NodeMetrics": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_NodeMetrics",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics"
+    },
+    "NodeMetricsList": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_NodeMetricsList",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList"
+    },
     "OAuthAccessToken": {
       "$ref": "#/definitions/os_oauth_OAuthAccessToken",
       "javaType": "io.fabric8.openshift.api.model.OAuthAccessToken"
@@ -20411,6 +20618,14 @@
     "PodList": {
       "$ref": "#/definitions/kubernetes_core_PodList",
       "javaType": "io.fabric8.kubernetes.api.model.PodList"
+    },
+    "PodMetrics": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_PodMetrics",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics"
+    },
+    "PodMetricsList": {
+      "$ref": "#/definitions/kubernetes_metrics_v1beta1_PodMetricsList",
+      "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList"
     },
     "PodPreset": {
       "$ref": "#/definitions/kubernetes_settings_PodPreset",
@@ -22095,7 +22310,7 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "rbac.authorization.k8s.io/v1",
+          "default": "authorization.openshift.io/v1",
           "required": true
         },
         "kind": {
@@ -22112,8 +22327,8 @@
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/kubernetes_rbac_PolicyRule",
-            "javaType": "io.fabric8.kubernetes.api.model.rbac.PolicyRule"
+            "$ref": "#/definitions/os_authorization_PolicyRule",
+            "javaType": "io.fabric8.openshift.api.model.PolicyRule"
           }
         }
       },
@@ -22173,15 +22388,15 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_ClusterRoleBinding",
-            "javaType": "io.fabric8.openshift.api.model.OpenshiftClusterRoleBinding"
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBinding",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding"
           }
         },
         "kind": {
@@ -22773,6 +22988,24 @@
           "type": "integer",
           "description": "",
           "javaType": "Long"
+        }
+      },
+      "additionalProperties": true
+    },
+    "containermetrics": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "usage": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "$ref": "#/definitions/kubernetes_resource_Quantity",
+            "javaType": "io.fabric8.kubernetes.api.model.Quantity"
+          },
+          "javaType": "java.util.Map\u003cString,io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -24426,9 +24659,44 @@
     },
     "deploymentstrategy": {
       "properties": {
-        "rollingUpdate": {
-          "$ref": "#/definitions/kubernetes_apps_RollingUpdateDeployment",
-          "javaType": "io.fabric8.kubernetes.api.model.apps.RollingUpdateDeployment"
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "type": "string",
+            "description": ""
+          },
+          "javaType": "java.util.Map\u003cString,String\u003e"
+        },
+        "customParams": {
+          "$ref": "#/definitions/os_deploy_CustomDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.CustomDeploymentStrategyParams"
+        },
+        "labels": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "type": "string",
+            "description": ""
+          },
+          "javaType": "java.util.Map\u003cString,String\u003e"
+        },
+        "recreateParams": {
+          "$ref": "#/definitions/os_deploy_RecreateDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.RecreateDeploymentStrategyParams"
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
+          "javaType": "io.fabric8.kubernetes.api.model.ResourceRequirements"
+        },
+        "rollingParams": {
+          "$ref": "#/definitions/os_deploy_RollingDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.RollingDeploymentStrategyParams"
         },
         "type": {
           "type": "string",
@@ -24590,6 +24858,16 @@
             "$ref": "#/definitions/kubernetes_core_DownwardAPIVolumeFile",
             "javaType": "io.fabric8.kubernetes.api.model.DownwardAPIVolumeFile"
           }
+        }
+      },
+      "additionalProperties": true
+    },
+    "duration": {
+      "properties": {
+        "Duration": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
         }
       },
       "additionalProperties": true
@@ -25176,24 +25454,28 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "v1",
+          "default": "events.k8s.io/v1beta1",
           "required": true
         },
-        "count": {
+        "deprecatedCount": {
           "type": "integer",
           "description": ""
+        },
+        "deprecatedFirstTimestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "deprecatedLastTimestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "deprecatedSource": {
+          "$ref": "#/definitions/kubernetes_core_EventSource",
+          "javaType": "io.fabric8.kubernetes.api.model.EventSource"
         },
         "eventTime": {
           "$ref": "#/definitions/kubernetes_apimachinery_MicroTime",
           "javaType": "io.fabric8.kubernetes.api.model.MicroTime"
-        },
-        "firstTimestamp": {
-          "$ref": "#/definitions/kubernetes_apimachinery_Time",
-          "javaType": "String"
-        },
-        "involvedObject": {
-          "$ref": "#/definitions/kubernetes_core_ObjectReference",
-          "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
         },
         "kind": {
           "type": "string",
@@ -25201,27 +25483,27 @@
           "default": "Event",
           "required": true
         },
-        "lastTimestamp": {
-          "$ref": "#/definitions/kubernetes_apimachinery_Time",
-          "javaType": "String"
-        },
-        "message": {
-          "type": "string",
-          "description": ""
-        },
         "metadata": {
           "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
           "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "note": {
+          "type": "string",
+          "description": ""
         },
         "reason": {
           "type": "string",
           "description": ""
         },
+        "regarding": {
+          "$ref": "#/definitions/kubernetes_core_ObjectReference",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
+        },
         "related": {
           "$ref": "#/definitions/kubernetes_core_ObjectReference",
           "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
         },
-        "reportingComponent": {
+        "reportingController": {
           "type": "string",
           "description": ""
         },
@@ -25230,12 +25512,8 @@
           "description": ""
         },
         "series": {
-          "$ref": "#/definitions/kubernetes_core_EventSeries",
-          "javaType": "io.fabric8.kubernetes.api.model.EventSeries"
-        },
-        "source": {
-          "$ref": "#/definitions/kubernetes_core_EventSource",
-          "javaType": "io.fabric8.kubernetes.api.model.EventSource"
+          "$ref": "#/definitions/kubernetes_events_EventSeries",
+          "javaType": "io.fabric8.kubernetes.api.model.events.EventSeries"
         },
         "type": {
           "type": "string",
@@ -25567,11 +25845,11 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/os_security_IDRange",
-            "javaType": "io.fabric8.openshift.api.model.IDRange"
+            "$ref": "#/definitions/kubernetes_extensions_IDRange",
+            "javaType": "io.fabric8.kubernetes.api.model.extensions.IDRange"
           }
         },
-        "type": {
+        "rule": {
           "type": "string",
           "description": ""
         }
@@ -28961,6 +29239,73 @@
       },
       "additionalProperties": true
     },
+    "nodemetrics": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "NodeMetrics",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "usage": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "$ref": "#/definitions/kubernetes_resource_Quantity",
+            "javaType": "io.fabric8.kubernetes.api.model.Quantity"
+          },
+          "javaType": "java.util.Map\u003cString,io.fabric8.kubernetes.api.model.Quantity\u003e"
+        },
+        "window": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Duration",
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        }
+      },
+      "additionalProperties": true
+    },
+    "nodemetricslist": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_NodeMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "NodeMetricsList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true
+    },
     "nodeselector": {
       "properties": {
         "nodeSelectorTerms": {
@@ -30685,6 +31030,72 @@
       },
       "additionalProperties": true
     },
+    "podmetrics": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "containers": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_ContainerMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.ContainerMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PodMetrics",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "window": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Duration",
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        }
+      },
+      "additionalProperties": true
+    },
+    "podmetricslist": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "metrics.k8s.io/v1beta1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/kubernetes_metrics_v1beta1_PodMetrics",
+            "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PodMetricsList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true
+    },
     "podpreset": {
       "properties": {
         "apiVersion": {
@@ -31439,11 +31850,14 @@
         "apiGroups": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string",
             "description": ""
           }
+        },
+        "attributeRestrictions": {
+          "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
+          "javaType": "io.fabric8.kubernetes.api.model.HasMetadata"
         },
         "nonResourceURLs": {
           "type": "array",
@@ -31466,7 +31880,6 @@
         "resources": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string",
             "description": ""
@@ -32536,7 +32949,7 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -32553,8 +32966,8 @@
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_PolicyRule",
-            "javaType": "io.fabric8.openshift.api.model.PolicyRule"
+            "$ref": "#/definitions/kubernetes_rbac_PolicyRule",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.PolicyRule"
           }
         }
       },
@@ -32565,8 +32978,16 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "rbac.authorization.k8s.io/v1",
+          "default": "authorization.openshift.io/v1",
           "required": true
+        },
+        "groupNames": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string",
+            "description": ""
+          }
         },
         "kind": {
           "type": "string",
@@ -32579,16 +33000,23 @@
           "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "roleRef": {
-          "$ref": "#/definitions/kubernetes_rbac_RoleRef",
-          "javaType": "io.fabric8.kubernetes.api.model.rbac.RoleRef"
+          "$ref": "#/definitions/kubernetes_core_ObjectReference",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
         },
         "subjects": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_rbac_Subject",
-            "javaType": "io.fabric8.kubernetes.api.model.rbac.Subject"
+            "$ref": "#/definitions/kubernetes_core_ObjectReference",
+            "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
+          }
+        },
+        "userNames": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string",
+            "description": ""
           }
         }
       },
@@ -32599,15 +33027,15 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "rbac.authorization.k8s.io/v1",
+          "default": "authorization.openshift.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/kubernetes_rbac_RoleBinding",
-            "javaType": "io.fabric8.kubernetes.api.model.rbac.RoleBinding"
+            "$ref": "#/definitions/os_authorization_RoleBinding",
+            "javaType": "io.fabric8.openshift.api.model.OpenshiftRoleBinding"
           }
         },
         "kind": {
@@ -33096,18 +33524,24 @@
     },
     "runasuserstrategyoptions": {
       "properties": {
-        "ranges": {
-          "type": "array",
-          "description": "",
-          "javaOmitEmpty": true,
-          "items": {
-            "$ref": "#/definitions/kubernetes_extensions_IDRange",
-            "javaType": "io.fabric8.kubernetes.api.model.extensions.IDRange"
-          }
-        },
-        "rule": {
+        "type": {
           "type": "string",
           "description": ""
+        },
+        "uid": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "uidRangeMax": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "uidRangeMin": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
         }
       },
       "additionalProperties": true
@@ -34869,8 +35303,24 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.k8s.io/v1",
+          "default": "authorization.openshift.io/v1",
           "required": true
+        },
+        "content": {
+          "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
+          "javaType": "io.fabric8.kubernetes.api.model.HasMetadata"
+        },
+        "groups": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string",
+            "description": ""
+          }
+        },
+        "isNonResourceURL": {
+          "type": "boolean",
+          "description": ""
         },
         "kind": {
           "type": "string",
@@ -34878,17 +35328,45 @@
           "default": "SubjectAccessReview",
           "required": true
         },
-        "metadata": {
-          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
-          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        "namespace": {
+          "type": "string",
+          "description": ""
         },
-        "spec": {
-          "$ref": "#/definitions/kubernetes_authorization_SubjectAccessReviewSpec",
-          "javaType": "io.fabric8.kubernetes.api.model.authorization.SubjectAccessReviewSpec"
+        "path": {
+          "type": "string",
+          "description": ""
         },
-        "status": {
-          "$ref": "#/definitions/kubernetes_authorization_SubjectAccessReviewStatus",
-          "javaType": "io.fabric8.kubernetes.api.model.authorization.SubjectAccessReviewStatus"
+        "resource": {
+          "type": "string",
+          "description": ""
+        },
+        "resourceAPIGroup": {
+          "type": "string",
+          "description": ""
+        },
+        "resourceAPIVersion": {
+          "type": "string",
+          "description": ""
+        },
+        "resourceName": {
+          "type": "string",
+          "description": ""
+        },
+        "scopes": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string",
+            "description": ""
+          }
+        },
+        "user": {
+          "type": "string",
+          "description": ""
+        },
+        "verb": {
+          "type": "string",
+          "description": ""
         }
       },
       "additionalProperties": true

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetricsTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.QuantityBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsListBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@EnableRuleMigrationSupport
+public class MetricsTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  public void testPodMetricsAllNamespace() {
+    server.expect().get().withPath("/apis/metrics.k8s.io/v1beta1/pods")
+      .andReturn(200, new PodMetricsListBuilder().withItems(getPodMetric()).build()).once();
+
+    KubernetesClient client = server.getClient();
+
+    PodMetricsList podMetricsList = client.top().pods().metrics();
+    assertEquals(1, podMetricsList.getItems().size());
+    assertEquals("foo", podMetricsList.getItems().get(0).getMetadata().getName());
+  }
+
+  @Test
+  public void testPodMetricsNamespace() {
+    server.expect().get().withPath("/apis/metrics.k8s.io/v1beta1/namespaces/test/pods")
+      .andReturn(200, new PodMetricsListBuilder().withItems(getPodMetric()).build()).once();
+
+    KubernetesClient client = server.getClient();
+
+    PodMetricsList podMetricsList = client.top().pods().metrics("test");
+    assertEquals(1, podMetricsList.getItems().size());
+    assertEquals("foo", podMetricsList.getItems().get(0).getMetadata().getName());
+  }
+
+  @Test
+  public void testPodMetricsNamespaceWithName() {
+    server.expect().get().withPath("/apis/metrics.k8s.io/v1beta1/namespaces/test/pods/test-pod")
+      .andReturn(200, getPodMetric()).once();
+
+    KubernetesClient client = server.getClient();
+
+    PodMetrics podMetrics = client.top().pods().metrics("test", "test-pod");
+    assertEquals("foo", podMetrics.getMetadata().getName());
+  }
+
+  @Test
+  public void testAllNodeMetrics() {
+    server.expect().get().withPath("/apis/metrics.k8s.io/v1beta1/nodes")
+      .andReturn(200, new NodeMetricsListBuilder().withItems(getNodeMetric()).build()).once();
+    KubernetesClient client = server.getClient();
+
+    NodeMetricsList nodeMetricsList = client.top().nodes().metrics();
+    assertEquals(1, nodeMetricsList.getItems().size());
+    assertEquals("foo", nodeMetricsList.getItems().get(0).getMetadata().getName());
+  }
+
+  @Test
+  public void testNodeMetric() {
+    server.expect().get().withPath("/apis/metrics.k8s.io/v1beta1/nodes/test-node")
+      .andReturn(200, getNodeMetric()).once();
+    KubernetesClient client = server.getClient();
+
+    NodeMetrics nodeMetrics = client.top().nodes().metrics("test-node");
+    assertEquals("foo", nodeMetrics.getMetadata().getName());
+  }
+
+  private PodMetrics getPodMetric() {
+    return new PodMetricsBuilder()
+      .withNewMetadata().withName("foo").endMetadata()
+      .withNewWindow("1m0s")
+      .addNewContainer()
+      .withName("test-container")
+      .withUsage(Collections.singletonMap("cpu", new Quantity("38m")))
+      .endContainer()
+      .build();
+  }
+
+  private NodeMetrics getNodeMetric() {
+    return new NodeMetricsBuilder()
+      .withNewMetadata().withName("foo").endMetadata()
+      .withNewWindow("1m0s")
+      .withUsage(Collections.singletonMap("cpu", new Quantity("38m")))
+      .build();
+  }
+
+
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -456,6 +456,9 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   public BatchAPIGroupDSL batch() { return adapt(BatchAPIGroupClient.class); }
 
   @Override
+  public MetricAPIGroupDSL top() { return adapt(MetricAPIGroupClient.class); }
+
+  @Override
   public PolicyAPIGroupDSL policy() { return adapt(PolicyAPIGroupClient.class); }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -476,6 +476,9 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   public BatchAPIGroupDSL batch() { return delegate.batch(); }
 
   @Override
+  public MetricAPIGroupDSL top() { return delegate.top(); }
+
+  @Override
   public PolicyAPIGroupDSL policy() { return delegate.policy(); }
 
   @Override


### PR DESCRIPTION
Fix #1282 

This PR enables fetching metrics from Kubernetes server via these dsl 

```
   client.top().pod().metrics();
   client.top().node().metrics();
```