### PR TITLE
Fix #2373: Unable to create a Template on OCP3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.10-SNAPSHOT
 #### Bugs
+* Fix #2373: Unable to create a Template on OCP3
 * Fix #2316: Cannot load resource from stream without apiVersion
 
 #### Improvements

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
@@ -132,8 +132,8 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
   public Response intercept(Chain chain) throws IOException {
     Request request = chain.request();
     Response response = chain.proceed(request);
-    if (isDeprecatedOpenshiftOapiRequest(request)) {
-      return handleOpenshiftOapiRequests(request, response, chain);
+    if (isOpenshiftApiRequest(request)) {
+      return handleOpenshiftRequests(request, response, chain);
     } else if (!response.isSuccessful() && responseCodeToTransformations.keySet().contains(response.code())) {
       String url = request.url().toString();
       Matcher matcher = getMatcher(url);
@@ -169,19 +169,26 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
     return m != null ? new ResourceKey(null, m.group(PATH), m.group(API_GROUP), m.group(API_VERSION)) : null;
   }
 
-  private static Response handleOpenshiftOapiRequests(Request request, Response response, Chain chain) throws IOException{
+  private static Response handleOpenshiftRequests(Request request, Response response, Chain chain) throws IOException{
     if (!response.isSuccessful()) {
-      String requestUrl = request.url().toString();
-      // handle case when /oapi is not available
-      String[] parts = requestUrl.split("/");
-      String resourcePath = parts[parts.length - 1];
-      ResourceKey target = openshiftOAPITransformations.get(resourcePath);
+      ResourceKey target = getResourceKeyFromRequest(request);
       if (target != null) {
-        requestUrl = requestUrl.replace("/oapi", "/apis/" + target.getGroup());
+        String requestUrl = request.url().toString();
+        requestUrl = isOpenShift4Request(requestUrl) ?
+          convertToOpenShiftOapiUrl(requestUrl, target) :
+          convertToOpenShift4Url(requestUrl, target);
         return handleNewRequestAndProceed(request, requestUrl, target, chain);
       }
     }
     return response;
+  }
+
+  private static String convertToOpenShift4Url(String requestUrl, ResourceKey target) {
+    return requestUrl.replace("/oapi", "/apis/" + target.getGroup());
+  }
+
+  private static String convertToOpenShiftOapiUrl(String requestUrl, ResourceKey target) {
+    return requestUrl.replace("/apis/" + target.getGroup() + "/" + target.getVersion(), "/oapi/v1");
   }
 
   private static Response handleNewRequestAndProceed(Request request, String newUrl, ResourceKey target, Chain chain) throws IOException {
@@ -206,10 +213,34 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
     return chain.proceed(newRequest.build());
   }
 
-  private static boolean isDeprecatedOpenshiftOapiRequest(Request request) {
-    if (request != null && request.url() != null) {
-      return request.url().toString().contains("oapi");
+  private static boolean isOpenshiftApiRequest(Request request) {
+    if (request != null) {
+      String requestUrl = request.url().toString();
+      return isOpenshift3OapiRequest(requestUrl) || isOpenShift4Request(requestUrl);
     }
     return false;
+  }
+
+  private static boolean isOpenShift4Request(String requestUrl) {
+    return requestUrl.contains(".openshift.io");
+  }
+
+  private static boolean isOpenshift3OapiRequest(String requestUrl) {
+    return requestUrl.contains("oapi");
+  }
+
+  private static ResourceKey getResourceKeyFromRequest(Request request) {
+    String requestUrl = request.url().toString();
+    String resourcePath;
+    String[] parts = requestUrl.split("/");
+    if (parts.length > 2) {
+      if (request.method().equalsIgnoreCase("POST")) {
+        resourcePath = parts[parts.length - 1];
+      } else {
+        resourcePath = parts[parts.length - 2];
+      }
+      return openshiftOAPITransformations.get(resourcePath);
+    }
+    return null;
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -38,6 +38,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigList;
 import io.fabric8.openshift.api.model.DeploymentConfigListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+import java.net.HttpURLConnection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @EnableRuleMigrationSupport
@@ -46,7 +47,7 @@ public class DeploymentConfigTest {
   public OpenShiftServer server = new OpenShiftServer();
 
   @Test
-  public void testList() {
+  void testList() {
    server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs").andReturn(200, new DeploymentConfigListBuilder().build()).once();
    server.expect().withPath("/apis").andReturn(200, new APIGroupListBuilder()
       .addNewGroup()
@@ -84,7 +85,7 @@ public class DeploymentConfigTest {
   }
 
   @Test
-  public void testGet() {
+  void testGet() {
    server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1").andReturn(200, new DeploymentConfigBuilder()
       .withNewMetadata().withName("dc1").endMetadata()
       .build()).once();
@@ -108,7 +109,7 @@ public class DeploymentConfigTest {
   }
 
   @Test
-  public void testDelete() throws InterruptedException {
+  void testDelete() throws InterruptedException {
     DeploymentConfig dc1 = new DeploymentConfigBuilder()
       .withNewMetadata()
         .withName("dc1")
@@ -165,7 +166,7 @@ public class DeploymentConfigTest {
   }
 
   @Test
-  public void testDeleteWithPropagationPolicy() throws InterruptedException {
+  void testDeleteWithPropagationPolicy() throws InterruptedException {
     server.expect().delete()
       .withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1")
       .andReturn(200, new DeploymentConfigBuilder().build())
@@ -179,7 +180,7 @@ public class DeploymentConfigTest {
   }
 
   @Test
-	public void testDeployingLatest() {
+	void testDeployingLatest() {
 		server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1")
 				.andReturn(200, new DeploymentConfigBuilder().withNewMetadata().withName("dc1").endMetadata()
 						.withNewStatus().withLatestVersion(1L).endStatus().build())
@@ -194,11 +195,11 @@ public class DeploymentConfigTest {
 
 		DeploymentConfig deploymentConfig = client.deploymentConfigs().withName("dc1").deployLatest();
 		assertNotNull(deploymentConfig);
-		assertEquals(new Long(2), deploymentConfig.getStatus().getLatestVersion());
+		assertEquals(Long.valueOf(2), deploymentConfig.getStatus().getLatestVersion());
 	}
 
   @Test
-  public void testDeployingLatestHandlesMissingLatestVersion() {
+  void testDeployingLatestHandlesMissingLatestVersion() {
     server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1")
       .andReturn(200, new DeploymentConfigBuilder().withNewMetadata().withName("dc1").endMetadata()
         .withNewStatus().endStatus().build())
@@ -213,43 +214,15 @@ public class DeploymentConfigTest {
 
     DeploymentConfig deploymentConfig = client.deploymentConfigs().withName("dc1").deployLatest();
     assertNotNull(deploymentConfig);
-    assertEquals(new Long(1), deploymentConfig.getStatus().getLatestVersion());
+    assertEquals(Long.valueOf(1), deploymentConfig.getStatus().getLatestVersion());
   }
 
   //This is a test that verifies a recent fix (sundrio #135).
   //According to this issue when editing a list of buildables using predicates, the object visitors get overwrriten.
   @Test
-  public void testDeploymentConfigVisitor() {
+  void testDeploymentConfigVisitor() {
    AtomicBoolean visitedContainer = new AtomicBoolean();
-
-   DeploymentConfig dc1 = new DeploymentConfigBuilder()
-      .withNewMetadata()
-        .withName("dc1")
-      .endMetadata()
-      .withNewSpec()
-        .withReplicas(1)
-        .addToSelector("name", "dc1")
-        .addNewTrigger()
-        .withType("ImageChange")
-        .withNewImageChangeParams()
-        .withAutomatic(true)
-        .withContainerNames("container")
-        .withNewFrom()
-        .withKind("ImageStreamTag")
-        .withName("image:1.0")
-        .endFrom()
-        .endImageChangeParams()
-        .endTrigger()
-        .withNewTemplate()
-          .withNewSpec()
-            .addNewContainer()
-              .withName("container")
-              .withImage("image")
-            .endContainer()
-          .endSpec()
-        .endTemplate()
-      .endSpec()
-      .build();
+   DeploymentConfig dc1 = getDeploymentConfig().build();
 
    DeploymentConfig dc2 = new DeploymentConfigBuilder(dc1)
      .accept(new TypedVisitor<DeploymentConfigSpecFluent<?>>() {
@@ -268,6 +241,54 @@ public class DeploymentConfigTest {
 
        }
      }).build();
+   assertNotNull(dc2);
    assertTrue(visitedContainer.get());
+  }
+
+  @Test
+  void testCreateOrReplaceOnOpenShift3() {
+    // Given
+    DeploymentConfig deploymentConfig = getDeploymentConfig().build();
+    server.expect().post().withPath("/oapi/v1/namespaces/ns1/deploymentconfigs")
+      .andReturn(HttpURLConnection.HTTP_OK, deploymentConfig)
+      .once();
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    // When
+    deploymentConfig = client.deploymentConfigs().inNamespace("ns1").createOrReplace(deploymentConfig);
+
+    // Then
+    assertNotNull(deploymentConfig);
+    assertEquals("dc1", deploymentConfig.getMetadata().getName());
+  }
+
+  private DeploymentConfigBuilder getDeploymentConfig() {
+    return new DeploymentConfigBuilder()
+      .withNewMetadata()
+      .withName("dc1")
+      .endMetadata()
+      .withNewSpec()
+      .withReplicas(1)
+      .addToSelector("name", "dc1")
+      .addNewTrigger()
+      .withType("ImageChange")
+      .withNewImageChangeParams()
+      .withAutomatic(true)
+      .withContainerNames("container")
+      .withNewFrom()
+      .withKind("ImageStreamTag")
+      .withName("image:1.0")
+      .endFrom()
+      .endImageChangeParams()
+      .endTrigger()
+      .withNewTemplate()
+      .withNewSpec()
+      .addNewContainer()
+      .withName("container")
+      .withImage("image")
+      .endContainer()
+      .endSpec()
+      .endTemplate()
+      .endSpec();
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.SecurityContextConstraints;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsBuilder;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
@@ -27,6 +28,9 @@ import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
+import java.net.HttpURLConnection;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,6 +40,49 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SecurityContextConstraintsTest {
   @Rule
   public OpenShiftServer server = new OpenShiftServer();
+
+  @Test
+  void testCreateOrReplace() {
+    // Given
+    SecurityContextConstraints scc = new SecurityContextConstraintsBuilder()
+      .withNewMetadata().withName("scc1").endMetadata()
+      .withAllowPrivilegedContainer(true)
+      .withNewRunAsUser().withType("RunAsAny").endRunAsUser()
+      .withNewSeLinuxContext().withType("RunAsAny").endSeLinuxContext()
+      .withUsers("admin")
+      .withGroups("admin-group")
+      .build();
+    server.expect().post().withPath("/apis/security.openshift.io/v1/securitycontextconstraints")
+      .andReturn(HttpURLConnection.HTTP_OK, scc)
+    .once();
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    // When
+    scc = client.securityContextConstraints().createOrReplace(scc);
+
+    // Then
+    assertNotNull(scc);
+    assertEquals("scc1", scc.getMetadata().getName());
+    assertEquals(1, scc.getUsers().size());
+    assertEquals(1, scc.getGroups().size());
+  }
+
+  @Test
+  void testLoad() {
+    // Given
+    server.expect().post().withPath("/apis/security.openshift.io/v1/securitycontextconstraints")
+      .andReturn(HttpURLConnection.HTTP_OK, new SecurityContextConstraintsBuilder().build())
+      .once();
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    // When
+    List<HasMetadata> items = client.load(getClass().getResourceAsStream("/test-scc.yml")).createOrReplace();
+
+    // Then
+    assertNotNull(items);
+    assertEquals(1, items.size());
+    assertTrue(items.get(0) instanceof SecurityContextConstraints);
+  }
 
   @Test
   public void testList() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -16,6 +16,7 @@
 package io.fabric8.openshift.client.server.mock;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,8 @@ import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
@@ -55,7 +58,7 @@ public class TemplateTest {
   public OpenShiftServer server = new OpenShiftServer();
 
   @Test
-  public void testList() {
+  void testList() {
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates").andReturn(200, new TemplateListBuilder().build()).once();
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/ns1/templates").andReturn(200, new TemplateListBuilder()
       .addNewItem().and()
@@ -93,7 +96,7 @@ public class TemplateTest {
   }
 
   @Test
-  public void testListWithParams() throws IOException {
+  void testListWithParams() throws IOException {
     String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-list-with-number-params.json"));
 
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates").andReturn(200, json).always();
@@ -110,7 +113,7 @@ public class TemplateTest {
 
 
   @Test
-  public void testGet() {
+  void testGet() {
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
       .withNewMetadata().withName("tmpl1").endMetadata()
       .build()).once();
@@ -135,7 +138,7 @@ public class TemplateTest {
 
 
   @Test
-  public void testDelete() {
+  void testDelete() {
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder().build()).once();
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/ns1/templates/tmpl2").andReturn(200, new TemplateBuilder().build()).once();
 
@@ -152,7 +155,7 @@ public class TemplateTest {
   }
 
   @Test
-  public void testCreateWithHandler() {
+  void testCreateWithHandler() {
     Template template = new TemplateBuilder()
       .editOrNewMetadata()
       .withName("tmpl3")
@@ -171,7 +174,7 @@ public class TemplateTest {
 
 
   @Test
-  public void testProcess() {
+  void testProcess() {
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder().build()).once();
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/processedtemplates").andReturn(201, new KubernetesListBuilder().build()).once();
 
@@ -181,7 +184,7 @@ public class TemplateTest {
   }
 
   @Test
-  public void shouldLoadTemplateWithNumberParameters() throws Exception {
+  void shouldLoadTemplateWithNumberParameters() {
     OpenShiftClient client = new DefaultOpenShiftClient(new OpenShiftConfigBuilder().build());
     Map<String, String> map = new HashMap<>();
     map.put("PORT", "8080");
@@ -205,11 +208,11 @@ public class TemplateTest {
     List<ServicePort> ports = serviceSpec.getPorts();
     assertEquals(1, ports.size());
     ServicePort port = ports.get(0);
-    assertEquals(new Integer(8080), port.getPort());
+    assertEquals(Integer.valueOf(8080), port.getPort());
   }
 
   @Test
-  public void testLoadParameterizedNumberTemplate() throws IOException {
+  void testLoadParameterizedNumberTemplate() throws IOException {
     String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-with-number-params.json"));
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
 
@@ -223,7 +226,7 @@ public class TemplateTest {
   }
 
   @Test
-  public void testProcessParameterizedNumberTemplate() throws IOException {
+  void testProcessParameterizedNumberTemplate() throws IOException {
     String json = IOHelpers.readFully(getClass().getResourceAsStream("/template-with-number-params.json"));
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, json).once();
 
@@ -236,7 +239,7 @@ public class TemplateTest {
   }
 
   @Test
-  public void testNullParameterMapValueShouldNotThrowNullPointerException() {
+  void testNullParameterMapValueShouldNotThrowNullPointerException() {
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
       .withNewMetadata().withName("tmpl1").endMetadata()
       .withParameters(new ParameterBuilder().withName("key").build())
@@ -248,7 +251,7 @@ public class TemplateTest {
   }
 
   @Test
-  public void testEmptyParameterMapValueShouldNotThrowNullPointerException() {
+  void testEmptyParameterMapValueShouldNotThrowNullPointerException() {
     server.expect().withPath("/apis/template.openshift.io/v1/namespaces/test/templates/tmpl1").andReturn(200, new TemplateBuilder()
       .withNewMetadata().withName("tmpl1").endMetadata()
       .withParameters(new ParameterBuilder().withName("key").build())
@@ -257,6 +260,70 @@ public class TemplateTest {
     Map<String, String> emptyValueMap = singletonMap("key", "");
     KubernetesList list = client.templates().withName("tmpl1").processLocally(emptyValueMap);
     assertNotNull(list);
+  }
+
+  @Test
+  void testCreateOrReplaceOpenShift3() {
+    // Given
+    Template template = getTemplateBuilder().build();
+    server.expect().post().withPath("/oapi/v1/namespaces/ns1/templates")
+      .andReturn(HttpURLConnection.HTTP_OK, template)
+      .once();
+
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    // When
+    template = client.templates().inNamespace("ns1").createOrReplace(template);
+
+    // Then
+    assertNotNull(template);
+  }
+
+  @Test
+  void testCreateOrReplaceOpenShif4() {
+    // Given
+    Template template = getTemplateBuilder().build();
+    server.expect().post().withPath("/apis/template.openshift.io/v1/namespaces/ns1/templates")
+      .andReturn(HttpURLConnection.HTTP_OK, template)
+      .once();
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    // When
+    template = client.templates().inNamespace("ns1").createOrReplace(template);
+
+    // Then
+    assertNotNull(template);
+  }
+
+  private TemplateBuilder getTemplateBuilder() {
+    Pod pod = new PodBuilder()
+      .withNewMetadata().withName("redis-master").endMetadata()
+      .withNewSpec()
+      .addNewContainer()
+      .addNewEnv().withName("REDIS_PASSWORD").withValue("${REDIS_PASSWORD}").endEnv()
+      .withImage("dockerfile/redis")
+      .addNewPort()
+      .withContainerPort(6379)
+      .withProtocol("TCP")
+      .endPort()
+      .endContainer()
+      .endSpec()
+      .build();
+    return new TemplateBuilder()
+      .withNewMetadata()
+      .withName("redis-template")
+      .addToAnnotations("description", "Description")
+      .addToAnnotations("iconClass", "icon-redis")
+      .addToAnnotations("tags", "database,nosql")
+      .endMetadata()
+      .addToObjects(pod)
+      .addNewParameter()
+      .withDescription("Password used for Redis authentication")
+      .withFrom("[A-Z0-9]{8}")
+      .withGenerate("expression")
+      .withName("REDIS_PASSWORD")
+      .endParameter()
+      .addToLabels("redis", "master");
   }
 
 }

--- a/kubernetes-tests/src/test/resources/test-scc.yml
+++ b/kubernetes-tests/src/test/resources/test-scc.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: scc-get
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+  - admin
+groups:
+  - admin-group


### PR DESCRIPTION
Fix #2373 

Looks like code added in #1956 BackwardCompatibilityInterceptor wasn't handling
`/oapi` `failures properly.

Fix BackwardCompatibilityInterceptor logic for routing to OpenShift 3 `/oapi/v1`
endpoints when OpenShift 4 `/apis/{group}/v1` endpoints not found. Also added some
tests to assert desired behavior

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
