### PR TITLE
Watch: Use Serialization not a default ObjectMapper

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -51,7 +51,6 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
 
   private static final Logger logger = LoggerFactory.getLogger(WatchConnectionManager.class);
 
-  private static final ObjectMapper mapper = new ObjectMapper();
   private final AtomicBoolean forceClosed = new AtomicBoolean();
   private final AtomicReference<String> resourceVersion;
   private final BaseOperation<T, L, ?, ?> baseOperation;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -16,7 +16,6 @@
 
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
@@ -49,7 +48,6 @@ import static java.net.HttpURLConnection.HTTP_GONE;
 public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourceList<T>> implements
   Watch {
   private static final Logger logger = LoggerFactory.getLogger(WatchHTTPManager.class);
-  private static final ObjectMapper mapper = new ObjectMapper();
 
   private final BaseOperation<T, L, ?, ?> baseOperation;
   private final Watcher<T> watcher;
@@ -299,7 +297,7 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
     // so lets try parse the message as a KubernetesResource
     // as it will probably be a list of resources like a BuildList
     if (object == null) {
-      object = mapper.readValue(messageSource, KubernetesResource.class);
+      object = Serialization.unmarshal(messageSource, KubernetesResource.class);
       if (event == null) {
         event = new WatchEvent(object, "MODIFIED");
       } else {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -288,7 +289,7 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
   }
 
   protected static WatchEvent readWatchEvent(String messageSource) throws IOException {
-    WatchEvent event = mapper.readValue(messageSource, WatchEvent.class);
+    WatchEvent event = Serialization.unmarshal(messageSource, WatchEvent.class);
     KubernetesResource object = null;
     if (event != null) {
       object = event.getObject();;


### PR DESCRIPTION
The `WatchHTTPManager` currently uses a default jackson `ObjectMapper` but this prevents the user from reconfiguring the object mapper with custom modules, which can in turn break deserialization into objects which use types handled by those modules. This PR updates the `WatchHTTPManager` to use the `Serialization` util and its `ObjectMapper`