### PR TITLE
Adds basic support for Kubernetes Pod Eviction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 #### Improvements
 * Fix #2199: KubernetesClient#customResources now accepts CustomResourceDefinitionContext
+* Adds basic support for Pod Eviction API
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Evictable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Evictable.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+public interface Evictable<B> {
+  /**
+   * Evicts resource, respecting {@link io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget}
+   * @return value indicating object was evicted or not
+   * @throws io.fabric8.kubernetes.client.KubernetesClientException if an error occurs.
+   */
+  B evict();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
@@ -29,5 +29,6 @@ public interface PodResource<T, D> extends Resource<T, D>,
         Loggable<String, LogWatch>,
         Containerable<String, ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream, Boolean>>,
         ContainerResource<String, LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, Boolean, InputStream, Boolean>,
-        PortForwardable<PortForward, LocalPortForward, ReadableByteChannel, WritableByteChannel> {
+        PortForwardable<PortForward, LocalPortForward, ReadableByteChannel, WritableByteChannel>,
+        Evictable<Boolean>{
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -129,6 +129,11 @@ public class PodIT {
   }
 
   @Test
+  public void evict() {
+    assertTrue(client.pods().inNamespace(currentNamespace).withName(pod1.getMetadata().getName()).evict());
+  }
+
+  @Test
   public void log() throws InterruptedException {
     // Wait for resources to get ready
     ReadyEntity<Pod> podReady = new ReadyEntity<Pod>(Pod.class, client, pod1.getMetadata().getName(), currentNamespace);

--- a/kubernetes-model/kubernetes-model-policy/cmd/generate/generate.go
+++ b/kubernetes-model/kubernetes-model-policy/cmd/generate/generate.go
@@ -62,6 +62,7 @@ type Schema struct {
   KubernetesRunAsUserStrategyOptions       policy.RunAsUserStrategyOptions
   PodDisruptionBudget                      policy.PodDisruptionBudget
   PodDisruptionBudgetList                  policy.PodDisruptionBudgetList
+  Eviction                                 policy.Eviction
 }
 
 func main() {

--- a/kubernetes-model/kubernetes-model-policy/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model/kubernetes-model-policy/src/main/resources/schema/kube-schema.json
@@ -1079,6 +1079,38 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_policy_Eviction": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "policy/v1beta1",
+          "required": true
+        },
+        "deleteOptions": {
+          "$ref": "#/definitions/kubernetes_apimachinery_DeleteOptions",
+          "javaType": "io.fabric8.kubernetes.api.model.DeleteOptions"
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "Eviction",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.policy.Eviction",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
+      ]
+    },
     "kubernetes_policy_FSGroupStrategyOptions": {
       "type": "object",
       "description": "",
@@ -1644,6 +1676,10 @@
     "DeleteOptions": {
       "$ref": "#/definitions/kubernetes_apimachinery_DeleteOptions",
       "javaType": "io.fabric8.kubernetes.api.model.DeleteOptions"
+    },
+    "Eviction": {
+      "$ref": "#/definitions/kubernetes_policy_Eviction",
+      "javaType": "io.fabric8.kubernetes.api.model.policy.Eviction"
     },
     "GetOptions": {
       "$ref": "#/definitions/kubernetes_apimachinery_GetOptions",

--- a/kubernetes-model/kubernetes-model-policy/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model/kubernetes-model-policy/src/main/resources/schema/validation-schema.json
@@ -1079,6 +1079,38 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_policy_Eviction": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "policy/v1beta1",
+          "required": true
+        },
+        "deleteOptions": {
+          "$ref": "#/definitions/kubernetes_apimachinery_DeleteOptions",
+          "javaType": "io.fabric8.kubernetes.api.model.DeleteOptions"
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "Eviction",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.policy.Eviction",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
+      ]
+    },
     "kubernetes_policy_FSGroupStrategyOptions": {
       "type": "object",
       "description": "",
@@ -1645,6 +1677,10 @@
       "$ref": "#/definitions/kubernetes_apimachinery_DeleteOptions",
       "javaType": "io.fabric8.kubernetes.api.model.DeleteOptions"
     },
+    "Eviction": {
+      "$ref": "#/definitions/kubernetes_policy_Eviction",
+      "javaType": "io.fabric8.kubernetes.api.model.policy.Eviction"
+    },
     "GetOptions": {
       "$ref": "#/definitions/kubernetes_apimachinery_GetOptions",
       "javaType": "io.fabric8.kubernetes.api.model.GetOptions"
@@ -1887,6 +1923,31 @@
         "propagationPolicy": {
           "type": "string",
           "description": ""
+        }
+      },
+      "additionalProperties": true
+    },
+    "eviction": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "",
+          "default": "policy/v1beta1",
+          "required": true
+        },
+        "deleteOptions": {
+          "$ref": "#/definitions/kubernetes_apimachinery_DeleteOptions",
+          "javaType": "io.fabric8.kubernetes.api.model.DeleteOptions"
+        },
+        "kind": {
+          "type": "string",
+          "description": "",
+          "default": "Eviction",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "javaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
Evictions allow for safer deletions, respecting PodDisruptionBudget. This PR adds support to the dsl, and adds Eviction to the generated schema. `Evictions` take a `DeleteOptions`, but don't support any of the fields yet except `dryRun` in 1.18. I decided not to add client support for `dryRun` in this implementation because it would involve a bunch more changes to the various generics and interfaces. DryRun support should be a separate contribution if desired, since it applies to more than just Eviction.

For reference, see:
- [Eviction API Docs](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#the-eviction-api)
- [Eviction type](https://github.com/kubernetes/kubernetes/blob/abe6321296123aaba8e83978f7d17951ab1b64fd/pkg/apis/policy/types.go#L113-L123)
- [Eviction API handling](https://github.com/kubernetes/kubernetes/blob/abe6321296123aaba8e83978f7d17951ab1b64fd/pkg/registry/core/pod/storage/eviction.go#L104)