### PR TITLE
fix: Do cleanup after LogWatchCallback finished

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
@@ -136,6 +136,7 @@ public class LogWatchCallback implements LogWatch, Callback, AutoCloseable {
         }
 
         LOGGER.error("Log Callback Failure.", ioe);
+        cleanUp();
         //We only need to queue startup failures.
         if (!started.get()) {
             queue.add(ioe);
@@ -150,7 +151,10 @@ public class LogWatchCallback implements LogWatch, Callback, AutoCloseable {
            } catch (IOException e) {
                throw KubernetesClientException.launderThrowable(e);
            }
-       }, () -> response.close());
+       }, () -> {
+         cleanUp();
+         response.close();
+       });
         executorService.submit(pumper);
         started.set(true);
         queue.add(true);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BlockingInputStreamPumper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BlockingInputStreamPumper.java
@@ -60,6 +60,8 @@ public class BlockingInputStreamPumper extends InputStreamPumper {
           } else {
             LOGGER.debug("Interrupted while pumping stream.");
           }
+        } finally {
+          close();
         }
     }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/InputStreamPumper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/InputStreamPumper.java
@@ -73,6 +73,8 @@ public class InputStreamPumper implements Runnable, Closeable {
           } else {
             LOGGER.debug("Interrupted while pumping stream.");
           }
+        } finally {
+          close();
         }
     }
 


### PR DESCRIPTION
I wrote some code to watch logs from a container in a pod, but found that when the pod was deleted, log inputstream that got from PodOperationsImpl.watchLog().getOutput() didn't close and read would hang forever. 

To reproduce the issue, following the steps below :

Step 1. create a simple pod, any image will be ok as long as it can long run and give some output continuously . (Infact, if the pod is not exists, the java code here would hang in the same way)

```
apiVersion: v1
kind: Pod
metadata:
  name: t01
  namespace: test
spec:
  containers:
  - image: any-image
    name: default

```
Step 2: Run the code 
```
public static void main(String[] args) throws IOException {
        KubernetesClient client = new DefaultKubernetesClient();
        InputStream in = client.pods()
                .inNamespace("test")
                .withName("t01")
                .inContainer("default")
                .watchLog()
                .getOutput();

        byte[] buf = new byte[1024];
        int len = -1;
        while ((len = in.read(buf)) > -1) {  // hang here
            System.out.println("read len " + len);
        }
        System.out.println("finished");
    }
```
Step 3:  delete the pod `kubectl -n test delete pod t01`, After the pod is deleted, Java code still hang at the line in.read(buf)

The reson is that LogWatchCallback not close the newly created piped stream, It has close and cleanUp methods but nowhere would call that.

 This fix had been tested.
