### PR TITLE
Tekton OperationsImpl Scope Fix

### DIFF
--- a/extensions/tekton/client/src/main/resources/resource-operation.vm
+++ b/extensions/tekton/client/src/main/resources/resource-operation.vm
@@ -24,11 +24,14 @@
   #if ($annotation.getClassRef().getName().equals("ApiGroup"))
     #set ($apiGroupName = $annotation.getParameters().get("value"))
   #end
-  #if ($annotation.getClassRef().getName().equals("Namespaced"))
-    #set ($isResourceNamespacedFlag = $annotation.getParameters().get("value"))
-  #end
 #end
 
+#set ($isResourceNamespacedFlag = false)
+#foreach ($impl in $model.getImplementsList())
+  #if ($impl.getFullyQualifiedName().equals("io.fabric8.kubernetes.api.model.Namespaced"))
+    #set ($isResourceNamespacedFlag = true)
+  #end
+#end
 
 package io.fabric8.tekton.client.internal.$apiGroupVersion;
 

--- a/extensions/tekton/generateModel.sh
+++ b/extensions/tekton/generateModel.sh
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+declare -a modules=("generator-v1alpha1" "generator-v1beta1"
+)
+
+for module in ${modules[*]}
+do
+    echo "Compiling ${module}"
+    cd $module
+    make
+    cd ..
+done    

--- a/extensions/tekton/generator-v1alpha1/cmd/generate/generate.go
+++ b/extensions/tekton/generator-v1alpha1/cmd/generate/generate.go
@@ -28,16 +28,16 @@ func main() {
 
 	// the CRD List types for which the model should be generated
 	// no other types need to be defined as they are auto discovered
-	crdLists := []reflect.Type{
+	crdLists := map[reflect.Type]schemagen.CrdScope{
 		// v1alpha1
-		reflect.TypeOf(v1alpha1.ConditionList{}),
-		reflect.TypeOf(v1alpha1.PipelineList{}),
-		reflect.TypeOf(v1alpha1.PipelineRunList{}),
-		reflect.TypeOf(v1alpha1.TaskList{}),
-		reflect.TypeOf(v1alpha1.TaskRunList{}),
-		reflect.TypeOf(v1alpha1.ClusterTaskList{}),
+		reflect.TypeOf(v1alpha1.ConditionList{}):   schemagen.Namespaced,
+		reflect.TypeOf(v1alpha1.PipelineList{}):    schemagen.Namespaced,
+		reflect.TypeOf(v1alpha1.PipelineRunList{}): schemagen.Namespaced,
+		reflect.TypeOf(v1alpha1.TaskList{}):        schemagen.Namespaced,
+		reflect.TypeOf(v1alpha1.TaskRunList{}):     schemagen.Namespaced,
+		reflect.TypeOf(v1alpha1.ClusterTaskList{}): schemagen.Cluster,
 
-		reflect.TypeOf(resource.PipelineResourceList{}),
+		reflect.TypeOf(resource.PipelineResourceList{}): schemagen.Namespaced,
 	}
 
 	// constraints and patterns for fields

--- a/extensions/tekton/generator-v1beta1/cmd/generate/generate.go
+++ b/extensions/tekton/generator-v1beta1/cmd/generate/generate.go
@@ -27,13 +27,13 @@ func main() {
 
 	// the CRD List types for which the model should be generated
 	// no other types need to be defined as they are auto discovered
-	crdLists := []reflect.Type{
+	crdLists := map[reflect.Type]schemagen.CrdScope{
 		// v1beta1
-		reflect.TypeOf(v1beta1.PipelineList{}),
-		reflect.TypeOf(v1beta1.PipelineRunList{}),
-		reflect.TypeOf(v1beta1.TaskList{}),
-		reflect.TypeOf(v1beta1.TaskRunList{}),
-		reflect.TypeOf(v1beta1.ClusterTaskList{}),
+		reflect.TypeOf(v1beta1.PipelineList{}):    schemagen.Namespaced,
+		reflect.TypeOf(v1beta1.PipelineRunList{}): schemagen.Namespaced,
+		reflect.TypeOf(v1beta1.TaskList{}):        schemagen.Namespaced,
+		reflect.TypeOf(v1beta1.TaskRunList{}):     schemagen.Namespaced,
+		reflect.TypeOf(v1beta1.ClusterTaskList{}): schemagen.Cluster,
 	}
 
 	// constraints and patterns for fields

--- a/extensions/tekton/model-v1alpha1/src/main/resources/schema/tekton-schema-v1alpha1.json
+++ b/extensions/tekton/model-v1alpha1/src/main/resources/schema/tekton-schema-v1alpha1.json
@@ -199,7 +199,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Condition",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_ConditionCheckStatus": {
@@ -390,7 +391,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Pipeline",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineList": {
@@ -549,7 +551,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.PipelineRun",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_PipelineRunConditionCheckStatus": {
@@ -944,7 +947,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.Task",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskList": {
@@ -1090,7 +1094,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1alpha1.TaskRun",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1alpha1_TaskRunInputs": {
@@ -1821,7 +1826,8 @@
       },
       "javaType": "io.fabric8.tekton.resource.v1alpha1.PipelineResource",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_resource_v1alpha1_PipelineResourceList": {

--- a/extensions/tekton/model-v1beta1/src/main/resources/schema/tekton-schema-v1beta1.json
+++ b/extensions/tekton/model-v1beta1/src/main/resources/schema/tekton-schema-v1beta1.json
@@ -281,7 +281,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1beta1.Pipeline",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineDeclaredResource": {
@@ -454,7 +455,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1beta1.PipelineRun",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_PipelineRunConditionCheckStatus": {
@@ -1094,7 +1096,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1beta1.Task",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskList": {
@@ -1290,7 +1293,8 @@
       },
       "javaType": "io.fabric8.tekton.pipeline.v1beta1.TaskRun",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata"
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
       ]
     },
     "github_com_tektoncd_pipeline_pkg_apis_pipeline_v1beta1_TaskRunList": {

--- a/kubernetes-model/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Namespaced.java
+++ b/kubernetes-model/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Namespaced.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model;
+
+public interface Namespaced {
+}


### PR DESCRIPTION
This PR updates the generation logic for *OperationsImpl to include proper scoping (namespaced vs cluster-wide) for all parts using the rewritten go generator.

Changes:
- go configuration requires scoping definition for all CRDs
- marker interface 'Namespaced' added
- go generator adds the marker interface to all Namespaced CRDs
- during the generation of the *OperationsImpl, the marker interface is used to detect the proper scoping.

This fixes #2193