### PR TITLE
Fix #1820: Override Createable.create(T) to avoid generic array creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 * Fix #2012: osgi: Allow the ManagedKubernetesClient to consume an available OAuthTokenProvider
 
 #### Dependency Upgrade
-+ Updated Knative model to v0.12.0
+* Updated Knative model to v0.12.0
 
 #### New Features
+* Fix #1820: Override Createable.create(T) to avoid generic array creation
 
 ### 4.8.0 (14-02-2020)
 #### Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Createable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Createable.java
@@ -19,5 +19,7 @@ public interface Createable<I, T, D>  {
 
   T create(I... item);
 
+  T create(I item);
+
   D createNew();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -327,6 +327,19 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
   }
 
   @Override
+  public T create(T resource) {
+    try {
+      if (resource != null) {
+        return handleCreate(resource);
+      } else {
+        throw new IllegalArgumentException("Nothing to create.");
+      }
+    } catch (InterruptedException | ExecutionException | IOException e) {
+      throw KubernetesClientException.launderThrowable(forOperationType("create"), e);
+    }
+  }
+
+  @Override
   public D createNew() throws KubernetesClientException {
     final Function<T, T> visitor = resource -> {
       try {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesListOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesListOperationsImpl.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.KubernetesListOperation;
 import io.fabric8.kubernetes.client.dsl.Loadable;
-import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import okhttp3.OkHttpClient;
-import io.fabric8.kubernetes.api.builder.Function;
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.DoneableKubernetesList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -79,15 +78,17 @@ public class KubernetesListOperationsImpl
       items = new KubernetesList[]{get()};
     }
     for (KubernetesList i : items) {
-      for (HasMetadata r : i.getItems()) {
-        HasMetadata created = create(r);
-        createdItems.add(created);
-      }
+      createdItems.addAll(createItemsInKubernetesList(i));
     }
 
     KubernetesList createdList = new KubernetesList();
     createdList.setItems(createdItems);
     return createdList;
+  }
+
+  @Override
+  public KubernetesList create(KubernetesList list) {
+    return create(new KubernetesList[]{list});
   }
 
   @Override
@@ -168,5 +169,14 @@ public class KubernetesListOperationsImpl
   @Override
   public Createable<KubernetesList, KubernetesList, DoneableKubernetesList> deletingExisting() {
     return new KubernetesListOperationsImpl(client, config, namespace, null, false, fromServer, true, item, null);
+  }
+
+  private List<HasMetadata> createItemsInKubernetesList(KubernetesList list) {
+    List<HasMetadata> createdItems = new ArrayList<>();
+    for (HasMetadata r : list.getItems()) {
+      HasMetadata created = create(r);
+      createdItems.add(created);
+    }
+    return createdItems;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/SubjectAccessReviewDSLImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/SubjectAccessReviewDSLImpl.java
@@ -69,6 +69,11 @@ public class SubjectAccessReviewDSLImpl extends OperationSupport implements Subj
   }
 
   @Override
+  public SubjectAccessReview create(SubjectAccessReview resource) {
+    return create(new SubjectAccessReview[]{resource});
+  }
+
+  @Override
   public DoneableSubjectAccessReview createNew() {
     return new CreatableSubjectAccessReview().createNew();
   }
@@ -128,6 +133,11 @@ public class SubjectAccessReviewDSLImpl extends OperationSupport implements Subj
       }
     }
 
+    @Override
+    public LocalSubjectAccessReview create(LocalSubjectAccessReview resource) {
+      return create(new LocalSubjectAccessReview[]{resource});
+    }
+
     private void setNamespace(LocalSubjectAccessReview resource) {
       ObjectMeta meta = resource.getMetadata();
 
@@ -173,6 +183,11 @@ public class SubjectAccessReviewDSLImpl extends OperationSupport implements Subj
     }
 
     @Override
+    public SubjectAccessReview create(SubjectAccessReview resource) {
+      return create(new SubjectAccessReview[]{resource});
+    }
+
+    @Override
     public DoneableSubjectAccessReview createNew() {
       return new DoneableSubjectAccessReview(this::create);
     }
@@ -196,6 +211,11 @@ public class SubjectAccessReviewDSLImpl extends OperationSupport implements Subj
     }
 
     @Override
+    public SelfSubjectAccessReview create(SelfSubjectAccessReview resource) {
+      return create(new SelfSubjectAccessReview[]{resource});
+    }
+
+    @Override
     public DoneableSelfSubjectAccessReview createNew() {
       return new DoneableSelfSubjectAccessReview(this::create);
     }
@@ -216,6 +236,11 @@ public class SubjectAccessReviewDSLImpl extends OperationSupport implements Subj
       } catch (InterruptedException | ExecutionException | IOException e) {
         throw KubernetesClientException.launderThrowable(e);
       }
+    }
+
+    @Override
+    public SelfSubjectRulesReview create(SelfSubjectRulesReview resource) {
+      return create(new SelfSubjectRulesReview[]{resource});
     }
 
     @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ProjectRequestsOperationImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/ProjectRequestsOperationImpl.java
@@ -91,6 +91,11 @@ public class ProjectRequestsOperationImpl extends OperationSupport implements Pr
   }
 
   @Override
+  public ProjectRequest create(ProjectRequest resource) {
+    return create(new ProjectRequest[]{resource});
+  }
+
+  @Override
   public DoneableProjectRequest createNew() {
     return new DoneableProjectRequest(item -> {
       try {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/SubjectAccessReviewOperationImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/SubjectAccessReviewOperationImpl.java
@@ -62,6 +62,11 @@ public class SubjectAccessReviewOperationImpl extends OperationSupport implement
   }
 
   @Override
+  public SubjectAccessReviewResponse create(SubjectAccessReview item) {
+    return create(new SubjectAccessReview[] {item});
+  }
+
+  @Override
   public CreateableSubjectAccessReview createNew() {
     return new CreateableSubjectAccessReviewImpl(client).createNew();
   }
@@ -131,6 +136,11 @@ public class SubjectAccessReviewOperationImpl extends OperationSupport implement
     }
 
     @Override
+    public SubjectAccessReviewResponse create(LocalSubjectAccessReview resource) {
+      return create(new LocalSubjectAccessReview[]{resource});
+    }
+
+    @Override
     public CreateableLocalSubjectAccessReview createNew() {
       return this;
     }
@@ -192,6 +202,11 @@ public class SubjectAccessReviewOperationImpl extends OperationSupport implement
     }
 
     @Override
+    public SubjectAccessReviewResponse create(SubjectAccessReview resource) {
+      return create(new SubjectAccessReview[]{resource});
+    }
+
+    @Override
     public CreateableSubjectAccessReview createNew() {
       return this;
     }
@@ -229,6 +244,11 @@ public class SubjectAccessReviewOperationImpl extends OperationSupport implement
       } catch (InterruptedException | ExecutionException | IOException e) {
         throw KubernetesClientException.launderThrowable(e);
       }
+    }
+
+    @Override
+    public SubjectAccessReviewResponse create(SelfSubjectAccessReview resource) {
+      return create(new SelfSubjectAccessReview[]{resource});
     }
 
     @Override


### PR DESCRIPTION
Fix #1820 