### PR TITLE
Fix #2046: OpenshiftClient getVersion returns null for Openshift ContainerPlatform v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #2057: Fix jar and osgi bundle generation for extensions
 * Fix #2075: KubernetesDeserializer registration for CustomResources
 * Fix #2078: watchLog for Deployment and StatefulSet
+* Fix #2046: OpenshiftClient getVersion returns null for Openshift ContainerPlatform v4
 
 #### Improvements
 * Fix #2019: Added CustomResourceCrudTest

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -298,7 +298,7 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
 
   @Override
   public VersionInfo getVersion() {
-    return new ClusterOperationsImpl(httpClient, getConfiguration(), "version").fetchVersion();
+    return new ClusterOperationsImpl(httpClient, getConfiguration(), ClusterOperationsImpl.KUBERNETES_VERSION_ENDPOINT).fetchVersion();
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/VersionInfo.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/VersionInfo.java
@@ -16,14 +16,14 @@
 
 package io.fabric8.kubernetes.client;
 
+import io.fabric8.openshift.api.model.ClusterVersion;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Map;
 
 public class VersionInfo {
-  private Map<String, String> data;
-  private final class VERSION_KEYS {
+  public final class VERSION_KEYS {
     public static final String BUILD_DATE = "buildDate";
     public static final String GIT_COMMIT = "gitCommit";
     public static final String GIT_VERSION = "gitVersion";
@@ -81,18 +81,85 @@ public class VersionInfo {
     return compiler;
   }
 
-  public VersionInfo(Map<String, String> jsonData) throws ParseException {
-      this.data = jsonData;
-      this.buildDate = new SimpleDateFormat(VERSION_KEYS.BUILD_DATE_FORMAT).parse(jsonData.get(VERSION_KEYS.BUILD_DATE));
-      this.gitCommit = jsonData.get(VERSION_KEYS.GIT_COMMIT);
-      this.gitVersion = jsonData.get(VERSION_KEYS.GIT_VERSION);
-      this.major = jsonData.get(VERSION_KEYS.MAJOR);
-      this.minor = jsonData.get(VERSION_KEYS.MINOR);
-      this.gitTreeState = jsonData.get(VERSION_KEYS.GIT_TREE_STATE);
-      this.platform = jsonData.get(VERSION_KEYS.PLATFORM);
-      this.goVersion = jsonData.get(VERSION_KEYS.GO_VERSION);
-      this.compiler = jsonData.get(VERSION_KEYS.COMPILER);
+  private VersionInfo() { }
+
+  public static VersionInfo parseVersionInfoFromClusterVersion(ClusterVersion clusterVersion) throws ParseException {
+    String[] versionParts = clusterVersion.getStatus().getDesired().getVersion().split("\\.");
+    VersionInfo.Builder versionInfoBuilder = new VersionInfo.Builder();
+    if (versionParts.length == 3) {
+      versionInfoBuilder.withMajor(versionParts[0]);
+      versionInfoBuilder.withMinor(versionParts[1] + "." + versionParts[2]);
+    }
+    versionInfoBuilder.withBuildDate(clusterVersion.getMetadata().getCreationTimestamp());
+    return versionInfoBuilder.build();
   }
 
-  public Map<String, String> getData() { return data; }
+  public static class Builder {
+    private VersionInfo versionInfo = new VersionInfo();
+
+    public Builder() { }
+
+    public Builder(VersionInfo versionInfo) {
+      if (versionInfo != null) {
+        this.versionInfo.buildDate = versionInfo.getBuildDate();
+        this.versionInfo.gitCommit = versionInfo.getGitCommit();
+        this.versionInfo.gitVersion = versionInfo.getGitVersion();
+        this.versionInfo.major = versionInfo.getMajor();
+        this.versionInfo.minor = versionInfo.getMinor();
+        this.versionInfo.gitTreeState = versionInfo.getGitTreeState();
+        this.versionInfo.platform = versionInfo.getPlatform();
+        this.versionInfo.goVersion = versionInfo.getGoVersion();
+        this.versionInfo.compiler = versionInfo.getCompiler();
+      }
+    }
+
+    public Builder withBuildDate(String buildDate) throws ParseException {
+      this.versionInfo.buildDate = new SimpleDateFormat(VERSION_KEYS.BUILD_DATE_FORMAT).parse(buildDate);
+      return this;
+    }
+
+    public Builder withGitCommit(String gitCommit) {
+      this.versionInfo.gitCommit = gitCommit;
+      return this;
+    }
+
+    public Builder withGitVersion(String gitVersion) {
+      this.versionInfo.gitVersion = gitVersion;
+      return this;
+    }
+
+    public Builder withMajor(String major) {
+      this.versionInfo.major = major;
+      return this;
+    }
+
+    public Builder withMinor(String minor) {
+      this.versionInfo.minor = minor;
+      return this;
+    }
+
+    public Builder withGitTreeState(String gitTreeState) {
+      this.versionInfo.gitTreeState = gitTreeState;
+      return this;
+    }
+
+    public Builder withPlatform(String platform) {
+      this.versionInfo.platform = platform;
+      return this;
+    }
+
+    public Builder withGoVersion(String goVersion) {
+      this.versionInfo.goVersion = goVersion;
+      return this;
+    }
+
+    public Builder withCompiler(String compiler) {
+      this.versionInfo.compiler = compiler;
+      return this;
+    }
+
+    public VersionInfo build() {
+      return versionInfo;
+    }
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterOperationsImpl.java
@@ -17,21 +17,30 @@
 package io.fabric8.kubernetes.client.dsl.internal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.client.Version;
 import io.fabric8.kubernetes.client.VersionInfo;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.utils.URLUtils;
+import io.fabric8.openshift.api.model.ClusterVersionList;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class ClusterOperationsImpl extends OperationSupport {
   private String versionEndpoint;
+  public static final String KUBERNETES_VERSION_ENDPOINT = "version";
+  public static final String OPENSHIFT_VERSION_ENDPOINT = "version/openshift";
+  public static final String OPENSHIFT4_VERSION_ENDPOINT = "apis/config.openshift.io/v1/clusterversions";
+  public static final ObjectMapper objectMapper = new ObjectMapper();
 
   public ClusterOperationsImpl(OkHttpClient client, Config config, String item) {
     super(new OperationContext().withOkhttpClient(client).withConfig(config));
@@ -40,16 +49,49 @@ public class ClusterOperationsImpl extends OperationSupport {
 
   public VersionInfo fetchVersion() {
     try {
-      Request.Builder requestBuilder = new Request.Builder()
-        .get()
-        .url(URLUtils.join(config.getMasterUrl(), versionEndpoint));
-      Response response = client.newCall(requestBuilder.build()).execute();
-      ObjectMapper objectMapper = new ObjectMapper();
+      Response response = handleVersionGet(versionEndpoint);
+      // Handle Openshift 4 version case
+      if (HttpURLConnection.HTTP_NOT_FOUND == response.code() && versionEndpoint.equals(OPENSHIFT_VERSION_ENDPOINT)) {
+        response.close();
+        return fetchOpenshift4Version();
+      }
+
       Map<String, String> myMap = objectMapper.readValue(response.body().string(), HashMap.class);
-      return new VersionInfo(myMap);
+      return fetchVersionInfoFromResponse(myMap);
     } catch(Exception e) {
       KubernetesClientException.launderThrowable(e);
     }
     return null;
+  }
+
+  private Response handleVersionGet(String versionEndpointToBeUsed) throws IOException {
+    Request.Builder requestBuilder = new Request.Builder()
+      .get()
+      .url(URLUtils.join(config.getMasterUrl(), versionEndpointToBeUsed));
+    return client.newCall(requestBuilder.build()).execute();
+  }
+
+  private VersionInfo fetchOpenshift4Version() throws IOException, ParseException {
+    Response response = handleVersionGet(OPENSHIFT4_VERSION_ENDPOINT);
+    if (response.isSuccessful() && response.body() != null) {
+      ClusterVersionList clusterVersionList = objectMapper.readValue(response.body().string(), ClusterVersionList.class);
+      if (!clusterVersionList.getItems().isEmpty()) {
+        return VersionInfo.parseVersionInfoFromClusterVersion(clusterVersionList.getItems().get(0));
+      }
+    }
+    return null;
+  }
+
+  private VersionInfo fetchVersionInfoFromResponse(Map<String, String> responseAsMap) throws ParseException {
+    return new VersionInfo.Builder().withBuildDate(responseAsMap.get(VersionInfo.VERSION_KEYS.BUILD_DATE))
+      .withGitCommit(responseAsMap.get(VersionInfo.VERSION_KEYS.GIT_COMMIT))
+      .withGitVersion(responseAsMap.get(VersionInfo.VERSION_KEYS.GIT_VERSION))
+      .withMajor(responseAsMap.get(VersionInfo.VERSION_KEYS.MAJOR))
+      .withMinor(responseAsMap.get(VersionInfo.VERSION_KEYS.MINOR))
+      .withGitTreeState(responseAsMap.get(VersionInfo.VERSION_KEYS.GIT_TREE_STATE))
+      .withPlatform(responseAsMap.get(VersionInfo.VERSION_KEYS.PLATFORM))
+      .withGoVersion(responseAsMap.get(VersionInfo.VERSION_KEYS.GO_VERSION))
+      .withCompiler(responseAsMap.get(VersionInfo.VERSION_KEYS.COMPILER))
+      .build();
   }
 }

--- a/kubernetes-model/Gopkg.lock
+++ b/kubernetes-model/Gopkg.lock
@@ -22,12 +22,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:91d7cd34ea6ce39307fb0849ea2758c92c271b09e7dc331e7c8ca9a8b6b6dc5d"
+  digest = "1:5b930e5385c3ec853e421c6db74c917cf4ac09d77c534c5c6a10c59786866091"
   name = "github.com/openshift/api"
   packages = [
     "apps/v1",
     "authorization/v1",
     "build/v1",
+    "config/v1",
     "image/docker10",
     "image/dockerpre012",
     "image/v1",
@@ -44,7 +45,7 @@
   revision = "a0e53e94816b9a26ceb82e248e63e0666c377f44"
 
 [[projects]]
-  digest = "1:ef03a648cc87c8f1a350ff49b2df30a9b8ad03ca71c388d2c2554997cdfbb2b4"
+  digest = "1:335519f138c02d5f5bd35c859d466a349674cf024e6db0fdaa571bb3488350aa"
   name = "github.com/openshift/origin"
   packages = ["."]
   pruneopts = "UT"
@@ -197,7 +198,7 @@
   version = "v1.17.0"
 
 [[projects]]
-  digest = "0:"
+  digest = "1:7814e7cc39cdcb500eafc02de1ec5ca87a5fd69c117f5225eb93ad79a83a7ff8"
   name = "k8s.io/metrics"
   packages = [
     "pkg/apis/metrics",
@@ -222,6 +223,7 @@
     "github.com/openshift/api/apps/v1",
     "github.com/openshift/api/authorization/v1",
     "github.com/openshift/api/build/v1",
+    "github.com/openshift/api/config/v1",
     "github.com/openshift/api/image/v1",
     "github.com/openshift/api/network/v1",
     "github.com/openshift/api/oauth/v1",

--- a/kubernetes-model/cmd/generate/generate.go
+++ b/kubernetes-model/cmd/generate/generate.go
@@ -30,6 +30,7 @@ import (
   securityapi "github.com/openshift/api/security/v1"
   templateapi "github.com/openshift/api/template/v1"
   userapi "github.com/openshift/api/user/v1"
+  openshiftconfigapi "github.com/openshift/api/config/v1"
   admission "k8s.io/api/admission/v1beta1"
   admissionregistration "k8s.io/api/admissionregistration/v1beta1"
   k8sappsapi "k8s.io/api/apps/v1"
@@ -260,6 +261,8 @@ type Schema struct {
   PodMetricsList                           metrics.PodMetricsList
   NodeMetrics                              metrics.NodeMetrics
   NodeMetricsList                          metrics.NodeMetricsList
+  ClusterVersion                           openshiftconfigapi.ClusterVersion
+  ClusterVersionList                       openshiftconfigapi.ClusterVersionList
 }
 
 func main() {
@@ -292,6 +295,7 @@ func main() {
     {"github.com/openshift/api/project/v1", "", "io.fabric8.openshift.api.model", "os_project_"},
     {"github.com/openshift/api/security/v1", "", "io.fabric8.openshift.api.model", "os_security_"},
     {"github.com/openshift/api/network/v1", "", "io.fabric8.openshift.api.model", "os_network_"},
+    {"github.com/openshift/api/config/v1", "", "io.fabric8.openshift.api.model", "os_config_"},
     {"k8s.io/kubernetes/pkg/api/unversioned", "", "io.fabric8.kubernetes.api.model", "api_"},
     {"k8s.io/api/discovery/v1beta1", "", "io.fabric8.kubernetes.api.model.discovery", "kubernetes_discovery_"},
     {"k8s.io/api/extensions/v1beta1", "", "io.fabric8.kubernetes.api.model.extensions", "kubernetes_extensions_"},

--- a/kubernetes-model/kubernetes-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/kubernetes-model/src/main/resources/schema/kube-schema.json
@@ -17046,6 +17046,283 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "os_config_ClusterOperatorStatusCondition": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "message": {
+          "type": "string",
+          "description": ""
+        },
+        "reason": {
+          "type": "string",
+          "description": ""
+        },
+        "status": {
+          "type": "string",
+          "description": ""
+        },
+        "type": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterOperatorStatusCondition",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_ClusterVersion": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "config.openshift.io/v1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterVersion",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/os_config_ClusterVersionSpec",
+          "javaType": "io.fabric8.openshift.api.model.ClusterVersionSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/os_config_ClusterVersionStatus",
+          "javaType": "io.fabric8.openshift.api.model.ClusterVersionStatus"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersion",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "os_config_ClusterVersionList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "config.openshift.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/os_config_ClusterVersion",
+            "javaType": "io.fabric8.openshift.api.model.ClusterVersion"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterVersionList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.openshift.api.model.ClusterVersion\u003e"
+      ]
+    },
+    "os_config_ClusterVersionSpec": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "description": ""
+        },
+        "clusterID": {
+          "type": "string",
+          "description": ""
+        },
+        "desiredUpdate": {
+          "$ref": "#/definitions/os_config_Update",
+          "javaType": "io.fabric8.openshift.api.model.Update"
+        },
+        "overrides": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_ComponentOverride",
+            "javaType": "io.fabric8.openshift.api.model.ComponentOverride"
+          }
+        },
+        "upstream": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_ClusterVersionStatus": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "availableUpdates": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/os_config_Update",
+            "javaType": "io.fabric8.openshift.api.model.Update"
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_ClusterOperatorStatusCondition",
+            "javaType": "io.fabric8.openshift.api.model.ClusterOperatorStatusCondition"
+          }
+        },
+        "desired": {
+          "$ref": "#/definitions/os_config_Update",
+          "javaType": "io.fabric8.openshift.api.model.Update"
+        },
+        "history": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_UpdateHistory",
+            "javaType": "io.fabric8.openshift.api.model.UpdateHistory"
+          }
+        },
+        "observedGeneration": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "versionHash": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_ComponentOverride": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "group": {
+          "type": "string",
+          "description": ""
+        },
+        "kind": {
+          "type": "string",
+          "description": ""
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "namespace": {
+          "type": "string",
+          "description": ""
+        },
+        "unmanaged": {
+          "type": "boolean",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ComponentOverride",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_Update": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "force": {
+          "type": "boolean",
+          "description": ""
+        },
+        "image": {
+          "type": "string",
+          "description": ""
+        },
+        "version": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.Update",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_UpdateHistory": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "completionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "image": {
+          "type": "string",
+          "description": ""
+        },
+        "startedTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "state": {
+          "type": "string",
+          "description": ""
+        },
+        "verified": {
+          "type": "boolean",
+          "description": ""
+        },
+        "version": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.UpdateHistory",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "os_deploy_CustomDeploymentStrategyParams": {
       "type": "object",
       "description": "",
@@ -20299,6 +20576,14 @@
     "ClusterRoleList": {
       "$ref": "#/definitions/kubernetes_rbac_ClusterRoleList",
       "javaType": "io.fabric8.kubernetes.api.model.rbac.ClusterRoleList"
+    },
+    "ClusterVersion": {
+      "$ref": "#/definitions/os_config_ClusterVersion",
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersion"
+    },
+    "ClusterVersionList": {
+      "$ref": "#/definitions/os_config_ClusterVersionList",
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionList"
     },
     "ComponentStatusList": {
       "$ref": "#/definitions/kubernetes_core_ComponentStatusList",

--- a/kubernetes-model/kubernetes-model/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model/kubernetes-model/src/main/resources/schema/validation-schema.json
@@ -17046,6 +17046,283 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "os_config_ClusterOperatorStatusCondition": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "message": {
+          "type": "string",
+          "description": ""
+        },
+        "reason": {
+          "type": "string",
+          "description": ""
+        },
+        "status": {
+          "type": "string",
+          "description": ""
+        },
+        "type": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterOperatorStatusCondition",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_ClusterVersion": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "config.openshift.io/v1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterVersion",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/os_config_ClusterVersionSpec",
+          "javaType": "io.fabric8.openshift.api.model.ClusterVersionSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/os_config_ClusterVersionStatus",
+          "javaType": "io.fabric8.openshift.api.model.ClusterVersionStatus"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersion",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "os_config_ClusterVersionList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "config.openshift.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/os_config_ClusterVersion",
+            "javaType": "io.fabric8.openshift.api.model.ClusterVersion"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterVersionList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.openshift.api.model.ClusterVersion\u003e"
+      ]
+    },
+    "os_config_ClusterVersionSpec": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "description": ""
+        },
+        "clusterID": {
+          "type": "string",
+          "description": ""
+        },
+        "desiredUpdate": {
+          "$ref": "#/definitions/os_config_Update",
+          "javaType": "io.fabric8.openshift.api.model.Update"
+        },
+        "overrides": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_ComponentOverride",
+            "javaType": "io.fabric8.openshift.api.model.ComponentOverride"
+          }
+        },
+        "upstream": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_ClusterVersionStatus": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "availableUpdates": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/os_config_Update",
+            "javaType": "io.fabric8.openshift.api.model.Update"
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_ClusterOperatorStatusCondition",
+            "javaType": "io.fabric8.openshift.api.model.ClusterOperatorStatusCondition"
+          }
+        },
+        "desired": {
+          "$ref": "#/definitions/os_config_Update",
+          "javaType": "io.fabric8.openshift.api.model.Update"
+        },
+        "history": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_UpdateHistory",
+            "javaType": "io.fabric8.openshift.api.model.UpdateHistory"
+          }
+        },
+        "observedGeneration": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "versionHash": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_ComponentOverride": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "group": {
+          "type": "string",
+          "description": ""
+        },
+        "kind": {
+          "type": "string",
+          "description": ""
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "namespace": {
+          "type": "string",
+          "description": ""
+        },
+        "unmanaged": {
+          "type": "boolean",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.ComponentOverride",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_Update": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "force": {
+          "type": "boolean",
+          "description": ""
+        },
+        "image": {
+          "type": "string",
+          "description": ""
+        },
+        "version": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.Update",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "os_config_UpdateHistory": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "completionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "image": {
+          "type": "string",
+          "description": ""
+        },
+        "startedTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "state": {
+          "type": "string",
+          "description": ""
+        },
+        "verified": {
+          "type": "boolean",
+          "description": ""
+        },
+        "version": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.openshift.api.model.UpdateHistory",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "os_deploy_CustomDeploymentStrategyParams": {
       "type": "object",
       "description": "",
@@ -20300,6 +20577,14 @@
       "$ref": "#/definitions/kubernetes_rbac_ClusterRoleList",
       "javaType": "io.fabric8.kubernetes.api.model.rbac.ClusterRoleList"
     },
+    "ClusterVersion": {
+      "$ref": "#/definitions/os_config_ClusterVersion",
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersion"
+    },
+    "ClusterVersionList": {
+      "$ref": "#/definitions/os_config_ClusterVersionList",
+      "javaType": "io.fabric8.openshift.api.model.ClusterVersionList"
+    },
     "ComponentStatusList": {
       "$ref": "#/definitions/kubernetes_core_ComponentStatusList",
       "javaType": "io.fabric8.kubernetes.api.model.ComponentStatusList"
@@ -22432,6 +22717,31 @@
       },
       "additionalProperties": true
     },
+    "clusteroperatorstatuscondition": {
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "message": {
+          "type": "string",
+          "description": ""
+        },
+        "reason": {
+          "type": "string",
+          "description": ""
+        },
+        "status": {
+          "type": "string",
+          "description": ""
+        },
+        "type": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true
+    },
     "clusterrole": {
       "properties": {
         "aggregationRule": {
@@ -22441,7 +22751,7 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "rbac.authorization.k8s.io/v1",
+          "default": "authorization.openshift.io/v1",
           "required": true
         },
         "kind": {
@@ -22458,8 +22768,8 @@
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/kubernetes_rbac_PolicyRule",
-            "javaType": "io.fabric8.kubernetes.api.model.rbac.PolicyRule"
+            "$ref": "#/definitions/os_authorization_PolicyRule",
+            "javaType": "io.fabric8.openshift.api.model.PolicyRule"
           }
         }
       },
@@ -22519,15 +22829,15 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_ClusterRoleBinding",
-            "javaType": "io.fabric8.openshift.api.model.OpenshiftClusterRoleBinding"
+            "$ref": "#/definitions/kubernetes_rbac_ClusterRoleBinding",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding"
           }
         },
         "kind": {
@@ -22593,6 +22903,138 @@
             "type": "string",
             "description": ""
           }
+        }
+      },
+      "additionalProperties": true
+    },
+    "clusterversion": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "config.openshift.io/v1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterVersion",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/os_config_ClusterVersionSpec",
+          "javaType": "io.fabric8.openshift.api.model.ClusterVersionSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/os_config_ClusterVersionStatus",
+          "javaType": "io.fabric8.openshift.api.model.ClusterVersionStatus"
+        }
+      },
+      "additionalProperties": true
+    },
+    "clusterversionlist": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "config.openshift.io/v1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/os_config_ClusterVersion",
+            "javaType": "io.fabric8.openshift.api.model.ClusterVersion"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterVersionList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true
+    },
+    "clusterversionspec": {
+      "properties": {
+        "channel": {
+          "type": "string",
+          "description": ""
+        },
+        "clusterID": {
+          "type": "string",
+          "description": ""
+        },
+        "desiredUpdate": {
+          "$ref": "#/definitions/os_config_Update",
+          "javaType": "io.fabric8.openshift.api.model.Update"
+        },
+        "overrides": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_ComponentOverride",
+            "javaType": "io.fabric8.openshift.api.model.ComponentOverride"
+          }
+        },
+        "upstream": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true
+    },
+    "clusterversionstatus": {
+      "properties": {
+        "availableUpdates": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/os_config_Update",
+            "javaType": "io.fabric8.openshift.api.model.Update"
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_ClusterOperatorStatusCondition",
+            "javaType": "io.fabric8.openshift.api.model.ClusterOperatorStatusCondition"
+          }
+        },
+        "desired": {
+          "$ref": "#/definitions/os_config_Update",
+          "javaType": "io.fabric8.openshift.api.model.Update"
+        },
+        "history": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/os_config_UpdateHistory",
+            "javaType": "io.fabric8.openshift.api.model.UpdateHistory"
+          }
+        },
+        "observedGeneration": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "versionHash": {
+          "type": "string",
+          "description": ""
         }
       },
       "additionalProperties": true
@@ -22673,6 +23115,31 @@
         },
         "type": {
           "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true
+    },
+    "componentoverride": {
+      "properties": {
+        "group": {
+          "type": "string",
+          "description": ""
+        },
+        "kind": {
+          "type": "string",
+          "description": ""
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "namespace": {
+          "type": "string",
+          "description": ""
+        },
+        "unmanaged": {
+          "type": "boolean",
           "description": ""
         }
       },
@@ -24790,9 +25257,44 @@
     },
     "deploymentstrategy": {
       "properties": {
-        "rollingUpdate": {
-          "$ref": "#/definitions/kubernetes_apps_RollingUpdateDeployment",
-          "javaType": "io.fabric8.kubernetes.api.model.apps.RollingUpdateDeployment"
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "description": "",
+          "javaType": "Long"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "type": "string",
+            "description": ""
+          },
+          "javaType": "java.util.Map\u003cString,String\u003e"
+        },
+        "customParams": {
+          "$ref": "#/definitions/os_deploy_CustomDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.CustomDeploymentStrategyParams"
+        },
+        "labels": {
+          "type": "object",
+          "description": "",
+          "additionalProperties": {
+            "type": "string",
+            "description": ""
+          },
+          "javaType": "java.util.Map\u003cString,String\u003e"
+        },
+        "recreateParams": {
+          "$ref": "#/definitions/os_deploy_RecreateDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.RecreateDeploymentStrategyParams"
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
+          "javaType": "io.fabric8.kubernetes.api.model.ResourceRequirements"
+        },
+        "rollingParams": {
+          "$ref": "#/definitions/os_deploy_RollingDeploymentStrategyParams",
+          "javaType": "io.fabric8.openshift.api.model.RollingDeploymentStrategyParams"
         },
         "type": {
           "type": "string",
@@ -25047,10 +25549,6 @@
     },
     "endpointport": {
       "properties": {
-        "appProtocol": {
-          "type": "string",
-          "description": ""
-        },
         "name": {
           "type": "string",
           "description": "",
@@ -31917,11 +32415,14 @@
         "apiGroups": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string",
             "description": ""
           }
+        },
+        "attributeRestrictions": {
+          "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
+          "javaType": "io.fabric8.kubernetes.api.model.HasMetadata"
         },
         "nonResourceURLs": {
           "type": "array",
@@ -31944,7 +32445,6 @@
         "resources": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string",
             "description": ""
@@ -33006,7 +33506,7 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -33023,8 +33523,8 @@
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_PolicyRule",
-            "javaType": "io.fabric8.openshift.api.model.PolicyRule"
+            "$ref": "#/definitions/kubernetes_rbac_PolicyRule",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.PolicyRule"
           }
         }
       },
@@ -33035,8 +33535,16 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "rbac.authorization.k8s.io/v1",
+          "default": "authorization.openshift.io/v1",
           "required": true
+        },
+        "groupNames": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string",
+            "description": ""
+          }
         },
         "kind": {
           "type": "string",
@@ -33049,16 +33557,23 @@
           "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "roleRef": {
-          "$ref": "#/definitions/kubernetes_rbac_RoleRef",
-          "javaType": "io.fabric8.kubernetes.api.model.rbac.RoleRef"
+          "$ref": "#/definitions/kubernetes_core_ObjectReference",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
         },
         "subjects": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_rbac_Subject",
-            "javaType": "io.fabric8.kubernetes.api.model.rbac.Subject"
+            "$ref": "#/definitions/kubernetes_core_ObjectReference",
+            "javaType": "io.fabric8.kubernetes.api.model.ObjectReference"
+          }
+        },
+        "userNames": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string",
+            "description": ""
           }
         }
       },
@@ -33069,15 +33584,15 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_RoleBinding",
-            "javaType": "io.fabric8.openshift.api.model.OpenshiftRoleBinding"
+            "$ref": "#/definitions/kubernetes_rbac_RoleBinding",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.RoleBinding"
           }
         },
         "kind": {
@@ -33140,15 +33655,15 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "authorization.openshift.io/v1",
+          "default": "rbac.authorization.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/os_authorization_Role",
-            "javaType": "io.fabric8.openshift.api.model.OpenshiftRole"
+            "$ref": "#/definitions/kubernetes_rbac_Role",
+            "javaType": "io.fabric8.kubernetes.api.model.rbac.Role"
           }
         },
         "kind": {
@@ -33566,24 +34081,18 @@
     },
     "runasuserstrategyoptions": {
       "properties": {
-        "type": {
+        "ranges": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_policy_IDRange",
+            "javaType": "io.fabric8.kubernetes.api.model.policy.IDRange"
+          }
+        },
+        "rule": {
           "type": "string",
           "description": ""
-        },
-        "uid": {
-          "type": "integer",
-          "description": "",
-          "javaType": "Long"
-        },
-        "uidRangeMax": {
-          "type": "integer",
-          "description": "",
-          "javaType": "Long"
-        },
-        "uidRangeMin": {
-          "type": "integer",
-          "description": "",
-          "javaType": "Long"
         }
       },
       "additionalProperties": true
@@ -35546,11 +36055,11 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/os_security_IDRange",
-            "javaType": "io.fabric8.openshift.api.model.IDRange"
+            "$ref": "#/definitions/kubernetes_policy_IDRange",
+            "javaType": "io.fabric8.kubernetes.api.model.policy.IDRange"
           }
         },
-        "type": {
+        "rule": {
           "type": "string",
           "description": ""
         }
@@ -36023,6 +36532,52 @@
           "description": ""
         },
         "kind": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true
+    },
+    "update": {
+      "properties": {
+        "force": {
+          "type": "boolean",
+          "description": ""
+        },
+        "image": {
+          "type": "string",
+          "description": ""
+        },
+        "version": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "additionalProperties": true
+    },
+    "updatehistory": {
+      "properties": {
+        "completionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "image": {
+          "type": "string",
+          "description": ""
+        },
+        "startedTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "javaType": "String"
+        },
+        "state": {
+          "type": "string",
+          "description": ""
+        },
+        "verified": {
+          "type": "boolean",
+          "description": ""
+        },
+        "version": {
           "type": "string",
           "description": ""
         }
@@ -36796,8 +37351,8 @@
           "description": ""
         },
         "service": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_ServiceReference",
-          "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.ServiceReference"
+          "$ref": "#/definitions/kubernetes_apiextensions_ServiceReference",
+          "javaType": "io.fabric8.kubernetes.api.model.apiextensions.ServiceReference"
         },
         "url": {
           "type": "string",

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
@@ -17,7 +17,10 @@
 package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
@@ -31,6 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class VersionInfoTest {
   @Rule
   public KubernetesServer server = new KubernetesServer();
+
+  @Rule
+  public OpenShiftServer openshiftServer = new OpenShiftServer();
 
   @Test
   public void testClusterVersioning() throws ParseException {
@@ -49,5 +55,97 @@ public class VersionInfoTest {
     assertEquals("6", client.getVersion().getMinor());
     assertEquals(client.getVersion().getBuildDate().getYear(), 118);
     assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse("2018-03-01T14:27:17Z").getTime(), client.getVersion().getBuildDate().getTime());
+  }
+
+  @Test
+  public void testClusterVersioningOpenshift4() throws ParseException {
+    openshiftServer.expect().get().withPath("/openshift/version").andReturn(404, "").always();
+
+    openshiftServer.expect().get().withPath("/apis/config.openshift.io/v1/clusterversions").andReturn(200, "{" +
+      "  \"apiVersion\": \"config.openshift.io/v1\"," +
+      "  \"items\": [" +
+      "    {" +
+      "      \"apiVersion\": \"config.openshift.io/v1\"," +
+      "      \"kind\": \"ClusterVersion\"," +
+      "      \"metadata\": {" +
+      "        \"creationTimestamp\": \"2020-01-30T04:05:33Z\"," +
+      "        \"generation\": 2," +
+      "        \"name\": \"version\"," +
+      "        \"resourceVersion\": \"44758\"," +
+      "        \"selfLink\": \"/apis/config.openshift.io/v1/clusterversions/version\"," +
+      "        \"uid\": \"c301755d-4315-11ea-9872-52540022f9dd\"" +
+      "      }," +
+      "      \"spec\": {" +
+      "        \"channel\": \"stable-4.2\"," +
+      "        \"clusterID\": \"c92835a5-395d-4448-840d-6a223f9a02c7\"," +
+      "        \"upstream\": \"https://api.openshift.com/api/upgrades_info/v1/graph\"" +
+      "      }," +
+      "      \"status\": {" +
+      "        \"availableUpdates\": [" +
+      "          {" +
+      "            \"force\": false," +
+      "            \"image\": \"quay.io/openshift-release-dev/ocp-release@sha256:e5a6e348721c38a78d9299284fbb5c60fb340135a86b674b038500bf190ad514\"," +
+      "            \"version\": \"4.2.16\"" +
+      "          }" +
+      "        ]," +
+      "        \"conditions\": [" +
+      "          {" +
+      "            \"lastTransitionTime\": \"2020-01-30T04:05:35Z\"," +
+      "            \"status\": \"False\"," +
+      "            \"type\": \"Available\"" +
+      "          }," +
+      "          {" +
+      "            \"lastTransitionTime\": \"2020-01-30T04:31:38Z\"," +
+      "            \"message\": \"Cluster operator monitoring is still updating\"," +
+      "            \"reason\": \"ClusterOperatorNotAvailable\"," +
+      "            \"status\": \"True\"," +
+      "            \"type\": \"Failing\"" +
+      "          }," +
+      "          {" +
+      "            \"lastTransitionTime\": \"2020-01-30T04:05:35Z\"," +
+      "            \"message\": \"Unable to apply 4.2.14: the cluster operator monitoring has not yet successfully rolled out\"," +
+      "            \"reason\": \"ClusterOperatorNotAvailable\"," +
+      "            \"status\": \"True\"," +
+      "            \"type\": \"Progressing\"" +
+      "          }," +
+      "          {" +
+      "            \"lastTransitionTime\": \"2020-01-30T04:05:36Z\"," +
+      "            \"status\": \"True\"," +
+      "            \"type\": \"RetrievedUpdates\"" +
+      "          }" +
+      "        ]," +
+      "        \"desired\": {" +
+      "          \"force\": false," +
+      "          \"image\": \"quay.io/openshift-release-dev/ocp-release@sha256:3fabe939da31f9a31f509251b9f73d321e367aba2d09ff392c2f452f6433a95a\"," +
+      "          \"version\": \"4.2.14\"" +
+      "        }," +
+      "        \"history\": [" +
+      "          {" +
+      "            \"completionTime\": null," +
+      "            \"image\": \"quay.io/openshift-release-dev/ocp-release@sha256:3fabe939da31f9a31f509251b9f73d321e367aba2d09ff392c2f452f6433a95a\"," +
+      "            \"startedTime\": \"2020-01-30T04:05:35Z\"," +
+      "            \"state\": \"Partial\"," +
+      "            \"verified\": false," +
+      "            \"version\": \"4.2.14\"" +
+      "          }" +
+      "        ]," +
+      "        \"observedGeneration\": 1," +
+      "        \"versionHash\": \"kEuk9MZ8sK4=\"" +
+      "      }" +
+      "    }" +
+      "  ]," +
+      "  \"kind\": \"ClusterVersionList\"," +
+      "  \"metadata\": {" +
+      "    \"continue\": \"\"," +
+      "    \"resourceVersion\": \"62446\"," +
+      "    \"selfLink\": \"/apis/config.openshift.io/v1/clusterversions\"" +
+      "  }" +
+      "}").once();
+
+    OpenShiftClient openShiftClient = openshiftServer.getOpenshiftClient();
+
+    VersionInfo versionInfo = openShiftClient.getVersion();
+    assertEquals("4", versionInfo.getMajor());
+    assertEquals("2.14", versionInfo.getMinor());
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -434,7 +434,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
 
   @Override
   public VersionInfo getVersion() {
-    return new ClusterOperationsImpl(httpClient, getConfiguration(), "version/openshift").fetchVersion();
+    return new ClusterOperationsImpl(httpClient, getConfiguration(), ClusterOperationsImpl.OPENSHIFT_VERSION_ENDPOINT).fetchVersion();
   }
 
   @Override


### PR DESCRIPTION
Fix #2046 

Right now I'm just converting Openshift v4's `ClusterVersion` object to `VersionInfo` which doesn't seem very elegant to me also :confused: . Shall I introduce another method in DSL like this:

```
ClusterVersionList clusterVersion()
```
But then it would be user's responsibility to fetch all the necessary parts.