### PR TITLE
Fix #2328: Using Watcher<Event> leads to "JsonMappingException: No resource type found for:v1#Event"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix Raw CustomResource API path generation to not having trailing slash
 * Fix #2131: Failing to parse CustomResourceDefinition with OpenAPIV3Schema using JSONSchemaPropOr\* fields
 * Fix #2297: Resuscitate ProjectRequestHandler in openshift-client
+* Fix #2328: Failure in deserialization while watching events
 * Fix KubernetesAttributesExctractor to extract metadata from unregistered custom resources, such when using Raw CustomResource API 
 * Fix #2296: No adapter available for type:interface io.fabric8.kubernetes.client.dsl.V1APIGroupDSL
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -264,10 +264,11 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
           String apiVersion = Helper.getAnnotationValue(clazz, ApiVersion.class);
           if (apiGroup != null && !apiGroup.isEmpty() && apiVersion != null && !apiVersion.isEmpty()) {
             return createKey(apiGroup + "/" + apiVersion, clazz.getSimpleName());
+          } else if (apiVersion != null && !apiVersion.isEmpty()) {
+            return createKey(apiVersion, clazz.getSimpleName());
           }
           return clazz.getSimpleName();
         }
-
 
         private Class<? extends KubernetesResource> loadClassIfExists(String className) {
             try {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.EventBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnableRuleMigrationSupport
+class EventTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @Test
+  @DisplayName("Should be able to watch events in specified namespace")
+  void watch() throws InterruptedException {
+    // Given
+    Event testEvent = new EventBuilder()
+      .withNewMetadata()
+      .withName("nginx-deployment-54f57cf6bf-84ssh.161e26b7b76b629e")
+      .withNamespace("ns1")
+      .endMetadata()
+      .build();
+
+    server.expect()
+      .withPath("/api/v1/namespaces/ns1/events?watch=true")
+      .andUpgradeToWebSocket().open().waitFor(50)
+      .andEmit(new WatchEvent(testEvent, "ADDED"))
+      .done().once();
+    KubernetesClient client = server.getClient();
+    final CountDownLatch eventReceivedLatch = new CountDownLatch(1);
+
+    // When
+    Watch watch = client.v1().events().inNamespace("ns1").watch(new Watcher<Event>() {
+      @Override
+      public void eventReceived(Action action, Event resource) {
+        eventReceivedLatch.countDown();
+      }
+
+      @Override
+      public void onClose(KubernetesClientException cause) {
+
+      }
+    });
+
+    // Then
+    assertTrue(eventReceivedLatch.await(1, TimeUnit.SECONDS));
+    watch.close();
+  }
+}


### PR DESCRIPTION
Fix #2328 

KubernetesDeserializer was missing the case when Kubernetes resource only had apiVersion and
no apiGroup when resolving Kubernetes resources with the same names.