### PR TITLE
Improve error handling on stream closing errors in S2I binary build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix #2278: Added type parameters for KubernetesList in KubernetesClient + test verifying waitUntilCondition **always** retrieves resource from server
 * Fix #2320: Added JUnit5 extension for mocking KubernetesClient in tests using @EnableKubernetesMockClient
 * Fix #2332: Added PodExecOptions model
+* Improve error handling on stream closing errors in S2I binary builds(#2032)
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ListOptions;
@@ -37,9 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -16,11 +16,13 @@
 
 package io.fabric8.kubernetes.client.utils;
 
+import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,6 +30,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 public class KubernetesResourceUtil {
+  private KubernetesResourceUtil() {}
 
   public static final Pattern KUBERNETES_DNS1123_LABEL_REGEX = Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?");
 
@@ -232,7 +235,7 @@ public class KubernetesResourceUtil {
         return labels;
       }
     }
-    return Collections.EMPTY_MAP;
+    return Collections.emptyMap();
   }
 
   /**
@@ -298,5 +301,16 @@ public class KubernetesResourceUtil {
       }
     }
     return null;
+  }
+
+  public static void sortEventListBasedOnTimestamp(List<Event> eventList) {
+    if (eventList != null) {
+      // Sort to get latest events in begining
+      eventList.sort((o1, o2) -> {
+          Instant d1 = Instant.parse(o1.getLastTimestamp());
+          Instant d2 = Instant.parse(o2.getLastTimestamp());
+          return (int) (d2.getEpochSecond() - d1.getEpochSecond());
+      });
+    }
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
@@ -18,11 +18,15 @@ package io.fabric8.kubernetes.client.internal;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -81,5 +85,31 @@ public class KubernetesResourceUtilTest {
 
     assertTrue(KubernetesResourceUtil.isValidName(KubernetesResourceUtil.sanitizeName("test.invalid.name")));
     assertTrue(KubernetesResourceUtil.isValidName(KubernetesResourceUtil.sanitizeName("90notcool-n@me")));
+  }
+
+  @Test
+  void testSortEventListBasedOnTimestamp() {
+    // Given
+    List<Event> eventList = new ArrayList<>();
+    eventList.add(new EventBuilder()
+      .withNewMetadata().withName("event2").endMetadata()
+      .withLastTimestamp("2020-06-12T06:45:16Z")
+      .build());
+    eventList.add(new EventBuilder()
+      .withNewMetadata().withName("event1").endMetadata()
+      .withLastTimestamp("2020-06-10T06:45:16Z")
+      .build());
+    eventList.add(new EventBuilder()
+      .withNewMetadata().withName("event3").endMetadata()
+      .withLastTimestamp("2020-06-13T06:45:16Z")
+      .build());
+
+    // When
+    KubernetesResourceUtil.sortEventListBasedOnTimestamp(eventList);
+
+    // Then
+    assertEquals("event3", eventList.get(0).getMetadata().getName());
+    assertEquals("event2", eventList.get(1).getMetadata().getName());
+    assertEquals("event1", eventList.get(2).getMetadata().getName());
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
@@ -143,7 +143,7 @@ public class BuildConfigTest {
     File warFile = new File("target/test.war");
     warFile.createNewFile();
 
-    server.expect().post().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?commit=&asFile=" + warFile.getName())
+    server.expect().post().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?name=bc2&namespace=ns1&asFile=" + warFile.getName())
       .andReturn(201, new BuildBuilder()
       .withNewMetadata().withName("bc2").endMetadata().build()).once();
 
@@ -155,6 +155,8 @@ public class BuildConfigTest {
       .instantiateBinary()
       .asFile(warFile.getName())
       .fromFile(warFile);
+    assertNotNull(build);
+    assertEquals("bc2", build.getMetadata().getName());
   }
 
   // TODO Add delay to mockwebserver. Disabled as too dependent on timing issues right now.

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -102,7 +102,13 @@
      <artifactId>junit-jupiter-migrationsupport</artifactId>
      <scope>test</scope>
    </dependency>
-  </dependencies>
+
+   <dependency>
+     <groupId>org.mockito</groupId>
+     <artifactId>mockito-core</artifactId>
+     <scope>test</scope>
+   </dependency>
+ </dependencies>
 
   <build>
     <plugins>

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationsImpl.java
@@ -15,14 +15,18 @@
  */
 package io.fabric8.openshift.client.dsl.internal;
 
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Triggerable;
 import io.fabric8.kubernetes.client.dsl.Typeable;
 import io.fabric8.kubernetes.client.dsl.Watchable;
-import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.dsl.internal.core.v1.EventOperationsImpl;
+import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.api.model.Build;
@@ -50,14 +54,17 @@ import okhttp3.RequestBody;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.fabric8.openshift.client.OpenShiftAPIGroups.BUILD;
@@ -66,6 +73,7 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
   BuildConfigResource<BuildConfig, DoneableBuildConfig, Void, Build>>
         implements BuildConfigOperation {
 
+  private static final Logger logger = LoggerFactory.getLogger(BuildConfigOperationsImpl.class);
   public static final String BUILD_CONFIG_LABEL = "openshift.io/build-config.name";
   public static final String BUILD_CONFIG_ANNOTATION = "openshift.io/build-config.name";
 
@@ -122,7 +130,7 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
     try {
       updateApiVersion(request);
       URL instantiationUrl = new URL(URLUtils.join(getResourceUrl().toString(), "instantiate"));
-      RequestBody requestBody = RequestBody.create(JSON, BaseOperation.JSON_MAPPER.writer().writeValueAsString(request));
+      RequestBody requestBody = RequestBody.create(JSON, OperationSupport.JSON_MAPPER.writer().writeValueAsString(request));
       Request.Builder requestBuilder = new Request.Builder().post(requestBody).url(instantiationUrl);
       return handleResponse(requestBuilder, Build.class);
     } catch (Exception e) {
@@ -141,7 +149,7 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
     try {
       //TODO: This needs some attention.
       String triggerUrl = URLUtils.join(getResourceUrl().toString(), "webhooks", secret, triggerType);
-      RequestBody requestBody = RequestBody.create(JSON, BaseOperation.JSON_MAPPER.writer().writeValueAsBytes(trigger));
+      RequestBody requestBody = RequestBody.create(JSON, OperationSupport.JSON_MAPPER.writer().writeValueAsBytes(trigger));
       Request.Builder requestBuilder = new Request.Builder()
         .post(requestBody)
         .url(triggerUrl)
@@ -205,62 +213,30 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
     try (InputStream is = new FileInputStream(file)) {
       // Use a length to prevent chunked encoding with OkHttp, which in turn
       // doesn't work with 'Expect: 100-continue' negotiation with the OpenShift API server
+      logger.debug("Uploading archive file \"{}\" as binary input for the build ...", file.getAbsolutePath());
       return fromInputStream(is, file.length());
-    } catch (Throwable t) {
-      throw KubernetesClientException.launderThrowable(t);
+    } catch (IOException e) {
+      throw KubernetesClientException.launderThrowable(e);
     }
   }
 
   private Build fromInputStream(final InputStream inputStream, final long contentLength) {
-    try {
-
-      RequestBody requestBody = new RequestBody() {
-        @Override
-        public MediaType contentType() {
-          return MediaType.parse("application/octet-stream");
-        }
-
-        @Override
-        public long contentLength() throws IOException {
-          return contentLength;
-        }
-
-        @Override
-        public void writeTo(BufferedSink sink) throws IOException {
-          Source source = null;
-          try {
-            source = Okio.source(inputStream);
-            OutputStream os = sink.outputStream();
-
-            sink.writeAll(source);
-          } catch (IOException e) {
-            throw KubernetesClientException.launderThrowable("Can't instantiate binary build, due to error reading/writing stream. "
-                                                             + "Can be caused if the output stream was closed by the server.", e);
-          }
-        }
-      };
-
-      OkHttpClient newClient = client.newBuilder()
-                                     .readTimeout(timeout, timeoutUnit)
-                                     .writeTimeout(timeout, timeoutUnit)
-                                     .build();
-      Request.Builder requestBuilder =
-          new Request.Builder().post(requestBody)
-                               .header("Expect", "100-continue")
-                               .url(getQueryParameters());
-      return handleResponse(newClient, requestBuilder, Build.class);
-    } catch (Exception e) {
-      throw KubernetesClientException.launderThrowable(e);
-    }
+    return submitToApiServerWithRequestBody(new ArchiveFileInputStreamRequestBody(client, config, inputStream, contentLength, name, namespace));
   }
 
   private String getQueryParameters() throws MalformedURLException {
     StringBuilder sb = new StringBuilder();
     sb.append(URLUtils.join(getResourceUrl().toString(), "instantiatebinary"));
-    if (Utils.isNullOrEmpty(message)) {
-      sb.append("?commit=");
-    } else {
-      sb.append("?commit=").append(message);
+    if (Utils.isNotNullOrEmpty(name)) {
+      sb.append("?name=").append(name);
+    }
+
+    if (Utils.isNotNullOrEmpty(namespace)) {
+      sb.append("&namespace=").append(namespace);
+    }
+
+    if (Utils.isNotNullOrEmpty(message)) {
+      sb.append("&commit=").append(message);
     }
 
     if (!Utils.isNullOrEmpty(authorName)) {
@@ -334,4 +310,79 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
     return new BuildConfigOperationsImpl(getContext().withSecret(secret));
   }
 
+  protected Build submitToApiServerWithRequestBody(RequestBody requestBody) {
+    try {
+      OkHttpClient newClient = client.newBuilder()
+        .readTimeout(timeout, timeoutUnit)
+        .writeTimeout(timeout, timeoutUnit)
+        .build();
+      Request.Builder requestBuilder =
+        new Request.Builder().post(requestBody)
+          .header("Expect", "100-continue")
+          .url(getQueryParameters());
+      return handleResponse(newClient, requestBuilder, Build.class);
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  public static class ArchiveFileInputStreamRequestBody extends RequestBody {
+    private long contentLength;
+    private InputStream inputStream;
+    private OkHttpClient okHttpClient;
+    private Config clientConfig;
+    private String name;
+    private String namespace;
+    public ArchiveFileInputStreamRequestBody(OkHttpClient client, Config config, InputStream inputStream, long contentLength, String name, String namespace) {
+      this.contentLength = contentLength;
+      this.inputStream = inputStream;
+      this.okHttpClient = client;
+      this.clientConfig = config;
+      this.name = name;
+      this.namespace = namespace;
+    }
+
+    @Override
+    public MediaType contentType() {
+      return MediaType.parse("application/octet-stream");
+    }
+
+    @Override
+    public long contentLength() throws IOException {
+      return contentLength;
+    }
+
+    @Override
+    public void writeTo(BufferedSink sink) throws IOException {
+      try {
+        writeToSink(sink);
+      } catch (IOException e) {
+        logger.error("Failed to upload archive file for the build: {}", name);
+        logger.error("Please check cluster events via `oc get events` to see what could have possibly gone wrong");
+        throw KubernetesClientException.launderThrowable("Can't instantiate binary build, due to error reading/writing stream. "
+          + "Can be caused if the output stream was closed by the server." +
+          "See if something's wrong in recent events in Cluster = " + getRecentEvents(), e);
+      }
+    }
+
+    public void writeToSink(BufferedSink sink) throws IOException {
+      try (final BufferedInputStream bis = new BufferedInputStream(inputStream);
+           final Source source = Okio.source(bis)) {
+        sink.writeAll(source);
+      }
+    }
+
+    protected String getRecentEvents() {
+      StringBuilder eventsAsStrBuilder = new StringBuilder();
+      List<Event> recentEventList = new EventOperationsImpl(okHttpClient, clientConfig).inNamespace(namespace).list().getItems();
+      KubernetesResourceUtil.sortEventListBasedOnTimestamp(recentEventList);
+      for (int i = 0; i < 10 && i < recentEventList.size(); i++) {
+        Event event = recentEventList.get(i);
+        eventsAsStrBuilder.append(event.getReason()).append(" ")
+          .append(event.getMetadata().getName()).append(" ")
+          .append(event.getMessage()).append("\n");
+      }
+      return eventsAsStrBuilder.toString();
+    }
+  }
 }

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/ArchiveFileInputStreamRequestBodyTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/ArchiveFileInputStreamRequestBodyTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.dsl.internal;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.client.OpenShiftConfig;
+import io.fabric8.openshift.client.OpenShiftConfigBuilder;
+import okhttp3.OkHttpClient;
+import okio.BufferedSink;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class ArchiveFileInputStreamRequestBodyTest {
+  @Mock
+  OkHttpClient okHttpClient;
+
+  @Mock
+  OpenShiftConfig config;
+
+  @Mock
+  BufferedSink bufferedSink;
+
+  @BeforeEach
+  public void setUp() {
+    this.okHttpClient = Mockito.mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    this.config = new OpenShiftConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    this.bufferedSink = Mockito.mock(BufferedSink.class, Mockito.RETURNS_DEEP_STUBS);
+  }
+
+  @Test
+  void testWriteToThrowsExceptionShouldAddEvents() throws IOException {
+    // Given
+    File tempFile = File.createTempFile("test-", ".war");
+    String eventMessage = "FailedScheduling demo-1-7zkjd.1619493da51f6b6f some error";
+    BuildConfigOperationsImpl.ArchiveFileInputStreamRequestBody body = new BuildConfigOperationsImpl.ArchiveFileInputStreamRequestBody(okHttpClient, config, new FileInputStream(tempFile), 50L, "test-bc", "ns1");
+    body = spy(body);
+    doThrow(IOException.class).when(body).writeToSink(any());
+    doReturn(eventMessage).when(body).getRecentEvents();
+    doCallRealMethod().when(body).writeTo(any());
+
+    // When
+    BuildConfigOperationsImpl.ArchiveFileInputStreamRequestBody finalBody = body;
+    KubernetesClientException exception = assertThrows(KubernetesClientException.class,
+      () -> finalBody.writeTo(bufferedSink));
+
+    // Then
+    assertTrue(exception.getMessage().contains(eventMessage));
+  }
+
+  @Test
+  void testWriteToShouldCompleteSuccessfully() throws IOException {
+    // Given
+    BuildConfigOperationsImpl.ArchiveFileInputStreamRequestBody body = mock(BuildConfigOperationsImpl.ArchiveFileInputStreamRequestBody.class, Mockito.RETURNS_DEEP_STUBS);
+    doNothing().when(body).writeToSink(any());
+
+    // When
+    body.writeTo(bufferedSink);
+
+    // Then
+    verify(body, times(0)).getRecentEvents();
+  }
+}


### PR DESCRIPTION
Relates to #2032

+ Add BuildConfig's name and namespace in query parameters in order to align with `oc`
+ Use BufferedInputStream while uploading the archive file to the sink.
+ Add recent events to exception message and some logging in case of upload failure of archive file