### PR TITLE
fix: remove dependency jsonschema2pojo-core in kubernetes-model

### DIFF
--- a/kubernetes-model/pom.xml
+++ b/kubernetes-model/pom.xml
@@ -71,12 +71,14 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jsonschema2pojo</groupId>
-      <artifactId>jsonschema2pojo-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.10</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <!-- Core versions -->
     <sundrio.version>0.21.0</sundrio.version>
-    <okhttp.version>3.12.11</okhttp.version>
+    <okhttp.version>3.12.12</okhttp.version>
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
@@ -140,7 +140,7 @@
     <maven.install.plugin.version>3.0.0-M1</maven.install.plugin.version>
     <jandex.plugin.version>1.0.8</jandex.plugin.version>
     <jandex.version>2.1.3.Final</jandex.version>
-    <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
 
     <!-- Other options -->


### PR DESCRIPTION
The dependency jsonschema2pojo-core is not needed at runtime, and it's only used at build time to generate source code by the maven plugin.

This fix the transitive dependency that should not be needed, this transitive dependency pulls others artifacts that should not be used like the Rule failing in the build of Quarkus:
```
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: commons-logging:commons-logging:jar:1.1.1
Found Banned Dependency: javax.validation:validation-api:jar:1.0.0.GA
```

A release shortly after this fix is merged should allow a more clean update in Quarkus of the latest version of kubernetes-client.