### PR TITLE
Fix #2319: Create Config without using auto-configure functionality or setting env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 #### New Features
 * Fix #2287: Add support for V1 and V1Beta1 CustomResourceDefinition
+* Fix #2319: Create Config without using auto-configure functionality or setting env variables
 
 ### 4.10.3 (2020-07-14)
 #### Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -211,14 +211,39 @@ public class Config {
    */
   private Map<String,String> customHeaders = null;
 
+  private Boolean autoConfigure = Boolean.FALSE;
+
   /**
    * @deprecated use {@link #autoConfigure(String)} or {@link ConfigBuilder} instead
    */
   @Deprecated
   public Config() {
-    if (!Utils.getSystemPropertyOrEnvVar(KUBERNETES_DISABLE_AUTO_CONFIG_SYSTEM_PROPERTY, false)) {
+    this(!Utils.getSystemPropertyOrEnvVar(KUBERNETES_DISABLE_AUTO_CONFIG_SYSTEM_PROPERTY, false));
+  }
+
+  private Config(Boolean autoConfigure) {
+    if (Boolean.TRUE.equals(autoConfigure)) {
+      this.autoConfigure = Boolean.TRUE;
       autoConfigure(this, null);
     }
+  }
+
+  /**
+   * Create an empty {@link Config} class without any automatic configuration
+   * (i.e. reading system properties/environment variables to load defaults.)
+   * You can also reuse this object to build your own {@link Config} object
+   * without any auto configuration like this:
+   *
+   * <pre>{@code
+   * Config configFromBuilder = new ConfigBuilder(Config.empty())
+   *                                // ...
+   *                               .build();
+   * }</pre>
+   *
+   * @return a Config object without any automatic configuration
+   */
+  public static Config empty() {
+    return new Config(false);
   }
 
   /**
@@ -1169,6 +1194,10 @@ public class Config {
 
   public void setCustomHeaders(Map<String, String> customHeaders) {
     this.customHeaders = customHeaders;
+  }
+
+  public Boolean getAutoConfigure() {
+    return autoConfigure;
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -22,6 +22,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
 import org.apache.commons.lang.SystemUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +45,7 @@ import static okhttp3.TlsVersion.TLS_1_2;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -103,7 +105,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithSystemProperties() {
+  void testWithSystemProperties() {
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
     System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "testns");
 
@@ -141,7 +143,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithBuilder() {
+  void testWithBuilder() {
     Config config = new ConfigBuilder()
       .withMasterUrl("http://somehost:80")
       .withApiVersion("v1")
@@ -175,7 +177,7 @@ public class ConfigTest {
 
 
   @Test
-  public void testWithBuilderAndSystemProperties() {
+  void testWithBuilderAndSystemProperties() {
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://tobeoverriden:80");
     System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "tobeoverriden");
 
@@ -214,7 +216,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testMasterUrlWithServiceAccount() {
+  void testMasterUrlWithServiceAccount() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, "/dev/null");
     System.setProperty(Config.KUBERNETES_SERVICE_HOST_PROPERTY, "10.0.0.1");
     System.setProperty(Config.KUBERNETES_SERVICE_PORT_PROPERTY, "443");
@@ -224,7 +226,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testMasterUrlWithServiceAccountIPv6() {
+  void testMasterUrlWithServiceAccountIPv6() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, "/dev/null");
     System.setProperty(Config.KUBERNETES_SERVICE_HOST_PROPERTY, "2001:db8:1f70::999:de8:7648:6e8");
     System.setProperty(Config.KUBERNETES_SERVICE_PORT_PROPERTY, "443");
@@ -234,7 +236,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithKubeConfig() {
+  void testWithKubeConfig() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE);
     Config config = new Config();
     assertNotNull(config);
@@ -247,7 +249,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithKubeConfigAndOverrideContext() {
+  void testWithKubeConfigAndOverrideContext() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE);
     Config config = Config.autoConfigure("production/172-28-128-4:8443/root");
     assertNotNull(config);
@@ -260,7 +262,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithMultipleKubeConfigAndOverrideContext() {
+  void testWithMultipleKubeConfigAndOverrideContext() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE + File.pathSeparator + "some-other-file");
 
     Config config = Config.autoConfigure("production/172-28-128-4:8443/root");
@@ -274,7 +276,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithKubeConfigAndSystemProperties() {
+  void testWithKubeConfigAndSystemProperties() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE);
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
 
@@ -286,7 +288,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithKubeConfigAndSytemPropertiesAndBuilder() {
+  void testWithKubeConfigAndSytemPropertiesAndBuilder() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_FILE);
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
 
@@ -301,7 +303,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithNamespacePath() {
+  void testWithNamespacePath() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, "nokubeconfigfile");
     System.setProperty(Config.KUBERNETES_NAMESPACE_FILE, TEST_NAMESPACE_FILE);
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
@@ -313,7 +315,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithNonExistingNamespacePath() {
+  void testWithNonExistingNamespacePath() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, "nokubeconfigfile");
     System.setProperty(Config.KUBERNETES_NAMESPACE_FILE, "nonamespace");
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
@@ -321,11 +323,11 @@ public class ConfigTest {
     Config config = new Config();
     assertNotNull(config);
     assertEquals("http://somehost:80/", config.getMasterUrl());
-    assertEquals(null, config.getNamespace());
+    Assertions.assertNull(config.getNamespace());
   }
 
   @Test
-  public void testWithNamespacePathAndSystemProperties() {
+  void testWithNamespacePathAndSystemProperties() {
     System.setProperty(Config.KUBERNETES_NAMESPACE_FILE, TEST_NAMESPACE_FILE);
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
     System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "testns");
@@ -337,7 +339,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithKubeConfigAndNoContext() {
+  void testWithKubeConfigAndNoContext() {
     System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_NO_CURRENT_CONTEXT_FILE);
     Config config = new Config();
     assertNotNull(config);
@@ -349,7 +351,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithNamespacePathAndSytemPropertiesAndBuilder() {
+  void testWithNamespacePathAndSytemPropertiesAndBuilder() {
     System.setProperty(Config.KUBERNETES_NAMESPACE_FILE, TEST_NAMESPACE_FILE);
     System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "http://somehost:80");
     System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "tobeoverriden");
@@ -364,8 +366,8 @@ public class ConfigTest {
   }
 
   @Test
-  public void testWithCustomHeader() {
-    Map<String,String> customHeaders = new HashMap();
+  void testWithCustomHeader() {
+    Map<String,String> customHeaders = new HashMap<>();
     customHeaders.put("user-id","test-user");
     customHeaders.put("cluster-id","test-cluster");
     Config config = new ConfigBuilder()
@@ -378,7 +380,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void shouldSetImpersonateUsernameAndGroupFromSystemProperty() {
+  void shouldSetImpersonateUsernameAndGroupFromSystemProperty() {
 
     System.setProperty(Config.KUBERNETES_IMPERSONATE_USERNAME, "username");
     System.setProperty(Config.KUBERNETES_IMPERSONATE_GROUP, "group");
@@ -393,12 +395,12 @@ public class ConfigTest {
 
     assertEquals("a", config.getImpersonateUsername());
     assertArrayEquals(new String[]{"group"}, config.getImpersonateGroups());
-    assertEquals(Arrays.asList("d"), config.getImpersonateExtras().get("c"));
+    assertEquals(Collections.singletonList("d"), config.getImpersonateExtras().get("c"));
 
   }
 
   @Test
-  public void shouldInstantiateClientUsingYaml() throws MalformedURLException {
+  void shouldInstantiateClientUsingYaml() {
     File configYml = new File(TEST_CONFIG_YML_FILE);
     try (InputStream is = new FileInputStream(configYml)){
       KubernetesClient client = DefaultKubernetesClient.fromConfig(is);
@@ -409,7 +411,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void shouldInstantiateClientUsingSerializeDeserialize() throws MalformedURLException {
+  void shouldInstantiateClientUsingSerializeDeserialize() {
     DefaultKubernetesClient original = new DefaultKubernetesClient();
     String json = Serialization.asJson(original.getConfiguration());
     DefaultKubernetesClient copy = DefaultKubernetesClient.fromConfig(json);
@@ -422,7 +424,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void shouldRespectMaxRequests() {
+  void shouldRespectMaxRequests() {
     Config config = new ConfigBuilder()
       .withMaxConcurrentRequests(120)
       .build();
@@ -435,7 +437,7 @@ public class ConfigTest {
   }
   
   @Test
-  public void shouldRespectMaxRequestsPerHost() {
+  void shouldRespectMaxRequestsPerHost() {
     Config config = new ConfigBuilder()
       .withMaxConcurrentRequestsPerHost(20)
       .build();
@@ -448,7 +450,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void shouldPropagateImpersonateSettings() {
+  void shouldPropagateImpersonateSettings() {
 
     final Map<String, List<String>> extras = new HashMap<>();
     extras.put("c", Collections.singletonList("d"));
@@ -464,11 +466,11 @@ public class ConfigTest {
 
     assertEquals("a", currentConfig.getImpersonateUsername());
     assertArrayEquals(new String[]{"b"}, currentConfig.getImpersonateGroups());
-    assertEquals(Arrays.asList("d"), currentConfig.getImpersonateExtras().get("c"));
+    assertEquals(Collections.singletonList("d"), currentConfig.getImpersonateExtras().get("c"));
   }
 
   @Test
-  public void honorClientAuthenticatorCommands() throws Exception {
+  void honorClientAuthenticatorCommands() throws Exception {
     if (SystemUtils.IS_OS_WINDOWS) {
       System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_WIN_FILE);
     } else {
@@ -482,7 +484,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void shouldBeUsedTokenSuppliedByProvider() throws Exception {
+  void shouldBeUsedTokenSuppliedByProvider() {
 
     Config config = new ConfigBuilder().withOauthToken("oauthToken")
                                        .withOauthTokenProvider(() -> "PROVIDER_TOKEN")
@@ -492,20 +494,55 @@ public class ConfigTest {
   }
 
   @Test
-  public void shouldHonorDefaultWebsocketPingInterval() {
+  void shouldHonorDefaultWebsocketPingInterval() {
     Config config = new ConfigBuilder().build();
 
     assertEquals(30000L, config.getWebsocketPingInterval());
   }
 
   @Test
-  public void testKubeConfigWithAuthConfigProvider() throws URISyntaxException  {
+  void testKubeConfigWithAuthConfigProvider() throws URISyntaxException  {
     System.setProperty("kubeconfig", new File(getClass().getResource("/test-kubeconfig").toURI()).getAbsolutePath());
     Config config = Config.autoConfigure("production/172-28-128-4:8443/mmosley");
 
     assertEquals("https://172.28.128.4:8443/", config.getMasterUrl());
     assertEquals("eyJraWQiOiJDTj1vaWRjaWRwLnRyZW1vbG8ubGFuLCBPVT1EZW1vLCBPPVRybWVvbG8gU2VjdXJpdHksIEw9QXJsaW5ndG9uLCBTVD1WaXJnaW5pYSwgQz1VUy1DTj1rdWJlLWNhLTEyMDIxNDc5MjEwMzYwNzMyMTUyIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL29pZGNpZHAudHJlbW9sby5sYW46ODQ0My9hdXRoL2lkcC9PaWRjSWRQIiwiYXVkIjoia3ViZXJuZXRlcyIsImV4cCI6MTQ4MzU0OTUxMSwianRpIjoiMm96US15TXdFcHV4WDlHZUhQdy1hZyIsImlhdCI6MTQ4MzU0OTQ1MSwibmJmIjoxNDgzNTQ5MzMxLCJzdWIiOiI0YWViMzdiYS1iNjQ1LTQ4ZmQtYWIzMC0xYTAxZWU0MWUyMTgifQ.w6p4J_6qQ1HzTG9nrEOrubxIMb9K5hzcMPxc9IxPx2K4xO9l-oFiUw93daH3m5pluP6K7eOE6txBuRVfEcpJSwlelsOsW8gb8VJcnzMS9EnZpeA0tW_p-mnkFc3VcfyXuhe5R3G7aa5d8uHv70yJ9Y3-UhjiN9EhpMdfPAoEB9fYKKkJRzF7utTTIPGrSaSU6d2pcpfYKaxIwePzEkT4DfcQthoZdy9ucNvvLoi1DIC-UocFD8HLs8LYKEqSxQvOcvnThbObJ9af71EwmuE21fO5KzMW20KtAeget1gnldOosPtz1G5EwvaQ401-RPQzPGMVBld0_zMCAwZttJ4knw",
       config.getOauthToken());
+  }
+
+  @Test
+  void testEmptyConfig() {
+    // Given
+    Config emptyConfig = null;
+
+    // When
+    emptyConfig = Config.empty();
+
+    // Then
+    assertNotNull(emptyConfig);
+    assertEquals("https://kubernetes.default.svc", emptyConfig.getMasterUrl());
+    assertTrue(emptyConfig.getContexts().isEmpty());
+    assertNull(emptyConfig.getCurrentContext());
+    assertEquals(64, emptyConfig.getMaxConcurrentRequests());
+    assertEquals(5, emptyConfig.getMaxConcurrentRequestsPerHost());
+    assertFalse(emptyConfig.isTrustCerts());
+    assertFalse(emptyConfig.isDisableHostnameVerification());
+    assertEquals("RSA", emptyConfig.getClientKeyAlgo());
+    assertEquals("changeit", emptyConfig.getClientKeyPassphrase());
+    assertEquals(1000, emptyConfig.getWatchReconnectInterval());
+    assertEquals(-1, emptyConfig.getWatchReconnectLimit());
+    assertEquals(10000, emptyConfig.getConnectionTimeout());
+    assertEquals(10000, emptyConfig.getRequestTimeout());
+    assertEquals(900000, emptyConfig.getRollingTimeout());
+    assertEquals(600000, emptyConfig.getScaleTimeout());
+    assertEquals(20000, emptyConfig.getLoggingInterval());
+    assertEquals(5000, emptyConfig.getWebsocketTimeout());
+    assertEquals(30000, emptyConfig.getWebsocketPingInterval());
+    assertTrue(emptyConfig.getImpersonateExtras().isEmpty());
+    assertEquals(0, emptyConfig.getImpersonateGroups().length);
+    assertFalse(emptyConfig.isHttp2Disable());
+    assertEquals(1, emptyConfig.getTlsVersions().length);
+    assertTrue(emptyConfig.getErrorMessages().isEmpty());
   }
 
   private void assertConfig(Config config) {


### PR DESCRIPTION
Fix #2319



## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
