### PR TITLE
fix: Improved running time of WatchTest (from ~2 minutes to ~3 seconds)

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -16,12 +16,16 @@
 
 package io.fabric8.kubernetes.client.mock;
 
+import static io.fabric8.kubernetes.client.Watcher.Action.DELETED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.api.model.WatchEventBuilder;
@@ -29,8 +33,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.Watchable;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import junit.framework.AssertionFailedError;
 
 import java.net.HttpURLConnection;
 import java.util.concurrent.CountDownLatch;
@@ -38,154 +42,166 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Rule;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @EnableRuleMigrationSupport
-public class WatchTest {
-  Logger logger = LoggerFactory.getLogger(WatchTest.class);
+class WatchTest {
+
+  private static final Long EVENT_WAIT_PERIOD_MS = 10L;
 
   @Rule
   public KubernetesServer server = new KubernetesServer(false);
 
-  static final Pod pod1 = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
-      .withResourceVersion("1").endMetadata().build();
+  private KubernetesClient client;
+  private Pod pod1;
 
-  static final Status outdatedStatus = new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
-      .withMessage(
-          "401: The event in requested index is outdated and cleared (the requested history has been cleared [3/1]) [2]")
-      .build();
-  static final WatchEvent outdatedEvent = new WatchEventBuilder().withStatusObject(outdatedStatus).build();
-  static final Long EVENT_WAIT_PERIOD = 10L;
+  @BeforeEach
+  void setUp() {
+    client = server.getClient().inNamespace("test");
+    pod1 = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
+      .withResourceVersion("1").endMetadata().build();
+  }
 
   @Test
-  public void testDeletedAndOutdated() throws InterruptedException {
-    logger.info("testDeletedAndOutdated");
-    KubernetesClient client = server.getClient().inNamespace("test");
-
-    // DELETED event, then history outdated
+  @DisplayName("TryWithResources, connects and receives event then receives GONE, should receive first event and then close")
+  void testTryWithResourcesConnectsThenReceivesEvent() throws InterruptedException {
+    // Given
     server.expect()
         .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
-        .andUpgradeToWebSocket().open().waitFor(EVENT_WAIT_PERIOD).andEmit(new WatchEvent(pod1, "DELETED")).waitFor(EVENT_WAIT_PERIOD)
-        .andEmit(outdatedEvent).done().once();
-
+        .andUpgradeToWebSocket().open()
+        .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "DELETED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(outdatedEvent()).done().once();
     final CountDownLatch deleteLatch = new CountDownLatch(1);
     final CountDownLatch closeLatch = new CountDownLatch(1);
-    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
+    final Watcher<Pod> watcher = new Watcher<Pod>() {
       @Override
       public void eventReceived(Action action, Pod resource) {
-        switch (action) {
-        case DELETED:
-          deleteLatch.countDown();
-          break;
-        default:
-          throw new AssertionFailedError();
+        if (action != DELETED) {
+          fail();
         }
+        deleteLatch.countDown();
       }
 
       @Override
       public void onClose(KubernetesClientException cause) {
+        assertEquals(410, cause.getCode());
         closeLatch.countDown();
       }
-    })) /* autoclose */ {
+    };
+    // When
+    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(watcher)) {
+      // Then
+      assertNotNull(watch);
       assertTrue(deleteLatch.await(10, TimeUnit.SECONDS));
       assertTrue(closeLatch.await(10, TimeUnit.SECONDS));
     }
   }
 
   @Test
-  public void testHttpErrorWithOutdated() {
-    Assertions.assertThrows(KubernetesClientException.class, () -> {
-      logger.info("testHttpErrorWithOutdated");
-      KubernetesClient client = server.getClient().inNamespace("test");
-      // http error: history outdated
-      server.expect()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
-        .andReturn(410, outdatedEvent).once();
-      final boolean[] onCloseCalled = {false};
-      try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
-        @Override
-        public void eventReceived(Action action, Pod resource) {
-          throw new AssertionFailedError();
-        }
-
-        @Override
-        public void onClose(KubernetesClientException cause) {
-          onCloseCalled[0] =true;
-        }
-      })) {
-
+  @DisplayName("TryWithResources, receives error when connecting, should NOT receive events and close before propagating the connect exception")
+  void testTryWithResourcesCantConnectShouldCloseAndThenThrowException() throws Exception {
+    // Given
+    final CountDownLatch closeLatch = new CountDownLatch(1);
+    server.expect()
+      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+      .andReturn(410, outdatedEvent()).once();
+    final Watcher<Pod> watcher = new Watcher<Pod>() {
+      @Override
+      public void eventReceived(Action action, Pod resource) {
+        fail();
       }
-      assertTrue(onCloseCalled[0]);
+
+      @Override
+      public void onClose(KubernetesClientException cause) {
+        assertNull("Close event should be invoked by try-with-resources successful completion, not by exception", cause);
+        closeLatch.countDown();
+      }
+    };
+    final Watchable<Watch, Watcher<Pod>> watchable = client.pods().withName("pod1").withResourceVersion("1");
+    // When
+    final KubernetesClientException result = Assertions.assertThrows(KubernetesClientException.class, () -> {
+      try (Watch watch = watchable.watch(watcher)) {
+        assertNull(watch);
+        fail("Close with resources should call Watcher#onClose when closing watch");
+      }
     });
+    // Then
+    assertTrue(closeLatch.await(10, TimeUnit.SECONDS));
+    assertEquals(410, result.getCode());
   }
 
   @Test
-  public void testWithTimeoutSeconds() throws InterruptedException {
+  void testWithTimeoutSecondsShouldAddQueryParam() throws InterruptedException {
     // Given
     server.expect()
       .withPath("/api/v1/namespaces/test/pods?timeoutSeconds=30&watch=true")
-      .andUpgradeToWebSocket().open().waitFor(EVENT_WAIT_PERIOD).andEmit(new WatchEvent(pod1, "DELETED")).waitFor(EVENT_WAIT_PERIOD)
-      .andEmit(outdatedEvent).done().once();
+      .andUpgradeToWebSocket().open()
+      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "DELETED"))
+      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(outdatedEvent()).done().once();
 
     KubernetesClient client = server.getClient();
 
     // When
-    final CountDownLatch eventRecievedLatch = new CountDownLatch(1);
+    final CountDownLatch eventReceivedLatch = new CountDownLatch(1);
     Watch watch = client.pods().watch(new ListOptionsBuilder().withTimeoutSeconds(30L).build(), new Watcher<Pod>() {
       @Override
-      public void eventReceived(Action action, Pod resource) { eventRecievedLatch.countDown(); }
+      public void eventReceived(Action action, Pod resource) { eventReceivedLatch.countDown(); }
 
       @Override
       public void onClose(KubernetesClientException cause) { }
     });
 
     // Then
-    assertTrue(eventRecievedLatch.await(3, TimeUnit.SECONDS));
+    assertTrue(eventReceivedLatch.await(3, TimeUnit.SECONDS));
     watch.close();
   }
 
+  /**
+   * Will attempt a reconnect after 10ms..20ms...40ms....80ms.....160ms......320ms
+   */
   @Test
-  public void testHttpErrorReconnect() throws InterruptedException {
-    logger.info("testHttpErrorReconnect");
-    String path = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true";
-    KubernetesClient client = server.getClient().inNamespace("test");
+  void testHttpErrorReconnect() throws InterruptedException {
+    // Given
+    client.getConfiguration().setWatchReconnectInterval(10);
+    final String path = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true";
     // accept watch and disconnect
     server.expect().withPath(path).andUpgradeToWebSocket().open().done().once();
     // refuse reconnect attempts 6 times
     server.expect().withPath(path).andReturn(503, new StatusBuilder().withCode(503).build()).times(6);
     // accept next reconnect and send outdated event to stop the watch
-    server.expect().withPath(path).andUpgradeToWebSocket().open(outdatedEvent).done().once();
-
+    server.expect().withPath(path).andUpgradeToWebSocket().open(outdatedEvent()).done().once();
     final CountDownLatch closeLatch = new CountDownLatch(1);
-    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
+    final Watcher<Pod> watcher = new Watcher<Pod>() {
       @Override
       public void eventReceived(Action action, Pod resource) {
-        throw new AssertionFailedError();
+        fail();
       }
 
       @Override
       public void onClose(KubernetesClientException cause) {
-        logger.debug("onClose", cause);
+        assertEquals(410, cause.getCode());
         closeLatch.countDown();
       }
-    })) /* autoclose */ {
+    };
+    // When
+    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(watcher)) {
+      // Then
+      assertNotNull(watch);
       assertTrue(closeLatch.await(3, TimeUnit.MINUTES));
     }
   }
 
   @Test
-  public void testOnCloseEvent() throws InterruptedException {
-    logger.info("testOnCloseEvent");
+  void testOnCloseEvent() throws InterruptedException {
     final CountDownLatch eventLatch = new CountDownLatch(2);
     final CountDownLatch closeLatch = new CountDownLatch(1);
-    KubernetesClient client = server.getClient().inNamespace("test");
 
     server.expect()
       .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
-      .andUpgradeToWebSocket().open().waitFor(EVENT_WAIT_PERIOD).andEmit(new WatchEvent(pod1, "MODIFIED")).waitFor(EVENT_WAIT_PERIOD)
+      .andUpgradeToWebSocket().open().waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "MODIFIED")).waitFor(EVENT_WAIT_PERIOD_MS)
       .andEmit(new WatchEvent(pod1, "MODIFIED")).done().once();
 
     Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
@@ -206,11 +222,8 @@ public class WatchTest {
   }
 
   @Test
-  public void testReconnectsWithLastResourceVersion() throws InterruptedException {
-    logger.info("testOnCloseEvent");
+  void testReconnectsWithLastResourceVersion() throws InterruptedException {
     final CountDownLatch eventLatch = new CountDownLatch(3);
-    KubernetesClient client = server.getClient().inNamespace("test");
-
 
     final Pod pod1initial = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
       .withResourceVersion("9").endMetadata().build();
@@ -224,8 +237,8 @@ public class WatchTest {
     server.expect()
       .withPath(path)
       .andUpgradeToWebSocket().open()
-      .waitFor(EVENT_WAIT_PERIOD).andEmit(new WatchEvent(pod1initial, "MODIFIED"))
-      .waitFor(EVENT_WAIT_PERIOD).andEmit(new WatchEvent(pod1update, "MODIFIED"))
+      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1initial, "MODIFIED"))
+      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1update, "MODIFIED"))
       .done().once();
 
     final String reconnectPath = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=10&watch=true";
@@ -233,7 +246,7 @@ public class WatchTest {
     server.expect()
       .withPath(reconnectPath)
       .andUpgradeToWebSocket().open()
-      .waitFor(EVENT_WAIT_PERIOD).andEmit(new WatchEvent(pod1update, "MODIFIED"))
+      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1update, "MODIFIED"))
       .done().once();
 
 
@@ -252,4 +265,11 @@ public class WatchTest {
     watch.close();
   }
 
+  private static WatchEvent outdatedEvent() {
+    return new WatchEventBuilder().withStatusObject(
+      new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
+        .withMessage(
+        "410: The event in requested index is outdated and cleared (the requested history has been cleared [3/1]) [2]")
+      .build()).build();
+  }
 }


### PR DESCRIPTION
## Description
fix: Improved running time of WatchTest (from ~2 minutes to ~3 seconds)

Relates to: #2425 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly~
 - [ ] ~No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report~
 - [ ] ~I tested my code in Kubernetes~
 - [ ] ~I tested my code in OpenShift~

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
