### PR TITLE
ci: Tuning Sonar Analysis + Fix Bug to see report

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This client provides access to the full [Kubernetes](http://kubernetes.io/) &
 [![CircleCI](https://img.shields.io/circleci/project/github/fabric8io/kubernetes-client/master.svg)](https://circleci.com/gh/fabric8io/kubernetes-client)
 [![Release](https://img.shields.io/github/v/release/fabric8io/kubernetes-client)](https://search.maven.org/search?q=g:io.fabric8%20a:kubernetes-client)
 [![Twitter](https://img.shields.io/twitter/follow/fabric8io?style=social)](https://twitter.com/jkubeio)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=kubernetes_client&metric=bugs)](https://sonarcloud.io/dashboard?id=kubernetes_client)
+
 
 * kubernetes-client: [![Maven Central](https://img.shields.io/maven-central/v/io.fabric8/kubernetes-client.svg?maxAge=2592000)](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aio.fabric8%20a%3Akubernetes-client)
 [![Javadocs](http://www.javadoc.io/badge/io.fabric8/kubernetes-client.svg?color=blue)](http://www.javadoc.io/doc/io.fabric8/kubernetes-client)

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -417,19 +417,15 @@ public class Config {
       }
       try {
         String serviceTokenCandidate = new String(Files.readAllBytes(new File(KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH).toPath()));
-        if (serviceTokenCandidate != null) {
-          LOGGER.debug("Found service account token at: ["+KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH+"].");
-          config.setOauthToken(serviceTokenCandidate);
-          String txt = "Configured service account doesn't have access. Service account may have been revoked.";
-          config.getErrorMessages().put(401, "Unauthorized! " + txt);
-          config.getErrorMessages().put(403, "Forbidden!" + txt);
-          return true;
-        } else {
-          LOGGER.debug("Did not find service account token at: ["+KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH+"].");
-        }
+        LOGGER.debug("Found service account token at: ["+KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH+"].");
+        config.setOauthToken(serviceTokenCandidate);
+        String txt = "Configured service account doesn't have access. Service account may have been revoked.";
+        config.getErrorMessages().put(401, "Unauthorized! " + txt);
+        config.getErrorMessages().put(403, "Forbidden!" + txt);
+        return true;
       } catch (IOException e) {
         // No service account token available...
-        LOGGER.warn("Error reading service account token from: ["+KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH+"]. Ignoring.");
+        LOGGER.warn("Error reading service account token from: [{}]. Ignoring.", KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH);
       }
     }
     return false;

--- a/kubernetes-tests/pom.xml
+++ b/kubernetes-tests/pom.xml
@@ -149,21 +149,34 @@
           </environmentVariables>
         </configuration>
       </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>1.6.0</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>java</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <classpathScope>test</classpathScope>
-          </configuration>
-        </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <classpathScope>test</classpathScope>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/platforms/karaf/itests/pom.xml
+++ b/platforms/karaf/itests/pom.xml
@@ -27,6 +27,10 @@
   <artifactId>kubernetes-karaf-itests</artifactId>
   <name>Fabric8 :: Kubernetes :: Platforms :: Karaf :: Tests</name>
 
+  <properties>
+    <sonar.skip>true</sonar.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
     <jandex.plugin.version>1.0.7</jandex.plugin.version>
     <jandex.version>2.1.2.Final</jandex.version>
+    <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
     <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
 
     <!-- Other options -->
@@ -414,6 +415,11 @@
           </dependencies>
         </plugin>
         <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
           <version>${sonar-maven-plugin.version}</version>
@@ -433,7 +439,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.4</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>
@@ -767,11 +772,18 @@
     <profile>
       <id>sonar</id>
       <properties>
-        <sonar.projectKey>fabric8io_kubernetes-client</sonar.projectKey>
+        <sonar.projectKey>kubernetes_client</sonar.projectKey>
         <sonar.moduleKey>${artifactId}</sonar.moduleKey>
-        <sonar.organization>fabric8io</sonar.organization>
+        <sonar.organization>jkubeio</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.login>${env.SONAR_LOGIN_TOKEN}</sonar.login>
+        <sonar.projectName>Fabric8 :: Kubernetes Client</sonar.projectName>
+        <sonar.links.homepage>https://github.com/fabric8io/kubernetes-client</sonar.links.homepage>
+        <sonar.links.ci>https://github.com/fabric8io/kubernetes-client/actions</sonar.links.ci>
+        <sonar.links.scm>https://github.com/fabric8io/kubernetes-client</sonar.links.scm>
+        <sonar.links.issue>https://github.com/fabric8io/kubernetes-client/issues</sonar.links.issue>
+        <sonar.coverage.exclusions>**/kubernetes-examples/**/*,**/extensions/**/examples/**/*</sonar.coverage.exclusions>
+        <karaf.itest.skip>true</karaf.itest.skip>
       </properties>
       <build>
         <plugins>

--- a/uberjar/pom.xml
+++ b/uberjar/pom.xml
@@ -28,7 +28,11 @@
   <packaging>jar</packaging>
   <name>Fabric8 :: Kubernetes and Openshift :: UberJar</name>
 
-<dependencies>
+  <properties>
+    <skip.sonar>true</skip.sonar>
+  </properties>
+
+  <dependencies>
     <!-- For inclusion -->
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/uberjar/src/main/java/io/fabric8/kubernetes/clnt/Uberjar.java
+++ b/uberjar/src/main/java/io/fabric8/kubernetes/clnt/Uberjar.java
@@ -16,7 +16,7 @@
 package io.fabric8.kubernetes.clnt;
 
 /**
- * This is just used so that we can force the genration of xxx-soruces.jar and xxx-javadoc.jar.
+ * This is just used so that we can force the generation of xxx-sources.jar and xxx-javadoc.jar.
  */
 public interface Uberjar {
 }


### PR DESCRIPTION
## Sonar Scanner tuning
- Examples code excluded from code coverage
- Links to project specific urls (issues, home, ci, etc.)
- Skipped Karaf iTest
- JaCoCo coverage aggregation

## Sonar Organization

I don't have access to Fabric8io organization in Sonar Cloud.

Moved project to JKube organization in order to be able to apply a different permission template for the project so that PRs don't require a token in order to execute and upload analysis (GH Actions don't propagate secretes to PR workflow executions for obvious security reasons)