### PR TITLE
Quickstarts fails on OCP 4.6

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -808,8 +808,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     } catch (MalformedURLException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("watch"), e);
     } catch (KubernetesClientException ke) {
-
-      if (ke.getCode() != 200) {
+      List<Integer> furtherProcessedCodes = Arrays.asList(200, 503);
+      if (! furtherProcessedCodes.contains(ke.getCode())) {
         if (watch != null) {
           //release the watch
           watch.close();
@@ -824,7 +824,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         watch.close();
       }
 
-      // If the HTTP return code is 200, we retry the watch again using a persistent hanging
+      // If the HTTP return code is 200 or 503, we retry the watch again using a persistent hanging
       // HTTP GET. This is meant to handle cases like kubectl local proxy which does not support
       // websockets. Issue: https://github.com/kubernetes/kubernetes/issues/25126
       try {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -180,9 +180,10 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
 
         // We do not expect a 200 in response to the websocket connection. If it occurs, we throw
         // an exception and try the watch via a persistent HTTP Get.
-        if (response != null && response.code() == HTTP_OK) {
+        // Newer Kubernetes might also return 503 Service Unavailable in case WebSockets are not supported
+        if (response != null && (response.code() == HTTP_OK || response.code() == 503)) {
           queue.clear();
-          queue.offer(new KubernetesClientException("Received 200 on websocket",
+          queue.offer(new KubernetesClientException("Received " + response.code() + " on websocket",
             response.code(), null));
           response.body().close();
           return;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -170,7 +170,7 @@ class WatchTest {
     // accept watch and disconnect
     server.expect().withPath(path).andUpgradeToWebSocket().open().done().once();
     // refuse reconnect attempts 6 times
-    server.expect().withPath(path).andReturn(503, new StatusBuilder().withCode(503).build()).times(6);
+    server.expect().withPath(path).andReturn(HttpURLConnection.HTTP_NOT_FOUND, new StatusBuilder().withCode(HttpURLConnection.HTTP_NOT_FOUND).build()).times(6);
     // accept next reconnect and send outdated event to stop the watch
     server.expect().withPath(path).andUpgradeToWebSocket().open(outdatedEvent()).done().once();
     final CountDownLatch closeLatch = new CountDownLatch(1);


### PR DESCRIPTION
From downstream: https://github.com/jboss-fuse/kubernetes-client/pull/12

On newer Kubernetes, when WebSockets are not available, the server returns 503 Service Unavailable status code (formerly it returned 200 OK). Watch service needs to consider this response code too when trying to fall back to HTTP watch.