### PR TITLE
Fix #2354: Fix NullPointerException in ResourceCompare when no resource is returned from fromServer.get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Bugs
 * Fix #2373: Unable to create a Template on OCP3
 * Fix #2316: Cannot load resource from stream without apiVersion
+* Fix #2354: Fix NullPointerException in ResourceCompare when no resource is returned from fromServer.get()
 * Fix #2389: KubernetesServer does not use value from https in crud mode
 
 #### Improvements

--- a/extensions/knative/tests/src/test/java/io/fabric8/knative/test/RouteTest.java
+++ b/extensions/knative/tests/src/test/java/io/fabric8/knative/test/RouteTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.knative.test;
+
+import io.fabric8.knative.client.KnativeClient;
+import io.fabric8.knative.mock.KnativeServer;
+import io.fabric8.knative.serving.v1.Route;
+import io.fabric8.knative.serving.v1.RouteBuilder;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.net.HttpURLConnection;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableRuleMigrationSupport
+class RouteTest {
+  @Rule
+  public KnativeServer server = new KnativeServer();
+
+  @Test
+  void testCreateOrReplace() {
+    // Given
+    Route route = new RouteBuilder()
+      .withNewMetadata()
+      .withName("helloworld-nodejs-red-blue1")
+      .withNamespace("test")
+      .endMetadata()
+      .withNewSpec()
+      .addNewTraffic()
+      .withConfigurationName("greeter")
+      .withPercent(100L)
+      .endTraffic()
+      .endSpec()
+      .build();
+    server.expect().post().withPath("/apis/serving.knative.dev/v1/namespaces/test/routes")
+      .andReturn(HttpURLConnection.HTTP_CONFLICT, route)
+      .once();
+    server.expect().get().withPath("/apis/serving.knative.dev/v1/namespaces/test/routes/helloworld-nodejs-red-blue1")
+      .andReturn(HttpURLConnection.HTTP_OK, route)
+      .times(2);
+    server.expect().put().withPath("/apis/serving.knative.dev/v1/namespaces/test/routes/helloworld-nodejs-red-blue1")
+      .andReturn(HttpURLConnection.HTTP_OK, route)
+      .once();
+    KnativeClient kn = server.getKnativeClient();
+
+    // When
+    route = kn.routes().createOrReplaceWithNew()
+      .withNewMetadata()
+      .withName("helloworld-nodejs-red-blue1")
+      .addToAnnotations("foo", "bar")
+      .withNamespace("test")
+      .endMetadata()
+      .withNewSpec()
+      .addNewTraffic()
+      .withConfigurationName("greeter")
+      .withPercent(100L)
+      .endTraffic()
+      .endSpec()
+      .done();
+
+    // Then
+    assertNotNull(route);
+  }
+}

--- a/extensions/knative/tests/src/test/java/io/fabric8/knative/test/crud/RouteCrudTest.java
+++ b/extensions/knative/tests/src/test/java/io/fabric8/knative/test/crud/RouteCrudTest.java
@@ -29,12 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableRuleMigrationSupport
-public class RouteTest {
+class RouteCrudTest {
   @Rule
   public KnativeServer server = new KnativeServer(true, true);
 
   @Test
-  public void shouldReturnEmptyList() {
+  void shouldReturnEmptyList() {
     // Given
     KnativeClient client = server.getKnativeClient();
 
@@ -47,7 +47,7 @@ public class RouteTest {
   }
 
   @Test
-  public void shouldListAndGetRoute() {
+  void shouldListAndGetRoute() {
     // Given
     KnativeClient client = server.getKnativeClient();
     Route Route2 = new RouteBuilder().withNewMetadata().withName("Route2").endMetadata()
@@ -71,7 +71,7 @@ public class RouteTest {
   }
 
   @Test
-  public void shouldDeleteARoute() {
+  void shouldDeleteARoute() {
     // Given
     KnativeClient client = server.getKnativeClient();
     Route route3 = new RouteBuilder().withNewMetadata().withName("route3").endMetadata().build();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ResourceCompare.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ResourceCompare.java
@@ -48,6 +48,13 @@ public class ResourceCompare {
    */
   public static <T>  boolean equals(T left, T right) {
     ObjectMapper jsonMapper = Serialization.jsonMapper();
+    if (left == null && right == null) {
+      return true;
+    } else if (left == null) {
+      return false;
+    } else if (right == null) {
+      return false;
+    }
     Map<String, Object> leftJson = jsonMapper.convertValue(left, TYPE_REF);
     Map<String, Object> rightJson = jsonMapper.convertValue(right, TYPE_REF);
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ResourceCompareTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ResourceCompareTest.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.utils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
@@ -24,6 +25,8 @@ import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -32,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 public class ResourceCompareTest {
 
@@ -130,4 +134,20 @@ public class ResourceCompareTest {
     assertTrue(result);
   }
 
+  @Test
+  void testEqualsWhenOneResourceIsNull() {
+    // Given
+    Pod pod2 = new PodBuilder().withNewMetadata().withName("foo").endMetadata().build();
+
+    // When
+    boolean result = ResourceCompare.equals(null, pod2);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  void testEqualsWhenBothNull() {
+    assertTrue(ResourceCompare.equals(null, null));
+  }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
@@ -36,7 +36,7 @@ public class RouteCrudTest {
   public OpenShiftServer server = new OpenShiftServer(true, true);
 
   @Test
-  public void testCrud() {
+  void testCrud() {
     OpenShiftClient client = server.getOpenshiftClient();
 
     Route route1 = new RouteBuilder().withNewMetadata().withName("route1")


### PR DESCRIPTION
Fix #2354 
Somehow resource was being returned as `null` from `fromServer.get()` call due to no
namespace being provided. Added a case of Null items in `ResourceCompare#equals`

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
