### PR TITLE
Generating toString for custom resource classes

### DIFF
--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -143,6 +143,11 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Testing Dependencies -->
     <dependency>

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.sundr.builder.annotations.Buildable;
+import lombok.ToString;
 
 /**
  * A base class for implementing a custom resource kind
@@ -27,6 +28,7 @@ import io.sundr.builder.annotations.Buildable;
 @JsonDeserialize(
     using = JsonDeserializer.None.class
 )
+@ToString
 @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
 public abstract class CustomResource implements HasMetadata {
   private String kind;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceDoneable.java
@@ -17,9 +17,11 @@ package io.fabric8.kubernetes.client;
 
 import io.fabric8.kubernetes.api.builder.Function;
 import io.fabric8.kubernetes.api.model.Doneable;
+import lombok.ToString;
 
 /**
  */
+@ToString
 public class CustomResourceDoneable<T extends CustomResource> implements Doneable<T> {
   private final T resource;
   private final Function<T,T> function;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ListMeta;
+import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.List;
 /**
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@ToString
 public class CustomResourceList<T extends HasMetadata> implements KubernetesResource, KubernetesResourceList<T> {
 
   @JsonProperty("apiVersion")


### PR DESCRIPTION
Most of the api model already has toString implementations providing sufficient insight during runtime. The CustomResource and associated classes was missing a toString implementation.

Similar to the many parts of the kubernetes client codebase, this has been implemented using lombok.