### PR TITLE
fix: JDK8 always uses http/1.1 protocol (Prevent OkHttp from wrongly enabling http/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #2201: Uberjar doesn't contain model classes anymore
 * Fix #2066: Uber Jar includes merged service entry for multiple implementations of the same interface
 * Fix #2195: Annotation processors and build time dependencies transitive
+* Fix #2212: JDK8 always uses http/1.1 protocol (Prevent OkHttp from wrongly enabling http/2)
 
 #### Improvements
 * Fix #2199: KubernetesClient#customResources now accepts CustomResourceDefinitionContext


### PR DESCRIPTION
Fix: #2212 