### PR TITLE
fixes #2075 KubernetesDeserializer registration for CustomResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## CHANGELOG
 
-### 4.8-SNAPSHOT
+### 4.9-SNAPSHOT
 #### Bugs
 Fix #2057: Fix jar and osgi bundle generation for extensions
+Fix #2075: KubernetesDeserializer registration for CustomResources 
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -64,7 +64,7 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
 
     CustomResourceDefinition crd = (CustomResourceDefinition) context.getCrd();
 
-    KubernetesDeserializer.registerCustomKind(crd.getApiVersion(), crd.getKind(), type);
+    KubernetesDeserializer.registerCustomKind(crd.getSpec().getGroup() + "/" + crd.getSpec().getVersion(), crd.getSpec().getNames().getKind(), type);
     if (KubernetesResource.class.isAssignableFrom(listType)) {
       KubernetesDeserializer.registerCustomKind(listType.getSimpleName(), (Class<? extends KubernetesResource>) listType);
     }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
@@ -43,8 +43,6 @@ public class CustomResourceOperationsImplTest {
   }
 
   private final CustomResourceDefinition crd = new CustomResourceDefinitionBuilder()
-    .withApiVersion("custom.group/v1alpha1")
-    .withKind("MyCustomResource")
     .withNewMetadata()
       .withName("custom.name")
     .endMetadata()


### PR DESCRIPTION
Fix #2075 
The current implementation in CustomResourceOperationsImpl passes the wrong apiVersion and Kind values to KubernetesDeserializer.registerCustomKind(...).

apiVersion and Kind for a CustomResourceDefinition are always apiextensions/v1beta1 and CustomResourceDefinition.

The values from the spec needs to be passed for registering the custom kind in the deserializer.