### PR TITLE
fix: Uber Jar includes merged service entry for multiple implementations of the same interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.10-SNAPSHOT
 #### Bugs
+* Fix #2066: Uber Jar includes merged service entry for multiple implementations of the same interface
 
 #### Improvements
 

--- a/uberjar/pom.xml
+++ b/uberjar/pom.xml
@@ -200,6 +200,9 @@
                   <include>io.fabric8:openshift-server-mock</include>
                 </includes>
               </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
Apparently uber-jar configuration has been wrong for a while now.

Service entry declarations were being lost because they collided both for openshift-client and
for kubernetes-client modules.

uberjar: `maven-shade-plugin:3.2.3:shade `
```
[WARNING] kubernetes-client-4.10-SNAPSHOT.jar, kubernetes-openshift-uberjar-4.10-SNAPSHOT.jar, openshift-client-4.10-SNAPSHOT.jar define 3 overlapping resources:
[WARNING]   - META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
[WARNING]   - META-INF/services/io.fabric8.kubernetes.client.ResourceHandler
[WARNING]   - META-INF/services/io.fabric8.kubernetes.client.ServiceToURLProvider
```

See: https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer

Should fix: #2066 