### PR TITLE
Fix #2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### 4.8-SNAPSHOT
 #### Bugs
 
+* Fix #2023: Class RawCustomResourceOperationsImpl can't handle HTTP responses with empty body coming from the k8s 
+cluster (Jackson deserialization error was throwed). This kind of response can be returned after executing operations 
+like the delete of a custom resource. 
+
 #### Improvements
 
 * Fix #2012: osgi: Allow the ManagedKubernetesClient to consume an available OAuthTokenProvider

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -745,7 +745,11 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
     Request request = (body == null) ? getRequest(url, callMethod) : getRequest(url, body, callMethod);
     try (Response response = client.newCall(request).execute()) {
       if (response.isSuccessful()) {
-        return objectMapper.readValue(response.body().string(), HashMap.class);
+        String respBody = response.body().string();
+        if(Utils.isNullOrEmpty(respBody))
+          return new HashMap<>();
+        else
+          return objectMapper.readValue(respBody, HashMap.class);
       } else {
         throw requestFailure(request, createStatus(response));
       }


### PR DESCRIPTION
Jackson is unable to deserialize an empty string (coming from an empty response body, which tipically occurs when you delete a CustomResource with the makeCall method defined in RawCustomResourceOperationsImpl (which is used when you use the RawCustomResource dsl).

Solution: Returning empty map when response body is an empty string


Fixes https://github.com/fabric8io/kubernetes-client/issues/2023