### PR TITLE
Enable querying for customResources using only CustomResourceDefinitionContext instead of full CustomResourceDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #2199: KubernetesClient#customResources now accepts CustomResourceDefinitionContext
 
 #### Dependency Upgrade
 

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1560,7 +1560,7 @@ Boolean deleted = client.customResourceDefinitions().withName("sparkclusters.rad
 ```
 
 ### CustomResource Typed API
-CustomResources are available in Kubernetes API via the `client.customResources(...)`. In order to use typed API, you need to provide POJOs for your Custom Resource which client can use for serialization/deserialization. `client.customResources(...)` take things like definition of `CustomResourceDefinition`, `CustomResource` class, it's list class etc. It returns an instance of a client which you can use for your `CustomResource` related operations. In order to get some idea of how POJOs should look like. Here's an example of POJO for `CronTab` CustomResource specified in [Kubernetes CustomResource docs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/)
+CustomResources are available in Kubernetes API via the `client.customResources(...)`. In order to use typed API, you need to provide POJOs for your Custom Resource which client can use for serialization/deserialization. `client.customResources(...)` take things like `CustomResourceDefinitionContext` for locating the CustomResources, `CustomResource` class, it's list class etc. It returns an instance of a client which you can use for your `CustomResource` related operations. In order to get some idea of how POJOs should look like. Here's an example of POJO for `CronTab` CustomResource specified in [Kubernetes CustomResource docs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/)
 *my-crontab.yml*
 ```
 apiVersion: "stable.example.com/v1"
@@ -1638,7 +1638,15 @@ You can find other helper classes related to `CronTab` in our [tests](https://gi
 
 - Get Instance of client for our `CustomResource`:
 ```
-CustomResourceDefinition cronTabCrd = client.customResourceDefinitions().load(new FileInputStream("crontab-crd.yml")).get();
+// Alternatively use CustomResourceDefinitionContext.fromCrd(crd) if you already have a CustomResourceDefinition
+CustomResourceDefinitionContext context = new CustomResourceDefinitionContext.Builder()
+      .withGroup("stable.example.com)
+      .withVersion("v1")
+      .withScope("Namespaced")
+      .withName("crontabs.stable.example.com)
+      .withPlural("crontabs")
+      .withKind("CronTab")
+      .build()
 MixedOperation<CronTab, CronTabList, DoneableCronTab, Resource<CronTab, DoneableCronTab>> cronTabClient = client
   .customResources(cronTabCrd, CronTab.class, CronTabList.class, DoneableCronTab.class);
 ```

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -281,6 +281,15 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return new CustomResourceOperationsImpl<T,L,D>(new CustomResourceOperationContext().withOkhttpClient(httpClient).withConfig(getConfiguration())
+      .withCrdContext(crdContext)
+      .withType(resourceType)
+      .withListType(listClass)
+      .withDoneableType(doneClass));
+  }
+
+  @Override
   public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return new CustomResourceOperationsImpl<T,L,D>(new CustomResourceOperationContext().withOkhttpClient(httpClient).withConfig(getConfiguration())
       .withCrd(crd)

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -100,6 +100,25 @@ public interface KubernetesClient extends Client {
    * CustomResource into this and with it you would be able to instantiate a client
    * specific to CustomResource.
    *
+   * @param crdContext CustomResourceDefinitionContext describes the core fields used to search for CustomResources
+   * @param resourceType Class for CustomResource
+   * @param listClass Class for list object for CustomResource
+   * @param doneClass Class for Doneable CustomResource object
+   * @param <T> T type represents CustomResource type
+   * @param <L> L type represents CustomResourceList type
+   * @param <D> D type represents DoneableCustomResource type
+   * @return returns a MixedOperation object with which you can do basic CustomResource operations
+   */
+  <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass, Class<D> doneClass);
+
+  /**
+   * Typed API for managing CustomResources. You would need to provide POJOs for
+   * CustomResource into this and with it you would be able to instantiate a client
+   * specific to CustomResource.
+   *
+   * @deprecated use {@link #customResources(CustomResourceDefinitionContext, Class, Class, Class)}, which takes a {@link CustomResourceDefinitionContext}
+   * instead of a full {@link CustomResourceDefinition}.
+   *
    * @param crd CustomResourceDefinition object on basic of which this CustomResource was created
    * @param resourceType Class for CustomResource
    * @param listClass Class for list object for CustomResource
@@ -109,12 +128,15 @@ public interface KubernetesClient extends Client {
    * @param <D> D type represents DoneableCustomResource type
    * @return returns a MixedOperation object with which you can do basic CustomResource operations
    */
+  @Deprecated
   <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass);
 
   /**
    * Old API for dealing with CustomResources.
    *
-   * @deprecated Use {@link #customResources(CustomResourceDefinition, Class, Class, Class)} instead.
+   * @deprecated use {@link #customResources(CustomResourceDefinitionContext, Class, Class, Class)}, which takes a {@link CustomResourceDefinitionContext}
+   * instead of a full {@link CustomResourceDefinition}.
+   *
    * @param crd Custom Resource Definition
    * @param resourceType resource type Pojo
    * @param listClass list class Pojo

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
@@ -15,12 +15,15 @@
  */
 package io.fabric8.kubernetes.client.dsl.base;
 
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+
 public class CustomResourceDefinitionContext {
   private String name;
   private String group;
   private String scope;
   private String plural;
   private String version;
+  private String kind;
 
   public String getName() { return name; }
 
@@ -40,8 +43,23 @@ public class CustomResourceDefinitionContext {
     return version;
   }
 
+  public String getKind() {
+    return kind;
+  }
+
+  public static CustomResourceDefinitionContext fromCrd(CustomResourceDefinition crd) {
+    return new CustomResourceDefinitionContext.Builder()
+      .withGroup(crd.getSpec().getGroup())
+      .withVersion(crd.getSpec().getVersion())
+      .withScope(crd.getSpec().getScope())
+      .withName(crd.getMetadata().getName())
+      .withPlural(crd.getSpec().getNames().getPlural())
+      .withKind(crd.getSpec().getNames().getKind())
+      .build();
+  }
+
   public static class Builder {
-    private CustomResourceDefinitionContext customResourceDefinitionContext;
+    private final CustomResourceDefinitionContext customResourceDefinitionContext;
 
     public Builder() {
       this.customResourceDefinitionContext = new CustomResourceDefinitionContext();
@@ -69,6 +87,11 @@ public class CustomResourceDefinitionContext {
 
     public Builder withVersion(String version) {
       this.customResourceDefinitionContext.version = version;
+      return this;
+    }
+
+    public Builder withKind(String kind) {
+      this.customResourceDefinitionContext.kind = kind;
       return this;
     }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationContext.java
@@ -15,17 +15,18 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
+import java.util.Map;
+
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import okhttp3.OkHttpClient;
 
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 public class CustomResourceOperationContext extends OperationContext {
   
-  protected Object crd;
+  protected CustomResourceDefinitionContext crdContext;
   protected Class type;
   protected Class listType;
   protected Class doneableType;
@@ -33,16 +34,16 @@ public class CustomResourceOperationContext extends OperationContext {
   public CustomResourceOperationContext() {
   }
 
-  public CustomResourceOperationContext(OkHttpClient client, Config config, String plural, String namespace, String name, String apiGroupName, String apiGroupVersion, boolean cascading, Object item, Map<String, String> labels, Map<String, String[]> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Map<String, String[]> fieldsNot, String resourceVersion, boolean reloadingFromServer, long gracePeriodSeconds, DeletionPropagation propagationPolicy, Object crd, Class type, Class listType, Class doneableType) {
+  public CustomResourceOperationContext(OkHttpClient client, Config config, String plural, String namespace, String name, String apiGroupName, String apiGroupVersion, boolean cascading, Object item, Map<String, String> labels, Map<String, String[]> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Map<String, String[]> fieldsNot, String resourceVersion, boolean reloadingFromServer, long gracePeriodSeconds, DeletionPropagation propagationPolicy, CustomResourceDefinitionContext crdContext, Class type, Class listType, Class doneableType) {
     super(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading, item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy);
-    this.crd = crd;
+    this.crdContext = crdContext;
     this.type = type;
     this.listType = listType;
     this.doneableType = doneableType;
   }
 
-  public Object getCrd() {
-    return crd;
+  public CustomResourceDefinitionContext getCrdContext() {
+    return crdContext;
   }
 
   public Class getType() {
@@ -58,95 +59,103 @@ public class CustomResourceOperationContext extends OperationContext {
   }
 
   public CustomResourceOperationContext withOkhttpClient(OkHttpClient client) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withConfig(Config config) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withPlural(String plural) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withNamespace(String namespace) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withName(String name) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withApiGroupName(String apiGroupName) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withApiGroupVersion(String apiGroupVersion) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   @Override
   public CustomResourceOperationContext withItem(Object item) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withCascading(boolean cascading) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withLabels(Map<String, String> labels) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withLabelsIn(Map<String, String[]> labelsIn) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withLabelsNot(Map<String, String[]> labelsNot) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withLabelsNotIn(Map<String, String[]> labelsNotIn) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withFields(Map<String, String> fields) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withFieldsNot(Map<String, String[]> fieldsNot) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withResourceVersion(String resourceVersion) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withReloadingFromServer(boolean reloadingFromServer) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withGracePeriodSeconds(long gracePeriodSeconds) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withPropagationPolicy(DeletionPropagation propagationPolicy) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
-  public CustomResourceOperationContext withCrd(Object crd) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+  /**
+   * @deprecated use {@link #withCrdContext(CustomResourceDefinitionContext)} instead
+   */
+  @Deprecated
+  public CustomResourceOperationContext withCrd(CustomResourceDefinition crd) {
+    return withCrdContext(CustomResourceDefinitionContext.fromCrd(crd));
+  }
+
+  public CustomResourceOperationContext withCrdContext(CustomResourceDefinitionContext crdContext) {
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withType(Class type) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withListType(Class listType) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 
   public CustomResourceOperationContext withDoneableType(Class doneableType) {
-    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crd, type, listType, doneableType);
+    return new CustomResourceOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, crdContext, type, listType, doneableType);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -19,25 +19,14 @@ import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
-import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.Watchable;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import okhttp3.OkHttpClient;
-
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 /**
  */
@@ -51,21 +40,19 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
   }
 
   public CustomResourceOperationsImpl(CustomResourceOperationContext context) {
-    super(context.withApiGroupName(apiGroup((CustomResourceDefinition) context.getCrd()))
-      .withApiGroupVersion(apiVersion((CustomResourceDefinition) context.getCrd()))
-      .withPlural(resourceT((CustomResourceDefinition) context.getCrd()))
+    super(context.withApiGroupName(context.getCrdContext().getGroup())
+      .withApiGroupVersion(context.getCrdContext().getVersion())
+      .withPlural(context.getCrdContext().getPlural())
       .withPropagationPolicy(DEFAULT_PROPAGATION_POLICY));
 
     this.type = context.getType();
     this.listType = context.getListType();
     this.doneableType = context.getDoneableType();
 
-    this.resourceNamespaced = resourceNamespaced((CustomResourceDefinition) context.getCrd());
+    this.resourceNamespaced = resourceNamespaced(context.getCrdContext());
     this.apiVersion = getAPIGroup() + "/" + getAPIVersion();
 
-    CustomResourceDefinition crd = (CustomResourceDefinition) context.getCrd();
-
-    KubernetesDeserializer.registerCustomKind(crd.getSpec().getGroup() + "/" + crd.getSpec().getVersion(), crd.getSpec().getNames().getKind(), type);
+    KubernetesDeserializer.registerCustomKind(apiVersion, kind(context.getCrdContext()), type);
     if (KubernetesResource.class.isAssignableFrom(listType)) {
       KubernetesDeserializer.registerCustomKind(listType.getSimpleName(), (Class<? extends KubernetesResource>) listType);
     }
@@ -76,24 +63,12 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
     return new CustomResourceOperationsImpl((CustomResourceOperationContext) context);
   }
 
-  protected static String apiGroup(CustomResourceDefinition crd) {
-    return crd.getSpec().getGroup();
+  protected static boolean resourceNamespaced(CustomResourceDefinitionContext crdContext) {
+    return "Namespaced".equals(crdContext.getScope());
   }
 
-  protected static String apiVersion(CustomResourceDefinition crd) {
-    return crd.getSpec().getVersion();
-  }
-
-  protected static String resourceT(CustomResourceDefinition crd) {
-    return crd.getSpec().getNames().getPlural();
-  }
-
-  protected static String name(CustomResourceDefinition crd) {
-    return crd.getMetadata().getName();
-  }
-
-  protected static boolean resourceNamespaced(CustomResourceDefinition crd) {
-    return "Namespaced".equals(crd.getSpec().getScope());
+  private String kind(CustomResourceDefinitionContext crdContext) {
+    return crdContext.getKind() != null ? crdContext.getKind() : getKind();
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -412,6 +412,11 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return delegate.customResources(crdContext, resourceType, listClass, doneClass);
+  }
+
+  @Override
   public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return delegate.customResources(crd, resourceType, listClass, doneClass);
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 
 import org.junit.jupiter.api.Test;
@@ -58,20 +59,36 @@ public class CustomResourceOperationsImplTest {
     .endSpec()
   .build();
 
-  private final CustomResourceOperationContext context = new CustomResourceOperationContext()
-    .withCrd(crd)
-    .withType(MyCustomResource.class)
-    .withListType(MyCustomResourceList.class);
-
   @Test
   public void shouldRegisterWithKubernetesDeserializer() throws IOException {
+    assertForContext(new CustomResourceOperationContext()
+      .withCrd(crd)
+      .withType(MyCustomResource.class)
+      .withListType(MyCustomResourceList.class));
+  }
+
+  @Test
+  void itFallsBackOnTypeKindIfNoKindSpecifiedInContext() throws IOException {
+    assertForContext(new CustomResourceOperationContext()
+      .withCrdContext(new CustomResourceDefinitionContext.Builder()
+      .withGroup(crd.getSpec().getGroup())
+      .withVersion(crd.getSpec().getVersion())
+      .withScope(crd.getSpec().getScope())
+      .withName(crd.getMetadata().getName())
+      .withPlural(crd.getSpec().getNames().getPlural())
+      .build())
+      .withType(MyCustomResource.class)
+      .withListType(MyCustomResourceList.class));
+  }
+
+  private void assertForContext(CustomResourceOperationContext context) throws IOException {
     // CustomResourceOperationsImpl constructor invokes KubernetesDeserializer::registerCustomKind
     new CustomResourceOperationsImpl<>(context);
 
     JsonFactory factory = new MappingJsonFactory();
-    JsonParser parser = factory.createParser("{\n" + 
-      "    \"apiVersion\": \"custom.group/v1alpha1\",\n" + 
-      "    \"kind\": \"MyCustomResource\"\n" + 
+    JsonParser parser = factory.createParser("{\n" +
+      "    \"apiVersion\": \"custom.group/v1alpha1\",\n" +
+      "    \"kind\": \"MyCustomResource\"\n" +
       "}");
 
     KubernetesDeserializer deserializer = new KubernetesDeserializer();
@@ -80,5 +97,4 @@ public class CustomResourceOperationsImplTest {
     assertThat(resource, instanceOf(MyCustomResource.class));
     assertEquals("custom.group/v1alpha1", ((MyCustomResource) resource).getApiVersion());
   }
-
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.JSONSchemaProps;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.mock.crd.CronTabSpec;
 import io.fabric8.kubernetes.client.mock.crd.DoneableCronTab;
 import io.fabric8.kubernetes.client.mock.crd.CronTab;
@@ -57,8 +58,9 @@ public class CustomResourceCrudTest {
     CustomResourceDefinition cronTabCrd = client.customResourceDefinitions().load(getClass().getResourceAsStream("/crontab-crd.yml")).get();
     client.customResourceDefinitions().create(cronTabCrd);
 
+    CustomResourceDefinitionContext crdContext = CustomResourceDefinitionContext.fromCrd(cronTabCrd);
     MixedOperation<CronTab, CronTabList, DoneableCronTab, Resource<CronTab, DoneableCronTab>> cronTabClient = client
-      .customResources(cronTabCrd, CronTab.class, CronTabList.class, DoneableCronTab.class);
+      .customResources(crdContext, CronTab.class, CronTabList.class, DoneableCronTab.class);
 
     cronTabClient.inNamespace("test-ns").create(cronTab1);
     cronTabClient.inNamespace("test-ns").create(cronTab2);

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -354,6 +354,11 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return new CustomResourceOperationsImpl<T,L,D>(new CustomResourceOperationContext().withOkhttpClient(httpClient).withConfig(getConfiguration()).withCrdContext(crdContext).withType(resourceType).withListType(listClass).withDoneableType(doneClass));
+  }
+
+  @Override
   public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return new CustomResourceOperationsImpl<T,L,D>(new CustomResourceOperationContext().withOkhttpClient(httpClient).withConfig(getConfiguration()).withCrd(crd).withType(resourceType).withListType(listClass).withDoneableType(doneClass));
   }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -401,6 +401,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
+  public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
+    return delegate.customResources(crdContext, resourceType, listClass, doneClass);
+  }
+
+  @Override
   public <T extends HasMetadata, L extends KubernetesResourceList, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return delegate.customResources(crd, resourceType, listClass, doneClass);
   }


### PR DESCRIPTION
Add a customResources method which takes a CustomResourceDefinitionContext instead of CustomResourceDefinition. Use that in CustomResourceOperationsImpl. Add a 'kind' field to CustomResourceDefinitionContext, defaulting to getKind if not specified

Fixes https://github.com/fabric8io/kubernetes-client/issues/2199

~This is a WIP (work in progress) because I am unable to run the tests in my environment. I haven't added any new tests yet, either. I'll take a look at that, though I think this should largely be covered by existing.~ I've taken a look at tests and updated existing tests.

This approach breaks the KubernetesClient interface due to the exposure of a new method for implementers to implement. I imagine most users are simply using one of the existing implementations, so I've left the old method around for backwards compatibility.