### PR TITLE
Fixes Issue 2306: make Informers work with KubernetesServer CRUD mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix #2373: Unable to create a Template on OCP3
 * Fix #2316: Cannot load resource from stream without apiVersion
 * Fix #2389: KubernetesServer does not use value from https in crud mode
+* Fix #2306: Make KubernetesServer CRUD mode work with informers
 
 #### Improvements
 * Fix #2331: Fixed documentation for namespaced informer for all custom types implementing `Namespaced` interface

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
@@ -39,7 +39,8 @@ public class KubernetesResponseComposer implements ResponseComposer {
   @Override
   public String compose(Collection<String> collection) {
     return String.format(
-        "{\"apiVersion\":\"v1\",\"kind\":\"List\", \"items\": [%s]}",
+        "{\"apiVersion\":\"v1\",\"kind\":\"List\", \"items\": [%s], " +
+         "\"metadata\": {\"resourceVersion\": \"\", \"selfLink\": \"\"}}",
         join(",", collection));
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CrudInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CrudInformerTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableRuleMigrationSupport
+public class CrudInformerTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer(true, true);
+
+  // https://github.com/fabric8io/kubernetes-client/issues/2306
+  @Test
+  void testCrudInformer() throws InterruptedException {
+    Pod podToCreate = new PodBuilder().withNewMetadata().withName("pod1").endMetadata().build();
+    KubernetesClient client = server.getClient();
+    SharedInformerFactory factory = client.informers();
+    SharedIndexInformer<Pod> podInformer = factory.sharedIndexInformerFor(Pod.class, PodList.class, 4000);
+    BlockingQueue<Pod> events = new LinkedBlockingQueue<>();
+    podInformer.addEventHandler(
+      new ResourceEventHandler<Pod>() {
+        @Override
+        public void onAdd(Pod obj) {
+          events.add(obj);
+        }
+
+        @Override
+        public void onUpdate(Pod oldObj, Pod newObj) {
+        }
+
+        @Override
+        public void onDelete(Pod oldObj, boolean deletedFinalStateUnknown) {
+        }
+      });
+    factory.startAllRegisteredInformers();
+    client.pods().create(podToCreate);
+    Pod readPod = events.poll(5, TimeUnit.SECONDS);
+    assertNotNull(readPod);
+    assertEquals(readPod.getMetadata().getName(), podToCreate.getMetadata().getName());
+    factory.stopAllRegisteredInformers();
+  }
+}


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

Fixes #2306: make Informers work with KubernetesServer CRUD mode

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
