### PR TITLE
    Fix #2115: Add Support for keeping both v1alpha1 and v1beta1 apis in tekton extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Improvements
 #### Dependency Upgrade
 #### New Features
+* Fix #2115: Keep tekton v1alpha1 api
 
 ### 4.9.1 (2020-04-17)
 #### Bugs

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
@@ -15,13 +15,13 @@
  */
 package io.fabric8.tekton.client;
 
-import io.fabric8.tekton.client.internal.ClusterTaskOperationsImpl;
-import io.fabric8.tekton.client.internal.ConditionOperationsImpl;
-import io.fabric8.tekton.client.internal.PipelineOperationsImpl;
-import io.fabric8.tekton.client.internal.PipelineResourceOperationsImpl;
-import io.fabric8.tekton.client.internal.PipelineRunOperationsImpl;
-import io.fabric8.tekton.client.internal.TaskOperationsImpl;
-import io.fabric8.tekton.client.internal.TaskRunOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.ClusterTaskOperationsImpl;
+import io.fabric8.tekton.client.internal.v1alpha1.ConditionOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.PipelineOperationsImpl;
+import io.fabric8.tekton.client.internal.v1alpha1.PipelineResourceOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.PipelineRunOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.TaskOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.TaskRunOperationsImpl;
 import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
 import io.fabric8.tekton.pipeline.v1beta1.ClusterTaskList;
 import io.fabric8.tekton.pipeline.v1alpha1.Condition;

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
@@ -15,34 +15,8 @@
  */
 package io.fabric8.tekton.client;
 
-import io.fabric8.tekton.client.internal.v1beta1.ClusterTaskOperationsImpl;
-import io.fabric8.tekton.client.internal.v1alpha1.ConditionOperationsImpl;
-import io.fabric8.tekton.client.internal.v1beta1.PipelineOperationsImpl;
-import io.fabric8.tekton.client.internal.v1alpha1.PipelineResourceOperationsImpl;
-import io.fabric8.tekton.client.internal.v1beta1.PipelineRunOperationsImpl;
-import io.fabric8.tekton.client.internal.v1beta1.TaskOperationsImpl;
-import io.fabric8.tekton.client.internal.v1beta1.TaskRunOperationsImpl;
-import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
-import io.fabric8.tekton.pipeline.v1beta1.ClusterTaskList;
-import io.fabric8.tekton.pipeline.v1alpha1.Condition;
-import io.fabric8.tekton.pipeline.v1alpha1.ConditionList;
-import io.fabric8.tekton.pipeline.v1beta1.DoneableClusterTask;
-import io.fabric8.tekton.pipeline.v1alpha1.DoneableCondition;
-import io.fabric8.tekton.pipeline.v1beta1.DoneablePipeline;
-import io.fabric8.tekton.pipeline.v1beta1.DoneablePipelineRun;
-import io.fabric8.tekton.pipeline.v1beta1.DoneableTask;
-import io.fabric8.tekton.pipeline.v1beta1.DoneableTaskRun;
-import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
-import io.fabric8.tekton.pipeline.v1beta1.PipelineList;
-import io.fabric8.tekton.pipeline.v1beta1.PipelineRun;
-import io.fabric8.tekton.pipeline.v1beta1.PipelineRunList;
-import io.fabric8.tekton.pipeline.v1beta1.Task;
-import io.fabric8.tekton.pipeline.v1beta1.TaskList;
-import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
-import io.fabric8.tekton.pipeline.v1beta1.TaskRunList;
-import io.fabric8.tekton.resource.v1alpha1.DoneablePipelineResource;
-import io.fabric8.tekton.resource.v1alpha1.PipelineResource;
-import io.fabric8.tekton.resource.v1alpha1.PipelineResourceList;
+import io.fabric8.tekton.client.dsl.V1alpha1APIGroupDSL;
+import io.fabric8.tekton.client.dsl.V1beta1APIGroupDSL;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.RequestConfig;
@@ -50,66 +24,48 @@ import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.BaseClient;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 
 public class DefaultTektonClient extends BaseClient implements NamespacedTektonClient {
 
-    public DefaultTektonClient() {
-        super();
-    }
+  public DefaultTektonClient() {
+    super();
+  }
 
-    public DefaultTektonClient(Config configuration) {
-        super(configuration);
-    }
+  public DefaultTektonClient(Config configuration) {
+    super(configuration);
+  }
 
-    public DefaultTektonClient(OkHttpClient httpClient, Config configuration) {
-        super(httpClient, configuration);
-    }
+  public DefaultTektonClient(OkHttpClient httpClient, Config configuration) {
+    super(httpClient, configuration);
+  }
 
-    @Override
-    public NamespacedTektonClient inAnyNamespace() {
-        return inNamespace(null);
-    }
+  @Override
+  public NamespacedTektonClient inAnyNamespace() {
+    return inNamespace(null);
+  }
 
-    @Override
-    public NamespacedTektonClient inNamespace(String namespace) {
-        Config updated = new ConfigBuilder(getConfiguration())
-                .withNamespace(namespace)
-                .build();
+  @Override
+  public NamespacedTektonClient inNamespace(String namespace) {
+    Config updated = new ConfigBuilder(getConfiguration())
+      .withNamespace(namespace)
+      .build();
 
-        return new DefaultTektonClient(getHttpClient(), updated);
-    }
+    return new DefaultTektonClient(getHttpClient(), updated);
+  }
+
   @Override
   public FunctionCallable<NamespacedTektonClient> withRequestConfig(RequestConfig requestConfig) {
     return new WithRequestCallable<NamespacedTektonClient>(this, requestConfig);
   }
 
-  public MixedOperation<Pipeline, PipelineList, DoneablePipeline, Resource<Pipeline, DoneablePipeline>> pipelines() {
-    return new PipelineOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  @Override
+  public V1beta1APIGroupDSL v1beta1() {
+    return adapt(V1beta1APIGroupClient.class);
   }
 
-  public MixedOperation<PipelineRun, PipelineRunList, DoneablePipelineRun, Resource<PipelineRun, DoneablePipelineRun>> pipelineRuns() {
-    return new PipelineRunOperationsImpl(this.getHttpClient(), this.getConfiguration());
-  }
-
-  public MixedOperation<PipelineResource, PipelineResourceList, DoneablePipelineResource, Resource<PipelineResource, DoneablePipelineResource>> pipelineResources() {
-    return new PipelineResourceOperationsImpl(this.getHttpClient(), this.getConfiguration());
-  }
-
-  public MixedOperation<Task, TaskList, DoneableTask, Resource<Task, DoneableTask>> tasks() {
-    return new TaskOperationsImpl(this.getHttpClient(), this.getConfiguration());
-  }
-  public MixedOperation<TaskRun, TaskRunList, DoneableTaskRun, Resource<TaskRun, DoneableTaskRun>> taskRuns() {
-    return new TaskRunOperationsImpl(this.getHttpClient(), this.getConfiguration());
-  }
-  public MixedOperation<Condition, ConditionList, DoneableCondition, Resource<Condition, DoneableCondition>> conditions() {
-    return new ConditionOperationsImpl(this.getHttpClient(), this.getConfiguration());
-  }
-
-  public NonNamespaceOperation<ClusterTask, ClusterTaskList, DoneableClusterTask, Resource<ClusterTask, DoneableClusterTask>> clusterTasks() {
-    return new ClusterTaskOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  @Override
+  public V1alpha1APIGroupDSL v1alpha1() {
+    return adapt(V1alpha1APIGroupClient.class);
   }
 
 }

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1alpha1APIGroupClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1alpha1APIGroupClient.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tekton.client;
+
+import io.fabric8.kubernetes.client.BaseClient;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.tekton.client.dsl.V1alpha1APIGroupDSL;
+import io.fabric8.tekton.client.internal.v1alpha1.ConditionOperationsImpl;
+import io.fabric8.tekton.client.internal.v1alpha1.PipelineResourceOperationsImpl;
+import io.fabric8.tekton.client.internal.v1alpha1.ClusterTaskOperationsImpl;
+import io.fabric8.tekton.client.internal.v1alpha1.PipelineRunOperationsImpl;
+import io.fabric8.tekton.client.internal.v1alpha1.TaskOperationsImpl;
+import io.fabric8.tekton.client.internal.v1alpha1.TaskRunOperationsImpl;
+import io.fabric8.tekton.pipeline.v1alpha1.ClusterTask;
+import io.fabric8.tekton.pipeline.v1alpha1.ClusterTaskList;
+import io.fabric8.tekton.pipeline.v1alpha1.Condition;
+import io.fabric8.tekton.pipeline.v1alpha1.ConditionList;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableClusterTask;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableCondition;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneablePipeline;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneablePipelineRun;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableTask;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableTaskRun;
+import io.fabric8.tekton.pipeline.v1alpha1.Pipeline;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineList;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineRun;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineRunList;
+import io.fabric8.tekton.pipeline.v1alpha1.Task;
+import io.fabric8.tekton.pipeline.v1alpha1.TaskList;
+import io.fabric8.tekton.pipeline.v1alpha1.TaskRun;
+import io.fabric8.tekton.pipeline.v1alpha1.TaskRunList;
+import io.fabric8.tekton.resource.v1alpha1.DoneablePipelineResource;
+import io.fabric8.tekton.resource.v1alpha1.PipelineResource;
+import io.fabric8.tekton.resource.v1alpha1.PipelineResourceList;
+import io.fabric8.tekton.client.internal.v1alpha1.PipelineOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class V1alpha1APIGroupClient extends BaseClient implements V1alpha1APIGroupDSL {
+  public V1alpha1APIGroupClient() {
+    super();
+  }
+
+  public V1alpha1APIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public MixedOperation<Pipeline, PipelineList, DoneablePipeline, Resource<Pipeline, DoneablePipeline>> pipelines() {
+    return new PipelineOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<PipelineRun, PipelineRunList, DoneablePipelineRun, Resource<PipelineRun, DoneablePipelineRun>> pipelineRuns() {
+    return new PipelineRunOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<PipelineResource, PipelineResourceList, DoneablePipelineResource, Resource<PipelineResource, DoneablePipelineResource>> pipelineResources() {
+    return new PipelineResourceOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<Task, TaskList, DoneableTask, Resource<Task, DoneableTask>> tasks() {
+    return new TaskOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<TaskRun, TaskRunList, DoneableTaskRun, Resource<TaskRun, DoneableTaskRun>> taskRuns() {
+    return new TaskRunOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<Condition, ConditionList, DoneableCondition, Resource<Condition, DoneableCondition>> conditions() {
+    return new ConditionOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public NonNamespaceOperation<ClusterTask, ClusterTaskList, DoneableClusterTask, Resource<ClusterTask, DoneableClusterTask>> clusterTasks() {
+    return new ClusterTaskOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+}

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1alpha1APIGroupExtensionAdapter.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1alpha1APIGroupExtensionAdapter.java
@@ -15,11 +15,23 @@
  */
 package io.fabric8.tekton.client;
 
+import io.fabric8.kubernetes.client.APIGroupExtensionAdapter;
 import io.fabric8.kubernetes.client.Client;
-import io.fabric8.tekton.client.dsl.V1alpha1APIGroupDSL;
-import io.fabric8.tekton.client.dsl.V1beta1APIGroupDSL;
+import okhttp3.OkHttpClient;
 
-public interface TektonClient extends Client {
-  V1beta1APIGroupDSL v1beta1();
-  V1alpha1APIGroupDSL v1alpha1();
+public class V1alpha1APIGroupExtensionAdapter extends APIGroupExtensionAdapter<V1alpha1APIGroupClient> {
+  @Override
+  protected String getAPIGroupName() {
+    return "v1alpha1";
+  }
+
+  @Override
+  public Class<V1alpha1APIGroupClient> getExtensionType() {
+    return V1alpha1APIGroupClient.class;
+  }
+
+  @Override
+  protected V1alpha1APIGroupClient newInstance(Client client) {
+    return new V1alpha1APIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
 }

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1beta1APIGroupClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1beta1APIGroupClient.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tekton.client;
+
+import io.fabric8.kubernetes.client.BaseClient;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.tekton.client.dsl.V1beta1APIGroupDSL;
+import io.fabric8.tekton.client.internal.v1beta1.ClusterTaskOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.PipelineRunOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.TaskOperationsImpl;
+import io.fabric8.tekton.client.internal.v1beta1.TaskRunOperationsImpl;
+import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
+import io.fabric8.tekton.pipeline.v1beta1.ClusterTaskList;
+import io.fabric8.tekton.pipeline.v1beta1.DoneableClusterTask;
+import io.fabric8.tekton.pipeline.v1beta1.DoneablePipeline;
+import io.fabric8.tekton.pipeline.v1beta1.DoneablePipelineRun;
+import io.fabric8.tekton.pipeline.v1beta1.DoneableTask;
+import io.fabric8.tekton.pipeline.v1beta1.DoneableTaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
+import io.fabric8.tekton.pipeline.v1beta1.PipelineList;
+import io.fabric8.tekton.pipeline.v1beta1.PipelineRun;
+import io.fabric8.tekton.pipeline.v1beta1.PipelineRunList;
+import io.fabric8.tekton.pipeline.v1beta1.Task;
+import io.fabric8.tekton.pipeline.v1beta1.TaskList;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunList;
+import io.fabric8.tekton.client.internal.v1beta1.PipelineOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class V1beta1APIGroupClient extends BaseClient implements V1beta1APIGroupDSL {
+  public V1beta1APIGroupClient() {
+    super();
+  }
+
+  public V1beta1APIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public MixedOperation<Pipeline, PipelineList, DoneablePipeline, Resource<Pipeline, DoneablePipeline>> pipelines() {
+    return new PipelineOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<PipelineRun, PipelineRunList, DoneablePipelineRun, Resource<PipelineRun, DoneablePipelineRun>> pipelineRuns() {
+    return new PipelineRunOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<Task, TaskList, DoneableTask, Resource<Task, DoneableTask>> tasks() {
+    return new TaskOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public MixedOperation<TaskRun, TaskRunList, DoneableTaskRun, Resource<TaskRun, DoneableTaskRun>> taskRuns() {
+    return new TaskRunOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+
+  @Override
+  public NonNamespaceOperation<ClusterTask, ClusterTaskList, DoneableClusterTask, Resource<ClusterTask, DoneableClusterTask>> clusterTasks() {
+    return new ClusterTaskOperationsImpl(this.getHttpClient(), this.getConfiguration());
+  }
+}

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1beta1APIGroupExtensionAdapter.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1beta1APIGroupExtensionAdapter.java
@@ -15,11 +15,23 @@
  */
 package io.fabric8.tekton.client;
 
+import io.fabric8.kubernetes.client.APIGroupExtensionAdapter;
 import io.fabric8.kubernetes.client.Client;
-import io.fabric8.tekton.client.dsl.V1alpha1APIGroupDSL;
-import io.fabric8.tekton.client.dsl.V1beta1APIGroupDSL;
+import okhttp3.OkHttpClient;
 
-public interface TektonClient extends Client {
-  V1beta1APIGroupDSL v1beta1();
-  V1alpha1APIGroupDSL v1alpha1();
+public class V1beta1APIGroupExtensionAdapter extends APIGroupExtensionAdapter<V1beta1APIGroupClient> {
+  @Override
+  protected String getAPIGroupName() {
+    return "v1beta1";
+  }
+
+  @Override
+  public Class<V1beta1APIGroupClient> getExtensionType() {
+    return V1beta1APIGroupClient.class;
+  }
+
+  @Override
+  protected V1beta1APIGroupClient newInstance(Client client) {
+    return new V1beta1APIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
 }

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/dsl/V1alpha1APIGroupDSL.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/dsl/V1alpha1APIGroupDSL.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tekton.client.dsl;
+
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.tekton.pipeline.v1alpha1.Condition;
+import io.fabric8.tekton.pipeline.v1alpha1.ConditionList;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableCondition;
+import io.fabric8.tekton.pipeline.v1alpha1.ClusterTask;
+import io.fabric8.tekton.pipeline.v1alpha1.ClusterTaskList;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableClusterTask;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneablePipeline;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneablePipelineRun;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableTask;
+import io.fabric8.tekton.pipeline.v1alpha1.DoneableTaskRun;
+import io.fabric8.tekton.pipeline.v1alpha1.Pipeline;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineList;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineRun;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineRunList;
+import io.fabric8.tekton.pipeline.v1alpha1.Task;
+import io.fabric8.tekton.pipeline.v1alpha1.TaskList;
+import io.fabric8.tekton.pipeline.v1alpha1.TaskRun;
+import io.fabric8.tekton.pipeline.v1alpha1.TaskRunList;
+import io.fabric8.tekton.resource.v1alpha1.DoneablePipelineResource;
+import io.fabric8.tekton.resource.v1alpha1.PipelineResource;
+import io.fabric8.tekton.resource.v1alpha1.PipelineResourceList;
+
+public interface V1alpha1APIGroupDSL extends Client {
+  MixedOperation<Pipeline, PipelineList, DoneablePipeline, Resource<Pipeline, DoneablePipeline>> pipelines();
+  MixedOperation<PipelineRun, PipelineRunList, DoneablePipelineRun, Resource<PipelineRun, DoneablePipelineRun>> pipelineRuns();
+  MixedOperation<PipelineResource, PipelineResourceList, DoneablePipelineResource, Resource<PipelineResource, DoneablePipelineResource>> pipelineResources();
+  MixedOperation<Task, TaskList, DoneableTask, Resource<Task, DoneableTask>> tasks();
+  MixedOperation<TaskRun, TaskRunList, DoneableTaskRun, Resource<TaskRun, DoneableTaskRun>> taskRuns();
+  MixedOperation<Condition, ConditionList, DoneableCondition, Resource<Condition, DoneableCondition>> conditions();
+
+  NonNamespaceOperation<ClusterTask, ClusterTaskList, DoneableClusterTask, Resource<ClusterTask, DoneableClusterTask>> clusterTasks();
+}

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/dsl/V1beta1APIGroupDSL.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/dsl/V1beta1APIGroupDSL.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tekton.client.dsl;
+
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
+import io.fabric8.tekton.pipeline.v1beta1.ClusterTaskList;
+import io.fabric8.tekton.pipeline.v1beta1.DoneableClusterTask;
+import io.fabric8.tekton.pipeline.v1beta1.DoneablePipeline;
+import io.fabric8.tekton.pipeline.v1beta1.DoneablePipelineRun;
+import io.fabric8.tekton.pipeline.v1beta1.DoneableTask;
+import io.fabric8.tekton.pipeline.v1beta1.DoneableTaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
+import io.fabric8.tekton.pipeline.v1beta1.PipelineList;
+import io.fabric8.tekton.pipeline.v1beta1.PipelineRun;
+import io.fabric8.tekton.pipeline.v1beta1.PipelineRunList;
+import io.fabric8.tekton.pipeline.v1beta1.Task;
+import io.fabric8.tekton.pipeline.v1beta1.TaskList;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
+import io.fabric8.tekton.pipeline.v1beta1.TaskRunList;
+
+public interface V1beta1APIGroupDSL extends Client {
+  MixedOperation<Pipeline, PipelineList, DoneablePipeline, Resource<Pipeline, DoneablePipeline>> pipelines();
+  MixedOperation<PipelineRun, PipelineRunList, DoneablePipelineRun, Resource<PipelineRun, DoneablePipelineRun>> pipelineRuns();
+  MixedOperation<Task, TaskList, DoneableTask, Resource<Task, DoneableTask>> tasks();
+  MixedOperation<TaskRun, TaskRunList, DoneableTaskRun, Resource<TaskRun, DoneableTaskRun>> taskRuns();
+
+  NonNamespaceOperation<ClusterTask, ClusterTaskList, DoneableClusterTask, Resource<ClusterTask, DoneableClusterTask>> clusterTasks();
+
+}

--- a/extensions/tekton/client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
+++ b/extensions/tekton/client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
@@ -15,3 +15,5 @@
 #
 
 io.fabric8.tekton.client.TektonExtensionAdapter
+io.fabric8.tekton.client.V1beta1APIGroupExtensionAdapter
+io.fabric8.tekton.client.V1alpha1APIGroupExtensionAdapter

--- a/extensions/tekton/client/src/main/resources/resource-handler-services.vm
+++ b/extensions/tekton/client/src/main/resources/resource-handler-services.vm
@@ -14,5 +14,10 @@
  * limitations under the License.
  *#
 #foreach ($m in ${model.values()})
-io.fabric8.tekton.client.handlers.${m.name}Handler
+#foreach ($annotation in $m.annotations)
+#if ($annotation.getClassRef().getName().equals("ApiVersion"))
+#set ($apiVersion = $annotation.getParameters().get("value"))
+#end
+#end
+io.fabric8.tekton.client.handlers.${apiVersion}.${m.name}Handler
 #end

--- a/extensions/tekton/client/src/main/resources/resource-handler.vm
+++ b/extensions/tekton/client/src/main/resources/resource-handler.vm
@@ -26,7 +26,7 @@
 #end
 
 
-package io.fabric8.tekton.client.handlers;
+package io.fabric8.tekton.client.handlers.$apiVersion;
 
 import java.util.function.Predicate;
 
@@ -34,7 +34,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.tekton.client.internal.${model.name}OperationsImpl;
+import io.fabric8.tekton.client.internal.$apiVersion.${model.name}OperationsImpl;
 
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import okhttp3.OkHttpClient;

--- a/extensions/tekton/client/src/main/resources/resource-operation.vm
+++ b/extensions/tekton/client/src/main/resources/resource-operation.vm
@@ -27,7 +27,7 @@
 #end
 
 
-package io.fabric8.tekton.client.internal;
+package io.fabric8.tekton.client.internal.$apiGroupVersion;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.Resource;

--- a/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/PipelineList.java
+++ b/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/PipelineList.java
@@ -22,7 +22,7 @@ public class PipelineList {
   public static void main(String[] args) {
     try ( TektonClient client = ClientFactory.newClient(args)) {
       System.out.println("Pipelines:");
-      client.pipelines().list().getItems().forEach(System.out::println);
+      client.v1beta1().pipelines().list().getItems().forEach(System.out::println);
       System.out.println("done.");
     }
     System.exit(0);

--- a/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/PipelineResourceCreate.java
+++ b/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/PipelineResourceCreate.java
@@ -41,7 +41,7 @@ public class PipelineResourceCreate {
         .endSpec()
         .build();
       
-      System.out.println("Created:" + client.pipelineResources().inNamespace(namespace).create(resource).getMetadata().getName());
+      System.out.println("Created:" + client.v1alpha1().pipelineResources().inNamespace(namespace).create(resource).getMetadata().getName());
     }
     System.exit(0);
   }

--- a/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/PipelineResourceList.java
+++ b/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/PipelineResourceList.java
@@ -22,7 +22,7 @@ public class PipelineResourceList {
   public static void main(String[] args) {
     try ( TektonClient client = ClientFactory.newClient(args)) {
       System.out.println("Pipeline resources:");
-      client.pipelineResources().list().getItems().forEach(System.out::println);
+      client.v1alpha1().pipelineResources().list().getItems().forEach(System.out::println);
       System.out.println("done.");
     }
     System.exit(0);

--- a/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/TaskCreate.java
+++ b/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/TaskCreate.java
@@ -40,11 +40,11 @@ public class TaskCreate {
         .build();
 
       // Create Task
-      task = tektonClient.tasks().inNamespace(namespace).create(task);
+      task = tektonClient.v1beta1().tasks().inNamespace(namespace).create(task);
       System.out.println("Created: " + task.getMetadata().getName());
 
       // List Task
-      TaskList taskList = tektonClient.tasks().inNamespace(namespace).list();
+      TaskList taskList = tektonClient.v1beta1().tasks().inNamespace(namespace).list();
       System.out.println("There are " + taskList.getItems().size() + " Tasks in " + namespace);
     }
   }

--- a/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/TaskRunCreate.java
+++ b/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/TaskRunCreate.java
@@ -49,11 +49,11 @@ public class TaskRunCreate {
         .build();
 
       // Create TaskRun
-      taskRun = tektonClient.taskRuns().inNamespace(namespace).create(taskRun);
+      taskRun = tektonClient.v1beta1().taskRuns().inNamespace(namespace).create(taskRun);
       System.out.println("Created: " + taskRun.getMetadata().getName());
 
       // List TaskRun
-      TaskRunList taskRunList = tektonClient.taskRuns().inNamespace(namespace).list();
+      TaskRunList taskRunList = tektonClient.v1beta1().taskRuns().inNamespace(namespace).list();
       System.out.println("There are " + taskRunList.getItems().size() + " TaskRun objects in " + namespace);
     }
   }

--- a/extensions/tekton/generator/cmd/generate/generate.go
+++ b/extensions/tekton/generator/cmd/generate/generate.go
@@ -34,11 +34,18 @@ func main() {
 	// no other types need to be defined as they are auto discovered
 	crdLists := []reflect.Type{
 		reflect.TypeOf(v1alpha1.ConditionList{}),
+		reflect.TypeOf(v1alpha1.PipelineList{}),
+		reflect.TypeOf(v1alpha1.PipelineRunList{}),
+		reflect.TypeOf(v1alpha1.TaskList{}),
+		reflect.TypeOf(v1alpha1.TaskRunList{}),
+		reflect.TypeOf(v1alpha1.ClusterTaskList{}),
+
 		reflect.TypeOf(v1beta1.PipelineList{}),
 		reflect.TypeOf(v1beta1.PipelineRunList{}),
 		reflect.TypeOf(v1beta1.TaskList{}),
 		reflect.TypeOf(v1beta1.TaskRunList{}),
 		reflect.TypeOf(v1beta1.ClusterTaskList{}),
+
 		reflect.TypeOf(resource.PipelineResourceList{}),
 	}
 

--- a/extensions/tekton/model/src/main/java/io/fabric8/tekton/TektonResourceMappingProvider.java
+++ b/extensions/tekton/model/src/main/java/io/fabric8/tekton/TektonResourceMappingProvider.java
@@ -17,15 +17,6 @@ package io.fabric8.tekton;
 
 import io.fabric8.kubernetes.api.KubernetesResourceMappingProvider;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
-import io.fabric8.tekton.pipeline.v1alpha1.Condition;
-import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
-import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
-import io.fabric8.tekton.pipeline.v1beta1.PipelineRun;
-import io.fabric8.tekton.pipeline.v1beta1.SidecarState;
-import io.fabric8.tekton.pipeline.v1beta1.Task;
-import io.fabric8.tekton.pipeline.v1beta1.TaskRef;
-import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
-import io.fabric8.tekton.resource.v1alpha1.PipelineResource;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,18 +26,22 @@ public class TektonResourceMappingProvider implements KubernetesResourceMappingP
     public final Map<String, Class<? extends KubernetesResource>> mappings = new HashMap<>();
 
     public TektonResourceMappingProvider() {
-        mappings.put("tekton.dev/v1alpha1#PipelineResource", PipelineResource.class);
-        mappings.put("tekton.dev/v1alpha1#Condition", Condition.class);
-        mappings.put("tekton.dev/v1beta1#Pipeline", Pipeline.class);
-        mappings.put("tekton.dev/v1beta1#PipelineRun", PipelineRun.class);
-        mappings.put("tekton.dev/v1beta1#Task", Task.class);
-        mappings.put("tekton.dev/v1beta1#TaskRun", TaskRun.class);
-        mappings.put("tekton.dev/v1beta1#TaskRef", TaskRef.class);
-        mappings.put("tekton.dev/v1beta1#ClusterTask", ClusterTask.class);
-        mappings.put("tekton.dev/v1beta1#SidecarState", SidecarState.class);
+        mappings.put("tekton.dev/v1alpha1#PipelineResource", io.fabric8.tekton.resource.v1alpha1.PipelineResource.class);
+        mappings.put("tekton.dev/v1alpha1#Condition", io.fabric8.tekton.pipeline.v1alpha1.Condition.class);
+        mappings.put("tekton.dev/v1beta1#Pipeline", io.fabric8.tekton.pipeline.v1beta1.Pipeline.class);
+        mappings.put("tekton.dev/v1alpha1#Pipeline", io.fabric8.tekton.pipeline.v1alpha1.Pipeline.class);
+        mappings.put("tekton.dev/v1beta1#PipelineRun", io.fabric8.tekton.pipeline.v1beta1.PipelineRun.class);
+        mappings.put("tekton.dev/v1alpha1#PipelineRun", io.fabric8.tekton.pipeline.v1alpha1.PipelineRun.class);
+        mappings.put("tekton.dev/v1beta1#Task", io.fabric8.tekton.pipeline.v1beta1.Task.class);
+        mappings.put("tekton.dev/v1alpha1#Task", io.fabric8.tekton.pipeline.v1alpha1.Task.class);
+        mappings.put("tekton.dev/v1beta1#TaskRun", io.fabric8.tekton.pipeline.v1beta1.TaskRun.class);
+        mappings.put("tekton.dev/v1alpha#TaskRun", io.fabric8.tekton.pipeline.v1alpha1.TaskRun.class);
+        mappings.put("tekton.dev/v1beta1#TaskRef", io.fabric8.tekton.pipeline.v1beta1.TaskRef.class);
+        mappings.put("tekton.dev/v1beta1#ClusterTask", io.fabric8.tekton.pipeline.v1beta1.ClusterTask.class);
+        mappings.put("tekton.dev/v1alpha1#ClusterTask", io.fabric8.tekton.pipeline.v1alpha1.ClusterTask.class);
+        mappings.put("tekton.dev/v1beta1#SidecarState", io.fabric8.tekton.pipeline.v1beta1.SidecarState.class);
     }
 
     public Map<String, Class<? extends KubernetesResource>> getMappings() {
         return mappings;
-    }
-}
+    }}

--- a/extensions/tekton/model/src/main/java/io/fabric8/tekton/pipeline/v1alpha1/ArrayOrString.java
+++ b/extensions/tekton/model/src/main/java/io/fabric8/tekton/pipeline/v1alpha1/ArrayOrString.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tekton.pipeline.v1alpha1;
+
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Inline;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.IOException;
+import java.util.*;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+  "arrayVal",
+  "stringVal",
+  "type"
+})
+@JsonDeserialize(using = ArrayOrString.Deserializer.class)
+@JsonSerialize(using = ArrayOrString.Serializer.class)
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done"))
+public class ArrayOrString implements KubernetesResource {
+
+  private static final String TYPE_STRING = "string";
+  private static final String TYPE_ARRAY = "array";
+
+  @JsonProperty("arrayVal")
+  private List<String> arrayVal = new ArrayList<String>();
+
+  @JsonProperty("stringVal")
+  private String stringVal;
+
+  @JsonProperty("type")
+  private String type;
+
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+  /**
+   * No args constructor for use in serialization
+   */
+  public ArrayOrString() {
+  }
+
+  //Builders are generated for the first non-empty constructor found.
+  public ArrayOrString(List<String> arrayVal, String stringVal, String type, Map<String, Object> additionalProperties) {
+    this.arrayVal = arrayVal;
+    this.stringVal = stringVal;
+    this.type = type;
+    this.additionalProperties = additionalProperties;
+  }
+
+  public ArrayOrString(String stringVal) {
+    this(null, stringVal, TYPE_STRING, new HashMap<>());
+  }
+
+  public ArrayOrString(List<String> arrayVal) {
+    this(arrayVal, null, TYPE_ARRAY, new HashMap<>());
+  }
+
+  @JsonProperty("arrayVal")
+  public List<String> getArrayVal() {
+    return arrayVal;
+  }
+
+  @JsonProperty("arrayVal")
+  public void setArrayVal(List<String> arrayVal) {
+    this.arrayVal = arrayVal;
+  }
+
+  @JsonProperty("stringVal")
+  public String getStringVal() {
+    return stringVal;
+  }
+
+  @JsonProperty("stringVal")
+  public void setStringVal(String stringVal) {
+    this.stringVal = stringVal;
+  }
+
+  @JsonProperty("type")
+  public String getType() {
+    return type;
+  }
+
+  @JsonProperty("type")
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
+
+  public static class Serializer extends JsonSerializer<ArrayOrString> {
+
+    @Override
+    public void serialize(ArrayOrString value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+      if (value != null) {
+        if (value.getType() == null) {
+          String stringVal = value.getStringVal();
+          if (stringVal != null) {
+            jgen.writeString(stringVal);
+          } else {
+            List<String> arrayVal = value.getArrayVal();
+            if (arrayVal != null) {
+              writeArray(value, jgen);
+            } else {
+              jgen.writeNull();
+            }
+          }
+        } else if (Objects.equals(value.getType(), TYPE_STRING)) {
+          jgen.writeString(value.stringVal);
+        } else if (Objects.equals(value.getType(), TYPE_ARRAY)) {
+          writeArray(value, jgen);
+        } else {
+          jgen.writeNull();
+        }
+      } else {
+        jgen.writeNull();
+      }
+    }
+
+    private void writeArray(ArrayOrString value, JsonGenerator jgen) throws IOException {
+      jgen.writeStartArray(value.getArrayVal().size());
+      for (String n : value.getArrayVal()) {
+        jgen.writeString(n);
+      }
+      jgen.writeEndArray();
+    }
+
+  }
+
+  public static class Deserializer extends JsonDeserializer<ArrayOrString> {
+
+    @Override
+    public ArrayOrString deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+      ObjectCodec oc = jsonParser.getCodec();
+      JsonNode node = oc.readTree(jsonParser);
+      ArrayOrString arrayOrString;
+      if (node.isArray()) {
+        List<String> elements = new ArrayList<>();
+        node.elements().forEachRemaining(n -> elements.add(n.asText()));
+        arrayOrString = new ArrayOrString(elements);
+      } else {
+        arrayOrString = new ArrayOrString(node.asText());
+      }
+      return arrayOrString;
+    }
+
+  }
+
+}

--- a/extensions/tekton/model/src/main/java/io/fabric8/tekton/pipeline/v1alpha1/ArrayOrString.java
+++ b/extensions/tekton/model/src/main/java/io/fabric8/tekton/pipeline/v1alpha1/ArrayOrString.java
@@ -51,7 +51,7 @@ public class ArrayOrString implements KubernetesResource {
   private static final String TYPE_ARRAY = "array";
 
   @JsonProperty("arrayVal")
-  private List<String> arrayVal = new ArrayList<String>();
+  private List<String> arrayVal = new ArrayList<>();
 
   @JsonProperty("stringVal")
   private String stringVal;
@@ -60,7 +60,7 @@ public class ArrayOrString implements KubernetesResource {
   private String type;
 
   @JsonIgnore
-  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  private Map<String, Object> additionalProperties = new HashMap<>();
 
   /**
    * No args constructor for use in serialization
@@ -127,7 +127,7 @@ public class ArrayOrString implements KubernetesResource {
   public static class Serializer extends JsonSerializer<ArrayOrString> {
 
     @Override
-    public void serialize(ArrayOrString value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+    public void serialize(ArrayOrString value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
       if (value != null) {
         if (value.getType() == null) {
           String stringVal = value.getStringVal();

--- a/extensions/tekton/model/src/main/resources/schema/tekton-schema.json
+++ b/extensions/tekton/model/src/main/resources/schema/tekton-schema.json
@@ -69,6 +69,69 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ClusterTask": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterTask",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskSpec"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.ClusterTask",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ClusterTaskList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ClusterTask",
+            "javaType": "io.fabric8.tekton.pipeline.v1alpha1.ClusterTask"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "ClusterTaskList",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.ClusterTaskList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.tekton.pipeline.v1alpha1.ClusterTask\u003e"
+      ]
+    },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Condition": {
       "type": "object",
       "description": "",
@@ -162,6 +225,709 @@
         }
       },
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.ConditionSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Inputs": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "params": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_ParamSpec",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.ParamSpec"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskResource",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskResource"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Inputs",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Outputs": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "resources": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskResource",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskResource"
+          }
+        },
+        "results": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TestResult",
+            "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TestResult"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Outputs",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Pipeline": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "Pipeline",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineStatus",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineStatus"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Pipeline",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Pipeline",
+            "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Pipeline"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PipelineList",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.tekton.pipeline.v1alpha1.Pipeline\u003e"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRun": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PipelineRun",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRunSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineRunStatus",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineRunStatus"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRun",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRun",
+            "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRun"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "PipelineRunList",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRunList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.tekton.pipeline.v1alpha1.PipelineRun\u003e"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunSpec": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "params": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_Param",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.Param"
+          }
+        },
+        "pipelineRef": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineRef",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineRef"
+        },
+        "pipelineSpec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineSpec"
+        },
+        "podTemplate": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_pod_Template",
+          "javaType": "io.fabric8.tekton.pipeline.pod.Template"
+        },
+        "resources": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineResourceBinding",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineResourceBinding"
+          }
+        },
+        "serviceAccountName": {
+          "type": "string",
+          "description": ""
+        },
+        "serviceAccountNames": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineRunSpecServiceAccountName",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineRunSpecServiceAccountName"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": ""
+        },
+        "timeout": {
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        },
+        "workspaces": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_WorkspaceBinding",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.WorkspaceBinding"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRunSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineSpec": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": ""
+        },
+        "params": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_ParamSpec",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.ParamSpec"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineDeclaredResource",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineDeclaredResource"
+          }
+        },
+        "tasks": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineTask",
+            "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineTask"
+          }
+        },
+        "workspaces": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_WorkspacePipelineDeclaration",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.WorkspacePipelineDeclaration"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineStatus": {
+      "type": "object",
+      "description": "",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineTask": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "conditions": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineTaskCondition",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineTaskCondition"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "params": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_Param",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.Param"
+          }
+        },
+        "resources": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineTaskResources",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineTaskResources"
+        },
+        "retries": {
+          "type": "integer",
+          "description": ""
+        },
+        "runAfter": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string",
+            "description": ""
+          }
+        },
+        "taskRef": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskRef",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskRef"
+        },
+        "taskSpec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskSpec"
+        },
+        "timeout": {
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        },
+        "workspaces": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_WorkspacePipelineTaskBinding",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.WorkspacePipelineTaskBinding"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineTask",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Task": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "Task",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskSpec"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Task",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Task",
+            "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Task"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "TaskList",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.tekton.pipeline.v1alpha1.Task\u003e"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRun": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "TaskRun",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskRunStatus",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskRunStatus"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRun",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunInputs": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "params": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_Param",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.Param"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskResourceBinding",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskResourceBinding"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunInputs",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunList": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "tekton.dev/v1alpha1",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRun",
+            "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRun"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "TaskRunList",
+          "required": true
+        },
+        "metadata": {
+          "javaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.tekton.pipeline.v1alpha1.TaskRun\u003e"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunOutputs": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "resources": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskResourceBinding",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskResourceBinding"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunOutputs",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunSpec": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "inputs": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunInputs",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunInputs"
+        },
+        "outputs": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunOutputs",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunOutputs"
+        },
+        "params": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_Param",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.Param"
+          }
+        },
+        "podTemplate": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_pod_Template",
+          "javaType": "io.fabric8.tekton.pipeline.pod.Template"
+        },
+        "resources": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskRunResources",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskRunResources"
+        },
+        "serviceAccountName": {
+          "type": "string",
+          "description": ""
+        },
+        "status": {
+          "type": "string",
+          "description": ""
+        },
+        "taskRef": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskRef",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskRef"
+        },
+        "taskSpec": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskSpec",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskSpec"
+        },
+        "timeout": {
+          "javaType": "io.fabric8.kubernetes.api.model.Duration"
+        },
+        "workspaces": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_WorkspaceBinding",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.WorkspaceBinding"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskSpec": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": ""
+        },
+        "inputs": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Inputs",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Inputs"
+        },
+        "outputs": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Outputs",
+          "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Outputs"
+        },
+        "params": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_ParamSpec",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.ParamSpec"
+          }
+        },
+        "resources": {
+          "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskResources",
+          "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskResources"
+        },
+        "results": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskResult",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskResult"
+          }
+        },
+        "sidecars": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_Step",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.Step"
+          }
+        },
+        "stepTemplate": {
+          "javaType": "io.fabric8.kubernetes.api.model.Container"
+        },
+        "steps": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_Step",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.Step"
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "javaType": "io.fabric8.kubernetes.api.model.Volume"
+          }
+        },
+        "workspaces": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_WorkspaceDeclaration",
+            "javaType": "io.fabric8.tekton.pipeline.v1beta1.WorkspaceDeclaration"
+          }
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TestResult": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "format": {
+          "type": "string",
+          "description": ""
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "path": {
+          "type": "string",
+          "description": ""
+        }
+      },
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TestResult",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -1923,6 +2689,14 @@
       "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_pod_Template",
       "javaType": "io.fabric8.tekton.pipeline.pod.Template"
     },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ClusterTask": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ClusterTask",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.ClusterTask"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ClusterTaskList": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ClusterTaskList",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.ClusterTaskList"
+    },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Condition": {
       "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Condition",
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Condition"
@@ -1934,6 +2708,82 @@
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ConditionSpec": {
       "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ConditionSpec",
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.ConditionSpec"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Inputs": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Inputs",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Inputs"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Outputs": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Outputs",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Outputs"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Pipeline": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Pipeline",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Pipeline"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineList": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineList",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineList"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRun": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRun",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRun"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunList": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunList",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRunList"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunSpec": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunSpec",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRunSpec"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineSpec": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineSpec",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineSpec"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineStatus": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineStatus",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineStatus"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineTask": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineTask",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineTask"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Task": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_Task",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Task"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskList": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskList",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskList"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRun": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRun",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRun"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunInputs": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunInputs",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunInputs"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunList": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunList",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunList"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunOutputs": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunOutputs",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunOutputs"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunSpec": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunSpec",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRunSpec"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskSpec": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskSpec",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskSpec"
+    },
+    "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TestResult": {
+      "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TestResult",
+      "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TestResult"
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_CloudEventDelivery": {
       "$ref": "#/definitions/github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_CloudEventDelivery",

--- a/extensions/tekton/tests/src/test/java/io/fabric8/tekton/test/crud/V1alpha1PipelineCrudTest.java
+++ b/extensions/tekton/tests/src/test/java/io/fabric8/tekton/test/crud/V1alpha1PipelineCrudTest.java
@@ -18,9 +18,9 @@ package io.fabric8.tekton.test.crud;
 import io.fabric8.tekton.client.TektonClient;
 import io.fabric8.tekton.mock.TektonServer;
 import io.fabric8.tekton.pipeline.v1beta1.Param;
-import io.fabric8.tekton.pipeline.v1beta1.Pipeline;
-import io.fabric8.tekton.pipeline.v1beta1.PipelineBuilder;
-import io.fabric8.tekton.pipeline.v1beta1.PipelineList;
+import io.fabric8.tekton.pipeline.v1alpha1.Pipeline;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineBuilder;
+import io.fabric8.tekton.pipeline.v1alpha1.PipelineList;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
@@ -29,10 +29,12 @@ import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableRuleMigrationSupport
-public class PipelineCrudTest {
+public class V1alpha1PipelineCrudTest {
 
   @Rule
   public TektonServer server = new TektonServer(true, true);
@@ -40,7 +42,7 @@ public class PipelineCrudTest {
   @Test
   public void shouldReturnEmptyList() {
     TektonClient client = server.getTektonClient();
-    PipelineList pipelineList = client.v1beta1().pipelines().inNamespace("ns1").list();
+    PipelineList pipelineList = client.v1alpha1().pipelines().inNamespace("ns1").list();
     assertNotNull(pipelineList);
     assertTrue(pipelineList.getItems().isEmpty());
   }
@@ -50,11 +52,11 @@ public class PipelineCrudTest {
     TektonClient client = server.getTektonClient();
     Pipeline pipeline2 = new PipelineBuilder().withNewMetadata().withName("pipeline2").endMetadata().build();
 
-    client.v1beta1().pipelines().inNamespace("ns2").create(pipeline2);
-    PipelineList pipelineList = client.v1beta1().pipelines().inNamespace("ns2").list();
+    client.v1alpha1().pipelines().inNamespace("ns2").create(pipeline2);
+    PipelineList pipelineList = client.v1alpha1().pipelines().inNamespace("ns2").list();
     assertNotNull(pipelineList);
     assertEquals(1, pipelineList.getItems().size());
-    Pipeline pipeline = client.v1beta1().pipelines().inNamespace("ns2").withName("pipeline2").get();
+    Pipeline pipeline = client.v1alpha1().pipelines().inNamespace("ns2").withName("pipeline2").get();
     assertNotNull(pipeline);
     assertEquals("pipeline2", pipeline.getMetadata().getName());
   }
@@ -64,8 +66,8 @@ public class PipelineCrudTest {
     TektonClient client = server.getTektonClient();
     Pipeline pipeline3 = new PipelineBuilder().withNewMetadata().withName("pipeline3").endMetadata().build();
 
-    client.v1beta1().pipelines().inNamespace("ns3").create(pipeline3);
-    Boolean deleted = client.v1beta1().pipelines().inNamespace("ns3").withName("pipeline3").delete();
+    client.v1alpha1().pipelines().inNamespace("ns3").create(pipeline3);
+    Boolean deleted = client.v1alpha1().pipelines().inNamespace("ns3").withName("pipeline3").delete();
     assertTrue(deleted);
   }
 
@@ -86,7 +88,7 @@ public class PipelineCrudTest {
       "          value: param-value"
     ));
 
-    Pipeline p = client.v1beta1().pipelines().inNamespace("ns4").load(new ByteArrayInputStream(pipelineDefinition.getBytes())).createOrReplace();
+    Pipeline p = client.v1alpha1().pipelines().inNamespace("ns4").load(new ByteArrayInputStream(pipelineDefinition.getBytes())).createOrReplace();
 
     final List<Param> taskParams = p.getSpec().getTasks().get(0).getParams();
     assertEquals(1, taskParams.size());


### PR DESCRIPTION

Fixes #2115
Added dsl support for `client.v1alpha1().*` and `client.v1beta1().*` for respective apigroups. Kudos to @Fabian-K  for initial work on this

