### PR TITLE
Javac release compiler flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,6 @@
     <!-- Other options -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.release>8</maven.compiler.release>
     <svc.version>1.1.1</svc.version>
 
     <exec.master>https://localhost:8443</exec.master>
@@ -794,6 +793,15 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>java9-plus</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <!-- Other options -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <svc.version>1.1.1</svc.version>
 
     <exec.master>https://localhost:8443</exec.master>


### PR DESCRIPTION
The --release compiler flag is required when building the project with a jdk > 8 to produce the right byte code for jdk8 (see https://github.com/eclipse/jetty.project/issues/3244#issuecomment-495322586).

Otherwise, there are issues e.g. with the PortForwarderWebsocket.

