### PR TITLE
Fixed parsing of exponential values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 cluster (Jackson deserialization error was throwed). This kind of response can be returned after executing operations 
 like the delete of a custom resource.
 * Fix #2017: Incorrect plural form for Endpoints kind
+* Fix #2053: Fixed parsing of exponential values. Added multiplication to the amount during parsing exponential values.
 
 #### Improvements
 

--- a/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model/kubernetes-model/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -121,7 +121,7 @@ public class Quantity  implements Serializable {
     if ((formatStr.startsWith("e") || formatStr.startsWith("E")) &&
         formatStr.length() > 1) {
       int exponent = Integer.parseInt(formatStr.substring(1));
-      return new BigDecimal("10").pow(exponent);
+      return new BigDecimal("10").pow(exponent).multiply(new BigDecimal(amountFormatPair.getAmount()));
     }
 
     BigDecimal digit = new BigDecimal(amountFormatPair.getAmount());

--- a/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
+++ b/kubernetes-model/kubernetes-model/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
@@ -67,6 +67,15 @@ public class QuantityTest {
   }
 
   @Test
+  public void testExponents() {
+    Quantity quantity1 = new Quantity("129e6");
+    Quantity quantity2 = new Quantity("129e+6");
+
+    assertEquals("129000000", Quantity.getAmountInBytes(quantity1).toString());
+    assertEquals("129000000", Quantity.getAmountInBytes(quantity2).toString());
+  }
+
+  @Test
   public void testEquality() {
     assertTrue(new Quantity(".5Mi").equals( new Quantity("512Ki")));
   }


### PR DESCRIPTION
Added multiplication to the amount during parsing exponential values.

Fixes https://github.com/fabric8io/kubernetes-client/issues/2052