### PR TITLE
fix: apiVersion and kind from CRD in registration

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -62,7 +62,9 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
     this.resourceNamespaced = resourceNamespaced((CustomResourceDefinition) context.getCrd());
     this.apiVersion = getAPIGroup() + "/" + getAPIVersion();
 
-    KubernetesDeserializer.registerCustomKind(type.getSimpleName(), type);
+    CustomResourceDefinition crd = (CustomResourceDefinition) context.getCrd();
+
+    KubernetesDeserializer.registerCustomKind(crd.getApiVersion(), crd.getKind(), type);
     if (KubernetesResource.class.isAssignableFrom(listType)) {
       KubernetesDeserializer.registerCustomKind(listType.getSimpleName(), (Class<? extends KubernetesResource>) listType);
     }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class CustomResourceOperationsImplTest {
+
+  public static class MyCustomResource extends CustomResource {
+  }
+
+  public static class MyCustomResourceList extends CustomResourceList<MyCustomResource> {
+  }
+
+  private final CustomResourceDefinition crd = new CustomResourceDefinitionBuilder()
+    .withApiVersion("custom.group/v1alpha1")
+    .withKind("MyCustomResource")
+    .withNewMetadata()
+      .withName("custom.name")
+    .endMetadata()
+    .withNewSpec()
+      .withGroup("custom.group")
+      .withVersion("v1alpha1")
+      .withNewNames()
+        .withKind("MyCustomResource")
+        .withListKind("MyCustomResourceList")
+        .withPlural("mycustomresources")
+        .withSingular("mycustomresource")
+      .endNames()
+    .endSpec()
+  .build();
+
+  private final CustomResourceOperationContext context = new CustomResourceOperationContext()
+    .withCrd(crd)
+    .withType(MyCustomResource.class)
+    .withListType(MyCustomResourceList.class);
+
+  @Test
+  public void shouldRegisterWithKubernetesDeserializer() throws IOException {
+    // CustomResourceOperationsImpl constructor invokes KubernetesDeserializer::registerCustomKind
+    new CustomResourceOperationsImpl<>(context);
+
+    JsonFactory factory = new MappingJsonFactory();
+    JsonParser parser = factory.createParser("{\n" + 
+      "    \"apiVersion\": \"custom.group/v1alpha1\",\n" + 
+      "    \"kind\": \"MyCustomResource\"\n" + 
+      "}");
+
+    KubernetesDeserializer deserializer = new KubernetesDeserializer();
+    KubernetesResource resource = deserializer.deserialize(parser, null);
+
+    assertThat(resource, instanceOf(MyCustomResource.class));
+    assertEquals("custom.group/v1alpha1", ((MyCustomResource) resource).getApiVersion());
+  }
+
+}


### PR DESCRIPTION
In `CustomResourceOperationsImpl` construction
`KubernetesDeserializer::registerCustomKind` is invoked without
`apiVersion` and with `kind` set to the class name. This could lead to
issues when deserializing custom resources, in my example:

```
com.fasterxml.jackson.databind.JsonMappingException: No resource type found for:camel.apache.org/v1alpha1#Integration
 at [Source: (String)"{"type":"DELETED","object":{"apiVersion":"camel.apache.org/v1alpha1","kind":"Integration","metadata":{"annotations":{"prometheus.io/port":"9779","prometheus.io/scrape":"true","syndesis.io/deploy-id":"i-M0SZstrdU_fCuujYkqGz:2","syndesis.io/deployment-version":"2","syndesis.io/integration-id":"i-M0SZstrdU_fCuujYkqGz","syndesis.io/integration-name":"t2l"},"creationTimestamp":"2020-02-19T13:14:10Z","generation":1,"labels":{"syndesis.io/app":"syndesis","syndesis.io/component":"integration","syndesis."[truncated 3644 chars]; line: 1, column: 4142] (through reference chain: io.fabric8.kubernetes.api.model.WatchEvent["object"])
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:271) ~[jackson-databind-2.10.2.jar:2.10.2]
	at io.fabric8.kubernetes.internal.KubernetesDeserializer.deserialize(KubernetesDeserializer.java:78) ~[kubernetes-model-4.6.1.jar:4.6.1]
	at io.fabric8.kubernetes.internal.KubernetesDeserializer.deserialize(KubernetesDeserializer.java:33) ~[kubernetes-model-4.6.1.jar:4.6.1]
```

Because only `"Integration"` would be registered, whereas type lookup is
using `apiVersion` and `kind.

This changes that to specify the `apiVersion` and `kind` based on the
definition given in the `CustomResource`.