### PR TITLE
Chore: Add Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Description
+<!--
+Thank a lot for taking time to contribute to Fabric8 <3!
+
+Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
+really helpful for people who would review your code.
+-->
+
+## Type of change
+<!---
+What types of changes does your code introduce? Put an `x` in all the boxes that apply
+-->
+ - [ ] Bug fix (non-breaking change which fixes an issue)
+ - [ ] Feature (non-breaking change which adds functionality)
+ - [ ] Breaking change (fix or feature that would cause existing functionality to change
+ - [ ] Chore (non-breaking change which doesn't affect codebase;
+   test, version modification, documentation, etc.)
+
+## Checklist
+ - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+ - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
+ - [ ] I have implemented unit tests to cover my changes
+ - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
+ - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
+ - [ ] I tested my code in Kubernetes
+ - [ ] I tested my code in OpenShift
+
+<!--
+Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
+Please check integration tests and provide/improve tests if applicable.
+
+Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
+-->


### PR DESCRIPTION
Recently @manusa added a pull request template in [Eclipse JKube](https://github.com/eclipse/jkube/blob/master/.github/pull_request_template.md). I think it would also be very useful for Fabric8 Kubernetes Client as we get lots of contributions outside of our organization
