### PR TITLE
Update createOrReplace to work more like BaseOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.10-SNAPSHOT
 #### Bugs
+* Fix #2285: Raw CustomResource API createOrReplace does not propagate exceptions from create
 * Fix Raw CustomResource API path generation to not having trailing slash
 * Fix #2131: Failing to parse CustomResourceDefinition with OpenAPIV3Schema using JSONSchemaPropOr\* fields
 * Fix KubernetesAttributesExctractor to extract metadata from unregistered custom resources, such when using Raw CustomResource API 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -15,37 +15,41 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
 import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-
-import org.bouncycastle.cert.ocsp.Req;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class RawCustomResourceOperationsImplTest {
   private OkHttpClient mockClient;
   private Config config;
   private CustomResourceDefinitionContext customResourceDefinitionContext;
+  private Response mockSuccessResponse;
 
   @BeforeEach
   public void setUp() throws IOException {
@@ -60,11 +64,9 @@ public class RawCustomResourceOperationsImplTest {
       .build();
 
     Call mockCall = mock(Call.class);
-    Response mockResponse = mock(Response.class);
-    when(mockResponse.isSuccessful()).thenReturn(true);
-    when(mockResponse.body()).thenReturn(ResponseBody.create(MediaType.get("application/json"), ""));
+    mockSuccessResponse = mockResponse(HttpURLConnection.HTTP_OK);
     when(mockCall.execute())
-      .thenReturn(mockResponse);
+      .thenReturn(mockSuccessResponse);
     when(mockClient.newCall(any())).thenReturn(mockCall);
   }
 
@@ -75,15 +77,44 @@ public class RawCustomResourceOperationsImplTest {
     String resourceAsString = "{\"metadata\":{\"name\":\"myresource\",\"namespace\":\"myns\"}, \"kind\":\"raw\", \"apiVersion\":\"v1\"}";
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
+    Call mockCall = mock(Call.class);
+    Response mockErrorResponse = mockResponse(HttpURLConnection.HTTP_INTERNAL_ERROR);
+    Response mockConflictResponse = mockResponse(HttpURLConnection.HTTP_CONFLICT);
+    when(mockCall.execute())
+      .thenReturn(mockErrorResponse, mockConflictResponse, mockSuccessResponse);
+    when(mockClient.newCall(any())).thenReturn(mockCall);
+
     // When
+    try {
+      rawCustomResourceOperations.createOrReplace(resourceAsString);
+      fail("expected first call to createOrReplace to throw exception due to 500 response");
+    } catch (KubernetesClientException e) {
+      assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, e.getCode());
+    }
     rawCustomResourceOperations.createOrReplace(resourceAsString);
     rawCustomResourceOperations.createOrReplace("myns", resourceAsString);
 
     // Then
-    verify(mockClient, times(2)).newCall(captor.capture());
-    assertEquals(2, captor.getAllValues().size());
+    verify(mockClient, times(4)).newCall(captor.capture());
+    assertEquals(4, captor.getAllValues().size());
     assertEquals("/apis/test.fabric8.io/v1alpha1/hellos", captor.getAllValues().get(0).url().encodedPath());
-    assertEquals("/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", captor.getAllValues().get(1).url().encodedPath());
+    assertEquals("POST", captor.getAllValues().get(0).method());
+    assertEquals("/apis/test.fabric8.io/v1alpha1/hellos", captor.getAllValues().get(1).url().encodedPath());
+    assertEquals("POST", captor.getAllValues().get(1).method());
+    assertEquals("/apis/test.fabric8.io/v1alpha1/hellos/myresource", captor.getAllValues().get(2).url().encodedPath());
+    assertEquals("PUT", captor.getAllValues().get(2).method());
+    assertEquals("/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", captor.getAllValues().get(3).url().encodedPath());
+    assertEquals("POST", captor.getAllValues().get(3).method());
+  }
+
+  private Response mockResponse(int code) {
+    return new Response.Builder()
+      .request(new Request.Builder().url("http://mock").build())
+      .protocol(Protocol.HTTP_1_1)
+      .code(code)
+      .body(ResponseBody.create(MediaType.get("application/json"), ""))
+      .message("mock")
+      .build();
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -15,37 +15,51 @@
  */
 package io.fabric8.kubernetes.client.mock;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.JSONSchemaProps;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.kubernetes.client.mock.crd.CronTabSpec;
-import io.fabric8.kubernetes.client.mock.crd.DoneableCronTab;
+import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.mock.crd.CronTab;
 import io.fabric8.kubernetes.client.mock.crd.CronTabList;
+import io.fabric8.kubernetes.client.mock.crd.CronTabSpec;
+import io.fabric8.kubernetes.client.mock.crd.DoneableCronTab;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
-import org.junit.Rule;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-
-import java.io.IOException;
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @EnableRuleMigrationSupport
 public class CustomResourceCrudTest {
   @Rule
   public KubernetesServer kubernetesServer = new KubernetesServer(true,true);
+  
+  private CustomResourceDefinition cronTabCrd;
+  private CustomResourceDefinitionContext crdContext;
 
-  private MixedOperation<CronTab, CronTabList, DoneableCronTab, Resource<CronTab, DoneableCronTab>> podSetClient;
+  @BeforeEach
+  void setUp() {
+    KubernetesDeserializer.registerCustomKind("stable.example.com/v1", "CronTab", CronTab.class);
+    cronTabCrd = kubernetesServer.getClient()
+      .customResourceDefinitions()
+      .load(getClass().getResourceAsStream("/crontab-crd.yml"))
+      .get();
+    kubernetesServer.getClient().customResourceDefinitions().create(cronTabCrd);
+    crdContext = CustomResourceDefinitionContext.fromCrd(cronTabCrd);
+  }
 
   @Test
   public void testCrud() throws IOException {
@@ -54,11 +68,6 @@ public class CustomResourceCrudTest {
     CronTab cronTab3 = createCronTab("my-third-cron-object", "* * * * */3", 1, "my-third-cron-image");
     KubernetesClient client = kubernetesServer.getClient();
 
-    KubernetesDeserializer.registerCustomKind("stable.example.com/v1", "CronTab", CronTab.class);
-    CustomResourceDefinition cronTabCrd = client.customResourceDefinitions().load(getClass().getResourceAsStream("/crontab-crd.yml")).get();
-    client.customResourceDefinitions().create(cronTabCrd);
-
-    CustomResourceDefinitionContext crdContext = CustomResourceDefinitionContext.fromCrd(cronTabCrd);
     MixedOperation<CronTab, CronTabList, DoneableCronTab, Resource<CronTab, DoneableCronTab>> cronTabClient = client
       .customResources(crdContext, CronTab.class, CronTabList.class, DoneableCronTab.class);
 
@@ -87,6 +96,27 @@ public class CustomResourceCrudTest {
     assertEquals(2, cronTabList.getItems().size());
   }
 
+  @Test
+  void testCreateOrReplaceRaw() throws IOException {
+    RawCustomResourceOperationsImpl raw = kubernetesServer.getClient().customResource(CustomResourceDefinitionContext.fromCrd(cronTabCrd));
+
+    Map<String, Object> object = new HashMap<>();
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("name", "foo");
+
+    object.put("metadata", metadata);
+    object.put("spec", "initial");
+
+    Map<String, Object> created = raw.createOrReplace(object);
+
+    assertEquals(object, created);
+
+    object.put("spec", "updated");
+
+    Map<String, Object> updated = raw.createOrReplace(object);
+    assertNotEquals(created, updated);
+    assertEquals(object, updated);
+  }
 
   @Test
   public void testCrudWithDashSymbolInCRDName() throws IOException {
@@ -94,10 +124,6 @@ public class CustomResourceCrudTest {
     CronTab cronTab2 = createCronTab("my-second-cron-object", "* * * * */4", 2, "my-second-cron-image");
     CronTab cronTab3 = createCronTab("my-third-cron-object", "* * * * */3", 1, "my-third-cron-image");
     KubernetesClient client = kubernetesServer.getClient();
-
-    KubernetesDeserializer.registerCustomKind("stable.example.com/v1", "CronTab", CronTab.class);
-    CustomResourceDefinition cronTabCrd = cronTabCRDWithDashSymbolName();
-    client.customResourceDefinitions().create(cronTabCrd);
 
     MixedOperation<CronTab, CronTabList, DoneableCronTab, Resource<CronTab, DoneableCronTab>> cronTabClient = client
       .customResources(cronTabCrd, CronTab.class, CronTabList.class, DoneableCronTab.class);
@@ -143,36 +169,5 @@ public class CustomResourceCrudTest {
     cronTabSpec.setReplicas(replicas);
     cronTab.setSpec(cronTabSpec);
     return cronTab;
-  }
-
-  public CustomResourceDefinition cronTabCRDWithDashSymbolName() throws IOException {
-      return new CustomResourceDefinitionBuilder()
-      .withApiVersion("apiextensions.k8s.io/v1beta1")
-      .withNewMetadata().withName("crontabs.stable.example.com")
-      .endMetadata()
-      .withNewSpec()
-      .withNewNames()
-      .withKind("CronTab")
-      .withPlural("cron-tabs")
-      .withSingular("cron-tab")
-      .endNames()
-      .withGroup("stable.example.com")
-      .withVersion("v1")
-      .withScope("Namespaced")
-      .withNewValidation()
-      .withNewOpenAPIV3SchemaLike(readSchema())
-      .endOpenAPIV3Schema()
-      .endValidation()
-      .endSpec()
-      .build();
-
-  }
-
-  private JSONSchemaProps readSchema() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-    final URL resource = getClass().getResource("/test-crd-validation-schema.json");
-
-    final JSONSchemaProps jsonSchemaProps = mapper.readValue(resource, JSONSchemaProps.class);
-    return jsonSchemaProps;
   }
 }


### PR DESCRIPTION
This fixes https://github.com/fabric8io/kubernetes-client/issues/2285

Rather than try to actually handle exception propagation for create-then-replace, I decided to mirror the BaseOperation implementation which does a get then branch accordingly. I added a couple tests.