### PR TITLE
Add support for Namespaced SharedInformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Add support for Namespaced SharedInformers, fixed probelms with OperationContext argument
 
 ### 4.10.1 (2020-05-06)
 #### Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -653,7 +653,7 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
 
   public L list() throws KubernetesClientException {
     try {
-      return listRequestHelper(getNamespacedUrl());
+      return listRequestHelper(getResourceUrl(namespace, name));
     } catch (IOException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("list"), e);
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationContext.java
@@ -229,4 +229,110 @@ public class OperationContext {
   public OperationContext withPropagationPolicy(DeletionPropagation propagationPolicy) {
     return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy);
   }
+
+  /**
+   * Returns an OperationContext object merged with current object
+   *
+   * @param operationContext object with modifications
+   * @return a merged object between passed argument and current object
+   */
+  public OperationContext withOperationContext(OperationContext operationContext) {
+    OkHttpClient clientCloned = getClient();
+    Config configCloned = getConfig();
+    Object itemCloned = getItem();
+    String resourceVersionCloned = getResourceVersion();
+    String pluralCloned = getPlural();
+    String apiGroupNameCloned = getApiGroupName();
+    String apiGroupVersionCloned = getApiGroupVersion();
+    String namespaceCloned = getNamespace();
+    String nameCloned = getName();
+    boolean cascadingCloned = getCascading();
+    boolean reloadingFromServerCloned = getReloadingFromServer();
+    long gracePeriodSecondsCloned = getGracePeriodSeconds();
+    DeletionPropagation propagationPolicyCloned = getPropagationPolicy();
+    Map<String, String> labelsCloned = getLabels();
+    Map<String, String[]> labelsNotCloned = getLabelsNot();
+    Map<String, String[]> labelsInCloned = getLabelsIn();
+    Map<String, String[]> labelsNotInCloned = getLabelsNotIn();
+    Map<String, String> fieldsCloned = getFields();
+    Map<String, String[]> fieldsNotCloned = getFieldsNot();
+
+    if (operationContext.getApiGroupVersion() != null) {
+      apiGroupVersionCloned = operationContext.getApiGroupVersion();
+    }
+
+    if (operationContext.getClient() != null) {
+      clientCloned = operationContext.getClient();
+    }
+
+    if (operationContext.getConfig() != null) {
+      configCloned = operationContext.getConfig();
+    }
+
+    if (operationContext.getPlural() != null) {
+      pluralCloned = operationContext.getPlural();
+    }
+
+    if (operationContext.getNamespace() != null) {
+      namespaceCloned = operationContext.getNamespace();
+    }
+
+    if (operationContext.getName() != null) {
+      nameCloned = operationContext.getName();
+    }
+
+    if (operationContext.getApiGroupName() != null) {
+      apiGroupNameCloned = operationContext.getApiGroupName();
+    }
+
+    if (operationContext.getCascading()) {
+      cascadingCloned = operationContext.getCascading();
+    }
+
+    if (operationContext.getItem() != null) {
+      itemCloned = operationContext.getItem();
+    }
+
+    if (operationContext.getLabels() != null) {
+      labelsCloned = operationContext.getLabels();
+    }
+
+    if (operationContext.getLabelsNot() != null) {
+      labelsNotCloned = operationContext.getLabelsNot();
+    }
+
+    if (operationContext.getLabelsIn() != null) {
+      labelsInCloned = operationContext.getLabelsIn();
+    }
+
+    if (operationContext.getLabelsNotIn() != null) {
+      labelsNotInCloned = operationContext.getLabelsNotIn();
+    }
+
+    if (operationContext.getFields() != null) {
+      fieldsCloned = operationContext.getFields();
+    }
+
+    if (operationContext.getFieldsNot() != null) {
+      fieldsNotCloned = operationContext.getFieldsNot();
+    }
+
+    if (operationContext.getResourceVersion() != null) {
+      resourceVersionCloned = operationContext.getResourceVersion();
+    }
+
+    if (operationContext.getReloadingFromServer()) {
+      reloadingFromServerCloned = operationContext.getReloadingFromServer();
+    }
+
+    if (operationContext.getGracePeriodSeconds() > 0) {
+      gracePeriodSecondsCloned = operationContext.getGracePeriodSeconds();
+    }
+
+    if (operationContext.getPropagationPolicy() != null) {
+      propagationPolicyCloned = operationContext.getPropagationPolicy();
+    }
+
+    return new OperationContext(clientCloned, configCloned, pluralCloned, namespaceCloned, nameCloned, apiGroupNameCloned, apiGroupVersionCloned, cascadingCloned, itemCloned, labelsCloned, labelsNotCloned, labelsInCloned, labelsNotInCloned, fieldsCloned, fieldsNotCloned, resourceVersionCloned, reloadingFromServerCloned, gracePeriodSecondsCloned, propagationPolicyCloned);
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -67,7 +67,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       return listerWatcher.list(new ListOptionsBuilder()
         .withWatch(Boolean.FALSE)
         .withResourceVersion(null)
-        .withTimeoutSeconds(null).build(), null, operationContext);
+        .withTimeoutSeconds(null).build(), operationContext.getNamespace(), operationContext);
     } catch (Exception exception) {
       store.isPopulated(false);
       throw new RejectedExecutionException("Error while doing ReflectorRunnable list", exception);
@@ -122,7 +122,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       watch.set(
         listerWatcher.watch(new ListOptionsBuilder()
           .withWatch(Boolean.TRUE).withResourceVersion(lastSyncResourceVersion.get()).withTimeoutSeconds(null).build(),
-        null, operationContext, watcher)
+        operationContext.getNamespace(), operationContext, watcher)
       );
     }
   }


### PR DESCRIPTION
Seems like passing namespace with `new OperationContext().withNamespace("ns1")` was broken. We were losing all the necessary fields populated by default in `OperationContext` due to a new instance being passed by the user. This
PR fixes it by merging passed `operationContext` with client's existing `operationContext`

Related to #1075 