### PR TITLE
Fix #2284: Support running/creating a particular image in a Pod operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix #2311: Add Support for creating bootstrap project template
 * Fix #2287: Add support for V1 and V1Beta1 CustomResourceDefinition
 * Fix #2319: Create Config without using auto-configure functionality or setting env variables
+* Fix #2284: Supports create and run a particular image in a pod operation using client
 
 _**Note**_: Some classes have been moved to other packages:
 - CustomResourceDefinition has been moved to `io.fabric8.kubernetes.api.model.apiextensions.v1` and `io.fabric8.kubernetes.api.model.apiextensions.v1beta1`

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -40,6 +40,7 @@ This document contains common usages of different resources using Fabric8 Kubern
   * [Delete Options](#delete-options)
   * [Watch Options](#watch-options)
   * [Serializing to yaml](#serializing-to-yaml)
+  * [Running a Pod](#running-a-pod)
 
 * [OpenShift Client DSL Usage](#openshift-client-dsl-usage)  
   * [Initializing OpenShift Client](#initializing-openshift-client)
@@ -2286,6 +2287,31 @@ Pod myPod;
 String myPodAsYaml = SerializationUtils.dumpAsYaml(myPod);
 // Your pod might have some state that you don't really care about, to remove it:
 String myPodAsYamlWithoutRuntimeState = SerializationUtils.dumpWithoutRuntimeStateAsYaml(myPod);
+```
+
+#### Running a Pod
+Kubernetes Client also provides mechanism similar to `kubectl run` in which you can spin a `Pod` just by specifying it's image and name:
+- Running a `Pod` by just providing image and name:
+```
+try (KubernetesClient client = new DefaultKubernetesClient()) {
+    client.run().inNamespace("default")
+            .withName("hazelcast")
+            .withImage("hazelcast/hazelcast:3.12.9")
+            .done();
+}
+```
+- You can also provide slighly complex configuration with `withGeneratorConfig` method in which you can specify labels, environment variables, ports etc:
+```
+try (KubernetesClient client = new DefaultKubernetesClient()) {
+    client.run().inNamespace("default")
+            .withRunConfig(new GeneratorRunConfigBuilder()
+                    .withName("nginx")
+                    .withImage("nginx:latest")
+                    .withLabels(Collections.singletonMap("foo", "bar"))
+                    .withEnv(Collections.singletonMap("KUBERNETES_TEST", "fabric8"))
+                    .build())
+            .done();
+}
 ```
 
 ### OpenShift Client DSL Usage

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
@@ -64,6 +64,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.utils.PodGeneratorImpl;
 import okhttp3.OkHttpClient;
 
 import java.io.InputStream;
@@ -259,6 +260,11 @@ public class AutoAdaptableKubernetesClient extends DefaultKubernetesClient {
   @Override
   public MixedOperation<LimitRange, LimitRangeList, DoneableLimitRange, Resource<LimitRange, DoneableLimitRange>> limitRanges() {
     return delegate.limitRanges();
+  }
+
+  @Override
+  public PodGeneratorImpl run() {
+    return delegate.run();
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -112,6 +112,8 @@ import io.fabric8.kubernetes.client.dsl.internal.core.v1.SecretOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.ServiceAccountOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.EventOperationsImpl;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
+import io.fabric8.kubernetes.client.utils.GeneratorRunConfigBuilder;
+import io.fabric8.kubernetes.client.utils.PodGeneratorImpl;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -438,5 +440,10 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public MixedOperation<Lease, LeaseList, DoneableLease, Resource<Lease, DoneableLease>> leases() {
     return new LeaseOperationsImpl(httpClient, getConfiguration());
+  }
+
+  @Override
+  public PodGeneratorImpl run() {
+    return new PodGeneratorImpl(httpClient, getConfiguration(), getNamespace(), new GeneratorRunConfigBuilder());
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -85,6 +85,7 @@ import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
+import io.fabric8.kubernetes.client.utils.PodGeneratorImpl;
 
 import java.io.InputStream;
 import java.util.Collection;
@@ -514,4 +515,11 @@ public interface KubernetesClient extends Client {
    * @return V1APIGroupDSL DSL object for core v1 resources
    */
   V1APIGroupDSL v1();
+
+  /**
+   * Run a Pod (core/v1)
+   *
+   * @return returns {@link PodGeneratorImpl} that allows you to run a pod based on few parameters(e.g. name, image etc)
+   */
+  PodGeneratorImpl run();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -124,6 +124,8 @@ import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
+import io.fabric8.kubernetes.client.utils.GeneratorRunConfigBuilder;
+import io.fabric8.kubernetes.client.utils.PodGeneratorImpl;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
@@ -556,5 +558,10 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public FunctionCallable<NamespacedKubernetesClient> withRequestConfig(RequestConfig requestConfig) {
     return delegate.withRequestConfig(requestConfig);
+  }
+
+  @Override
+  public PodGeneratorImpl run() {
+    return new PodGeneratorImpl(httpClient, getConfiguration(), getNamespace(), new GeneratorRunConfigBuilder());
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/GeneratorRunConfig.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/GeneratorRunConfig.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.sundr.builder.annotations.Buildable;
+
+import java.util.Map;
+
+/**
+ * Configuration for client run
+ */
+public class GeneratorRunConfig {
+  /**
+   * Name of resource
+   */
+  private String name;
+  /**
+   * Image to use
+   */
+  private String image;
+  /**
+   * ImagePullPolicy to be used
+   */
+  private String imagePullPolicy;
+  /**
+   * Pod restart policy
+   */
+  private String restartPolicy;
+  /**
+   * Service Account name to be used
+   */
+  private String serviceAccount;
+  /**
+   * labels to add
+   */
+  private Map<String, String> labels;
+  /**
+   * Environment variables to be add
+   */
+  private Map<String, String> env;
+  /**
+   * Resource limits
+   */
+  private Map<String, Quantity> limits;
+  /**
+   * Resource requests
+   */
+  private Map<String, Quantity> requests;
+  /**
+   * replicas
+   */
+  private int replicas;
+  /**
+   * Port to use
+   */
+  private int port;
+
+  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+  public GeneratorRunConfig(String name, String image, String imagePullPolicy, String restartPolicy, String serviceAccount, Map<String, String> labels, Map<String, String> env, Map<String, Quantity> limits, Map<String, Quantity> requests, int replicas, int port) {
+    this.name = name;
+    this.image = image;
+    this.imagePullPolicy = imagePullPolicy;
+    this.restartPolicy = restartPolicy;
+    this.serviceAccount = serviceAccount;
+    this.labels = labels;
+    this.env = env;
+    this.limits = limits;
+    this.requests = requests;
+    this.replicas = replicas;
+    this.port = port;
+  }
+
+  public String getName() { return name; }
+
+  public String getImage() {
+    return image;
+  }
+
+  public String getImagePullPolicy() {
+    return imagePullPolicy;
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  public Map<String, String> getEnv() {
+    return env;
+  }
+
+  public Map<String, Quantity> getLimits() {
+    return limits;
+  }
+
+  public Map<String, Quantity> getRequests() {
+    return requests;
+  }
+
+  public int getReplicas() {
+    return replicas;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getRestartPolicy() {
+    return restartPolicy;
+  }
+
+  public String getServiceAccount() {
+    return serviceAccount;
+  }
+
+  public void setRestartPolicy(String restartPolicy) {
+    this.restartPolicy = restartPolicy;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setServiceAccount(String serviceAccount) {
+    this.serviceAccount = serviceAccount;
+  }
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public void setReplicas(int replicas) {
+    this.replicas = replicas;
+  }
+
+  public void setRequests(Map<String, Quantity> requests) {
+    this.requests = requests;
+  }
+
+  public void setLimits(Map<String, Quantity> limits) {
+    this.limits = limits;
+  }
+
+  public void setEnv(Map<String, String> env) {
+    this.env = env;
+  }
+
+  public void setLabels(Map<String, String> labels) {
+    this.labels = labels;
+  }
+
+  public void setImagePullPolicy(String imagePullPolicy) {
+    this.imagePullPolicy = imagePullPolicy;
+  }
+
+  public void setImage(String image) {
+    this.image = image;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/GeneratorRunConfigUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/GeneratorRunConfigUtil.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+
+public class GeneratorRunConfigUtil {
+  private static final String DEFAULT_RESTART_POLICY = "Always";
+  private GeneratorRunConfigUtil() { }
+
+  public static ObjectMeta getObjectMetadataFromRunConfig(GeneratorRunConfig generatorRunConfig) {
+    ObjectMetaBuilder objectMetaBuilder = new ObjectMetaBuilder();
+    if (generatorRunConfig.getName() != null) {
+      objectMetaBuilder.withName(generatorRunConfig.getName());
+      objectMetaBuilder.addToLabels("run", generatorRunConfig.getName());
+    }
+
+    if (generatorRunConfig.getLabels() != null) {
+      objectMetaBuilder.addToLabels(generatorRunConfig.getLabels());
+    }
+
+    return objectMetaBuilder.build();
+  }
+
+  public static PodSpec getPodSpecFromRunConfig(GeneratorRunConfig generatorRunConfig) {
+    PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+    if (generatorRunConfig.getRestartPolicy() != null) {
+      podSpecBuilder.withRestartPolicy(generatorRunConfig.getRestartPolicy());
+    } else {
+      podSpecBuilder.withRestartPolicy(DEFAULT_RESTART_POLICY);
+    }
+
+    if (generatorRunConfig.getServiceAccount() != null) {
+      podSpecBuilder.withServiceAccountName(generatorRunConfig.getServiceAccount());
+    }
+
+    podSpecBuilder.addToContainers(getContainersFromRunConfig(generatorRunConfig));
+
+    return podSpecBuilder.build();
+  }
+
+  public static Container getContainersFromRunConfig(GeneratorRunConfig generatorRunConfig) {
+    ContainerBuilder containerBuilder = new ContainerBuilder();
+    if (generatorRunConfig.getName() != null) {
+      containerBuilder.withName(generatorRunConfig.getName());
+    }
+
+    if (generatorRunConfig.getImage() != null) {
+      containerBuilder.withImage(generatorRunConfig.getImage());
+    }
+
+    if (generatorRunConfig.getImagePullPolicy() != null) {
+      containerBuilder.withImagePullPolicy(generatorRunConfig.getImagePullPolicy());
+    }
+
+    if (generatorRunConfig.getEnv() != null) {
+      containerBuilder.withEnv(KubernetesResourceUtil.convertMapToEnvVarList(generatorRunConfig.getEnv()));
+    }
+
+    if (generatorRunConfig.getPort() > 0) {
+      containerBuilder.withPorts(new ContainerPortBuilder()
+        .withContainerPort(generatorRunConfig.getPort())
+        .build());
+    }
+
+    if (generatorRunConfig.getLimits() != null) {
+      containerBuilder.editOrNewResources()
+        .addToLimits(generatorRunConfig.getLimits())
+        .endResources();
+    }
+
+    if (generatorRunConfig.getRequests() != null) {
+      containerBuilder.editOrNewResources()
+        .addToRequests(generatorRunConfig.getRequests())
+        .endResources();
+    }
+    return containerBuilder.build();
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -16,6 +16,8 @@
 
 package io.fabric8.kubernetes.client.utils;
 
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
@@ -23,6 +25,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -327,5 +330,18 @@ public class KubernetesResourceUtil {
           return (int) (d2.getEpochSecond() - d1.getEpochSecond());
       });
     }
+  }
+
+  public static List<EnvVar> convertMapToEnvVarList(Map<String, String> envVarMap) {
+    List<EnvVar> envVars = new ArrayList<>();
+    for (Map.Entry<String, String> entry : envVarMap.entrySet()) {
+      if (entry.getKey() != null && entry.getValue() != null) {
+        envVars.add(new EnvVarBuilder()
+          .withName(entry.getKey())
+          .withValue(entry.getValue())
+          .build());
+      }
+    }
+    return envVars;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/PodGeneratorImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/PodGeneratorImpl.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class PodGeneratorImpl {
+  private final OkHttpClient client;
+  private final Config config;
+  private final String namespace;
+  private final GeneratorRunConfigBuilder generatorRunConfigBuilder;
+
+  public PodGeneratorImpl(OkHttpClient client, Config config, String namespace, GeneratorRunConfigBuilder runConfig) {
+    this.client = client;
+    this.config = config;
+    this.namespace = namespace;
+    this.generatorRunConfigBuilder = runConfig;
+  }
+
+  /**
+   * Specify namespace for the operation
+   *
+   * @param namespace namespace in which resource needs to be created
+   * @return {@link PodGeneratorImpl} with injected namespace
+   */
+  public PodGeneratorImpl inNamespace(String namespace) {
+    return new PodGeneratorImpl(this.client, this.config, namespace, this.generatorRunConfigBuilder);
+  }
+
+  /**
+   * Specify image for the Pod
+   *
+   * @param image image as a string
+   * @return {@link PodGeneratorImpl} with image injected into {@link GeneratorRunConfig}
+   */
+  public PodGeneratorImpl withImage(String image) {
+    return new PodGeneratorImpl(this.client, this.config, namespace, this.generatorRunConfigBuilder.withImage(image));
+  }
+
+  /**
+   * Specify name for the Pod
+   *
+   * @param name name of the pod to be created
+   * @return {@link PodGeneratorImpl} with name injected into {@link GeneratorRunConfig}
+   */
+  public PodGeneratorImpl withName(String name) {
+    return new PodGeneratorImpl(this.client, this.config, namespace, this.generatorRunConfigBuilder.withName(name));
+  }
+
+  /**
+   * Specify complex configuration for Pod creating using {@link GeneratorRunConfig}
+   *
+   * @param generatorRunConfig {@link GeneratorRunConfig} which allows to provide configuring environment variables, labels, resources, ports etc
+   * @return {@link PodGeneratorImpl} with specified configuration
+   */
+  public PodGeneratorImpl withRunConfig(GeneratorRunConfig generatorRunConfig) {
+    return new PodGeneratorImpl(this.client, this.config, namespace, new GeneratorRunConfigBuilder(generatorRunConfig));
+  }
+
+  /**
+   * Apply the {@link GeneratorRunConfig} onto the cluster and create Pod
+   *
+   * @return Pod which got created from the operation
+   */
+  public Pod done() {
+    PodOperationsImpl podOperations = new PodOperationsImpl(client, config, namespace);
+    return podOperations.create(convertRunConfigIntoPod());
+  }
+
+  protected Pod convertRunConfigIntoPod() {
+    GeneratorRunConfig finalGeneratorConfig = generatorRunConfigBuilder.build();
+    return new PodBuilder()
+      .withMetadata(GeneratorRunConfigUtil.getObjectMetadataFromRunConfig(finalGeneratorConfig))
+      .withSpec(GeneratorRunConfigUtil.getPodSpecFromRunConfig(finalGeneratorConfig))
+      .build();
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/GeneratorRunConfigUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/GeneratorRunConfigUtilTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class GeneratorRunConfigUtilTest {
+  @Test
+  void testGetObjectMetadataFromRunConfig() {
+    // Given
+    GeneratorRunConfig config = new GeneratorRunConfigBuilder()
+      .withName("test")
+      .withLabels(Collections.singletonMap("foo", "bar"))
+      .build();
+
+    // When
+    ObjectMeta objectMeta = GeneratorRunConfigUtil.getObjectMetadataFromRunConfig(config);
+
+    // Then
+    assertNotNull(objectMeta);
+    assertEquals("test", objectMeta.getName());
+    assertFalse(objectMeta.getLabels().isEmpty());
+    assertEquals("bar", objectMeta.getLabels().get("foo"));
+  }
+
+  @Test
+  void testGetPodSpecFromRunConfig() {
+    // Given
+    GeneratorRunConfig config = new GeneratorRunConfigBuilder()
+      .withName("test")
+      .withImage("test:latest")
+      .withEnv(Collections.singletonMap("TEST_KEY", "TEST_VALUE"))
+      .withImagePullPolicy("IfNotPresent")
+      .withLimits(getLimits())
+      .build();
+
+    // When
+    PodSpec podSpec = GeneratorRunConfigUtil.getPodSpecFromRunConfig(config);
+
+    // Then
+    assertNotNull(podSpec);
+    assertNotNull(podSpec.getContainers());
+    assertEquals(1, podSpec.getContainers().size());
+    assertEquals("test", podSpec.getContainers().get(0).getName());
+    assertEquals("IfNotPresent", podSpec.getContainers().get(0).getImagePullPolicy());
+    assertEquals("test:latest", podSpec.getContainers().get(0).getImage());
+    assertEquals(1, podSpec.getContainers().get(0).getEnv().size());
+    assertEquals("TEST_KEY", podSpec.getContainers().get(0).getEnv().get(0).getName());
+    assertEquals("TEST_VALUE", podSpec.getContainers().get(0).getEnv().get(0).getValue());
+  }
+
+  @Test
+  void testGetContainersFromRunConfig() {
+    // Given
+    GeneratorRunConfig config = getCompleteGeneratorRunConfig();
+
+    // When
+    Container container = GeneratorRunConfigUtil.getContainersFromRunConfig(config);
+
+    // Then
+    assertNotNull(container);
+    assertEquals("test", container.getName());
+    assertEquals("IfNotPresent", container.getImagePullPolicy());
+    assertEquals("test:latest", container.getImage());
+    assertEquals(1, container.getEnv().size());
+    assertEquals(1, container.getPorts().size());
+    assertEquals(5701, container.getPorts().get(0).getContainerPort());
+    assertEquals("TEST_KEY", container.getEnv().get(0).getName());
+    assertEquals("TEST_VALUE", container.getEnv().get(0).getValue());
+    assertEquals(new Quantity("200m"), container.getResources().getLimits().get("cpu"));
+    assertEquals(new Quantity("512Mi"), container.getResources().getLimits().get("memory"));
+    assertEquals(new Quantity("150m"), container.getResources().getRequests().get("cpu"));
+    assertEquals(new Quantity("64Mi"), container.getResources().getRequests().get("memory"));
+  }
+
+
+  private Map<String, Quantity> getLimits() {
+    Map<String, Quantity> limits = new HashMap<>();
+    limits.put("cpu", new Quantity("200m"));
+    limits.put("memory", new Quantity("512Mi"));
+    return limits;
+  }
+
+  private Map<String, Quantity> getRequests() {
+    Map<String, Quantity> requests = new HashMap<>();
+    requests.put("memory", new Quantity("64Mi"));
+    requests.put("cpu", new Quantity("150m"));
+    return requests;
+  }
+
+  private GeneratorRunConfig getCompleteGeneratorRunConfig() {
+    return new GeneratorRunConfigBuilder()
+      .withName("test")
+      .withImage("test:latest")
+      .withReplicas(1)
+      .withEnv(Collections.singletonMap("TEST_KEY", "TEST_VALUE"))
+      .withImagePullPolicy("IfNotPresent")
+      .withPort(5701)
+      .withLimits(getLimits())
+      .withRequests(getRequests())
+      .build();
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodGeneratorImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodGeneratorImplTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class PodGeneratorImplTest {
+  private OkHttpClient mockClient;
+  private Config config;
+
+  @BeforeEach
+  public void init() {
+    this.mockClient = Mockito.mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    this.config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+  }
+
+  @Test
+  void testConvertRunConfigIntoPod() {
+    // Given
+    Map<String, Quantity> limits = new HashMap<>();
+    limits.put("cpu", new Quantity("200m"));
+    limits.put("memory", new Quantity("512Mi"));
+    Map<String, Quantity> requests = new HashMap<>();
+    requests.put("memory", new Quantity("64Mi"));
+    requests.put("cpu", new Quantity("150m"));
+    Map<String, String> labels = new HashMap<>();
+    labels.put("first", "FIRST");
+    labels.put("second", "SECOND");
+    GeneratorRunConfigBuilder generatorRunConfig = new GeneratorRunConfigBuilder()
+      .withName("test")
+      .withImage("test:latest")
+      .withLabels(labels)
+      .withEnv(Collections.singletonMap("TEST_KEY", "TEST_VALUE"))
+      .withImagePullPolicy("IfNotPresent")
+      .withRestartPolicy("OnFailure")
+      .withServiceAccount("ribbon")
+      .withPort(5701)
+      .withLimits(limits)
+      .withRequests(requests);
+    PodGeneratorImpl deploymentGenerator = new PodGeneratorImpl(mockClient, config, "ns1", generatorRunConfig);
+
+    // When
+    Pod pod = deploymentGenerator.convertRunConfigIntoPod();
+
+    // Then
+    assertNotNull(pod);
+    assertEquals("test", pod.getMetadata().getName());
+    assertEquals("FIRST", pod.getMetadata().getLabels().get("first"));
+    assertEquals("SECOND", pod.getMetadata().getLabels().get("second"));
+    assertEquals("test", pod.getMetadata().getLabels().get("run"));
+    assertNotNull(pod.getSpec());
+    assertEquals("OnFailure", pod.getSpec().getRestartPolicy());
+    assertEquals("ribbon", pod.getSpec().getServiceAccountName());
+    assertEquals("test", pod.getSpec().getContainers().get(0).getName());
+    assertEquals("IfNotPresent", pod.getSpec().getContainers().get(0).getImagePullPolicy());
+    assertEquals("test:latest", pod.getSpec().getContainers().get(0).getImage());
+    assertEquals(1, pod.getSpec().getContainers().get(0).getEnv().size());
+    assertEquals(1, pod.getSpec().getContainers().get(0).getPorts().size());
+    assertEquals(5701, pod.getSpec().getContainers().get(0).getPorts().get(0).getContainerPort());
+    assertEquals("TEST_KEY", pod.getSpec().getContainers().get(0).getEnv().get(0).getName());
+    assertEquals("TEST_VALUE", pod.getSpec().getContainers().get(0).getEnv().get(0).getValue());
+    assertEquals(new Quantity("200m"), pod.getSpec().getContainers().get(0).getResources().getLimits().get("cpu"));
+    assertEquals(new Quantity("512Mi"), pod.getSpec().getContainers().get(0).getResources().getLimits().get("memory"));
+    assertEquals(new Quantity("150m"), pod.getSpec().getContainers().get(0).getResources().getRequests().get("cpu"));
+    assertEquals(new Quantity("64Mi"), pod.getSpec().getContainers().get(0).getResources().getRequests().get("memory"));
+  }
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -57,7 +57,9 @@ import io.fabric8.kubernetes.client.dsl.internal.coordination.v1.LeaseOperations
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.ComponentStatusOperationsImpl;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
 import io.fabric8.kubernetes.client.utils.BackwardsCompatibilityInterceptor;
+import io.fabric8.kubernetes.client.utils.GeneratorRunConfigBuilder;
 import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
+import io.fabric8.kubernetes.client.utils.PodGeneratorImpl;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -522,6 +524,11 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public V1APIGroupDSL v1() {
     return adapt(V1APIGroupClient.class);
+  }
+
+  @Override
+  public PodGeneratorImpl run() {
+    return new PodGeneratorImpl(httpClient, getConfiguration(), getNamespace(), new GeneratorRunConfigBuilder());
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -43,6 +43,7 @@ import io.fabric8.kubernetes.client.dsl.*;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.internal.RawCustomResourceOperationsImpl;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
+import io.fabric8.kubernetes.client.utils.PodGeneratorImpl;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.fabric8.openshift.api.model.*;
@@ -497,6 +498,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public V1APIGroupDSL v1() {
     return delegate.v1();
+  }
+
+  @Override
+  public PodGeneratorImpl run() {
+    return delegate.run();
   }
 
   @Override


### PR DESCRIPTION
Fix #2284 

Add support for client.run() with which we should be able to create
Pod/Deployments just based on few parameters. For example, creating
a simple pod should be like:

```
client.run().pods().withName("nginx").withImage("nginx:1.39").done()
```

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
