### PR TITLE
Fix #2174: Warn for multiple values in KUBECONFIG variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #2124: Raw Watch on CustomResource does not work if name specified
 
 #### Improvements
+* Fix #2174: Change log level to warn for multiple `kubeconfig` warning
 * Fix #2088: Support networking.k8s.io/v1beta1 alongside extensions/v1beta1
 
 #### Dependency Upgrade

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -474,13 +474,13 @@ public class Config {
       String[] fileNames = fileName.split(File.pathSeparator);
 
       if (fileNames.length > 1) {
-        LOGGER.debug("Found multiple Kubernetes config files [{}], using the first one: [{}].", fileNames, fileNames[0]);
+        LOGGER.warn("Found multiple Kubernetes config files [{}], using the first one: [{}]. If not desired file, please change it by doing `export KUBECONFIG=/path/to/kubeconfig` on Unix systems or `$Env:KUBECONFIG=/path/to/kubeconfig` on Windows.", fileNames, fileNames[0]);
         fileName = fileNames[0];
       }
 
       File kubeConfigFile = new File(fileName);
       if (kubeConfigFile.isFile()) {
-        LOGGER.debug("Found for Kubernetes config at: ["+kubeConfigFile.getPath()+"].");
+        LOGGER.debug("Found for Kubernetes config at: [{}].", kubeConfigFile.getPath());
         String kubeconfigContents;
         try (FileReader reader = new FileReader(kubeConfigFile)){
           kubeconfigContents = IOHelpers.readFully(reader);


### PR DESCRIPTION
Support for multiple values in KUBECONFIG was already implemented in https://github.com/fabric8io/kubernetes-client/pull/1306

I changed log level to warn in case of multiple `kubeconfig` are found in `KUBECONFIG`
environment variable.

Fix #2174 