### PR TITLE
Allow waitUntilCondition() to follow withResourceVersion().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 #### Improvements
 * Fix #2331: Fixed documentation for namespaced informer for all custom types implementing `Namespaced` interface
 * Fix #2406: Add documentation for serializing resources to YAML
+* Fix #2414: Allow withResourceVersion() to be followed by waitUntilCondition(), enabling recovery from HTTP 410 GONE errors.
 
 #### Dependency Upgrade
 * Fix #2360: bump mockito-core from 3.4.0 to 3.4.2

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/FilterWatchListMultiDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/FilterWatchListMultiDeletable.java
@@ -15,6 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface FilterWatchListMultiDeletable<T, L, B, H, W> extends FilterWatchListDeletable<T, L, B, H, W>, MultiDeleteable<T, B> {
+public interface FilterWatchListMultiDeletable<T, L, B, H> extends FilterWatchListDeletable<T, L, B, H>, MultiDeleteable<T, B> {
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
@@ -16,7 +16,6 @@
 package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 
 /**
  * The entry point to client operations that are either "cross namespace resources", or are available in the invocation chain
@@ -28,7 +27,7 @@ import io.fabric8.kubernetes.client.Watcher;
  */
 public interface NonNamespaceOperation<T, L, D, R> extends
   Nameable<R>,
-  FilterWatchListMultiDeletable<T, L, Boolean, Watch, Watcher<T>>,
+  FilterWatchListMultiDeletable<T, L, Boolean, Watch>,
   Createable<T, T, D>,
   CreateOrReplaceable<T, T, D>,
   Loadable<R> {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Operation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Operation.java
@@ -16,7 +16,6 @@
 package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 
 /**
  * The entry point to client operations.
@@ -27,8 +26,8 @@ import io.fabric8.kubernetes.client.Watcher;
  */
 public interface Operation<T, L, D, R>
   extends
-  AnyNamespaceable<FilterWatchListMultiDeletable<T, L, Boolean, Watch, Watcher<T>>>,
+  AnyNamespaceable<FilterWatchListMultiDeletable<T, L, Boolean, Watch>>,
   Namespaceable<NonNamespaceOperation<T, L, D, R>>,
-  FilterWatchListMultiDeletable<T, L, Boolean, Watch, Watcher<T>>,
+  FilterWatchListMultiDeletable<T, L, Boolean, Watch>,
   Loadable<R> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
@@ -16,7 +16,6 @@
 package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 
 /**
  * Interface that describes the operation that can be done on a Kubernetes resource (e.g. Pod, Service etc).
@@ -27,6 +26,6 @@ import io.fabric8.kubernetes.client.Watcher;
 public interface Resource<T, D> extends CreateOrReplaceable<T, T, D>,
   CreateFromServerGettable<T, T, D>,
   CascadingEditReplacePatchDeletable<T, T, D, Boolean>,
-  VersionWatchable<Watch, Watcher<T>>,
-  Waitable<T, T>, Requirable<T>, Readiable {
+  VersionWatchAndWaitable<Watch, T>,
+  Requirable<T>, Readiable {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VersionWatchAndWaitable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VersionWatchAndWaitable.java
@@ -15,6 +15,5 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface VersionWatchable<H, W> extends Watchable<H, W>, Versionable<Watchable<H, W>> {
-
+public interface VersionWatchAndWaitable<H, T> extends WatchAndWaitable<H, T>, Versionable<WatchAndWaitable<H, T>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchAndWaitable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchAndWaitable.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface FilterWatchListDeletable<T, L, B, H> extends Filterable<FilterWatchListDeletable<T, L, B, H>>, WatchListDeletable<T, L, B, H> {
+import io.fabric8.kubernetes.client.Watcher;
 
+public interface WatchAndWaitable<H, T> extends Watchable<H, Watcher<T>>, Waitable<T, T> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
@@ -17,8 +17,8 @@ package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.GracePeriodConfigurable;
 
-public interface WatchListDeletable<T, L, B, H, W> extends VersionWatchable<H, W>, Listable<L>, Deletable<B>,
-                                                           GracePeriodConfigurable<Deletable<B>>,
-                                                           StatusUpdatable<T>
+public interface WatchListDeletable<T, L, B, H> extends VersionWatchAndWaitable<H, T>, Listable<L>, Deletable<B>,
+                                                        GracePeriodConfigurable<Deletable<B>>,
+                                                        StatusUpdatable<T>
 {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -524,7 +524,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withInvolvedObject(ObjectReference objectReference) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withInvolvedObject(ObjectReference objectReference) {
     if (objectReference != null) {
       if (objectReference.getName() != null) {
         fields.put(INVOLVED_OBJECT_NAME, objectReference.getName());

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -47,7 +47,6 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.Watchable;
 import io.fabric8.kubernetes.client.dsl.base.WaitForConditionWatcher.WatchException;
 import io.fabric8.kubernetes.client.dsl.internal.DefaultOperationInfo;
 import io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager;
@@ -79,6 +78,8 @@ import java.util.function.Predicate;
 
 import okhttp3.HttpUrl;
 import okhttp3.Request;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceList<T>, D extends Doneable<T>, R extends Resource<T, D>>
   extends OperationSupport
@@ -420,13 +421,13 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabels(Map<String, String> labels) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withLabels(Map<String, String> labels) {
     this.labels.putAll(labels);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabelSelector(LabelSelector selector) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withLabelSelector(LabelSelector selector) {
     Map<String, String> matchLabels = selector.getMatchLabels();
     if (matchLabels != null) {
       this.labels.putAll(matchLabels);
@@ -465,37 +466,37 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
    */
   @Override
   @Deprecated
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabels(Map<String, String> labels) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withoutLabels(Map<String, String> labels) {
     // Re-use "withoutLabel" to convert values from String to String[]
     labels.forEach(this::withoutLabel);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabelIn(String key, String... values) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withLabelIn(String key, String... values) {
     labelsIn.put(key, values);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabelNotIn(String key, String... values) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withLabelNotIn(String key, String... values) {
     labelsNotIn.put(key, values);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabel(String key, String value) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withLabel(String key, String value) {
     labels.put(key, value);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabel(String key) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withLabel(String key) {
     return withLabel(key, null);
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabel(String key, String value) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withoutLabel(String key, String value) {
     labelsNot.merge(key, new String[]{value}, (oldList, newList) -> {
       final String[] concatList = (String[]) Array.newInstance(String.class, oldList.length + newList.length);
       System.arraycopy(oldList, 0, concatList, 0, oldList.length);
@@ -506,18 +507,18 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabel(String key) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withoutLabel(String key) {
     return withoutLabel(key, null);
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withFields(Map<String, String> fields) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withFields(Map<String, String> fields) {
     this.fields.putAll(fields);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withField(String key, String value) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withField(String key, String value) {
     fields.put(key, value);
     return this;
   }
@@ -561,14 +562,14 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
    */
   @Override
   @Deprecated
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutFields(Map<String, String> fields) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withoutFields(Map<String, String> fields) {
     // Re-use "withoutField" to convert values from String to String[]
     labels.forEach(this::withoutField);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutField(String key, String value) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withoutField(String key, String value) {
     fieldsNot.merge(key, new String[]{value}, (oldList, newList) -> {
       if (Utils.isNotNullOrEmpty(newList[0])) { // Only add new values when not null
         final String[] concatList = (String[]) Array.newInstance(String.class, oldList.length + newList.length);
@@ -782,8 +783,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public Watchable<Watch, Watcher<T>> withResourceVersion(String resourceVersion) {
-    return newInstance(context.withResourceVersion(resourceVersion));
+  public R withResourceVersion(String resourceVersion) {
+    return (R) newInstance(context.withResourceVersion(resourceVersion));
   }
 
   public Watch watch(final Watcher<T> watcher) {
@@ -803,9 +804,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   public Watch watch(ListOptions options, final Watcher<T> watcher) {
     WatcherToggle<T> watcherToggle = new WatcherToggle<>(watcher, true);
     options.setWatch(Boolean.TRUE);
-    WatchConnectionManager watch = null;
+    WatchConnectionManager<T, L> watch = null;
     try {
-      watch = new WatchConnectionManager(
+      watch = new WatchConnectionManager<>(
         client,
         this,
         options,
@@ -839,7 +840,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       // HTTP GET. This is meant to handle cases like kubectl local proxy which does not support
       // websockets. Issue: https://github.com/kubernetes/kubernetes/issues/25126
       try {
-        return new WatchHTTPManager(
+        return new WatchHTTPManager<>(
           client,
           this,
           options,
@@ -1034,7 +1035,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withGracePeriod(long gracePeriodSeconds) {
+  public FilterWatchListDeletable<T, L, Boolean, Watch> withGracePeriod(long gracePeriodSeconds) {
     return newInstance(context.withGracePeriodSeconds(gracePeriodSeconds));
   }
 
@@ -1114,40 +1115,54 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   private T waitUntilConditionWithRetries(Predicate<T> condition, long timeoutNanos, long backoffMillis)
     throws InterruptedException {
+    ListOptions options = null;
 
-    T item = fromServer().get();
-    if (condition.test(item)) {
-      return item;
+    if (resourceVersion != null) {
+      options = createListOptions(resourceVersion);
     }
 
-    long end = System.nanoTime() + timeoutNanos;
+    long currentBackOff = backoffMillis;
+    long remainingNanosToWait = timeoutNanos;
+    while (remainingNanosToWait > 0) {
 
-    WaitForConditionWatcher<T> watcher = new WaitForConditionWatcher<>(condition);
-    Watch watch = item == null
-      ? watch(new ListOptionsBuilder()
-      .withResourceVersion(null)
-      .build(), watcher)
-      : watch(item.getMetadata().getResourceVersion(), watcher);
-
-    try {
-      return watcher.getFuture()
-        .get(timeoutNanos, TimeUnit.NANOSECONDS);
-    } catch (ExecutionException e) {
-      if (e.getCause() instanceof WatchException && ((WatchException) e.getCause()).isShouldRetry()) {
-        watch.close();
-        LOG.debug("retryable watch exception encountered, retrying after {} millis", backoffMillis, e.getCause());
-        Thread.sleep(backoffMillis);
-        long newTimeout = end - System.nanoTime();
-        long newBackoff = (long) (backoffMillis * watchRetryBackoffMultiplier);
-        return waitUntilConditionWithRetries(condition, newTimeout, newBackoff);
+      T item = fromServer().get();
+      if (condition.test(item)) {
+        return item;
+      } else if (options == null) {
+        options = createListOptions(getResourceVersion(item));
       }
-      throw KubernetesClientException.launderThrowable(e.getCause());
-    } catch (TimeoutException e) {
-      LOG.debug("ran out of time waiting for watcher, wait condition not met");
-      throw new IllegalArgumentException(type.getSimpleName() + " with name:[" + name + "] in namespace:[" + namespace + "] matching condition not found!");
-    } finally {
-      watch.close();
+
+      final WaitForConditionWatcher<T> watcher = new WaitForConditionWatcher<>(condition);
+      final long startTime = System.nanoTime();
+      try (Watch ignored = watch(options, watcher)) {
+        return watcher.getFuture().get(remainingNanosToWait, NANOSECONDS);
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof WatchException && ((WatchException) cause).isShouldRetry()) {
+          LOG.debug("retryable watch exception encountered, retrying after {} millis", currentBackOff, cause);
+          Thread.sleep(currentBackOff);
+          currentBackOff *= watchRetryBackoffMultiplier;
+          remainingNanosToWait -= (System.nanoTime() - startTime);
+        } else {
+          throw KubernetesClientException.launderThrowable(cause);
+        }
+      } catch (TimeoutException e) {
+        break;
+      }
     }
+
+    LOG.debug("ran out of time waiting for watcher, wait condition not met");
+    throw new IllegalArgumentException(type.getSimpleName() + " with name:[" + name + "] in namespace:[" + namespace + "] matching condition not found!");
+  }
+
+  private static String getResourceVersion(HasMetadata item) {
+    return (item == null) ? null : item.getMetadata().getResourceVersion();
+  }
+
+  private static ListOptions createListOptions(String resourceVersion) {
+    return new ListOptionsBuilder()
+      .withResourceVersion(resourceVersion)
+      .build();
   }
 
   public void setType(Class<T> type) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -147,6 +147,13 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
         futures.add(CompletableFuture.supplyAsync(() -> {
           try {
             return h.waitUntilCondition(client, config, meta.getMetadata().getNamespace(), meta, condition, amount, timeUnit);
+          } catch (InterruptedException e) {
+            // Don't forget that this thread was interrupted.
+            Thread.currentThread().interrupt();
+
+            //consider all errors as not ready.
+            logAsNotReady(e, meta);
+            return null;
           } catch (Exception e) {
             //consider all errors as not ready.
             logAsNotReady(e, meta);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -53,7 +53,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -74,7 +76,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
     private final List<Visitor> visitors;
     private final long watchRetryInitialBackoffMillis;
     private final double watchRetryBackoffMultiplier;
-  private final Object item;
+    private final Object item;
     private final InputStream inputStream;
 
     private final long gracePeriodSeconds;
@@ -108,8 +110,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
               LOGGER.info("{} {} does not support readiness. skipping..", meta.getKind(), meta.getMetadata().getName());
               latch.countDown();
             } catch (IllegalStateException t) {
-              LOGGER.warn("Error while waiting for: [{}] with name: [{}] in namespace: [{}]: {}. The resource will be considered not ready.", meta.getKind(), meta.getMetadata().getName(), meta.getMetadata().getNamespace(), t.getMessage());
-              LOGGER.debug("The error stack trace:", t);
+              logAsNotReady(t, meta);
             } finally {
               // Resource got ready and was returned properly
               latch.countDown();
@@ -129,49 +130,69 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
   }
 
   @Override
-  public List<HasMetadata> waitUntilCondition(Predicate<HasMetadata> condition, long amount,
-    TimeUnit timeUnit) throws InterruptedException {
+  public List<HasMetadata> waitUntilCondition(Predicate<HasMetadata> condition,
+                                              long amount,
+                                              TimeUnit timeUnit) throws InterruptedException {
     List<HasMetadata> items = acceptVisitors(asHasMetadata(item, true), visitors);
-    if (items.size() == 0) {
+    if (items.isEmpty()) {
       return Collections.emptyList();
     }
 
-    final List<HasMetadata> result = new ArrayList<>();
-    final List<HasMetadata> itemsWithConditionNotMatched = new ArrayList<>(items);
-    final int size = items.size();
-    final AtomicInteger conditionMatched = new AtomicInteger(0);
-    final ExecutorService executor = Executors.newFixedThreadPool(size);
+    final List<CompletableFuture<HasMetadata>> futures = new ArrayList<>(items.size());
+    final ExecutorService executor = Executors.newFixedThreadPool(items.size());
 
     try {
-      final CountDownLatch latch = new CountDownLatch(size);
       for (final HasMetadata meta : items) {
         final ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(meta);
-        if (!executor.isShutdown()) {
-          executor.submit(() -> {
-            try {
-              result.add(h.waitUntilCondition(client, config, meta.getMetadata().getNamespace(), meta, condition, amount, timeUnit));
-              conditionMatched.incrementAndGet();
-              itemsWithConditionNotMatched.remove(meta);
-            } catch (Throwable t) {
-              //consider all errors as not ready.
-              LOGGER.warn("Error while waiting for: [{}] with name: [{}] in namespace: [{}]: {}. The resource will be considered not ready.", meta.getKind(), meta.getMetadata().getName(), meta.getMetadata().getNamespace(), t.getMessage());
-              LOGGER.debug("The error stack trace:", t);
-            } finally {
-              //We don't want to wait for items that will never become ready
-              latch.countDown();
-            }
-          });
-        }
+        futures.add(CompletableFuture.supplyAsync(() -> {
+          try {
+            return h.waitUntilCondition(client, config, meta.getMetadata().getNamespace(), meta, condition, amount, timeUnit);
+          } catch (Exception e) {
+            //consider all errors as not ready.
+            logAsNotReady(e, meta);
+            return null;
+          }
+        }, executor));
       }
-      if (checkConditionMetForAll(latch, size, conditionMatched, amount, timeUnit)) {
-        return result;
-      } else {
-        throw new KubernetesClientTimeoutException(itemsWithConditionNotMatched, amount, timeUnit);
-      }
+
+      // Wait for all futures to complete, remembering that every future
+      // has been given the same timeout value.
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     } finally {
       executor.shutdown();
     }
 
+    final List<HasMetadata> results = new ArrayList<>();
+    final List<HasMetadata> itemsWithConditionNotMatched = new ArrayList<>();
+
+    // Iterate over the items because we don't know what kind of List it is.
+    // But the futures use an ArrayList, so accessing by index is efficient.
+    int i = 0;
+    for (final HasMetadata meta : items) {
+      try {
+        HasMetadata result = futures.get(i).get();
+        if (result != null) {
+          results.add(result);
+        } else {
+          itemsWithConditionNotMatched.add(meta);
+        }
+      } catch (ExecutionException e) {
+        itemsWithConditionNotMatched.add(meta);
+        logAsNotReady(e.getCause(), meta);
+      }
+      ++i;
+    }
+
+    if (!itemsWithConditionNotMatched.isEmpty()) {
+      throw new KubernetesClientTimeoutException(itemsWithConditionNotMatched, amount, timeUnit);
+    }
+
+    return results;
+  }
+
+  private static void logAsNotReady(Throwable t, HasMetadata meta) {
+    LOGGER.warn("Error while waiting for: [{}] with name: [{}] in namespace: [{}]: {}. The resource will be considered not ready.", meta.getKind(), meta.getMetadata().getName(), meta.getMetadata().getNamespace(), t.getMessage());
+    LOGGER.debug("The error stack trace:", t);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentRollingUpdater.java
@@ -25,7 +25,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Operation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
@@ -57,7 +56,7 @@ class DeploymentRollingUpdater extends RollingUpdater<Deployment, DeploymentList
 
   @Override
   protected PodList listSelectedPods(Deployment obj) {
-    FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister = pods().inNamespace(namespace);
+    FilterWatchListDeletable<Pod, PodList, Boolean, Watch> podLister = pods().inNamespace(namespace);
     if (obj.getSpec().getSelector().getMatchLabels() != null) {
       podLister.withLabels(obj.getSpec().getSelector().getMatchLabels());
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
@@ -25,7 +25,6 @@ import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Operation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
@@ -57,7 +56,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
 
   @Override
   protected PodList listSelectedPods(ReplicaSet obj) {
-    FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister = pods().inNamespace(namespace);
+    FilterWatchListDeletable<Pod, PodList, Boolean, Watch> podLister = pods().inNamespace(namespace);
     if (obj.getSpec().getSelector().getMatchLabels() != null) {
       podLister.withLabels(obj.getSpec().getSelector().getMatchLabels());
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetRollingUpdater.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Operation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
@@ -57,7 +56,7 @@ class StatefulSetRollingUpdater extends RollingUpdater<StatefulSet, StatefulSetL
 
   @Override
   protected PodList listSelectedPods(StatefulSet obj) {
-    FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister = pods().inNamespace(namespace);
+    FilterWatchListDeletable<Pod, PodList, Boolean, Watch> podLister = pods().inNamespace(namespace);
     if (obj.getSpec().getSelector().getMatchLabels() != null) {
       podLister.withLabels(obj.getSpec().getSelector().getMatchLabels());
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentRollingUpdater.java
@@ -58,7 +58,7 @@ class DeploymentRollingUpdater extends RollingUpdater<Deployment, DeploymentList
 
   @Override
   protected PodList listSelectedPods(Deployment obj) {
-    FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister = pods().inNamespace(namespace);
+    FilterWatchListDeletable<Pod, PodList, Boolean, Watch>  podLister = pods().inNamespace(namespace);
     if (obj.getSpec().getSelector().getMatchLabels() != null) {
       podLister.withLabels(obj.getSpec().getSelector().getMatchLabels());
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetRollingUpdater.java
@@ -58,7 +58,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
 
   @Override
   protected PodList listSelectedPods(ReplicaSet obj) {
-    FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister = pods().inNamespace(namespace);
+    FilterWatchListDeletable<Pod, PodList, Boolean, Watch>  podLister = pods().inNamespace(namespace);
     if (obj.getSpec().getSelector().getMatchLabels() != null) {
       podLister.withLabels(obj.getSpec().getSelector().getMatchLabels());
     }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
@@ -29,7 +29,8 @@ import io.fabric8.kubernetes.client.dsl.Deletable;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.fabric8.kubernetes.client.dsl.Watchable;
+import io.fabric8.kubernetes.client.dsl.Waitable;
+import io.fabric8.kubernetes.client.dsl.WatchAndWaitable;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -107,7 +109,7 @@ class PodOperationUtilTest {
     // Given
     String controllerUid = "some-uid";
     Map<String, String> selectorLabels = Collections.singletonMap("foo", "bar");
-    FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> filterWatchListDeletable = getMockPodFilterOperation(controllerUid);
+    FilterWatchListDeletable<Pod, PodList, Boolean, Watch> filterWatchListDeletable = getMockPodFilterOperation(controllerUid);
     when(podOperations.withLabels(any())).thenReturn(filterWatchListDeletable);
 
     // When
@@ -134,8 +136,8 @@ class PodOperationUtilTest {
       .build();
   }
 
-  private FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> getMockPodFilterOperation(String controllerUid) {
-    return new FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>>() {
+  private FilterWatchListDeletable<Pod, PodList, Boolean, Watch> getMockPodFilterOperation(String controllerUid) {
+    return new FilterWatchListDeletable<Pod, PodList, Boolean, Watch>() {
       @Override
       public Deletable<Boolean> withGracePeriod(long gracePeriodSeconds) { return null; }
 
@@ -143,43 +145,43 @@ class PodOperationUtilTest {
       public Boolean delete() { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withLabels(Map<String, String> labels) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withLabels(Map<String, String> labels) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withoutLabels(Map<String, String> labels) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withoutLabels(Map<String, String> labels) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withLabelIn(String key, String... values) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withLabelIn(String key, String... values) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withLabelNotIn(String key, String... values) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withLabelNotIn(String key, String... values) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withLabel(String key, String value) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withLabel(String key, String value) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withLabel(String key) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withLabel(String key) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withoutLabel(String key, String value) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withoutLabel(String key, String value) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withoutLabel(String key) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withoutLabel(String key) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withFields(Map<String, String> labels) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withFields(Map<String, String> labels) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withField(String key, String value) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withField(String key, String value) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withoutFields(Map<String, String> fields) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withoutFields(Map<String, String> fields) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withoutField(String key, String value) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withoutField(String key, String value) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withLabelSelector(LabelSelector selector) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withLabelSelector(LabelSelector selector) { return null; }
 
       @Override
       public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withInvolvedObject(ObjectReference objectReference) { return null; }
@@ -197,7 +199,16 @@ class PodOperationUtilTest {
       public Pod updateStatus(Pod item) { return null; }
 
       @Override
-      public Watchable<Watch, Watcher<Pod>> withResourceVersion(String resourceVersion) { return null; }
+      public WatchAndWaitable<Watch, Pod> withResourceVersion(String resourceVersion) { return null; }
+
+      @Override
+      public Pod waitUntilReady(long amount, TimeUnit timeUnit) { return null; }
+
+      @Override
+      public Pod waitUntilCondition(Predicate<Pod> condition, long amount, TimeUnit timeUnit) { return null; }
+
+      @Override
+      public Waitable<Pod, Pod> withWaitRetryBackoff(long initialBackoff, TimeUnit backoffUnit, double backoffMultiplier) { return null; }
 
       @Override
       public Watch watch(Watcher<Pod> watcher) { return null; }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
@@ -184,7 +184,7 @@ class PodOperationUtilTest {
       public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withLabelSelector(LabelSelector selector) { return null; }
 
       @Override
-      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withInvolvedObject(ObjectReference objectReference) { return null; }
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch> withInvolvedObject(ObjectReference objectReference) { return null; }
 
       @Override
       public PodList list() { return getMockPodList(controllerUid); }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -27,8 +27,13 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
+import io.fabric8.kubernetes.client.dsl.ListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 
@@ -38,10 +43,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
-import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_GONE;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +89,7 @@ public class ResourceListTest {
   void testCreateOrReplace() {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HTTP_CREATED, pod1).once();
 
     List<HasMetadata> response = client.resourceList(new PodListBuilder().addToItems(pod1).build()).createOrReplace();
     assertTrue(response.contains(pod1));
@@ -87,7 +99,7 @@ public class ResourceListTest {
   void testCreateOrReplaceFailedCreate() {
     // Given
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_UNAVAILABLE, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HTTP_UNAVAILABLE, pod1).once();
     NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> listOp = client.resourceList(new PodListBuilder().addToItems(pod1).build());
 
     // When
@@ -98,7 +110,7 @@ public class ResourceListTest {
   void testCreateWithExplicitNamespace() {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HTTP_CREATED, pod1).once();
 
     List<HasMetadata> response = client.resourceList(new PodListBuilder().addToItems(pod1).build()).inNamespace("ns1").apply();
     assertTrue(response.contains(pod1));
@@ -111,9 +123,9 @@ public class ResourceListTest {
     Pod pod3 = new PodBuilder().withNewMetadata().withName("pod3").withNamespace("any").and().build();
 
 
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).times(2);
-    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(HttpURLConnection.HTTP_OK, pod2).times(2);
-    server.expect().withPath("/api/v1/namespaces/any/pods/pod3").andReturn(HttpURLConnection.HTTP_OK, pod3).times(1);
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(HTTP_OK, pod1).times(2);
+    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(HTTP_OK, pod2).times(2);
+    server.expect().withPath("/api/v1/namespaces/any/pods/pod3").andReturn(HTTP_OK, pod3).times(1);
 
     //First time all items should be deleted.
     Boolean deleted = client.resourceList(new PodListBuilder().withItems(pod1, pod2, pod3).build()).delete();
@@ -126,12 +138,12 @@ public class ResourceListTest {
 
   @Test
   void testCreateOrReplaceWithoutDeleteExisting() throws Exception {
-    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HttpURLConnection.HTTP_CONFLICT, service).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HttpURLConnection.HTTP_CONFLICT, configMap).once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HttpURLConnection.HTTP_OK , service).once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HttpURLConnection.HTTP_OK, configMap).once();
-    server.expect().put().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HttpURLConnection.HTTP_OK, updatedService).once();
-    server.expect().put().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HttpURLConnection.HTTP_OK, updatedConfigMap).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HTTP_CONFLICT, service).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HTTP_CONFLICT, configMap).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK , service).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, configMap).once();
+    server.expect().put().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK, updatedService).once();
+    server.expect().put().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, updatedConfigMap).once();
 
     client.resourceList(resourcesToUpdate).inNamespace("ns1").createOrReplace();
 
@@ -143,12 +155,12 @@ public class ResourceListTest {
 
   @Test
   void testCreateOrReplaceWithDeleteExisting() throws Exception {
-    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HttpURLConnection.HTTP_CONFLICT, service).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HttpURLConnection.HTTP_CONFLICT, configMap).once();
-    server.expect().delete().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HttpURLConnection.HTTP_OK , service).once();
-    server.expect().delete().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HttpURLConnection.HTTP_OK, configMap).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HttpURLConnection.HTTP_OK, updatedService).once();
-    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HttpURLConnection.HTTP_OK, updatedConfigMap).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HTTP_CONFLICT, service).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HTTP_CONFLICT, configMap).once();
+    server.expect().delete().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK , service).once();
+    server.expect().delete().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, configMap).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/services").andReturn(HTTP_OK, updatedService).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/configmaps").andReturn(HTTP_OK, updatedConfigMap).once();
 
     client.resourceList(resourcesToUpdate).inNamespace("ns1").deletingExisting().createOrReplace();
 
@@ -156,6 +168,165 @@ public class ResourceListTest {
     RecordedRequest request = server.getLastRequest();
     assertEquals("/api/v1/namespaces/ns1/configmaps", request.getPath());
     assertEquals("POST", request.getMethod());
+  }
+
+  @Test
+  void testSuccessfulWaitUntilCondition() throws InterruptedException {
+    Pod pod1 = new PodBuilder().withNewMetadata()
+      .withName("pod1")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady1 = createReadyFrom(pod1, "False");
+    Pod ready1 = createReadyFrom(pod1, "True");
+
+    Pod pod2 = new PodBuilder().withNewMetadata()
+      .withName("pod2")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady2 = createReadyFrom(pod2, "False");
+    Pod ready2 = createReadyFrom(pod2, "True");
+
+    Predicate<HasMetadata> isReady = p -> "Pod".equals(p.getKind()) && ((Pod) p).getStatus().getConditions().stream()
+      .anyMatch(c -> "True".equals(c.getStatus()));
+
+    // The pods are never ready if you request them directly.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HTTP_OK, noReady1).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(HTTP_OK, noReady2).once();
+
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(ready1, "MODIFIED"))
+      .done()
+      .once();
+
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&watch=true").andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
+      .done()
+      .once();
+
+    try (KubernetesClient client = server.getClient()) {
+      KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
+      List<HasMetadata> results = client.resourceList(list).inNamespace("ns1")
+        .waitUntilCondition(isReady, 5, SECONDS);
+      assertThat(results)
+        .containsExactlyInAnyOrder(ready1, ready2);
+    }
+  }
+
+  @Test
+  void testPartialSuccessfulWaitUntilCondition() {
+    Pod pod1 = new PodBuilder().withNewMetadata()
+      .withName("pod1")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady1 = createReadyFrom(pod1, "False");
+
+    Pod pod2 = new PodBuilder().withNewMetadata()
+      .withName("pod2")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady2 = createReadyFrom(pod2, "False");
+    Pod ready2 = createReadyFrom(pod2, "True");
+
+    Predicate<HasMetadata> isReady = p -> "Pod".equals(p.getKind()) && ((Pod) p).getStatus().getConditions().stream()
+      .anyMatch(c -> "True".equals(c.getStatus()));
+
+    // The pods are never ready if you request them directly.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HTTP_OK, noReady1).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(HTTP_OK, noReady2).once();
+
+    Status gone = new StatusBuilder()
+      .withCode(HTTP_GONE)
+      .build();
+
+    // This pod has a non-retryable error.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
+      .done()
+      .once();
+
+    // This pod succeeds.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
+      .done()
+      .once();
+
+    try (KubernetesClient client = server.getClient()) {
+      KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
+      final ListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> ops = client.resourceList(list).inNamespace("ns1");
+      KubernetesClientTimeoutException ex = assertThrows(KubernetesClientTimeoutException.class, () ->
+        ops.waitUntilCondition(isReady, 5, SECONDS)
+      );
+      assertThat(ex.getResourcesNotReady())
+        .containsExactly(pod1);
+    }
+  }
+
+  @Test
+  void testAllFailedWaitUntilCondition() {
+    Pod pod1 = new PodBuilder().withNewMetadata()
+      .withName("pod1")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady1 = createReadyFrom(pod1, "False");
+
+    Pod pod2 = new PodBuilder().withNewMetadata()
+      .withName("pod2")
+      .withResourceVersion("1")
+      .withNamespace("ns1").and().build();
+    Pod noReady2 = createReadyFrom(pod2, "False");
+
+    Predicate<HasMetadata> isReady = p -> "Pod".equals(p.getKind()) && ((Pod) p).getStatus().getConditions().stream()
+      .anyMatch(c -> "True".equals(c.getStatus()));
+
+    // The pods are never ready if you request them directly.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HTTP_OK, noReady1).once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(HTTP_OK, noReady2).once();
+
+    Status gone = new StatusBuilder()
+      .withCode(HTTP_GONE)
+      .build();
+
+    // Both pods have a non-retryable error.
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
+      .done()
+      .once();
+
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
+      .done()
+      .once();
+
+    try (KubernetesClient client = server.getClient()) {
+      KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
+      final ListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> ops = client.resourceList(list).inNamespace("ns1");
+      KubernetesClientTimeoutException ex = assertThrows(KubernetesClientTimeoutException.class, () ->
+        ops.waitUntilCondition(isReady, 5, SECONDS)
+      );
+      assertThat(ex.getResourcesNotReady())
+        .containsExactlyInAnyOrder(pod1, pod2);
+    }
+  }
+
+  private static Pod createReadyFrom(Pod pod, String status) {
+    return new PodBuilder(pod)
+      .withNewStatus()
+      .addNewCondition()
+      .withType("Ready")
+      .withStatus(status)
+      .endCondition()
+      .endStatus()
+      .build();
   }
 
   private static ServiceBuilder mockService() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -17,13 +17,23 @@
 package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.ResourceNotFoundException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Applicable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.base.WaitForConditionWatcher;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -35,19 +45,11 @@ import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import java.net.HttpURLConnection;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.WatchEvent;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-
+import static java.net.HttpURLConnection.HTTP_GONE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -190,7 +192,7 @@ public class ResourceTest {
 
       }
     });
-    Assert.assertTrue(latch.await(5000, TimeUnit.MILLISECONDS));
+    Assert.assertTrue(latch.await(5000, MILLISECONDS));
     watch.close();
   }
 
@@ -202,22 +204,8 @@ public class ResourceTest {
       .withResourceVersion("1")
       .withNamespace("test").and().build();
 
-
-    Pod noReady = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-          .withType("Ready")
-          .withStatus("False")
-        .endCondition()
-      .endStatus()
-      .build();
-
-    Pod ready = new PodBuilder(pod1).withNewStatus()
-        .addNewCondition()
-          .withType("Ready")
-          .withStatus("True")
-        .endCondition()
-      .endStatus()
-      .build();
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, noReady).once();
 
@@ -228,7 +216,7 @@ public class ResourceTest {
       .always();
 
     KubernetesClient client = server.getClient();
-    Pod p = client.resource(noReady).waitUntilReady(5, TimeUnit.SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -239,22 +227,8 @@ public class ResourceTest {
       .withResourceVersion("1")
       .withNamespace("test").and().build();
 
-
-    Pod noReady = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-          .withType("Ready")
-          .withStatus("False")
-        .endCondition()
-      .endStatus()
-      .build();
-
-    Pod ready = new PodBuilder(pod1).withNewStatus()
-        .addNewCondition()
-          .withType("Ready")
-          .withStatus("True")
-        .endCondition()
-      .endStatus()
-      .build();
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
 
     // so that "waitUntilExists" actually has some waiting to do
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(404, "").times(2);
@@ -269,7 +243,7 @@ public class ResourceTest {
       .always();
 
     KubernetesClient client = server.getClient();
-    Pod p = client.pods().withName("pod1").waitUntilReady(5, TimeUnit.SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -280,22 +254,8 @@ public class ResourceTest {
       .withResourceVersion("1")
       .withNamespace("test").and().build();
 
-
-    Pod noReady = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
-
-    Pod ready = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
 
     Pod withConditionBeingFalse = new PodBuilder(pod1).withNewStatus()
       .addNewCondition()
@@ -337,12 +297,69 @@ public class ResourceTest {
       r -> r.getStatus().getConditions()
             .stream()
             .anyMatch(c -> "Dummy".equals(c.getType()) && "True".equals(c.getStatus())),
-      8, TimeUnit.SECONDS
+      8, SECONDS
     );
 
     assertThat(p.getStatus().getConditions())
       .extracting("type", "status")
       .containsExactly(tuple("Ready", "True"), tuple("Dummy", "True"));
+  }
+
+  @Test
+  void testWaitUntilConditionWhenResourceVersionTooOld() throws InterruptedException {
+    Pod pod1 = new PodBuilder().withNewMetadata()
+      .withName("pod1")
+      .withResourceVersion("1")
+      .withNamespace("test").and().build();
+
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
+
+    // The pod is never ready if you request it directly.
+    server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, noReady).always();
+
+    Status gone = new StatusBuilder()
+      .withCode(HTTP_GONE)
+      .build();
+
+    // Watches with the pod's own resource version fail with 410 "GONE".
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
+      .done()
+      .once();
+
+    // Watches with a later resource version will return the "ready" pod.
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=2&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
+      .done()
+      .once();
+
+    Predicate<Pod> isReady = p -> p.getStatus().getConditions().stream()
+      .anyMatch(c -> "True".equals(c.getStatus()));
+
+    try (KubernetesClient client = server.getClient()) {
+      final PodResource<Pod, DoneablePod> ops = client.pods().withName("pod1");
+      KubernetesClientException ex = assertThrows(KubernetesClientException.class, () ->
+        ops.waitUntilCondition(isReady, 4, SECONDS)
+      );
+      assertThat(ex)
+        .hasCauseExactlyInstanceOf(WaitForConditionWatcher.WatchException.class);
+      assertThat(ex.getCause())
+        .hasCauseExactlyInstanceOf(KubernetesClientException.class)
+        .hasMessage("Watcher closed");
+
+      Pod pod = client.pods()
+        .withName("pod1")
+        .withResourceVersion("2")
+        .waitUntilCondition(isReady, 4, SECONDS);
+      assertThat(pod.getMetadata().getName()).isEqualTo("pod1");
+      assertThat(pod.getMetadata().getResourceVersion()).isEqualTo("1");
+      assertTrue(isReady.test(pod));
+    }
   }
 
   @Test
@@ -352,22 +369,8 @@ public class ResourceTest {
       .withResourceVersion("1")
       .withNamespace("test").and().build();
 
-
-    Pod noReady = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
-
-    Pod ready = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
 
     Status status = new StatusBuilder()
       .withCode(HttpURLConnection.HTTP_FORBIDDEN)
@@ -385,7 +388,7 @@ public class ResourceTest {
       .once();
 
     KubernetesClient client = server.getClient();
-    Pod p = client.resource(noReady).waitUntilReady(5, TimeUnit.SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -396,21 +399,8 @@ public class ResourceTest {
       .withResourceVersion("1")
       .withNamespace("test").and().build();
 
-    Pod noReady = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
-
-    Pod ready = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
 
     Status status = new StatusBuilder()
       .withCode(HttpURLConnection.HTTP_FORBIDDEN)
@@ -432,7 +422,7 @@ public class ResourceTest {
       .once();
 
     KubernetesClient client = server.getClient();
-    Pod p = client.resource(noReady).waitUntilReady(5, TimeUnit.SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -443,28 +433,14 @@ public class ResourceTest {
       .withResourceVersion("1")
       .withNamespace("test").and().build();
 
-
-    Pod noReady = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
-
-    Pod ready = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
 
     // once not ready, to begin watch
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, ready).once();
 
     KubernetesClient client = server.getClient();
-    Pod p = client.resource(noReady).waitUntilReady(5, TimeUnit.SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -482,7 +458,7 @@ public class ResourceTest {
       .build();
 
     Status status = new StatusBuilder()
-      .withCode(HttpURLConnection.HTTP_GONE)
+      .withCode(HTTP_GONE)
       .build();
 
     // once not ready, to begin watch
@@ -496,7 +472,7 @@ public class ResourceTest {
 
     KubernetesClient client = server.getClient();
     try {
-      client.resource(noReady).waitUntilReady(5, TimeUnit.SECONDS);
+      client.resource(noReady).waitUntilReady(5, SECONDS);
       fail("should have thrown KubernetesClientException");
     } catch (KubernetesClientException e) {
       assertTrue(e.getCause() instanceof WaitForConditionWatcher.WatchException);
@@ -525,7 +501,7 @@ public class ResourceTest {
       .once();
 
     KubernetesClient client = server.getClient();
-    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull,8, TimeUnit.SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull,8, SECONDS);
     assertNull(p);
   }
 
@@ -536,22 +512,8 @@ public class ResourceTest {
       .withResourceVersion("1")
       .withNamespace("test").and().build();
 
-
-    Pod noReady = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
-
-    Pod ready = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod noReady = createReadyFrom(pod1, "False");
+    Pod ready = createReadyFrom(pod1, "True");
 
     // once so that "waitUntilExists" successfully ends
     // and again so that "periodicWatchUntilReady" successfully begins
@@ -565,7 +527,7 @@ public class ResourceTest {
       .always();
 
     KubernetesClient client = server.getClient();
-    Pod p = client.resource(noReady).createOrReplaceAnd().waitUntilReady(10, TimeUnit.SECONDS);
+    Pod p = client.resource(noReady).createOrReplaceAnd().waitUntilReady(10, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -611,11 +573,21 @@ public class ResourceTest {
     // When
     HasMetadata response = server.getClient()
       .resource(new PodBuilder(conditionMetPod).build())
-      .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, TimeUnit.SECONDS);
+      .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
     // Then
     assertEquals(conditionMetPod, response);
     assertEquals(2, server.getMockServer().getRequestCount());
   }
 
+  private static Pod createReadyFrom(Pod pod, String status) {
+    return new PodBuilder(pod)
+      .withNewStatus()
+        .addNewCondition()
+          .withType("Ready")
+          .withStatus(status)
+        .endCondition()
+      .endStatus()
+      .build();
+  }
 }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationsImpl.java
@@ -18,11 +18,8 @@ package io.fabric8.openshift.client.dsl.internal;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Triggerable;
 import io.fabric8.kubernetes.client.dsl.Typeable;
-import io.fabric8.kubernetes.client.dsl.Watchable;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.EventOperationsImpl;
@@ -167,7 +164,7 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
   }
 
   @Override
-  public Watchable<Watch, Watcher<BuildConfig>> withResourceVersion(String resourceVersion) {
+  public BuildConfigResource<BuildConfig, DoneableBuildConfig, Void, Build> withResourceVersion(String resourceVersion) {
     return new BuildConfigOperationsImpl(getContext().withResourceVersion(resourceVersion));
   }
 


### PR DESCRIPTION
## Description
Allow `withResourceVersion()` to be followed by `waitUntilCondition()`. This enables recovery from HTTP 410 GONE errors, at the cost of breaking the current API slightly, i.e. new `WatchAndWaitable` interface, and replacing `VersionWatchable` with `VersionWatchAndWaitable`. I've also removed a now-surplus type parameter from `WatchListDeletable`.

The existing code for handling `waitUntilCondition()` for a `ResourceList` looks like it could fail with `ConcurrentModificationException` errors if multiple threads try to modify the `result` and `itemsWithConditionNotMatched` lists simultaneously, and so I have used `CompletableFuture`s instead.

Fixes #2414 
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
