### PR TITLE
Refactor Quantity Class to handle format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #1902: Fix the usage of reflection, so that `getMetadata` is detected properly
 * Fix #1486: Creating CRDs with schema validation is broken
 * Fix #1707: HorizontalPodAutoscalerSpecBuilder found no metric method
+* Fix #885: Quantity doesn't honour the unit
 
 #### Improvements
 * Fix #1880: Remove use of reapers manually doing cascade deletion of resources, leave it upto Kubernetes APIServer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #1486: Creating CRDs with schema validation is broken
 * Fix #1707: HorizontalPodAutoscalerSpecBuilder found no metric method
 * Fix #885: Quantity doesn't honour the unit
+* Fix #1895: Parsing different quantity formats
 
 #### Improvements
 * Fix #1880: Remove use of reapers manually doing cascade deletion of resources, leave it upto Kubernetes APIServer

--- a/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -108,8 +108,15 @@ public class Quantity  implements Serializable {
 
         @Override
         public void serialize(Quantity value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
-            if (value != null && value.getAmount() != null) {
-                jgen.writeString(value.getAmount());
+            if (value != null) {
+              StringBuilder objAsStringBuilder = new StringBuilder();
+              if (value.getAmount() != null) {
+                objAsStringBuilder.append(value.getAmount());
+              }
+              if (value.getFormat() != null) {
+                objAsStringBuilder.append(value.getFormat());
+              }
+              jgen.writeString(objAsStringBuilder.toString());
             } else {
                 jgen.writeNull();
             }

--- a/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -30,13 +30,16 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.io.Serializable;
 
 
 /**
- *
+ * Quantity is fixed point representation of a number.
+ * It provides convenient marshalling/unmarshalling in JSON or YAML,
+ * in addition to String or getAmountInBytes accessors.
  *
  */
 @JsonDeserialize(using = Quantity.Deserializer.class)
@@ -46,93 +49,206 @@ import java.io.Serializable;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage=true, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
 public class Quantity  implements Serializable {
 
-    private String amount;
-    private String format;
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  private String amount;
+  private String format;
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-    /**
-     * No args constructor for use in serialization
-     *
-     */
-    public Quantity() {
+  /**
+   * No args constructor for use in serialization
+   *
+   */
+  public Quantity() {
+  }
+
+  /**
+   * Single argument constructor for setting amount.
+   *
+   * @param amount amount of quantity specified.
+   */
+  public Quantity(String amount) {
+    Quantity parsedQuantity = parse(amount);
+    this.amount = parsedQuantity.getAmount();
+    this.format = parsedQuantity.getFormat();
+  }
+
+  /**
+   * Double argument constructor for setting amount along with format.
+   *
+   * @param amount amount of quantity specified
+   * @param format format for the amount.
+   */
+  public Quantity(String amount, String format) {
+    this.amount = amount;
+    this.format = format;
+  }
+
+  public String getAmount() {
+    return amount;
+  }
+
+  public void setAmount(String amount) {
+    this.amount = amount;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  public void setFormat(String format) {
+    this.format = format;
+  }
+
+  public static BigDecimal getAmountInBytes(Quantity quantity) {
+    String value = "";
+    if (quantity.getAmount() != null && quantity.getFormat() != null) {
+      value = quantity.getAmount() + quantity.getFormat();
+    } else if (quantity.getAmount() != null) {
+      value = quantity.getAmount();
     }
 
-    /**
-     * Single argument constructor for setting amount.
-     *
-     * @param amount amount of quantity specified.
-     */
-    public Quantity(String amount) {
-        this.amount = amount;
+    if (value == null || value.isEmpty()) {
+      throw new IllegalArgumentException("Invalid quantity value passed to parse");
+    }
+    // Append Extra zeroes if starting with decimal
+    if (!Character.isDigit(value.indexOf(0)) && value.startsWith(".")) {
+        value = "0" + value;
     }
 
-    /**
-     * Double argument constructor for setting amount along with format.
-     *
-     * @param amount amount of quantity specified
-     * @param format format for the amount.
-     */
-    public Quantity(String amount, String format) {
-        this.amount = amount;
-        this.format = format;
+    Quantity amountFormatPair = parse(value);
+    String formatStr = amountFormatPair.getFormat();
+    // Handle Decimal exponent case
+    if ((formatStr.startsWith("e") || formatStr.startsWith("E")) &&
+        formatStr.length() > 1) {
+      int exponent = Integer.parseInt(formatStr.substring(1));
+      return new BigDecimal("10").pow(exponent);
     }
 
-    public String getAmount() {
-        return amount;
+    BigDecimal digit = new BigDecimal(amountFormatPair.getAmount());
+    BigDecimal multiple = new BigDecimal("1");
+    BigDecimal binaryFactor = new BigDecimal("2");
+    BigDecimal decimalFactor = new BigDecimal("10");
+
+    switch (formatStr) {
+      case "Ki":
+        multiple = binaryFactor.pow(10);
+        break;
+      case "Mi":
+        multiple = binaryFactor.pow(20);
+        break;
+      case "Gi":
+        multiple = binaryFactor.pow(30);
+        break;
+      case "Ti":
+        multiple = binaryFactor.pow(40);
+        break;
+      case "Pi":
+        multiple = binaryFactor.pow(50);
+        break;
+      case "Ei":
+        multiple = binaryFactor.pow(60);
+        break;
+      case "n":
+        multiple = decimalFactor.pow(-9);
+        break;
+      case "u":
+        multiple = decimalFactor.pow(-6);
+        break;
+      case "m":
+        multiple = decimalFactor.pow(-3);
+        break;
+      case "k":
+        multiple = decimalFactor.pow(3);
+        break;
+      case "M":
+        multiple = decimalFactor.pow(6);
+        break;
+      case "G":
+        multiple = decimalFactor.pow(9);
+        break;
+      case "T":
+        multiple = decimalFactor.pow(12);
+        break;
+      case "P":
+        multiple = decimalFactor.pow(15);
+        break;
+      case "E":
+        multiple = decimalFactor.pow(18);
+        break;
     }
 
-    public void setAmount(String amount) {
-        this.amount = amount;
+    return digit.multiply(multiple);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
 
-    public String getFormat() {
-        return format;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
 
-    public void setFormat(String format) {
-        this.format = format;
+    Quantity quantity = (Quantity) o;
+    return getAmountInBytes(this)
+      .toBigInteger()
+      .equals(getAmountInBytes(quantity).toBigInteger());
+  }
+
+  @Override
+  public int hashCode() {
+    return getAmountInBytes(this).toBigInteger().hashCode();
+  }
+
+  public static Quantity parse(String quantityAsString) {
+    String quantityComponents[] = quantityAsString.split("[eEinumkKMGTP]+");
+    if (quantityComponents.length == 0) {
+      throw new IllegalArgumentException("Invalid quantity string format passed.");
     }
+    String amountStr = quantityComponents[0];
+    String formatStr = quantityAsString.substring(quantityComponents[0].length());
+    return new Quantity(amountStr, formatStr);
+  }
 
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-    @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties;
-    }
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
-    @JsonAnySetter
-    public void setAdditionalProperty(String name, Object value) {
-        this.additionalProperties.put(name, value);
-    }
+  public static class Serializer extends JsonSerializer<Quantity> {
 
-    public static class Serializer extends JsonSerializer<Quantity> {
-
-        @Override
-        public void serialize(Quantity value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
-            if (value != null) {
-              StringBuilder objAsStringBuilder = new StringBuilder();
-              if (value.getAmount() != null) {
-                objAsStringBuilder.append(value.getAmount());
-              }
-              if (value.getFormat() != null) {
-                objAsStringBuilder.append(value.getFormat());
-              }
-              jgen.writeString(objAsStringBuilder.toString());
-            } else {
-                jgen.writeNull();
-            }
+    @Override
+    public void serialize(Quantity value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+      if (value != null) {
+        StringBuilder objAsStringBuilder = new StringBuilder();
+        if (value.getAmount() != null) {
+          objAsStringBuilder.append(value.getAmount());
         }
-    }
-
-    public static class Deserializer extends JsonDeserializer<Quantity> {
-
-        @Override
-        public Quantity deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-            ObjectCodec oc = jsonParser.getCodec();
-            JsonNode node = oc.readTree(jsonParser);
-            Quantity quantity = new Quantity(node.asText());
-            return quantity;
+        if (value.getFormat() != null) {
+          objAsStringBuilder.append(value.getFormat());
         }
-
+        jgen.writeString(objAsStringBuilder.toString());
+      } else {
+        jgen.writeNull();
+      }
     }
+  }
+
+  public static class Deserializer extends JsonDeserializer<Quantity> {
+
+    @Override
+    public Quantity deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+      ObjectCodec oc = jsonParser.getCodec();
+      JsonNode node = oc.readTree(jsonParser);
+      Quantity quantity = new Quantity(node.asText());
+      return quantity;
+    }
+
+  }
 
 }

--- a/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
+++ b/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuantityTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testAmountUnitSeparately() throws JsonProcessingException {
+    Quantity quantity = new Quantity("256", "Mi");
+    String serializedObj = mapper.writeValueAsString(quantity);
+    assertEquals("256Mi", serializedObj);
+  }
+
+  @Test
+  public void testAmount() throws JsonProcessingException {
+    Quantity quantity = new Quantity("256Mi");
+    String serializedObj = mapper.writeValueAsString(quantity);
+    assertEquals("256Mi", serializedObj);
+  }
+}

--- a/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
+++ b/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
@@ -17,9 +17,12 @@ package io.fabric8.kubernetes.api.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuantityTest {
   private final ObjectMapper mapper = new ObjectMapper();
@@ -28,13 +31,39 @@ public class QuantityTest {
   public void testAmountUnitSeparately() throws JsonProcessingException {
     Quantity quantity = new Quantity("256", "Mi");
     String serializedObj = mapper.writeValueAsString(quantity);
-    assertEquals("256Mi", serializedObj);
+    assertEquals("\"256Mi\"", serializedObj);
   }
 
   @Test
   public void testAmount() throws JsonProcessingException {
     Quantity quantity = new Quantity("256Mi");
     String serializedObj = mapper.writeValueAsString(quantity);
-    assertEquals("256Mi", serializedObj);
+    assertEquals("\"256Mi\"", serializedObj);
+  }
+
+  @Test
+  public void testQuantityObj() {
+    Quantity quantity = new Quantity("32Mi");
+    assertEquals("32", quantity.getAmount());
+    assertEquals("Mi", quantity.getFormat());
+  }
+
+  @Test
+  public void testNormalization() {
+    Quantity quantity = new Quantity(".5Mi");
+    assertEquals(new BigDecimal("524288.0"), Quantity.getAmountInBytes(quantity));
+
+    Quantity quantity1 =  new Quantity("512Ki");
+    assertEquals(Quantity.getAmountInBytes(quantity1).toBigInteger(), Quantity.getAmountInBytes(quantity).toBigInteger());
+  }
+
+  @Test
+  public void testEquality() {
+    assertTrue(new Quantity(".5Mi").equals( new Quantity("512Ki")));
+  }
+
+  @Test
+  public void testExponent() {
+    assertEquals("10000", Quantity.getAmountInBytes(new Quantity("1e4")).toString());
   }
 }


### PR DESCRIPTION
Fix #885 #1895 

+ Added parsing logic to parse `format` from `amount` string
+ Added equality operator for comparing Quantity objects regardless of their formats