### PR TITLE
Test and fix for the wrong "Kind" declared on KubernetesListHandler

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
@@ -16,7 +16,6 @@
 
 package io.fabric8.kubernetes.client;
 
-
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesListHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesListHandler.java
@@ -44,9 +44,11 @@ public class KubernetesListHandler implements ResourceHandler<KubernetesList, Ku
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesListHandler.class);
 
+  private static final String KIND = new KubernetesList().getKind();
+  
   @Override
   public String getKind() {
-    return Service.class.getSimpleName();
+    return KIND;
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR changes `KubernetesListHandler.getKind()` from returning `"Service"` to returning `"List"`.  The latter is what `KubernetesList.getKind()` returns, and the former causes the resulting `ResourceHandler.Key` to be identical to what is computed for `ServiceHandler`, meaning `Handlers.of(key)` can return the wrong handler.

In practice the problem noted above can cause the Kubernetes client to fail when working with `kind: Service` YAML manifests, in some circumstances.  This was observed under OSGi using the `DefaultKubernetesClient`.  `Handlers.of(<Service,v1>)` returned the `KubernetesListHandler` which subsequently threw the following exception:

```
Failed after 466ms: io.fabric8.kubernetes.api.model.Service cannot be cast to io.fabric8.kubernetes.api.model.KubernetesList
java.lang.ClassCastException: io.fabric8.kubernetes.api.model.Service cannot be cast to io.fabric8.kubernetes.api.model.KubernetesList
	at io.fabric8.kubernetes.client.handlers.KubernetesListHandler.edit(KubernetesListHandler.java:39)
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.acceptVisitors(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:331)
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.createOrReplace(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:248)
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.createOrReplace(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:64)
	at ...
```

The problem is not usually observed because `KubernetesListHandler` is not registered as a service in POJO, but it is under OSGi, and of course because `Handlers` keeps a map based on the key, whether the problem actually happens depends which of the two handlers was registered last.

This PR also includes a test which asserts there are no conflicts among the stock handlers, which fails prior to the fix and passes subsequently.

## Type of change

 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
