### PR TITLE
Fix #1925: Kubernetes Service should always be loaded from server while patching it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Bugs
 * Fix #1850: Add option to disable timestamps in build logs on Openshift
 * Fix #1902: Fix the usage of reflection, so that `getMetadata` is detected properly
+* Fix #1925: Client should always read services from server during replace
 * Fix #1486: Creating CRDs with schema validation is broken
 * Fix #1707: HorizontalPodAutoscalerSpecBuilder found no metric method
 * Fix #885: Quantity doesn't honour the unit

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ServiceOperationsImpl.java
@@ -62,7 +62,7 @@ public class ServiceOperationsImpl extends HasMetadataOperation<Service, Service
   @Override
   public Service replace(Service item) {
       try {
-        Service old = getMandatory();
+        Service old = fromServer().get();
         return super.replace(new ServiceBuilder(item)
           .editSpec()
           .withClusterIP(old.getSpec().getClusterIP())

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ListMeta;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@EnableRuleMigrationSupport
+public class ServiceTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  public Service service;
+
+  @Before
+  public void prepareService() {
+    service = new ServiceBuilder()
+      .withNewMetadata()
+      .withName("httpbin")
+      .withLabels(Collections.singletonMap("app", "httpbin"))
+      .endMetadata()
+      .withNewSpec()
+      .addNewPort()
+      .withName("http")
+      .withPort(5511)
+      .withTargetPort(new IntOrString(8080))
+      .endPort()
+      .addToSelector("deploymentconfig", "httpbin")
+      .endSpec()
+      .build();
+  }
+
+  @Test
+  public void testLoad() {
+    KubernetesClient client = server.getClient();
+    Service svc = client.services().load(getClass().getResourceAsStream("/test-service.yml")).get();
+    assertNotNull(svc);
+    assertEquals("httpbin", svc.getMetadata().getName());
+  }
+
+  @Test
+  public void testCreate() {
+    server.expect().post()
+      .withPath("/api/v1/namespaces/test/services")
+      .andReturn(200, service)
+      .once();
+
+    KubernetesClient client = server.getClient();
+    Service responseSvc = client.services().inNamespace("test").create(service);
+    assertNotNull(responseSvc);
+    assertEquals("httpbin", responseSvc.getMetadata().getName());
+  }
+
+  @Test
+  public void testReplace() throws InterruptedException {
+    Service serviceFromServer = new ServiceBuilder(service)
+      .editOrNewSpec().withClusterIP("10.96.129.1").endSpec().build();
+
+    server.expect().get()
+      .withPath("/api/v1/namespaces/test/services/httpbin")
+      .andReturn(200, serviceFromServer)
+      .times(3);
+
+    server.expect().put()
+      .withPath("/api/v1/namespaces/test/services/httpbin")
+      .andReturn(200, serviceFromServer)
+      .once();
+
+    KubernetesClient client = server.getClient();
+    Service responseSvc = client.services().inNamespace("test").createOrReplace(service);
+    assertNotNull(responseSvc);
+    assertEquals("httpbin", responseSvc.getMetadata().getName());
+
+    RecordedRequest recordedRequest = server.getLastRequest();
+    assertEquals("PUT", recordedRequest.getMethod());
+    assertEquals("{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"labels\":{\"app\":\"httpbin\"},\"name\":\"httpbin\"},\"spec\":{\"clusterIP\":\"10.96.129.1\",\"ports\":[{\"name\":\"http\",\"port\":5511,\"targetPort\":8080}],\"selector\":{\"deploymentconfig\":\"httpbin\"}}}",
+      recordedRequest.getBody().readUtf8());
+  }
+
+  @Test
+  public void testDelete() {
+    server.expect().delete()
+      .withPath("/api/v1/namespaces/test/services/httpbin")
+      .andReturn(200, service)
+      .once();
+
+    KubernetesClient client = server.getClient();
+    boolean isDeleted = client.services().inNamespace("test").withName("httpbin").delete();
+    assertTrue(isDeleted);
+  }
+
+  @Test
+  public void testUpdate() {
+    Service serviceFromServer = new ServiceBuilder(service)
+      .editOrNewMetadata().addToLabels("foo", "bar").endMetadata()
+      .editOrNewSpec().withClusterIP("10.96.129.1").endSpec().build();
+
+    server.expect().get()
+      .withPath("/api/v1/namespaces/test/services/httpbin")
+      .andReturn(200, serviceFromServer)
+      .times(3);
+    server.expect().patch()
+      .withPath("/api/v1/namespaces/test/services/httpbin")
+      .andReturn(200, serviceFromServer)
+      .once();
+
+    KubernetesClient client = server.getClient();
+    Service responseFromServer = client.services().inNamespace("test").withName("httpbin").edit()
+      .editOrNewMetadata().addToLabels("foo", "bar").endMetadata()
+      .done();
+
+    assertNotNull(responseFromServer);
+    assertEquals("bar", responseFromServer.getMetadata().getLabels().get("foo"));
+  }
+}

--- a/kubernetes-tests/src/test/resources/test-service.yml
+++ b/kubernetes-tests/src/test/resources/test-service.yml
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - name: http
+    port: 5511
+    targetPort: 8080
+  selector:
+    deploymentconfig: httpbin


### PR DESCRIPTION
Fix #1925 
While replace method, client was showing variable behaviors when done through different
ways in dsl. For example,

   client.services().inNamespace("test").createOrReplace(item);

Used to load Service from server since reloadingFromServer was set to true in this case but
if we use a generic handler reloadingFromServer was set to false. I think in case of replace
operations we should always load object from server since Kubernetes API doesn't accept
patching Service object wihout ClusterIP.