### PR TITLE
Fix #2316: Cannot load resource from stream without apiVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ### 4.10-SNAPSHOT
 #### Bugs
+* Fix #2316: Cannot load resource from stream without apiVersion
 
 #### Improvements
 
 #### Dependency Upgrade
 * Fix #2355: bump jandex from 2.1.3.Final to 2.2.0.Final
-* Fix #2353: bump workflow action-setup-* versions + kubernetes to 1.18.6
+* Fix #2353: bump workflow action-setup- versions + kubernetes to 1.18.6
 
 #### New Features
 * Fix #2287: Add support for V1 and V1Beta1 CustomResourceDefinition

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -41,6 +41,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 
 import io.fabric8.kubernetes.client.utils.Utils;
+import io.fabric8.kubernetes.model.util.Helper;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Rule;
 import org.junit.jupiter.api.DisplayName;
@@ -770,6 +771,22 @@ public class DeploymentTest {
       .endSpec()
       .endTemplate()
       .endSpec();
+  }
+
+  @Test
+  void testDeploymentLoadWithoutApiVersion() {
+    // Given
+    KubernetesClient client = server.getClient();
+
+    // When
+    List<HasMetadata> list = client.load(getClass().getResourceAsStream("/valid-deployment-without-apiversion.json")).get();
+    Deployment deployment = (Deployment) list.get(0);
+
+    // Then
+    assertNotNull(deployment);
+    assertEquals("test", deployment.getMetadata().getName());
+    assertEquals(1, deployment.getSpec().getReplicas());
+    assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
   }
 
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkingV1beta1IngressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkingV1beta1IngressTest.java
@@ -54,7 +54,7 @@ public class NetworkingV1beta1IngressTest {
   }
 
   @Test
-  public void testList() {
+  void testList() {
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/test/ingresses").andReturn(200, new IngressListBuilder().build()).once();
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/ns1/ingresses").andReturn(200, new IngressListBuilder()
       .addNewItem().and()
@@ -82,7 +82,7 @@ public class NetworkingV1beta1IngressTest {
   }
 
   @Test
-  public void testListWithLables() {
+  void testListWithLables() {
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/test/ingresses?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3=value3")).andReturn(200, new IngressListBuilder().build()).always();
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/test/ingresses?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2")).andReturn(200, new IngressListBuilder()
       .addNewItem().and()
@@ -112,7 +112,7 @@ public class NetworkingV1beta1IngressTest {
 
 
   @Test
-  public void testGet() {
+  void testGet() {
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/test/ingresses/ingress1").andReturn(200, new IngressBuilder().build()).once();
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/ns1/ingresses/ingress2").andReturn(200, new IngressBuilder().build()).once();
 
@@ -130,7 +130,7 @@ public class NetworkingV1beta1IngressTest {
 
 
   @Test
-  public void testDelete() {
+  void testDelete() {
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/test/ingresses/ingress1").andReturn(200, new IngressBuilder().build()).once();
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/ns1/ingresses/ingress2").andReturn(200, new IngressBuilder().build()).once();
 
@@ -148,7 +148,7 @@ public class NetworkingV1beta1IngressTest {
 
 
   @Test
-  public void testDeleteMulti() {
+  void testDeleteMulti() {
     Ingress ingress1 = new IngressBuilder().withNewMetadata().withName("ingress1").withNamespace("test").and().build();
     Ingress ingress2 = new IngressBuilder().withNewMetadata().withName("ingress2").withNamespace("ns1").and().build();
     Ingress ingress3 = new IngressBuilder().withNewMetadata().withName("ingress3").withNamespace("any").and().build();
@@ -166,7 +166,7 @@ public class NetworkingV1beta1IngressTest {
   }
 
   @Test
-  public void testDeleteWithNamespaceMismatch() {
+  void testDeleteWithNamespaceMismatch() {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       Ingress ingress1 = new IngressBuilder().withNewMetadata().withName("ingress1").withNamespace("test").and().build();
       Ingress ingress2 = new IngressBuilder().withNewMetadata().withName("ingress2").withNamespace("ns1").and().build();
@@ -178,7 +178,7 @@ public class NetworkingV1beta1IngressTest {
   }
 
   @Test
-  public void testCreateWithNameMismatch() {
+  void testCreateWithNameMismatch() {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       Ingress ingress1 = new IngressBuilder().withNewMetadata().withName("ingress1").withNamespace("test").and().build();
       Ingress ingress2 = new IngressBuilder().withNewMetadata().withName("ingress2").withNamespace("ns1").and().build();
@@ -186,6 +186,20 @@ public class NetworkingV1beta1IngressTest {
 
       client.network().ingress().inNamespace("test1").withName("myingress1").create(ingress1);
     });
+  }
+
+  @Test
+  void testIngressLoadWithoutApiVersion() {
+    // Given
+    KubernetesClient client = server.getClient();
+
+    // When
+    List<HasMetadata> items = client.load(getClass().getResourceAsStream("/test-ingress-no-apiversion.yml")).get();
+
+    // Then
+    assertNotNull(items);
+    assertEquals(1, items.size());
+    assertTrue(items.get(0) instanceof Ingress);
   }
 
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CustomResourceDefinitionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CustomResourceDefinitionTest.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
@@ -122,6 +123,20 @@ public class V1CustomResourceDefinitionTest {
 
     Boolean deleted = client.apiextensions().v1().customResourceDefinitions().withName("sparkclusters.radanalytics.io").delete();
     assertTrue(deleted);
+  }
+
+  @Test
+  void testCustomResourceDefinitionTest() {
+    // Given
+    KubernetesClient client = server.getClient();
+
+    // When
+    List<HasMetadata> items = client.load(getClass().getResourceAsStream("/test-crd-no-apiversion.yml")).get();
+
+    // Then
+    Assertions.assertNotNull(items);
+    Assertions.assertEquals(1, items.size());
+    Assertions.assertTrue(items.get(0) instanceof CustomResourceDefinition);
   }
 
   JSONSchemaProps readSchema() throws IOException {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1HorizontalPodAutoscalerTest.java
@@ -57,7 +57,7 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testList() {
+  void testList() {
     server.expect().withPath("/apis/autoscaling/v1/namespaces/test/horizontalpodautoscalers").andReturn(200, new HorizontalPodAutoscalerListBuilder().build()).once();
     server.expect().withPath("/apis/autoscaling/v1/namespaces/ns1/horizontalpodautoscalers").andReturn(200, new HorizontalPodAutoscalerListBuilder()
       .addNewItem().and()
@@ -75,7 +75,7 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testListWithLabels() {
+  void testListWithLabels() {
     server.expect().withPath("/apis/autoscaling/v1/namespaces/test/horizontalpodautoscalers?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3=value3")).andReturn(200, new HorizontalPodAutoscalerListBuilder().build()).once();
     server.expect().withPath("/apis/autoscaling/v1/namespaces/ns1/horizontalpodautoscalers?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2")).andReturn(200, new HorizontalPodAutoscalerListBuilder()
       .addNewItem().and()
@@ -101,7 +101,7 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testGet() {
+  void testGet() {
     server.expect().withPath("/apis/autoscaling/v1/namespaces/test/horizontalpodautoscalers/horizontalpodautoscaler1").andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
     server.expect().withPath("/apis/autoscaling/v1/namespaces/ns1/horizontalpodautoscalers/horizontalpodautoscaler2").andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
 
@@ -117,7 +117,7 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testEditMissing() {
+  void testEditMissing() {
 
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       server.expect().withPath("/apis/autoscaling/v1/namespaces/test/horizontalpodautoscalers/horizontalpodautoscaler").andReturn(404, "error message from kubernetes").always();
@@ -128,7 +128,7 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testDelete() {
+  void testDelete() {
     server.expect().withPath("/apis/autoscaling/v1/namespaces/test/horizontalpodautoscalers/horizontalpodautoscaler1").andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
     server.expect().withPath("/apis/autoscaling/v1/namespaces/ns1/horizontalpodautoscalers/horizontalpodautoscaler2").andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
 
@@ -144,7 +144,7 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testDeleteMulti() {
+  void testDeleteMulti() {
     HorizontalPodAutoscaler horizontalPodAutoscaler1 = new HorizontalPodAutoscalerBuilder().withNewMetadata().withName("horizontalpodautoscaler1").withNamespace("test").endMetadata().build();
     HorizontalPodAutoscaler horizontalPodAutoscaler2 = new HorizontalPodAutoscalerBuilder().withNewMetadata().withName("horizontalpodautoscaler2").withNamespace("ns1").endMetadata().build();
     HorizontalPodAutoscaler horizontalPodAutoscaler3 = new HorizontalPodAutoscalerBuilder().withNewMetadata().withName("horizontalpodautoscaler3").withNamespace("any").endMetadata().build();
@@ -161,7 +161,7 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testCreateWithNameMismatch() {
+  void testCreateWithNameMismatch() {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       HorizontalPodAutoscaler horizontalPodAutoscaler1 = new HorizontalPodAutoscalerBuilder().withNewMetadata().withName("horizontalpodautoscaler1").withNamespace("test").endMetadata().build();
       KubernetesClient client = server.getClient();
@@ -170,14 +170,14 @@ public class V1HorizontalPodAutoscalerTest {
   }
 
   @Test
-  public void testLoadFromFile() {
+  void testLoadFromFile() {
     KubernetesClient client = server.getClient();
     HorizontalPodAutoscaler horizontalPodAutoscaler = client.autoscaling().v1().horizontalPodAutoscalers().load(getClass().getResourceAsStream("/test-horizontalpodautoscaler.yml")).get();
     assertEquals("php-apache", horizontalPodAutoscaler.getMetadata().getName());
   }
 
   @Test
-  public void testBuild() {
+  void testBuild() {
     HorizontalPodAutoscaler horizontalPodAutoscaler = new HorizontalPodAutoscalerBuilder()
       .withNewMetadata().withName("test-hpa").withNamespace("test").endMetadata()
       .withNewSpec()
@@ -196,6 +196,20 @@ public class V1HorizontalPodAutoscalerTest {
     KubernetesClient client = server.getClient();
     horizontalPodAutoscaler = client.autoscaling().v1().horizontalPodAutoscalers().inNamespace("test").withName("test-hpa").get();
     assertNotNull(horizontalPodAutoscaler);
+  }
+
+  @Test
+  void testHorizontalPodAutoscalerLoadWithNoApiVersion() {
+    // Given
+    KubernetesClient client = server.getClient();
+
+    // When
+    List<HasMetadata> items = client.load(getClass().getResourceAsStream("/test-hpa-no-apiversion.yml")).get();
+
+    // Then
+    assertNotNull(items);
+    assertEquals(1, items.size());
+    assertTrue(items.get(0) instanceof HorizontalPodAutoscaler);
   }
 
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1MutatingWebhookConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1MutatingWebhookConfigurationTest.java
@@ -27,6 +27,8 @@ import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,6 +104,20 @@ public class V1MutatingWebhookConfigurationTest {
 
     // Then
     assertTrue(isDeleted);
+  }
+
+  @Test
+  void testMutatingWebhookConfigurationLoadWithNoApiVersion() {
+    // Given
+    KubernetesClient client = server.getClient();
+
+    // When
+    List<HasMetadata> items = client.load(getClass().getResourceAsStream("/test-mwc-no-apiversion.yml")).get();
+
+    // Then
+    assertNotNull(items);
+    assertEquals(1, items.size());
+    assertTrue(items.get(0) instanceof MutatingWebhookConfiguration);
   }
 
   public MutatingWebhookConfiguration getMutatingWebhookConfigurationSample() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingWebhookConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingWebhookConfigurationTest.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package io.fabric8.kubernetes.client.mock;
+
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookBuilder;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
@@ -25,6 +26,8 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -110,6 +113,20 @@ public class V1ValidatingWebhookConfigurationTest {
 
     // Then
     assertTrue(isDeleted);
+  }
+
+  @Test
+  void testValidatingWebhookConfigurationLoadWithNoApiVersion() {
+    // Given
+    KubernetesClient client = server.getClient();
+
+    // When
+    List<HasMetadata> items = client.load(getClass().getResourceAsStream("/test-vwc-no-apiversion.yml")).get();
+
+    // Then
+    assertNotNull(items);
+    assertEquals(1, items.size());
+    assertTrue(items.get(0) instanceof ValidatingWebhookConfiguration);
   }
 
   public ValidatingWebhookConfiguration getValidatingWebhookConfigurationSample() {

--- a/kubernetes-tests/src/test/resources/test-crd-no-apiversion.yml
+++ b/kubernetes-tests/src/test/resources/test-crd-no-apiversion.yml
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: CustomResourceDefinition
+metadata:
+  name: dummies.demo.fabric8.io
+spec:
+  group: demo.fabric8.io
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Dummy
+    plural: dummies
+    shortNames:
+      - dummy

--- a/kubernetes-tests/src/test/resources/test-hpa-no-apiversion.yml
+++ b/kubernetes-tests/src/test/resources/test-hpa-no-apiversion.yml
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/kubernetes-tests/src/test/resources/test-ingress-no-apiversion.yml
+++ b/kubernetes-tests/src/test/resources/test-ingress-no-apiversion.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: Ingress
+metadata:
+  name: test-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /testpath
+            pathType: Prefix
+            backend:
+              serviceName: test
+              servicePort: 80

--- a/kubernetes-tests/src/test/resources/test-mwc-no-apiversion.yml
+++ b/kubernetes-tests/src/test/resources/test-mwc-no-apiversion.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: MutatingWebhookConfiguration
+metadata:
+  name: "my-webhook.example.com"
+webhooks:
+  - name: my-webhook.example.com
+    objectSelector:
+      matchLabels:
+        foo: bar
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["*"]
+        scope: "*"

--- a/kubernetes-tests/src/test/resources/test-vwc-no-apiversion.yml
+++ b/kubernetes-tests/src/test/resources/test-vwc-no-apiversion.yml
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "pod-policy.example.com"
+webhooks:
+  - name: "pod-policy.example.com"
+    rules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CREATE"]
+        resources:   ["pods"]
+        scope:       "Namespaced"
+    clientConfig:
+      service:
+        namespace: "example-namespace"
+        name: "example-service"
+      caBundle: "Ci0tLS0tQk...<`caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.>...tLS0K"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5

--- a/kubernetes-tests/src/test/resources/valid-deployment-without-apiversion.json
+++ b/kubernetes-tests/src/test/resources/valid-deployment-without-apiversion.json
@@ -1,0 +1,39 @@
+{
+  "kind": "Deployment",
+  "metadata": {
+    "name": "test",
+    "labels": {
+      "app": "test"
+    }
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "test"
+      }
+    },
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "test"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "test",
+            "image": "busybox:latest",
+            "command": [
+              "/bin/sh",
+              "-c"
+            ],
+            "args": [
+              "sleep 60"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix #2316 
In case of duplicate Kubernetes resources found, when no apiVersion
is provided return first item found instead of null

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
