### PR TITLE
chore: bump workflow action-setup-* versions + kubernetes to 1.18.6

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,12 +35,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.18.3,v1.12.0]
+        kubernetes: [v1.18.6,v1.12.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v1.0.2
+        uses: manusa/actions-setup-minikube@v1.1.0
         with:
           minikube version: v1.9.2
           kubernetes version: ${{ matrix.kubernetes }}
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.0.3
+        uses: manusa/actions-setup-openshift@v1.0.5
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
bump workflow action-setup-* versions + kubernetes to 1.18.6

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] ~I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change~
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

