### PR TITLE
Fixes for Raw Custom Resource API testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 4.10-SNAPSHOT
 #### Bugs
+* Fix Raw CustomResource API path generation to not having trailing slash
+* Fix KubernetesAttributesExctractor to extract metadata from unregistered custom resources, such when using Raw CustomResource API 
 
 #### Improvements
 * Fix #2233: client.service().getUrl(..) should be able to fetch URL for ClusterIP based services

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -324,7 +324,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws KubernetesClientException in case any failure from Kubernetes APIs
    */
   public Map<String, Object> updateStatus(String name, Map<String, Object> objectAsMap) throws IOException, KubernetesClientException {
-    return validateAndSubmitRequest(fetchUrl(null, null) + (name != null ? name : "") + "/status", objectMapper.writeValueAsString(objectAsMap), HttpCallMethod.PUT);
+    return validateAndSubmitRequest(fetchUrl(null, name, null) + "/status", objectMapper.writeValueAsString(objectAsMap), HttpCallMethod.PUT);
   }
 
   /**
@@ -338,7 +338,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws KubernetesClientException in case any failure from Kubernetes APIs
    */
   public Map<String, Object> updateStatus(String name, String objectAsJsonString) throws IOException, KubernetesClientException {
-    return validateAndSubmitRequest(fetchUrl(null, null) + (name != null ? name : "") + "/status", objectAsJsonString, HttpCallMethod.PUT);
+    return validateAndSubmitRequest(fetchUrl(null, name, null) + "/status", objectAsJsonString, HttpCallMethod.PUT);
   }
 
   /**
@@ -353,7 +353,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws KubernetesClientException in case any failure from Kubernetes APIs
    */
   public Map<String, Object> updateStatus(String namespace, String name, Map<String, Object> objectAsMap) throws IOException, KubernetesClientException {
-    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : "") + "/status", objectMapper.writeValueAsString(objectAsMap), HttpCallMethod.PUT);
+    return validateAndSubmitRequest(fetchUrl(namespace, name, null) + "/status", objectMapper.writeValueAsString(objectAsMap), HttpCallMethod.PUT);
   }
 
   /**
@@ -367,7 +367,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws KubernetesClientException in case any failure from Kubernetes APIs
    */
   public Map<String, Object> updateStatus(String name, InputStream objectAsStream) throws IOException, KubernetesClientException {
-    return validateAndSubmitRequest(fetchUrl(null, null) + (name != null ? name : "") + "/status", IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
+    return validateAndSubmitRequest(fetchUrl(null, name, null) + "/status", IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
   }
 
   /**
@@ -382,7 +382,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws KubernetesClientException in case any failure from Kubernetes APIs
    */
   public Map<String, Object> updateStatus(String namespace, String name, InputStream objectAsStream) throws IOException, KubernetesClientException {
-    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : "") + "/status", IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
+    return validateAndSubmitRequest(fetchUrl(namespace, name, null) + "/status", IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
   }
 
   /**
@@ -397,7 +397,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws KubernetesClientException in case any failure from Kubernetes APIs
    */
   public Map<String, Object> updateStatus(String namespace, String name, String objectAsJsonString) throws IOException, KubernetesClientException {
-    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : "") + "/status", objectAsJsonString, HttpCallMethod.PUT);
+    return validateAndSubmitRequest(fetchUrl(namespace, name, null) + "/status", objectAsJsonString, HttpCallMethod.PUT);
   }
 
   /**
@@ -407,7 +407,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @return Object as HashMap
    */
   public Map<String, Object> get(String name) {
-    return makeCall(fetchUrl(null, null) + name, null, HttpCallMethod.GET);
+    return makeCall(fetchUrl(null, name, null), null, HttpCallMethod.GET);
   }
 
   /**
@@ -418,7 +418,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @return Object as HashMap
    */
   public Map<String, Object> get(String namespace, String name) {
-      return makeCall(fetchUrl(namespace, null) + name, null, HttpCallMethod.GET);
+      return makeCall(fetchUrl(namespace, name, null), null, HttpCallMethod.GET);
   }
 
   /**
@@ -427,7 +427,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @return list of custom resources as HashMap
    */
   public Map<String, Object> list() {
-    return makeCall(fetchUrl(null, null), null, HttpCallMethod.GET);
+    return makeCall(fetchUrl(null, null, null), null, HttpCallMethod.GET);
   }
 
   /**
@@ -437,7 +437,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @return list of custom resources as HashMap
    */
   public Map<String, Object> list(String namespace) {
-    return makeCall(fetchUrl(namespace, null), null, HttpCallMethod.GET);
+    return makeCall(fetchUrl(namespace, null, null), null, HttpCallMethod.GET);
   }
 
   /**
@@ -448,7 +448,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @return list of custom resources as HashMap
    */
   public Map<String, Object> list(String namespace, Map<String, String> labels) {
-    return makeCall(fetchUrl(namespace, labels), null, HttpCallMethod.GET);
+    return makeCall(fetchUrl(namespace, null, labels), null, HttpCallMethod.GET);
   }
 
   /**
@@ -458,7 +458,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @return deleted objects as HashMap
    */
   public Map<String, Object> delete(String namespace) {
-    return makeCall(fetchUrl(namespace, null), null, HttpCallMethod.DELETE);
+    return makeCall(fetchUrl(namespace, null, null), null, HttpCallMethod.DELETE);
   }
 
   /**
@@ -471,7 +471,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws IOException in case of any network/parsing exception
    */
   public Map<String, Object> delete(String namespace, boolean cascading) throws IOException {
-    return makeCall(fetchUrl(namespace, null), objectMapper.writeValueAsString(fetchDeleteOptions(cascading, null)), HttpCallMethod.DELETE);
+    return makeCall(fetchUrl(namespace, null, null), objectMapper.writeValueAsString(fetchDeleteOptions(cascading, null)), HttpCallMethod.DELETE);
   }
 
   /**
@@ -484,7 +484,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws IOException in case of any network/object parse problems
    */
   public Map<String, Object> delete(String namespace, DeleteOptions deleteOptions) throws IOException {
-    return makeCall(fetchUrl(namespace, null), objectMapper.writeValueAsString(deleteOptions), HttpCallMethod.DELETE);
+    return makeCall(fetchUrl(namespace, null, null), objectMapper.writeValueAsString(deleteOptions), HttpCallMethod.DELETE);
   }
 
   /**
@@ -495,7 +495,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @return object as HashMap
    */
   public Map<String, Object> delete(String namespace, String name) throws IOException {
-    return makeCall(fetchUrl(namespace, null) + name, objectMapper.writeValueAsString(fetchDeleteOptions(false, DeletionPropagation.BACKGROUND.toString())), HttpCallMethod.DELETE);
+    return makeCall(fetchUrl(namespace, name, null), objectMapper.writeValueAsString(fetchDeleteOptions(false, DeletionPropagation.BACKGROUND.toString())), HttpCallMethod.DELETE);
   }
 
   /**
@@ -509,7 +509,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws IOException exception related to network/object parsing
    */
   public Map<String, Object> delete(String namespace, String name, boolean cascading) throws IOException {
-    return makeCall(fetchUrl(namespace, null) + name, objectMapper.writeValueAsString(fetchDeleteOptions(cascading, null)), HttpCallMethod.DELETE);
+    return makeCall(fetchUrl(namespace, name, null), objectMapper.writeValueAsString(fetchDeleteOptions(cascading, null)), HttpCallMethod.DELETE);
   }
 
   /**
@@ -528,7 +528,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws IOException in case of network/object parse exception
    */
   public Map<String, Object> delete(String namespace, String name, String propagationPolicy) throws IOException {
-    return makeCall(fetchUrl(namespace, null) + name, objectMapper.writeValueAsString(fetchDeleteOptions(false, propagationPolicy)) , HttpCallMethod.DELETE);
+    return makeCall(fetchUrl(namespace, name, null), objectMapper.writeValueAsString(fetchDeleteOptions(false, propagationPolicy)) , HttpCallMethod.DELETE);
   }
 
   /**
@@ -542,7 +542,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
    * @throws IOException in case of any network/object parse exception
    */
   public Map<String, Object> delete(String namespace, String name, DeleteOptions deleteOptions) throws IOException {
-    return makeCall(fetchUrl(namespace, null) + name, objectMapper.writeValueAsString(deleteOptions), HttpCallMethod.DELETE);
+    return makeCall(fetchUrl(namespace, name, null), objectMapper.writeValueAsString(deleteOptions), HttpCallMethod.DELETE);
   }
 
   /**
@@ -720,7 +720,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
   }
 
   protected HttpUrl.Builder fetchWatchUrl(String namespace, String name, Map<String, String> labels, ListOptions options) throws MalformedURLException {
-    String resourceUrl = fetchUrl(namespace, labels);
+    String resourceUrl = fetchUrl(namespace, null, labels);
     if (resourceUrl.endsWith("/")) {
       resourceUrl = resourceUrl.substring(0, resourceUrl.length() - 1);
     }
@@ -735,7 +735,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
     return httpUrlBuilder;
   }
 
-  private String fetchUrl(String namespace, Map<String, String> labels) {
+  private String fetchUrl(String namespace, String name, Map<String, String> labels) {
     if (config.getMasterUrl() == null) {
       return null;
     }
@@ -752,9 +752,11 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
     if(customResourceDefinition.getScope().equals("Namespaced") && namespace != null) {
       urlBuilder.append("namespaces/").append(namespace).append("/");
     }
-    urlBuilder.append(customResourceDefinition.getPlural()).append("/");
+    urlBuilder.append(customResourceDefinition.getPlural());
+    if (name != null) {
+      urlBuilder.append("/").append(name);
+    }
     if(labels != null) {
-      urlBuilder.deleteCharAt(urlBuilder.lastIndexOf("/"));
       urlBuilder.append("?labelSelector").append("=").append(getLabelsQueryParam(labels));
     }
     return urlBuilder.toString();
@@ -789,7 +791,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
   }
 
   private Map<String, Object> validateAndSubmitRequest(String namespace, String name, String objectAsString, HttpCallMethod httpCallMethod) throws IOException {
-    return validateAndSubmitRequest(fetchUrl(namespace, null) + (name != null ? name : ""), objectAsString, httpCallMethod);
+    return validateAndSubmitRequest(fetchUrl(namespace, name, null), objectAsString, httpCallMethod);
   }
 
   private Map<String, Object> validateAndSubmitRequest(String resourceUrl, String objectAsString, HttpCallMethod httpCallMethod) throws IOException {

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/FallbackHasMetadata.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/FallbackHasMetadata.java
@@ -28,7 +28,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
  */
 // Override the default KubernetesSerializer so that it doesn't try to deserialize into registered types
 @JsonDeserialize(using = None.class)
-public class RawHasMetadata implements HasMetadata {
+public class FallbackHasMetadata implements HasMetadata {
 
   private String apiVersion;
   private String kind;
@@ -38,10 +38,10 @@ public class RawHasMetadata implements HasMetadata {
    * No args constructor for use in serialization
    *
    */
-  public RawHasMetadata() {
+  public FallbackHasMetadata() {
   }
 
-  public RawHasMetadata(String apiVersion, String kind, ObjectMeta metadata) {
+  public FallbackHasMetadata(String apiVersion, String kind, ObjectMeta metadata) {
     this.apiVersion = apiVersion;
     this.kind = kind;
     this.metadata = metadata;

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -248,6 +248,14 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
     try (InputStream stream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8.name()))) {
       return Serialization.unmarshal(stream);
     } catch (Exception e) {
+      return toRawHasMetadata(s);
+    }
+  }
+
+  private static HasMetadata toRawHasMetadata(String s) {
+    try (InputStream stream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8.name()))) {
+      return Serialization.jsonMapper().readValue(stream, RawHasMetadata.class);
+    } catch (Exception e) {
       return null;
     }
   }

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -254,7 +254,7 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
 
   private static HasMetadata toRawHasMetadata(String s) {
     try (InputStream stream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8.name()))) {
-      return Serialization.jsonMapper().readValue(stream, RawHasMetadata.class);
+      return Serialization.jsonMapper().readValue(stream, FallbackHasMetadata.class);
     } catch (Exception e) {
       return null;
     }

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/RawHasMetadata.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/RawHasMetadata.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+/**
+ * This class is used by KubernetesAttributesExtractor as a fallback for when it can't deserialize
+ * the request bodies into KubernetesResource. This happens when using the Raw CustomResource API.
+ */
+// Override the default KubernetesSerializer so that it doesn't try to deserialize into registered types
+@JsonDeserialize(using = None.class)
+public class RawHasMetadata implements HasMetadata {
+
+  private String apiVersion;
+  private String kind;
+  private ObjectMeta metadata;
+
+  /**
+   * No args constructor for use in serialization
+   *
+   */
+  public RawHasMetadata() {
+  }
+
+  public RawHasMetadata(String apiVersion, String kind, ObjectMeta metadata) {
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+    this.metadata = metadata;
+  }
+
+
+  @Override
+  @JsonProperty("apiVersion")
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  @Override
+  @JsonProperty("apiVersion")
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  @Override
+  @JsonProperty("kind")
+  public String getKind() {
+    return kind;
+  }
+
+  @JsonProperty("kind")
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  @Override
+  @JsonProperty("metadata")
+  public ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  @JsonProperty("metadata")
+  public void setMetadata(ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+
+}

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
@@ -32,7 +32,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.mockwebserver.crud.Attribute;
 import io.fabric8.mockwebserver.crud.AttributeSet;
-import io.fabric8.zjsonpatch.internal.guava.Lists;
 
 public class KubernetesAttributesExtractorTest {
 
@@ -92,10 +91,23 @@ public class KubernetesAttributesExtractorTest {
 		expected = expected.add(new Attribute("namespace", "myns"));
 		expected = expected.add(new Attribute("name", "mypod"));
 		assertTrue(attributes.matches(expected));
-
 	}
 
-	@Test
+  @Test
+  void shouldHandleRawResource() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    String resource = "{\"metadata\":{\"name\":\"myresource\",\"namespace\":\"myns\"}, \"kind\":\"raw\", \"apiVersion\":\"v1\"}";
+
+    AttributeSet attributes = extractor.extract(resource);
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("kind", "raw"));
+    expected = expected.add(new Attribute("namespace", "myns"));
+    expected = expected.add(new Attribute("name", "myresource"));
+    assertTrue(attributes.matches(expected));
+  }
+
+  @Test
 	public void shouldHandleResourceWithLabel() {
 		KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
 		Map<String, String> labels = new HashMap<>();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -79,7 +79,7 @@ public class CustomResourceTest {
     String jsonObject = "{\"apiVersion\": \"test.fabric8.io/v1alpha1\",\"kind\": \"Hello\"," +
       "\"metadata\": {\"name\": \"example-hello\"},\"spec\": {\"size\": 3}}";
 
-    server.expect().post().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
+    server.expect().post().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
     KubernetesClient client = server.getClient();
 
     Map<String, Object> resource = client.customResource(customResourceDefinitionContext).create("ns1", jsonObject);
@@ -91,7 +91,7 @@ public class CustomResourceTest {
     String jsonObject = "{\"apiVersion\": \"test.fabric8.io/v1alpha1\",\"kind\": \"Hello\"," +
       "\"metadata\": {\"resourceVersion\":\"1\", \"name\": \"example-hello\"},\"spec\": {\"size\": 3}}";
 
-    server.expect().post().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
+    server.expect().post().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
     server.expect().get().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello").andReturn(HttpURLConnection.HTTP_OK, jsonObject).once();
     server.expect().put().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello").andReturn(HttpURLConnection.HTTP_OK, jsonObject).once();
     KubernetesClient client = server.getClient();
@@ -108,7 +108,7 @@ public class CustomResourceTest {
     String jsonObject = "{\"metadata\":{\"continue\":\"\",\"resourceVersion\":\"539617\",\"selfLink\":\"test.fabric8.io/v1alpha1/namespaces/ns1/hellos/\"},\"apiVersion\":\"test.fabric8.io/v1alpha1\",\"kind\":\"HelloList\",\"items\":[{\"apiVersion\": \"test.fabric8.io/v1alpha1\",\"kind\": \"Hello\"," +
       "\"metadata\": {\"name\": \"example-hello\"},\"spec\": {\"size\": 3},\"uid\":\"3525437a-6a56-11e9-8787-525400b18c1d\"}]}";
 
-    server.expect().get().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
+    server.expect().get().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
     KubernetesClient client = server.getClient();
 
     Map<String, Object> list = client.customResource(customResourceDefinitionContext).list("ns1");


### PR DESCRIPTION
I've been using the raw API recently and noticed two bugs:

1. There was a trailing slash added to the end of POST requests. This was causing the KubernetesAttributeExtractor to fail to extract metadata from the request path. The simple fix here would be to allow a trailing slash in KubernetesAttributeExtractor path regex, but I believe the correct fix is to not add the trailing slash at all. No paths in the kube api docs have trailing slashes. I refactored RawCustomResourceOperationsImpl a bit to fix this issue, and added some tests.
2. Users of the RawCustomResourceOperationsImpl do not need to register a custom kind with the KubernetesSerializer. As such, the KubernetesAttributeExtractor fails to extract metadata from these resources. The attributes in the CrudDispatcher map then do not match across requests. I've added a RawHasMetadata resource to kubernetes-server-mock and use that as a fallback if the toKubernetesResource call fails.