### PR TITLE
Fix #2292: Update BaseOperation#createOrReplace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #2360: bump mockito-core from 3.4.0 to 3.4.2
 * Fix #2355: bump jandex from 2.1.3.Final to 2.2.0.Final 
 * Fix #2353: chore: bump workflow action-setup versions + kubernetes to 1.18.6
+* Fix #2292: Update createOrReplace to do replace when create fails with conflict
 
 #### New Features
 * Fix #2287: Add support for V1 and V1Beta1 CustomResourceDefinition

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -17,7 +17,20 @@ package io.fabric8.kubernetes.client.dsl;
 
 public interface CreateOrReplaceable<I, T, D> {
 
+  /**
+   * Creates a provided resource in a Kubernetes Cluster. If creation
+   * fails with a HTTP_CONFLICT, it tries to replace resource.
+   *
+   * @param item item to create or replace
+   * @return created item returned in kubernetes api response
+   */
   T createOrReplace(I... item);
 
+  /**
+   * Create or replace a resource in a Kubernetes Cluster dynamically with
+   * the help of Kubernetes Model Builders.
+   *
+   * @return created item returned in kubernetes api response
+   */
   D createOrReplaceWithNew();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -17,7 +17,10 @@ package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.kubernetes.client.utils.Utils;
+
+import java.net.HttpURLConnection;
 import java.util.function.Predicate;
 
 import org.slf4j.Logger;
@@ -137,22 +140,33 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
   public HasMetadata createOrReplace() {
     HasMetadata meta = acceptVisitors(asHasMetadata(item), visitors);
     ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(meta);
-    HasMetadata r = h.reload(client, config, meta.getMetadata().getNamespace(), meta);
     String namespaceToUse = meta.getMetadata().getNamespace();
 
-    if (r == null) {
+    String resourceVersion = KubernetesResourceUtil.getResourceVersion(meta);
+    try {
+      // Create
+      KubernetesResourceUtil.setResourceVersion(meta, null);
       return h.create(client, config, namespaceToUse, meta);
-    } else if (deletingExisting) {
-      Boolean deleted = h.delete(client, config, namespaceToUse, propagationPolicy, meta);
-      if (!deleted) {
-        throw new KubernetesClientException("Failed to delete existing item:" + meta);
+    } catch (KubernetesClientException exception) {
+      if (exception.getCode() != HttpURLConnection.HTTP_CONFLICT) {
+        throw exception;
       }
-      return h.create(client, config, namespaceToUse, meta);
-    } else if (ResourceCompare.equals(r, meta)) {
-      LOGGER.debug("Item has not changed. Skipping");
-      return meta;
-    } else {
-      return h.replace(client, config, namespaceToUse, meta);
+
+      // Conflict; check deleteExisting flag otherwise replace
+      HasMetadata r = h.reload(client, config, meta.getMetadata().getNamespace(), meta);
+      if (Boolean.TRUE.equals(deletingExisting)) {
+        Boolean deleted = h.delete(client, config, namespaceToUse, propagationPolicy, meta);
+        if (Boolean.FALSE.equals(deleted)) {
+          throw new KubernetesClientException("Failed to delete existing item:" + meta);
+        }
+        return h.create(client, config, namespaceToUse, meta);
+      } else if (ResourceCompare.equals(r, meta)) {
+        LOGGER.debug("Item has not changed. Skipping");
+        return meta;
+      } else {
+        KubernetesResourceUtil.setResourceVersion(meta, resourceVersion);
+        return h.replace(client, config, namespaceToUse, meta);
+      }
     }
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -56,6 +56,21 @@ public class KubernetesResourceUtil {
   }
 
   /**
+   * Set resource version of a kubernetes resource
+   *
+   * @param entity entity provided
+   * @param resourceVersion updated resource version
+   */
+  public static void setResourceVersion(HasMetadata entity, String resourceVersion) {
+    if (entity != null) {
+      ObjectMeta metadata = entity.getMetadata();
+      if (metadata != null) {
+        metadata.setResourceVersion(resourceVersion);
+      }
+    }
+  }
+
+  /**
    * Returns the kind of the entity
    *
    * @param entity provided entity

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
@@ -20,8 +20,11 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -111,5 +114,35 @@ public class KubernetesResourceUtilTest {
     assertEquals("event3", eventList.get(0).getMetadata().getName());
     assertEquals("event2", eventList.get(1).getMetadata().getName());
     assertEquals("event1", eventList.get(2).getMetadata().getName());
+  }
+
+  @Test
+  @DisplayName("Should be able to get resource version")
+  void testGetResourceVersion() {
+    // Given
+    Pod pod = new PodBuilder()
+      .withNewMetadata().withName("test").withResourceVersion("1001").endMetadata()
+      .build();
+
+    // When
+    String resourceVersion = KubernetesResourceUtil.getResourceVersion(pod);
+
+    // Then
+    assertEquals("1001", resourceVersion);
+  }
+
+  @Test
+  @DisplayName("Should be able to update resource version")
+  void testSetResourceVersion() {
+    // Given
+    Pod pod = new PodBuilder()
+      .withNewMetadata().withName("test").withResourceVersion("1001").endMetadata()
+      .build();
+
+    // When
+    KubernetesResourceUtil.setResourceVersion(pod, "1002");
+
+    // Then
+    assertEquals("1002", pod.getMetadata().getResourceVersion());
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ResourceCompareTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ResourceCompareTest.java
@@ -17,7 +17,9 @@ package io.fabric8.kubernetes.client.utils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -52,12 +54,12 @@ public class ResourceCompareTest {
   }
 
   @Test
-  public void testResourceCompareEqualsTrue() throws Exception {
+  void testResourceCompareEqualsTrue() {
     assertThat(ResourceCompare.equals(kubeList, kubeList), is(true));
   }
 
   @Test
-  public void testResourceCompareEqualsFalse() throws Exception {
+  void testResourceCompareEqualsFalse() {
     final ReplicationController rc = new ReplicationControllerBuilder()
       .withNewMetadata().withName("repl1").withNamespace("test").endMetadata()
       .withNewSpec().withReplicas(2).endSpec()
@@ -68,20 +70,64 @@ public class ResourceCompareTest {
   }
 
   @Test
-  public void testPodResourceCompareEqualsFalseNoLabels() throws Exception {
+  void testPodResourceCompareEqualsTrueNoLabels() {
     Pod podNoLabels = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
-    assertThat(ResourceCompare.equals(pod, podNoLabels), is(false));
+    assertThat(ResourceCompare.equals(pod, podNoLabels), is(true));
   }
 
   @Test
-  public void testPodResourceCompareEqualsTrueMatchingLabels() throws Exception {
+  void testPodResourceCompareEqualsTrueMatchingLabels() {
     Pod podWithLabels = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").withLabels(Collections.singletonMap("label", "value")).and().build();
     assertThat(ResourceCompare.equals(pod, podWithLabels), is(true));
   }
 
   @Test
-  public void testPodResourceCompareEqualsFalseDifferentLabels() throws Exception {
+  void testPodResourceCompareEqualsFalseDifferentLabels() {
     Pod podWithLabels = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").withLabels(Collections.singletonMap("label", "another value")).and().build();
     assertThat(ResourceCompare.equals(pod, podWithLabels), is(false));
   }
+
+  @Test
+  void testServiceDifferenceFromClusterAndAsObject() {
+    // Given
+    Service serviceFromCluster = new ServiceBuilder()
+      .withNewMetadata()
+      .withCreationTimestamp("2020-07-27T10:36:33Z")
+      .withName("my-service")
+      .withNamespace("default")
+      .withResourceVersion("202998")
+      .withSelfLink("/api/v1/namespaces/default/services/my-service")
+      .withUid("99fe3964-b53b-473f-b1d8-bdb0390d1634")
+      .endMetadata()
+      .withNewSpec()
+      .withClusterIP("10.110.153.70")
+      .addNewPort()
+      .withPort(80)
+      .withProtocol("TCP")
+      .withTargetPort(new IntOrString("9376"))
+      .endPort()
+      .addToSelector(Collections.singletonMap("app", "MyApp"))
+      .withType("ClusterIP")
+      .endSpec()
+      .build();
+
+    Service serviceAsObj = new ServiceBuilder()
+      .withNewMetadata().withName("my-service").endMetadata()
+      .withNewSpec()
+      .addToSelector(Collections.singletonMap("app", "MyApp"))
+      .addNewPort()
+      .withPort(80)
+      .withProtocol("TCP")
+      .withTargetPort(new IntOrString("9376"))
+      .endPort()
+      .endSpec()
+      .build();
+
+    // When
+    boolean result = ResourceCompare.equals(serviceFromCluster, serviceAsObj);
+
+    // Then
+    assertTrue(result);
+  }
+
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ResourceIT.java
@@ -130,7 +130,6 @@ public class ResourceIT {
     client.resourceList(list).inNamespace(session.getNamespace()).createOrReplace();
 
     // Modify
-    service = client.services().inNamespace(session.getNamespace()).withName("my-service").get();
     service.getSpec().getPorts().get(0).setTargetPort(new IntOrString(9998));
     configMap.getData().put("test", "createOrReplace");
     configMap.getData().put("io", "fabric8");

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
+import java.net.HttpURLConnection;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -91,8 +92,9 @@ class TypedClusterScopeCustomResourceApiTest {
 
     @Test
     void createOrReplace() {
-      server.expect().get().withPath("/apis/example.crd.com/v1alpha1/stars/sun").andReturn(200, getStar()).times(2);
-      server.expect().put().withPath("/apis/example.crd.com/v1alpha1/stars/sun").andReturn(200, getStar()).once();
+      server.expect().get().withPath("/apis/example.crd.com/v1alpha1/stars/sun").andReturn(HttpURLConnection.HTTP_OK, getStar()).times(2);
+      server.expect().post().withPath("/apis/example.crd.com/v1alpha1/stars").andReturn(HttpURLConnection.HTTP_CONFLICT, getStar()).times(2);
+      server.expect().put().withPath("/apis/example.crd.com/v1alpha1/stars/sun").andReturn(HttpURLConnection.HTTP_OK, getStar()).once();
 
       starClient = server.getClient().customResources(crdContext, Star.class, StarList.class, DoneableStar.class);
       Star returnedStar = starClient.inNamespace("test").createOrReplace(getStar());

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedCustomResourceApiTest.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.client.mock.crd.PodSetStatus;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
+import java.net.HttpURLConnection;
 import java.util.Collections;
 
 import org.junit.Rule;
@@ -92,8 +93,9 @@ class TypedCustomResourceApiTest {
 
   @Test
   void createOrReplace() {
-    server.expect().get().withPath("/apis/demo.k8s.io/v1alpha1/namespaces/test/podsets/example-podset").andReturn(200, getPodSet()).times(2);
-    server.expect().put().withPath("/apis/demo.k8s.io/v1alpha1/namespaces/test/podsets/example-podset").andReturn(200, getPodSet()).once();
+    server.expect().get().withPath("/apis/demo.k8s.io/v1alpha1/namespaces/test/podsets/example-podset").andReturn(HttpURLConnection.HTTP_OK, getPodSet()).times(2);
+    server.expect().post().withPath("/apis/demo.k8s.io/v1alpha1/namespaces/test/podsets").andReturn(HttpURLConnection.HTTP_CONFLICT, getPodSet()).times(2);
+    server.expect().put().withPath("/apis/demo.k8s.io/v1alpha1/namespaces/test/podsets/example-podset").andReturn(HttpURLConnection.HTTP_OK, getPodSet()).once();
 
     podSetClient = server.getClient().customResources(crdContext, PodSet.class, PodSetList.class, DoneablePodSet.class);
     PodSet returnedPodSet = podSetClient.inNamespace("test").createOrReplace(getPodSet());


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #2292 

+ Updated BaseOperation#createOrReplace to fallback to replace() after doing create() rather than get() -> replace()
+ Updated ResourceCompare#equals() to only compare entities present in provided resource when compared with
  resource from cluster.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
