### PR TITLE
Fix #2019: customResource.get() Returns 404 if name is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Fix #2075: KubernetesDeserializer registration for CustomResources
 Fix #2078: watchLog for Deployment and StatefulSet 
 
 #### Improvements
+* Fix #2019: Added CustomResourceCrudTest
 
 #### Dependency Upgrade
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.mock.crd.CronTabSpec;
+import io.fabric8.kubernetes.client.mock.crd.DoneableCronTab;
+import io.fabric8.kubernetes.client.mock.crd.CronTab;
+import io.fabric8.kubernetes.client.mock.crd.CronTabList;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@EnableRuleMigrationSupport
+public class CustomResourceCrudTest {
+  @Rule
+  public KubernetesServer kubernetesServer = new KubernetesServer(true,true);
+
+  private MixedOperation<CronTab, CronTabList, DoneableCronTab, Resource<CronTab, DoneableCronTab>> podSetClient;
+
+  @Test
+  public void testCrud() {
+    CronTab cronTab1 = createCronTab("my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
+    CronTab cronTab2 = createCronTab("my-second-cron-object", "* * * * */4", 2, "my-second-cron-image");
+    CronTab cronTab3 = createCronTab("my-third-cron-object", "* * * * */3", 1, "my-third-cron-image");
+    KubernetesClient client = kubernetesServer.getClient();
+
+    KubernetesDeserializer.registerCustomKind("stable.example.com/v1", "CronTab", CronTab.class);
+    CustomResourceDefinition cronTabCrd = client.customResourceDefinitions().load(getClass().getResourceAsStream("/crontab-crd.yml")).get();
+    client.customResourceDefinitions().create(cronTabCrd);
+
+    MixedOperation<CronTab, CronTabList, DoneableCronTab, Resource<CronTab, DoneableCronTab>> cronTabClient = client
+      .customResources(cronTabCrd, CronTab.class, CronTabList.class, DoneableCronTab.class);
+
+    cronTabClient.inNamespace("test-ns").create(cronTab1);
+    cronTabClient.inNamespace("test-ns").create(cronTab2);
+    cronTabClient.inNamespace("test-ns").create(cronTab3);
+
+    CronTabList cronTabList = cronTabClient.inNamespace("test-ns").list();
+    assertNotNull(cronTabList);
+    assertEquals(3, cronTabList.getItems().size());
+
+    CronTab fromServerCronTab = cronTabClient.inNamespace("test-ns").withName("my-new-cron-object").get();
+    assertNotNull(fromServerCronTab);
+    assertCronTab(fromServerCronTab, "my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
+
+    CronTab fromServerCronTab2 = cronTabClient.inNamespace("test-ns").withName("my-second-cron-object").get();
+    assertNotNull(fromServerCronTab2);
+    assertCronTab(fromServerCronTab2, "my-second-cron-object", "* * * * */4", 2, "my-second-cron-image");
+
+    CronTab fromServerCronTab3 = cronTabClient.inNamespace("test-ns").withName("my-third-cron-object").get();
+    assertNotNull(fromServerCronTab3);
+    assertCronTab(fromServerCronTab3, "my-third-cron-object", "* * * * */3", 1, "my-third-cron-image");
+
+    cronTabClient.inNamespace("test-ns").withName("my-third-cron-object").delete();
+    cronTabList = cronTabClient.inNamespace("test-ns").list();
+    assertEquals(2, cronTabList.getItems().size());
+  }
+
+  public void assertCronTab(CronTab cronTab, String name, String cronTabSpec, int replicas, String image) {
+    assertEquals(name, cronTab.getMetadata().getName());
+    assertEquals(cronTabSpec, cronTab.getSpec().getCronSpec());
+    assertEquals(replicas, cronTab.getSpec().getReplicas());
+    assertEquals(image, cronTab.getSpec().getImage());
+  }
+
+  public CronTab createCronTab(String name, String cronTabSpecStr, int replicas, String image) {
+    CronTab cronTab = new CronTab();
+    cronTab.setMetadata(new ObjectMetaBuilder().withName(name).build());
+    CronTabSpec cronTabSpec = new CronTabSpec();
+    cronTabSpec.setCronSpec(cronTabSpecStr);
+    cronTabSpec.setImage(image);
+    cronTabSpec.setReplicas(replicas);
+    cronTab.setSpec(cronTabSpec);
+    return cronTab;
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTab.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTab.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class CronTab extends CustomResource {
+    private CronTabSpec spec;
+    private CronTabStatus status;
+
+    @Override
+    public ObjectMeta getMetadata() {
+        return super.getMetadata();
+    }
+
+    public CronTabSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(CronTabSpec spec) {
+        this.spec = spec;
+    }
+
+    public CronTabStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(CronTabStatus status) {
+        this.status = status;
+    }
+
+    @Override
+    public String getApiVersion() {
+        return "stable.example.com/v1";
+    }
+
+    @Override
+    public String toString() {
+        return "CronTab{"+
+                "apiVersion='" + getApiVersion() + "'" +
+                ", metadata=" + getMetadata() +
+                ", spec=" + spec +
+                ", status=" + status +
+                "}";
+    }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTabList.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTabList.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class CronTabList extends CustomResourceList<CronTab> {
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTabSpec.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTabSpec.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+@JsonDeserialize(
+        using = JsonDeserializer.None.class
+)
+public class CronTabSpec implements KubernetesResource {
+    public String getCronSpec() {
+        return cronSpec;
+    }
+
+    public void setCronSpec(String cronSpec) {
+        this.cronSpec = cronSpec;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public int getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(int replicas) {
+        this.replicas = replicas;
+    }
+
+    private String cronSpec;
+    private String image;
+    private int replicas;
+
+    @Override
+    public String toString() {
+        return "CronTabSpec{" +
+                "replicas=" + replicas  +
+                ", cronSpec='" + cronSpec + "'" +
+                ", image='" + image + "'" +
+                "}";
+    }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTabStatus.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/CronTabStatus.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+@JsonDeserialize(
+        using = JsonDeserializer.None.class
+)
+public class CronTabStatus implements KubernetesResource {
+    public int getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(int replicas) {
+        this.replicas = replicas;
+    }
+
+    private int replicas;
+
+    public String getLabelSelector() {
+        return labelSelector;
+    }
+
+    public void setLabelSelector(String labelSelector) {
+        this.labelSelector = labelSelector;
+    }
+
+    private String labelSelector;
+
+    @Override
+    public String toString() {
+        return "CronTabStatus{" +
+                " replicas=" + replicas +
+                " , labelSelector='" + labelSelector + "'" +
+                "}";
+    }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/DoneableCronTab.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/DoneableCronTab.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+
+
+public class DoneableCronTab extends CustomResourceDoneable<CronTab> {
+    public DoneableCronTab(CronTab resource, Function function) { super(resource, function); }
+}

--- a/kubernetes-tests/src/test/resources/crontab-crd.yml
+++ b/kubernetes-tests/src/test/resources/crontab-crd.yml
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                labelSelector:
+                  type: string
+      # subresources describes the subresources for custom resources.
+      subresources:
+        # status enables the status subresource.
+        status: {}
+        # scale enables the scale subresource.
+        scale:
+          # specReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Spec.Replicas.
+          specReplicasPath: .spec.replicas
+          # statusReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Replicas.
+          statusReplicasPath: .status.replicas
+          # labelSelectorPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Selector.
+          labelSelectorPath: .status.labelSelector
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+    shortNames:
+      - ct


### PR DESCRIPTION
Added CustomResourceCrudTest for demonstrating usage of CRUD mode
for Custom Resources.