### PR TITLE
expose current (named) and all (named) contexts

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -16,26 +16,7 @@
 
 package io.fabric8.kubernetes.client;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.fabric8.kubernetes.api.model.AuthInfo;
-import io.fabric8.kubernetes.api.model.Cluster;
-import io.fabric8.kubernetes.api.model.ConfigBuilder;
-import io.fabric8.kubernetes.api.model.Context;
-import io.fabric8.kubernetes.api.model.ExecConfig;
-import io.fabric8.kubernetes.api.model.ExecEnvVar;
-import io.fabric8.kubernetes.client.internal.CertUtils;
-import io.fabric8.kubernetes.client.internal.KubeConfigUtils;
-import io.fabric8.kubernetes.client.internal.SSLUtils;
-import io.fabric8.kubernetes.client.utils.IOHelpers;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.kubernetes.client.utils.Utils;
-import io.sundr.builder.annotations.Buildable;
-import okhttp3.TlsVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static okhttp3.TlsVersion.TLS_1_2;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -51,7 +32,29 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static okhttp3.TlsVersion.TLS_1_2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.fabric8.kubernetes.api.model.AuthInfo;
+import io.fabric8.kubernetes.api.model.Cluster;
+import io.fabric8.kubernetes.api.model.ConfigBuilder;
+import io.fabric8.kubernetes.api.model.Context;
+import io.fabric8.kubernetes.api.model.ExecConfig;
+import io.fabric8.kubernetes.api.model.ExecEnvVar;
+import io.fabric8.kubernetes.api.model.NamedContext;
+import io.fabric8.kubernetes.client.internal.CertUtils;
+import io.fabric8.kubernetes.client.internal.KubeConfigUtils;
+import io.fabric8.kubernetes.client.internal.SSLUtils;
+import io.fabric8.kubernetes.client.utils.IOHelpers;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.kubernetes.client.utils.Utils;
+import io.sundr.builder.annotations.Buildable;
+import okhttp3.TlsVersion;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true, allowGetters = true, allowSetters = true)
@@ -158,6 +161,9 @@ public class Config {
 
   private RequestConfig requestConfig = new RequestConfig();
 
+  private List<NamedContext> contexts = new ArrayList<>();
+  private NamedContext currentContext = null;
+
   /**
    * fields not used but needed for builder generation.
    */
@@ -233,14 +239,25 @@ public class Config {
     }
     configFromSysPropsOrEnvVars(config);
 
-    if (!config.masterUrl.toLowerCase(Locale.ROOT).startsWith(HTTP_PROTOCOL_PREFIX) && !config.masterUrl.toLowerCase(Locale.ROOT).startsWith(HTTPS_PROTOCOL_PREFIX)) {
-      config.masterUrl = (SSLUtils.isHttpsAvailable(config) ? HTTPS_PROTOCOL_PREFIX : HTTP_PROTOCOL_PREFIX) + config.masterUrl;
-    }
+    config.masterUrl = ensureHttps(config.masterUrl, config);
+    config.masterUrl = ensureEndsWithSlash(config.masterUrl);
 
-    if (!config.masterUrl.endsWith("/")) {
-      config.masterUrl = config.masterUrl + "/";
-    }
     return config;
+  }
+
+  private static String ensureEndsWithSlash(String masterUrl) {
+    if (!masterUrl.endsWith("/")) {
+      masterUrl = masterUrl + "/";
+    }
+    return masterUrl;
+  }
+
+  private static String ensureHttps(String masterUrl, Config config) {
+    if (!masterUrl.toLowerCase(Locale.ROOT).startsWith(HTTP_PROTOCOL_PREFIX)
+          && !masterUrl.toLowerCase(Locale.ROOT).startsWith(HTTPS_PROTOCOL_PREFIX)) {
+        masterUrl = (SSLUtils.isHttpsAvailable(config) ? HTTPS_PROTOCOL_PREFIX : HTTP_PROTOCOL_PREFIX) + masterUrl;
+    }
+    return masterUrl;
   }
 
   @Deprecated
@@ -460,41 +477,52 @@ public class Config {
   public static Config fromKubeconfig(String context, String kubeconfigContents, String kubeconfigPath) {
     // we allow passing context along here, since downstream accepts it
     Config config = new Config();
-    Config.loadFromKubeconfig(config, context, kubeconfigContents, kubeconfigPath);
+    loadFromKubeconfig(config, context, kubeconfigContents, kubeconfigPath);
     return config;
   }
 
   private static boolean tryKubeConfig(Config config, String context) {
     LOGGER.debug("Trying to configure client from Kubernetes config...");
-    if (Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, true)) {
-      String fileName = Utils.getSystemPropertyOrEnvVar(KUBERNETES_KUBECONFIG_FILE, new File(getHomeDir(), ".kube" + File.separator + "config").toString());
-
-      // if system property/env var contains multiple files take the first one based on the environment
-      // we are running in (eg. : for Linux, ; for Windows)
-      String[] fileNames = fileName.split(File.pathSeparator);
-
-      if (fileNames.length > 1) {
-        LOGGER.warn("Found multiple Kubernetes config files [{}], using the first one: [{}]. If not desired file, please change it by doing `export KUBECONFIG=/path/to/kubeconfig` on Unix systems or `$Env:KUBECONFIG=/path/to/kubeconfig` on Windows.", fileNames, fileNames[0]);
-        fileName = fileNames[0];
-      }
-
-      File kubeConfigFile = new File(fileName);
-      if (kubeConfigFile.isFile()) {
-        LOGGER.debug("Found for Kubernetes config at: [{}].", kubeConfigFile.getPath());
-        String kubeconfigContents;
-        try (FileReader reader = new FileReader(kubeConfigFile)){
-          kubeconfigContents = IOHelpers.readFully(reader);
-        } catch(IOException e) {
-          LOGGER.error("Could not load Kubernetes config file from {}", kubeConfigFile.getPath(), e);
-          return false;
-        }
-        Config.loadFromKubeconfig(config, context, kubeconfigContents, kubeConfigFile.getPath());
-        return true;
-      } else {
-        LOGGER.debug("Did not find Kubernetes config at: ["+kubeConfigFile.getPath()+"]. Ignoring.");
-      }
+    if (!Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, true)) {
+      return false;
     }
-    return false;
+    File kubeConfigFile = new File(getKubeconfigFilename());
+    if (!kubeConfigFile.isFile()) {
+      LOGGER.debug("Did not find Kubernetes config at: ["+kubeConfigFile.getPath()+"]. Ignoring.");
+      return false;
+    }
+    LOGGER.debug("Found for Kubernetes config at: [{}].", kubeConfigFile.getPath());
+    String kubeconfigContents = getKubeconfigContents(kubeConfigFile);
+    if (kubeconfigContents == null) {
+      return false;
+    }
+    loadFromKubeconfig(config, context, kubeconfigContents, kubeConfigFile.getPath());
+    return true;
+  }
+
+  private static String getKubeconfigFilename() {
+    String fileName = Utils.getSystemPropertyOrEnvVar(KUBERNETES_KUBECONFIG_FILE, new File(getHomeDir(), ".kube" + File.separator + "config").toString());
+
+    // if system property/env var contains multiple files take the first one based on the environment
+    // we are running in (eg. : for Linux, ; for Windows)
+    String[] fileNames = fileName.split(File.pathSeparator);
+
+    if (fileNames.length > 1) {
+      LOGGER.warn("Found multiple Kubernetes config files [{}], using the first one: [{}]. If not desired file, please change it by doing `export KUBECONFIG=/path/to/kubeconfig` on Unix systems or `$Env:KUBECONFIG=/path/to/kubeconfig` on Windows.", fileNames, fileNames[0]);
+      fileName = fileNames[0];
+    }
+    return fileName;
+  }
+
+  private static String getKubeconfigContents(File kubeConfigFile) {
+    String kubeconfigContents = null;
+    try (FileReader reader = new FileReader(kubeConfigFile)){
+      kubeconfigContents = IOHelpers.readFully(reader);
+    } catch(IOException e) {
+      LOGGER.error("Could not load Kubernetes config file from {}", kubeConfigFile.getPath(), e);
+      return null;
+    }
+    return kubeconfigContents;
   }
 
   // Note: kubeconfigPath is optional
@@ -503,14 +531,14 @@ public class Config {
   private static boolean loadFromKubeconfig(Config config, String context, String kubeconfigContents, String kubeconfigPath) {
     try {
       io.fabric8.kubernetes.api.model.Config kubeConfig = KubeConfigUtils.parseConfigFromString(kubeconfigContents);
-      if (context != null) {
-        kubeConfig.setCurrentContext(context);
-      }
-      Context currentContext = KubeConfigUtils.getCurrentContext(kubeConfig);
+      config.setContexts(kubeConfig.getContexts());
+      Context currentContext = setCurrentContext(context, config, kubeConfig);
       Cluster currentCluster = KubeConfigUtils.getCluster(kubeConfig, currentContext);
+      if (currentContext != null) {
+          config.setNamespace(currentContext.getNamespace());
+      }
       if (currentCluster != null) {
         config.setMasterUrl(currentCluster.getServer());
-        config.setNamespace(currentContext.getNamespace());
         config.setTrustCerts(currentCluster.getInsecureSkipTlsVerify() != null && currentCluster.getInsecureSkipTlsVerify());
         config.setDisableHostnameVerification(currentCluster.getInsecureSkipTlsVerify() != null && currentCluster.getInsecureSkipTlsVerify());
         config.setCaCertData(currentCluster.getCertificateAuthorityData());
@@ -597,6 +625,20 @@ public class Config {
 
     return false;
   }
+
+  private static Context setCurrentContext(String context, Config config, io.fabric8.kubernetes.api.model.Config kubeConfig) {
+    if (context != null) {
+      kubeConfig.setCurrentContext(context);
+    }
+    Context currentContext = null;
+    NamedContext currentNamedContext = KubeConfigUtils.getCurrentContext(kubeConfig);
+    if (currentNamedContext != null) {
+      config.setCurrentContext(currentNamedContext);
+      currentContext = currentNamedContext.getContext();
+    }
+    return currentContext;
+  }
+
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static final class ExecCredential {
     public String kind;
@@ -1128,4 +1170,21 @@ public class Config {
   public void setCustomHeaders(Map<String, String> customHeaders) {
     this.customHeaders = customHeaders;
   }
+
+  public List<NamedContext> getContexts() {
+    return contexts;
+  }
+
+  public void setContexts(List<NamedContext> contexts) {
+    this.contexts = contexts;
+  }
+
+  public NamedContext getCurrentContext() {
+    return currentContext;
+  }
+
+  public void setCurrentContext(NamedContext context) {
+    this.currentContext = context;
+  }
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -488,7 +488,7 @@ public class Config {
     }
     File kubeConfigFile = new File(getKubeconfigFilename());
     if (!kubeConfigFile.isFile()) {
-      LOGGER.debug("Did not find Kubernetes config at: ["+kubeConfigFile.getPath()+"]. Ignoring.");
+      LOGGER.debug("Did not find Kubernetes config at: [{}]. Ignoring.", kubeConfigFile.getPath());
       return false;
     }
     LOGGER.debug("Found for Kubernetes config at: [{}].", kubeConfigFile.getPath());
@@ -615,7 +615,7 @@ public class Config {
           }
 
           config.getErrorMessages().put(401, "Unauthorized! Token may have expired! Please log-in again.");
-          config.getErrorMessages().put(403, "Forbidden! User "+currentContext.getUser()+ " doesn't have permission.");
+          config.getErrorMessages().put(403, "Forbidden! User " + (currentContext != null? currentContext.getUser() : "") + " doesn't have permission.");
         }
         return true;
       }
@@ -1171,6 +1171,13 @@ public class Config {
     this.customHeaders = customHeaders;
   }
 
+  /**
+   * Returns all the {@link NamedContext}s that exist in the kube config
+   * 
+   * @return all the contexts
+   * 
+   * @see NamedContext
+   */
   public List<NamedContext> getContexts() {
     return contexts;
   }
@@ -1179,6 +1186,13 @@ public class Config {
     this.contexts = contexts;
   }
 
+  /**
+   * Returns the current context that's defined in the kube config. Returns {@code null} if there's none
+   * 
+   * @return the current context
+   * 
+   * @see NamedContext
+   */
   public NamedContext getCurrentContext() {
     return currentContext;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
@@ -51,14 +51,14 @@ public class KubeConfigUtils {
    * @param config Config object
    * @return returns context in config if found, otherwise null
    */
-  public static Context getCurrentContext(Config config) {
+  public static NamedContext getCurrentContext(Config config) {
     String contextName = config.getCurrentContext();
     if (contextName != null) {
       List<NamedContext> contexts = config.getContexts();
       if (contexts != null) {
         for (NamedContext context : contexts) {
           if (contextName.equals(context.getName())) {
-            return context.getContext();
+            return context;
           }
         }
       }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -95,7 +95,7 @@ public class Utils {
     return getSystemPropertyOrEnvVar(systemPropertyName, (String) null);
   }
 
-  public static Boolean getSystemPropertyOrEnvVar(String systemPropertyName, Boolean defaultValue) {
+  public static boolean getSystemPropertyOrEnvVar(String systemPropertyName, Boolean defaultValue) {
     String result = getSystemPropertyOrEnvVar(systemPropertyName, defaultValue.toString());
     return Boolean.parseBoolean(result);
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 import static okhttp3.TlsVersion.TLS_1_1;
 import static okhttp3.TlsVersion.TLS_1_2;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,6 +59,9 @@ public class ConfigTest {
   private static final String TEST_TOKEN_GENERATOR_FILE = Utils.filePath(ConfigTest.class.getResource("/token-generator"));
 
   private static final String TEST_KUBECONFIG_EXEC_WIN_FILE = Utils.filePath(ConfigTest.class.getResource("/test-kubeconfig-exec-win"));
+
+  private static final String TEST_KUBECONFIG_NO_CURRENT_CONTEXT_FILE = Utils.filePath(ConfigTest.class.getResource("/test-kubeconfig-nocurrentctxt.yml"));
+  
   @BeforeEach
   public void setUp() {
     System.getProperties().remove(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY);
@@ -333,6 +337,18 @@ public class ConfigTest {
   }
 
   @Test
+  public void testWithKubeConfigAndNoContext() {
+    System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_NO_CURRENT_CONTEXT_FILE);
+    Config config = new Config();
+    assertNotNull(config);
+
+    assertNull(config.getCurrentContext());
+    assertEquals(3, config.getContexts().size());
+    assertEquals(Config.DEFAULT_MASTER_URL + "/", config.getMasterUrl());
+    assertNull(config.getNamespace());
+  }
+
+  @Test
   public void testWithNamespacePathAndSytemPropertiesAndBuilder() {
     System.setProperty(Config.KUBERNETES_NAMESPACE_FILE, TEST_NAMESPACE_FILE);
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
@@ -346,7 +362,6 @@ public class ConfigTest {
     assertEquals("http://somehost:80/", config.getMasterUrl());
     assertEquals("testns2", config.getNamespace());
   }
-
 
   @Test
   public void testWithCustomHeader() {

--- a/kubernetes-client/src/test/resources/test-kubeconfig-nocurrentctxt.yml
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-nocurrentctxt.yml
@@ -1,0 +1,43 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: testns/ca.pem
+    insecure-skip-tls-verify: true
+    server: https://172.28.128.4:8443
+  name: 172-28-128-4:8443
+contexts:
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: testns
+    user: user/172-28-128-4:8443
+  name: testns/172-28-128-4:8443/user
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: production
+    user: root/172-28-128-4:8443
+  name: production/172-28-128-4:8443/root
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: production
+    user: mmosley
+  name: production/172-28-128-4:8443/mmosley
+kind: Config
+preferences: {}
+users:
+- name: user/172-28-128-4:8443
+  user:
+    token: token
+- name: root/172-28-128-4:8443
+  user:
+    token: supertoken
+- name: mmosley
+  user:
+    auth-provider:
+      config:
+        client-id: kubernetes
+        client-secret: 1db158f6-177d-4d9c-8a8b-d36869918ec5
+        id-token: eyJraWQiOiJDTj1vaWRjaWRwLnRyZW1vbG8ubGFuLCBPVT1EZW1vLCBPPVRybWVvbG8gU2VjdXJpdHksIEw9QXJsaW5ndG9uLCBTVD1WaXJnaW5pYSwgQz1VUy1DTj1rdWJlLWNhLTEyMDIxNDc5MjEwMzYwNzMyMTUyIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL29pZGNpZHAudHJlbW9sby5sYW46ODQ0My9hdXRoL2lkcC9PaWRjSWRQIiwiYXVkIjoia3ViZXJuZXRlcyIsImV4cCI6MTQ4MzU0OTUxMSwianRpIjoiMm96US15TXdFcHV4WDlHZUhQdy1hZyIsImlhdCI6MTQ4MzU0OTQ1MSwibmJmIjoxNDgzNTQ5MzMxLCJzdWIiOiI0YWViMzdiYS1iNjQ1LTQ4ZmQtYWIzMC0xYTAxZWU0MWUyMTgifQ.w6p4J_6qQ1HzTG9nrEOrubxIMb9K5hzcMPxc9IxPx2K4xO9l-oFiUw93daH3m5pluP6K7eOE6txBuRVfEcpJSwlelsOsW8gb8VJcnzMS9EnZpeA0tW_p-mnkFc3VcfyXuhe5R3G7aa5d8uHv70yJ9Y3-UhjiN9EhpMdfPAoEB9fYKKkJRzF7utTTIPGrSaSU6d2pcpfYKaxIwePzEkT4DfcQthoZdy9ucNvvLoi1DIC-UocFD8HLs8LYKEqSxQvOcvnThbObJ9af71EwmuE21fO5KzMW20KtAeget1gnldOosPtz1G5EwvaQ401-RPQzPGMVBld0_zMCAwZttJ4knw
+        idp-certificate-authority: /root/ca.pem
+        idp-issuer-url: https://oidcidp.tremolo.lan:8443/auth/idp/OidcIdP
+        refresh-token: q1bKLFOyUiosTfawzA93TzZIDzH2TNa2SMm0zEiPKTUwME6BkEo6Sql5yUWVBSWpKUGphaWpxSVAfekBOZbBhaEW+VlFUeVRGcluyVF5JT4+haZmPsluFoFu5XkpXk5BXq
+      name: oidc


### PR DESCRIPTION
This PR changes `io.fabric8.kubernetes.client.Configuration` so that it stores all contexts that exist in the kubeconfig, does the same with the current context and exposes them via getters.

fixes #2215 
