### PR TITLE
Fix #2054: JobExample doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 #### Improvements
 * Fix #2019: Added CustomResourceCrudTest
+* Fix #2054: JobExample doesn't work
 
 #### Dependency Upgrade
 


### PR DESCRIPTION
Fix #2054: Corrected JobExample to first wait till pods created by job complete first and then
print job logs