### PR TITLE
Add waitUntilCondition() operation that accepts a new resource version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 #### Improvements
 * Fix #2331: Fixed documentation for namespaced informer for all custom types implementing `Namespaced` interface
 * Fix #2406: Add documentation for serializing resources to YAML
+* Fix #2414: Add waitUntilCondition() operation that accepts a new resource version. This enables recovery from HTTP 410 GONE errors.
 
 #### Dependency Upgrade
 * Fix #2360: bump mockito-core from 3.4.0 to 3.4.2

--- a/extensions/knative/client/src/main/resources/resource-handler.vm
+++ b/extensions/knative/client/src/main/resources/resource-handler.vm
@@ -29,8 +29,6 @@
 
 package io.fabric8.knative.client.${group}.${apiVersion}.handlers;
 
-import java.util.function.Predicate;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.Watch;
@@ -45,8 +43,10 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import ${model.fullyQualifiedName};
 import ${model.fullyQualifiedName}Builder;
 
+import java.time.Duration;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class ${model.name}Handler implements ResourceHandler<${model.name}, ${model.name}Builder> {
 
@@ -112,5 +112,10 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   @Override
   public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
     return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, amount, timeUnit);
+  }
+
+  @Override
+  public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, String resourceVersion, Duration timeout) throws InterruptedException {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, resourceVersion, timeout);
   }
 }

--- a/extensions/service-catalog/client/src/main/resources/resource-handler.vm
+++ b/extensions/service-catalog/client/src/main/resources/resource-handler.vm
@@ -28,8 +28,6 @@
 
 package io.fabric8.servicecatalog.client.handlers;
 
-import java.util.function.Predicate;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.Watch;
@@ -44,8 +42,10 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import ${model.fullyQualifiedName};
 import ${model.fullyQualifiedName}Builder;
 
+import java.time.Duration;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class ${model.name}Handler implements ResourceHandler<${model.name}, ${model.name}Builder> {
 
@@ -111,5 +111,10 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   @Override
   public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
     return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, amount, timeUnit);
+  }
+
+  @Override
+  public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, String resourceVersion, Duration timeout) throws InterruptedException {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, resourceVersion, timeout);
   }
 }

--- a/extensions/tekton/client/src/main/resources/resource-handler.vm
+++ b/extensions/tekton/client/src/main/resources/resource-handler.vm
@@ -28,8 +28,6 @@
 
 package io.fabric8.tekton.client.handlers.$apiVersion;
 
-import java.util.function.Predicate;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.Watch;
@@ -44,8 +42,10 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import ${model.fullyQualifiedName};
 import ${model.fullyQualifiedName}Builder;
 
+import java.time.Duration;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class ${model.name}Handler implements ResourceHandler<${model.name}, ${model.name}Builder> {
 
@@ -111,5 +111,10 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   @Override
   public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
     return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, amount, timeUnit);
+  }
+
+  @Override
+  public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, String resourceVersion, Duration timeout) throws InterruptedException {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, resourceVersion, timeout);
   }
 }

--- a/extensions/volumesnapshot/client/src/main/resources/resource-handler.vm
+++ b/extensions/volumesnapshot/client/src/main/resources/resource-handler.vm
@@ -28,8 +28,6 @@
 
 package io.fabric8.volumesnapshot.client.handlers;
 
-import java.util.function.Predicate;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.Watch;
@@ -44,8 +42,10 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import ${model.fullyQualifiedName};
 import ${model.fullyQualifiedName}Builder;
 
+import java.time.Duration;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class ${model.name}Handler implements ResourceHandler<${model.name}, ${model.name}Builder> {
 
@@ -111,5 +111,10 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   @Override
   public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
     return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, amount, timeUnit);
+  }
+
+  @Override
+  public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, String resourceVersion, Duration timeout) throws InterruptedException {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, resourceVersion, timeout);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.kubernetes.client;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -178,4 +179,6 @@ public interface ResourceHandler<T, V extends VisitableBuilder<T, V>> {
   T waitUntilReady(OkHttpClient client, Config config, String namespace, T item, long amount, TimeUnit timeUnit) throws InterruptedException;
 
   T waitUntilCondition(OkHttpClient client, Config config, String namespace, T item, Predicate<T> condition, long amount, TimeUnit timeUnit) throws InterruptedException;
+
+  T waitUntilCondition(OkHttpClient client, Config config, String namespace, T item, Predicate<T> condition, String resourceVersion, Duration timeout) throws InterruptedException;
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Waitable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Waitable.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
@@ -26,6 +27,8 @@ public interface Waitable<T, P> {
   T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException;
 
   T waitUntilCondition(Predicate<P> condition, long amount, TimeUnit timeUnit) throws InterruptedException;
+
+  T waitUntilCondition(Predicate<P> condition, String resourceVersion, Duration timeout) throws InterruptedException;
 
   /**
    * Configure the backoff strategy to use when waiting for conditions, in case the watcher encounters a retryable error.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -20,16 +20,19 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.kubernetes.client.utils.Utils;
 
-import java.net.HttpURLConnection;
-import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
@@ -278,6 +281,14 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
     return h.waitUntilCondition(client, config, meta.getMetadata().getNamespace(), meta, condition, amount, timeUnit);
   }
 
+  @Override
+  public HasMetadata waitUntilCondition(Predicate<HasMetadata> condition,
+                                        String resourceVersion,
+                                        Duration timeout) throws InterruptedException {
+    HasMetadata meta = acceptVisitors(asHasMetadata(get()), visitors);
+    ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(meta);
+    return h.waitUntilCondition(client, config, meta.getMetadata().getNamespace(), meta, condition, resourceVersion, timeout);
+  }
 
   private static HasMetadata acceptVisitors(HasMetadata item, List<Visitor> visitors) {
     ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(item);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesListHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesListHandler.java
@@ -17,26 +17,26 @@ package io.fabric8.kubernetes.client.handlers;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.ListOptions;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import java.util.function.Predicate;
-import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.HasMetadataVisitiableBuilder;
 import io.fabric8.kubernetes.client.ResourceHandler;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.internal.KubernetesListOperationsImpl;
+import okhttp3.OkHttpClient;
 import org.apache.felix.scr.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 @Component
 @org.apache.felix.scr.annotations.Service
@@ -123,6 +123,11 @@ public class KubernetesListHandler implements ResourceHandler<KubernetesList, Ku
 
   @Override
   public KubernetesList waitUntilCondition(OkHttpClient client, Config config, String namespace, KubernetesList item, Predicate<KubernetesList> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
+    throw new UnsupportedOperationException("Watch is not supported on KubernetesList.");
+  }
+
+  @Override
+  public KubernetesList waitUntilCondition(OkHttpClient client, Config config, String namespace, KubernetesList item, Predicate<KubernetesList> condition, String resourceVersion, Duration timeout) throws InterruptedException {
     throw new UnsupportedOperationException("Watch is not supported on KubernetesList.");
   }
 }

--- a/kubernetes-client/src/main/resources/resource-handler.vm
+++ b/kubernetes-client/src/main/resources/resource-handler.vm
@@ -30,8 +30,6 @@
 
 package io.fabric8.kubernetes.client.handlers$packageSuffix;
 
-import java.util.function.Predicate;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import io.fabric8.kubernetes.client.Watch;
@@ -46,8 +44,10 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import ${model.fullyQualifiedName};
 import ${model.fullyQualifiedName}Builder;
 
+import java.time.Duration;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class ${model.name}Handler implements ResourceHandler<${model.name}, ${model.name}Builder> {
 
@@ -113,5 +113,10 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   @Override
   public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
     return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, amount, timeUnit);
+  }
+
+  @Override
+  public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, String resourceVersion, Duration timeout) throws InterruptedException {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, resourceVersion, timeout);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -27,8 +27,13 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
+import io.fabric8.kubernetes.client.dsl.ListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 
@@ -38,10 +43,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
-import java.net.HttpURLConnection;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_GONE;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +90,7 @@ public class ResourceListTest {
   void testCreateOrReplace() {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HTTP_CREATED, pod1).once();
 
     List<HasMetadata> response = client.resourceList(new PodListBuilder().addToItems(pod1).build()).createOrReplace();
     assertTrue(response.contains(pod1));
@@ -87,7 +100,7 @@ public class ResourceListTest {
   void testCreateOrReplaceFailedCreate() {
     // Given
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_UNAVAILABLE, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HTTP_UNAVAILABLE, pod1).once();
     NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> listOp = client.resourceList(new PodListBuilder().addToItems(pod1).build());
 
     // When
@@ -98,7 +111,7 @@ public class ResourceListTest {
   void testCreateWithExplicitNamespace() {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HTTP_CREATED, pod1).once();
 
     List<HasMetadata> response = client.resourceList(new PodListBuilder().addToItems(pod1).build()).inNamespace("ns1").apply();
     assertTrue(response.contains(pod1));
@@ -111,9 +124,9 @@ public class ResourceListTest {
     Pod pod3 = new PodBuilder().withNewMetadata().withName("pod3").withNamespace("any").and().build();
 
 
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).times(2);
-    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(HttpURLConnection.HTTP_OK, pod2).times(2);
-    server.expect().withPath("/api/v1/namespaces/any/pods/pod3").andReturn(HttpURLConnection.HTTP_OK, pod3).times(1);
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(HTTP_OK, pod1).times(2);
+    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(HTTP_OK, pod2).times(2);
+    server.expect().withPath("/api/v1/namespaces/any/pods/pod3").andReturn(HTTP_OK, pod3).times(1);
 
     //First time all items should be deleted.
     Boolean deleted = client.resourceList(new PodListBuilder().withItems(pod1, pod2, pod3).build()).delete();
@@ -126,12 +139,12 @@ public class ResourceListTest {
 
   @Test
   void testCreateOrReplaceWithoutDeleteExisting() throws Exception {
-    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HttpURLConnection.HTTP_CONFLICT, service).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HttpURLConnection.HTTP_CONFLICT, configMap).once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HttpURLConnection.HTTP_OK , service).once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HttpURLConnection.HTTP_OK, configMap).once();
-    server.expect().put().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HttpURLConnection.HTTP_OK, updatedService).once();
-    server.expect().put().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HttpURLConnection.HTTP_OK, updatedConfigMap).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HTTP_CONFLICT, service).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HTTP_CONFLICT, configMap).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK , service).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, configMap).once();
+    server.expect().put().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK, updatedService).once();
+    server.expect().put().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, updatedConfigMap).once();
 
     client.resourceList(resourcesToUpdate).inNamespace("ns1").createOrReplace();
 
@@ -143,12 +156,12 @@ public class ResourceListTest {
 
   @Test
   void testCreateOrReplaceWithDeleteExisting() throws Exception {
-    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HttpURLConnection.HTTP_CONFLICT, service).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HttpURLConnection.HTTP_CONFLICT, configMap).once();
-    server.expect().delete().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HttpURLConnection.HTTP_OK , service).once();
-    server.expect().delete().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HttpURLConnection.HTTP_OK, configMap).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HttpURLConnection.HTTP_OK, updatedService).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HttpURLConnection.HTTP_OK, updatedConfigMap).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HTTP_CONFLICT, service).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HTTP_CONFLICT, configMap).once();
+    server.expect().delete().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK , service).once();
+    server.expect().delete().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, configMap).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HTTP_OK, updatedService).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HTTP_OK, updatedConfigMap).once();
 
     client.resourceList(resourcesToUpdate).inNamespace("ns1").deletingExisting().createOrReplace();
 
@@ -156,6 +169,167 @@ public class ResourceListTest {
     RecordedRequest request = server.getLastRequest();
     assertEquals("/api/v1/namespaces/ns1/configmaps", request.getPath());
     assertEquals("POST", request.getMethod());
+  }
+
+  @Test
+  void testSuccessfulWaitUntilCondition() throws InterruptedException {
+    Pod pod1 = new PodBuilder().withNewMetadata()
+      .withName("pod1")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady1 = createReadyFrom(pod1, "False");
+    Pod ready1 = createReadyFrom(pod1, "True");
+
+    Pod pod2 = new PodBuilder().withNewMetadata()
+      .withName("pod2")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady2 = createReadyFrom(pod2, "False");
+    Pod ready2 = createReadyFrom(pod2, "True");
+
+    Predicate<HasMetadata> isReady = p -> "Pod".equals(p.getKind()) && ((Pod) p).getStatus().getConditions().stream()
+      .anyMatch(c -> "True".equals(c.getStatus()));
+
+    // The pods are never ready if you request them directly.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(200, noReady1).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, noReady2).once();
+
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&watch=true").andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(ready1, "MODIFIED"))
+      .done()
+      .once();
+
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&watch=true").andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
+      .done()
+      .once();
+
+    try (KubernetesClient client = server.getClient()) {
+      KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
+      List<HasMetadata> results = client.resourceList(list).inNamespace("ns1")
+        .waitUntilCondition(isReady, null, ofSeconds(5));
+      assertThat(results)
+        .containsExactlyInAnyOrder(ready1, ready2);
+    }
+  }
+
+  @Test
+  void testPartialSuccessfulWaitUntilCondition() {
+    Pod pod1 = new PodBuilder().withNewMetadata()
+      .withName("pod1")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady1 = createReadyFrom(pod1, "False");
+
+    Pod pod2 = new PodBuilder().withNewMetadata()
+      .withName("pod2")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady2 = createReadyFrom(pod2, "False");
+    Pod ready2 = createReadyFrom(pod2, "True");
+
+    Predicate<HasMetadata> isReady = p -> "Pod".equals(p.getKind()) && ((Pod) p).getStatus().getConditions().stream()
+      .anyMatch(c -> "True".equals(c.getStatus()));
+
+    // The pods are never ready if you request them directly.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(200, noReady1).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, noReady2).once();
+
+    Status gone = new StatusBuilder()
+      .withCode(HTTP_GONE)
+      .build();
+
+    // This pod has a non-retryable error.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
+      .done()
+      .once();
+
+    // This pod succeeds.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
+      .done()
+      .once();
+
+    try (KubernetesClient client = server.getClient()) {
+      KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
+      final ListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> ops = client.resourceList(list).inNamespace("ns1");
+      final Duration timeout = ofSeconds(5);
+      KubernetesClientTimeoutException ex = assertThrows(KubernetesClientTimeoutException.class, () ->
+        ops.waitUntilCondition(isReady, null, timeout)
+      );
+      assertThat(ex.getResourcesNotReady())
+        .containsExactly(pod1);
+    }
+  }
+
+  @Test
+  void testAllFailedWaitUntilCondition() {
+    Pod pod1 = new PodBuilder().withNewMetadata()
+      .withName("pod1")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady1 = createReadyFrom(pod1, "False");
+
+    Pod pod2 = new PodBuilder().withNewMetadata()
+      .withName("pod2")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady2 = createReadyFrom(pod2, "False");
+
+    Predicate<HasMetadata> isReady = p -> "Pod".equals(p.getKind()) && ((Pod) p).getStatus().getConditions().stream()
+      .anyMatch(c -> "True".equals(c.getStatus()));
+
+    // The pods are never ready if you request them directly.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(200, noReady1).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, noReady2).once();
+
+    Status gone = new StatusBuilder()
+      .withCode(HTTP_GONE)
+      .build();
+
+    // Both pods have a non-retryable error.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
+      .done()
+      .once();
+
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
+      .done()
+      .once();
+
+    try (KubernetesClient client = server.getClient()) {
+      KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
+      final ListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> ops = client.resourceList(list).inNamespace("ns1");
+      final Duration timeout = ofSeconds(5);
+      KubernetesClientTimeoutException ex = assertThrows(KubernetesClientTimeoutException.class, () ->
+        ops.waitUntilCondition(isReady, null, timeout)
+      );
+      assertThat(ex.getResourcesNotReady())
+        .containsExactlyInAnyOrder(pod1, pod2);
+    }
+  }
+
+  private static Pod createReadyFrom(Pod pod, String status) {
+    return new PodBuilder(pod)
+      .withNewStatus()
+        .addNewCondition()
+          .withType("Ready")
+          .withStatus(status)
+        .endCondition()
+      .endStatus()
+      .build();
   }
 
   private static ServiceBuilder mockService() {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/ProjectRequestHandler.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/ProjectRequestHandler.java
@@ -20,6 +20,8 @@ import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+
+import java.time.Duration;
 import java.util.function.Predicate;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.client.Config;
@@ -93,6 +95,11 @@ public class ProjectRequestHandler implements ResourceHandler<ProjectRequest, Pr
 
   @Override
   public ProjectRequest waitUntilCondition(OkHttpClient client, Config config, String namespace, ProjectRequest item, Predicate<ProjectRequest> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ProjectRequest waitUntilCondition(OkHttpClient client, Config config, String namespace, ProjectRequest item, Predicate<ProjectRequest> condition, String resourceVersion, Duration timeout) throws InterruptedException {
     throw new UnsupportedOperationException();
   }
 }

--- a/openshift-client/src/main/resources/resource-handler.vm
+++ b/openshift-client/src/main/resources/resource-handler.vm
@@ -27,8 +27,6 @@
 
 package io.fabric8.openshift.client.handlers;
 
-import java.util.function.Predicate;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.kubernetes.client.ResourceHandler;
@@ -46,8 +44,10 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import ${model.fullyQualifiedName};
 import ${model.fullyQualifiedName}Builder;
 
+import java.time.Duration;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class ${model.name}Handler implements ResourceHandler<${model.name}, ${model.name}Builder> {
 
@@ -114,5 +114,10 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   @Override
   public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, long amount, TimeUnit timeUnit) throws InterruptedException {
     return new ${model.name}OperationsImpl(client, OpenShiftConfig.wrap(config)).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, amount, timeUnit);
+  }
+
+  @Override
+  public ${model.name} waitUntilCondition(OkHttpClient client, Config config, String namespace, ${model.name} item, Predicate<${model.name}> condition, String resourceVersion, Duration timeout) throws InterruptedException {
+    return new ${model.name}OperationsImpl(client, OpenShiftConfig.wrap(config)).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).waitUntilCondition(condition, resourceVersion, timeout);
   }
 }


### PR DESCRIPTION
## Description
Add a new `waitUntilCondition()` operation that allows you to specify the resource version to use. Previously, this API could use either the resource version from an item's metadata or null, which made it difficult to recover from HTTP 410 GONE errors. I have refactored the existing code so that it also supports this new use-case.

The existing code for handling `waitUntilCondition()` for a `ResourceList` looks like it could fail with `ConcurrentModificationException` errors if multiple threads try to modify the `result` and `itemsWithConditionNotMatched` lists simultaneously, and so I have used `CompletableFuture`s instead for this new API operation.

Fixes #2414 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
