### PR TITLE
doc: add YAML serialization example in the cheatsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Improvements
 * Fix #2331: Fixed documentation for namespaced informer for all custom types implementing `Namespaced` interface
+* Fix #2406: Add documentation for serializing resources to YAML
 
 #### Dependency Upgrade
 * Fix #2360: bump mockito-core from 3.4.0 to 3.4.2

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -34,6 +34,7 @@ This document contains common usages of different resources using Fabric8 Kubern
   * [List Options](#list-options)
   * [Delete Options](#delete-options)
   * [Watch Options](#watch-options)
+  * [Serializing to yaml](#serializing-to-yaml)
 
 * [OpenShift Client DSL Usage](#openshift-client-dsl-usage)  
   * [Initializing OpenShift Client](#initializing-openshift-client)
@@ -2171,6 +2172,16 @@ client.pods().watch(new ListOptionsBuilder().withTimeoutSeconds(30L).build(), ne
   @Override
   public void onClose(KubernetesClientException cause) { }
 });
+```
+
+#### Serializing to yaml
+Resources can be exported to a yaml String via the `SerializationUtils` class:
+```
+Pod myPod;
+
+String myPodAsYaml = SerializationUtils.dumpAsYaml(myPod);
+// Your pod might have some state that you don't really care about, to remove it:
+String myPodAsYamlWithoutRuntimeState = dumpWithoutRuntimeStateAsYaml(myPod);
 ```
 
 ### OpenShift Client DSL Usage


### PR DESCRIPTION
## Description
This PR add a simple serialization to YAML in the cheatsheet. I couldn't find any documentation on this easily. It should also closes #2363.

## Type of change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
