### PR TITLE
Fix: authenticator uses id-token from ~/.kube/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Improvements
 * Fix #1874: Added unit tests verifying windows line-ends (CRLF) work
+* Fix #1177: Added support for OpenID Connect token in kubeconfig
 
 #### Dependency Upgrade
 * Update Jackson Bom to 2.10.2

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -136,6 +136,7 @@ public class Config {
   public static final String HTTPS_PROTOCOL_PREFIX = "https://";
 
   private static final String ACCESS_TOKEN = "access-token";
+  private static final String ID_TOKEN = "id-token";
 
   private boolean trustCerts;
   private boolean disableHostnameVerification;
@@ -537,8 +538,14 @@ public class Config {
           config.setUsername(currentAuthInfo.getUsername());
           config.setPassword(currentAuthInfo.getPassword());
 
-          if (Utils.isNullOrEmpty(config.getOauthToken()) && currentAuthInfo.getAuthProvider() != null && !Utils.isNullOrEmpty(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN))) {
-            config.setOauthToken(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN));
+          if (Utils.isNullOrEmpty(config.getOauthToken()) && currentAuthInfo.getAuthProvider() != null) {
+            if (!Utils.isNullOrEmpty(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN))) {
+              // GKE token
+              config.setOauthToken(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN));
+            } else if (!Utils.isNullOrEmpty(currentAuthInfo.getAuthProvider().getConfig().get(ID_TOKEN))) {
+              // OpenID Connect token
+              config.setOauthToken(currentAuthInfo.getAuthProvider().getConfig().get(ID_TOKEN));
+            }
           } else if (config.getOauthTokenProvider() == null) {  // https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
             ExecConfig exec = currentAuthInfo.getExec();
             if (exec != null) {


### PR DESCRIPTION
Fixes #1177 

According to the official [documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens):
> the authenticator uses the id_token (not the access_token) from the OAuth2 token response as a bearer token

This explains why there is no `access-token` in the file.