### PR TITLE
Added a manualTypeMapping parameter for providing manual type mappings

### DIFF
--- a/kubernetes-model-generator/go.mod
+++ b/kubernetes-model-generator/go.mod
@@ -1,4 +1,4 @@
-module github.com/fabric8io/kubernetes-client/kubernetes-model
+module github.com/fabric8io/kubernetes-client/kubernetes-model-generator
 
 go 1.14
 

--- a/kubernetes-model-generator/go.sum
+++ b/kubernetes-model-generator/go.sum
@@ -120,6 +120,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fabric8io/kubernetes-client v1.4.35 h1:uxi2o/28eo/SMD6+6g0dwNj3oAIrocrgac/6wGQzt+Q=
+github.com/fabric8io/kubernetes-client v4.10.2+incompatible h1:4qE4aOrv3GBCRo9wQf4VwKkIEznVq7l+4HHesCEGIUk=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/cmd/generate/generate.go
@@ -37,7 +37,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -87,11 +87,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/api/admission/v1beta1", "admission.k8s.io", "io.fabric8.kubernetes.api.model.admission", "kubernetes_admission_"},
     {"k8s.io/api/admissionregistration/v1beta1", "admissionregistration.k8s.io", "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1", "kubernetes_admissionregistration_v1beta1_"},
@@ -108,7 +103,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "admissionregistration")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{}, "admissionregistration")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/main/resources/schema/validation-schema.json
@@ -3265,15 +3265,14 @@
         "admissionReviewVersions": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string",
             "description": ""
           }
         },
         "clientConfig": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_WebhookClientConfig",
-          "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.WebhookClientConfig"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1_WebhookClientConfig",
+          "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.WebhookClientConfig"
         },
         "failurePolicy": {
           "type": "string",
@@ -3304,8 +3303,8 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_RuleWithOperations",
-            "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.RuleWithOperations"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_RuleWithOperations",
+            "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.RuleWithOperations"
           }
         },
         "sideEffects": {
@@ -4262,15 +4261,14 @@
         "admissionReviewVersions": {
           "type": "array",
           "description": "",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string",
             "description": ""
           }
         },
         "clientConfig": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_WebhookClientConfig",
-          "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.WebhookClientConfig"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1_WebhookClientConfig",
+          "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.WebhookClientConfig"
         },
         "failurePolicy": {
           "type": "string",
@@ -4297,8 +4295,8 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_RuleWithOperations",
-            "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.RuleWithOperations"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_RuleWithOperations",
+            "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.RuleWithOperations"
           }
         },
         "sideEffects": {
@@ -4347,15 +4345,15 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "admissionregistration.k8s.io/v1beta1",
+          "default": "admissionregistration.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ValidatingWebhookConfiguration",
-            "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingWebhookConfiguration"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_ValidatingWebhookConfiguration",
+            "javaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration"
           }
         },
         "kind": {

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/kube-schema.json
@@ -455,7 +455,7 @@
         }
       },
       "additionalProperties": true,
-      "javaType": "io.fabric8.kubernetes.api.model.apiextensions.JSON",
+      "javaType": "com.fasterxml.jackson.databind.JsonNode",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -499,6 +499,7 @@
           }
         },
         "default": {
+          "$ref": "#/definitions/kubernetes_apiextensions_JSON",
           "javaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "definitions": {
@@ -528,10 +529,12 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
+            "$ref": "#/definitions/kubernetes_apiextensions_JSON",
             "javaType": "com.fasterxml.jackson.databind.JsonNode"
           }
         },
         "example": {
+          "$ref": "#/definitions/kubernetes_apiextensions_JSON",
           "javaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "exclusiveMaximum": {
@@ -1770,7 +1773,7 @@
       "$ref": "#/definitions/kubernetes_apimachinery_pkg_version_Info",
       "javaType": "io.fabric8.kubernetes.api.model.version.Info"
     },
-    "JSONSchemaPropsorStringArray": {
+    "JSONSchemaPropsOrStringArray": {
       "$ref": "#/definitions/kubernetes_apiextensions_JSONSchemaPropsOrStringArray",
       "javaType": "io.fabric8.kubernetes.api.model.apiextensions.JSONSchemaPropsOrStringArray"
     },

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/validation-schema.json
@@ -455,7 +455,7 @@
         }
       },
       "additionalProperties": true,
-      "javaType": "io.fabric8.kubernetes.api.model.apiextensions.JSON",
+      "javaType": "com.fasterxml.jackson.databind.JsonNode",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -499,6 +499,7 @@
           }
         },
         "default": {
+          "$ref": "#/definitions/kubernetes_apiextensions_JSON",
           "javaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "definitions": {
@@ -528,10 +529,12 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
+            "$ref": "#/definitions/kubernetes_apiextensions_JSON",
             "javaType": "com.fasterxml.jackson.databind.JsonNode"
           }
         },
         "example": {
+          "$ref": "#/definitions/kubernetes_apiextensions_JSON",
           "javaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "exclusiveMaximum": {
@@ -1770,7 +1773,7 @@
       "$ref": "#/definitions/kubernetes_apimachinery_pkg_version_Info",
       "javaType": "io.fabric8.kubernetes.api.model.version.Info"
     },
-    "JSONSchemaPropsorStringArray": {
+    "JSONSchemaPropsOrStringArray": {
       "$ref": "#/definitions/kubernetes_apiextensions_JSONSchemaPropsOrStringArray",
       "javaType": "io.fabric8.kubernetes.api.model.apiextensions.JSONSchemaPropsOrStringArray"
     },
@@ -2430,6 +2433,7 @@
           }
         },
         "default": {
+          "$ref": "#/definitions/kubernetes_apiextensions_JSON",
           "javaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "definitions": {
@@ -2459,10 +2463,12 @@
           "description": "",
           "javaOmitEmpty": true,
           "items": {
+            "$ref": "#/definitions/kubernetes_apiextensions_JSON",
             "javaType": "com.fasterxml.jackson.databind.JsonNode"
           }
         },
         "example": {
+          "$ref": "#/definitions/kubernetes_apiextensions_JSON",
           "javaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "exclusiveMaximum": {

--- a/kubernetes-model-generator/kubernetes-model-apps/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-apps/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -99,11 +99,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -122,7 +117,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "apps")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"apps")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/cmd/generate/generate.go
@@ -35,7 +35,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -67,11 +67,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -87,7 +82,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "autoscaling")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"autoscaling")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
@@ -2613,15 +2613,15 @@
         "apiVersion": {
           "type": "string",
           "description": "",
-          "default": "autoscaling/v2beta1",
+          "default": "autoscaling/v2beta2",
           "required": true
         },
         "items": {
           "type": "array",
           "description": "",
           "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_HorizontalPodAutoscaler",
-            "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscaler"
+            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscaler",
+            "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscaler"
           }
         },
         "kind": {
@@ -2643,43 +2643,26 @@
           "type": "integer",
           "description": ""
         },
-        "metrics": {
-          "type": "array",
-          "description": "",
-          "javaOmitEmpty": true,
-          "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_MetricSpec",
-            "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.MetricSpec"
-          }
-        },
         "minReplicas": {
           "type": "integer",
           "description": ""
         },
         "scaleTargetRef": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_CrossVersionObjectReference",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.CrossVersionObjectReference"
+          "$ref": "#/definitions/kubernetes_autoscaling_v1_CrossVersionObjectReference",
+          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.CrossVersionObjectReference"
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer",
+          "description": ""
         }
       },
       "additionalProperties": true
     },
     "horizontalpodautoscalerstatus": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_HorizontalPodAutoscalerCondition",
-            "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscalerCondition"
-          }
-        },
-        "currentMetrics": {
-          "type": "array",
-          "description": "",
-          "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_MetricStatus",
-            "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.MetricStatus"
-          }
+        "currentCPUUtilizationPercentage": {
+          "type": "integer",
+          "description": ""
         },
         "currentReplicas": {
           "type": "integer",
@@ -2976,20 +2959,20 @@
     "metricspec": {
       "properties": {
         "external": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ExternalMetricSource",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ExternalMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ExternalMetricSource",
+          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ExternalMetricSource"
         },
         "object": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ObjectMetricSource",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ObjectMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ObjectMetricSource",
+          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ObjectMetricSource"
         },
         "pods": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_PodsMetricSource",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.PodsMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_PodsMetricSource",
+          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.PodsMetricSource"
         },
         "resource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ResourceMetricSource",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ResourceMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ResourceMetricSource",
+          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ResourceMetricSource"
         },
         "type": {
           "type": "string",
@@ -3161,17 +3144,25 @@
     },
     "objectmetricsource": {
       "properties": {
-        "describedObject": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_CrossVersionObjectReference",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.CrossVersionObjectReference"
+        "averageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "javaType": "io.fabric8.kubernetes.api.model.Quantity"
         },
-        "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
+        "metricName": {
+          "type": "string",
+          "description": ""
+        },
+        "selector": {
+          "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
+          "javaType": "io.fabric8.kubernetes.api.model.LabelSelector"
         },
         "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_CrossVersionObjectReference",
+          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.CrossVersionObjectReference"
+        },
+        "targetValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "javaType": "io.fabric8.kubernetes.api.model.Quantity"
         }
       },
       "additionalProperties": true
@@ -3341,9 +3332,13 @@
     },
     "resourcemetricstatus": {
       "properties": {
-        "current": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricValueStatus",
-          "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricValueStatus"
+        "currentAverageUtilization": {
+          "type": "integer",
+          "description": ""
+        },
+        "currentAverageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "javaType": "io.fabric8.kubernetes.api.model.Quantity"
         },
         "name": {
           "type": "string",

--- a/kubernetes-model-generator/kubernetes-model-batch/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-batch/cmd/generate/generate.go
@@ -35,7 +35,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -66,11 +66,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -85,7 +80,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "batch")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"batch")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-certificates/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-certificates/cmd/generate/generate.go
@@ -33,7 +33,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -63,11 +63,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -80,7 +75,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "certificates")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"certificates")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-coordination/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-coordination/cmd/generate/generate.go
@@ -33,7 +33,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -60,11 +60,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -77,7 +72,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "coordination")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"coordination")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-core/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-core/cmd/generate/generate.go
@@ -32,7 +32,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -97,11 +97,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/api/resource", "", "io.fabric8.kubernetes.api.model", "kubernetes_resource_"},
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
@@ -121,7 +116,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "core")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"core")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-discovery/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-discovery/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -63,11 +63,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -81,7 +76,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "discovery")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"discovery")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-events/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-events/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -64,11 +64,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -82,7 +77,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "events")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{}, "events")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-extensions/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-extensions/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -71,11 +71,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -89,7 +84,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "extensions")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"extensions")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-metrics/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-metrics/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -64,11 +64,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -84,7 +79,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "metrics")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"metrics")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-networking/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-networking/cmd/generate/generate.go
@@ -35,7 +35,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -65,11 +65,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -84,7 +79,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "networking")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"networking")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-policy/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-policy/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -66,11 +66,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -84,7 +79,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "policy")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"policy")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-rbac/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-rbac/cmd/generate/generate.go
@@ -33,7 +33,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -67,11 +67,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -84,7 +79,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "rbac")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"rbac")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-scheduling/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -62,11 +62,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -80,7 +75,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "scheduling")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"scheduling")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-settings/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-settings/cmd/generate/generate.go
@@ -34,7 +34,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -63,11 +63,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -81,7 +76,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "settings")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"settings")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/kubernetes-model-storageclass/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/cmd/generate/generate.go
@@ -35,7 +35,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -69,11 +69,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/apimachinery/pkg/util/intstr", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_pkg_util_intstr_"},
     {"k8s.io/apimachinery/pkg/runtime", "", "io.fabric8.kubernetes.api.model.runtime", "kubernetes_apimachinery_pkg_runtime_"},
@@ -88,7 +83,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "storage")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"storage")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return

--- a/kubernetes-model-generator/openshift-model/cmd/generate/generate.go
+++ b/kubernetes-model-generator/openshift-model/cmd/generate/generate.go
@@ -44,7 +44,7 @@ import (
 
   "os"
 
-  "github.com/fabric8io/kubernetes-client/kubernetes-model/pkg/schemagen"
+  "github.com/fabric8io/kubernetes-client/kubernetes-model-generator/pkg/schemagen"
 )
 
 type Schema struct {
@@ -124,11 +124,6 @@ type Schema struct {
 }
 
 func main() {
-  customTypeNames := map[string]string{
-    "K8sSubjectAccessReview": "SubjectAccessReview",
-    "K8sLocalSubjectAccessReview":  "LocalSubjectAccessReview",
-    "JSONSchemaPropsorStringArray": "JSONSchemaPropsOrStringArray",
-  }
   packages := []schemagen.PackageDescriptor{
     {"k8s.io/api/core/v1", "", "io.fabric8.kubernetes.api.model", "kubernetes_core_"},
     {"k8s.io/apimachinery/pkg/api/resource", "", "io.fabric8.kubernetes.api.model", "kubernetes_resource_"},
@@ -161,7 +156,7 @@ func main() {
     reflect.TypeOf(time.Time{}): reflect.TypeOf(""),
     reflect.TypeOf(struct{}{}):  reflect.TypeOf(""),
   }
-  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, customTypeNames, "openshift")
+  schema, err := schemagen.GenerateSchema(reflect.TypeOf(Schema{}), packages, typeMap, map[reflect.Type]string{},"openshift")
   if err != nil {
     fmt.Fprintf(os.Stderr, "An error occurred: %v", err)
     return


### PR DESCRIPTION
This PR modifies `kubernetes-model-generator` to accommodate manual type mapping. This was discussed in https://github.com/fabric8io/kubernetes-client/pull/2288 . With this in place we should be able to provide a HashMap in which we can configure which go structs should be mapped to some already existing java types