### PR TITLE
chore(deps): bump commons-compress from 1.18 to 1.20 (fix CVE-2019-12402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ like the delete of a custom resource.
 
 #### Dependency Upgrade
 * Updated Knative model to v0.12.0
+* Updated Commons-Compress to v1.20 to avoid https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12402
 
 #### New Features
 * Fix #1820: Override Createable.create(T) to avoid generic array creation

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <snakeyaml.version>1.24</snakeyaml.version>
     <bouncycastle.version>1.64</bouncycastle.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <commons-compress.version>1.18</commons-compress.version>
+    <commons-compress.version>1.20</commons-compress.version>
     <scr.annotations.version>1.12.0</scr.annotations.version>
     <jsonschema2pojo.version>0.4.23</jsonschema2pojo.version>
 


### PR DESCRIPTION
As reported in issue #2031 (@Morty-se) that has been deleted :flushed: 