### PR TITLE
fix: ConfigMap and other resources are replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.11-SNAPSHOT
 
 #### Bugs
+* Fix #2445: ConfigMap and other resources are replaced
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -16,7 +16,6 @@
 package io.fabric8.kubernetes.client.dsl.base;
 
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
-import io.fabric8.kubernetes.client.utils.ResourceCompare;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,26 +130,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     this.watchRetryBackoffMultiplier = ctx.getWatchRetryBackoffMultiplier();
   }
 
-  /**
-   * Returns the name and falls back to the item name.
-   * @param item  The item.
-   * @param name  The name to check.
-   * @param <T>
-   * @return
-   */
-  private static <T> String name(T item, String name) {
-    if (name != null && !name.isEmpty()) {
-      return name;
-    } else if (item instanceof HasMetadata) {
-      HasMetadata h = (HasMetadata) item;
-      return h.getMetadata() != null ? h.getMetadata().getName() : null;
-    }
-    return null;
-  }
-
-
   public BaseOperation<T, L, D, R> newInstance(OperationContext context) {
-    return new BaseOperation<T, L, D, R>(context);
+    return new BaseOperation<>(context);
   }
 
   /**
@@ -188,14 +169,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   @Override
   public T get() {
     try {
-      T answer = getMandatory();
-      if (answer instanceof HasMetadata) {
-        HasMetadata hasMetadata = (HasMetadata) answer;
-        updateApiVersion(hasMetadata);
-      } else if (answer instanceof KubernetesResourceList) {
-        KubernetesResourceList list = (KubernetesResourceList) answer;
-        updateApiVersion(list);
-      }
+      final T answer = getMandatory();
+      updateApiVersion(answer);
       return answer;
     } catch (KubernetesClientException e) {
       if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
@@ -206,19 +181,13 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public T require() throws ResourceNotFoundException {
+  public T require() {
     try {
       T answer = getMandatory();
       if (answer == null) {
         throw new ResourceNotFoundException("The resource you request doesn't exist or couldn't be fetched.");
       }
-      if (answer instanceof HasMetadata) {
-        HasMetadata hasMetadata = (HasMetadata) answer;
-        updateApiVersion(hasMetadata);
-      } else if (answer instanceof KubernetesResourceList) {
-        KubernetesResourceList list = (KubernetesResourceList) answer;
-        updateApiVersion(list);
-      }
+      updateApiVersion(answer);
       return answer;
     } catch (KubernetesClientException e) {
       if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
@@ -265,7 +234,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public D edit() throws KubernetesClientException {
+  public D edit() {
     throw new KubernetesClientException("Cannot edit read-only resources");
   }
 
@@ -332,8 +301,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return newInstance(context.withReloadingFromServer(true));
   }
 
+  @SafeVarargs
   @Override
-  public T create(T... resources) throws KubernetesClientException {
+  public final T create(T... resources) {
     try {
       if (resources.length > 1) {
         throw new IllegalArgumentException("Too many items to create.");
@@ -363,7 +333,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public D createNew() throws KubernetesClientException {
+  public D createNew() {
     final Function<T, T> visitor = resource -> {
       try {
         return create(resource);
@@ -381,7 +351,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
 
   @Override
-  public D createOrReplaceWithNew() throws KubernetesClientException {
+  public D createOrReplaceWithNew() {
     final Function<T, T> visitor = resource -> {
       try {
         return createOrReplace(resource);
@@ -397,8 +367,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     }
   }
 
+  @SafeVarargs
   @Override
-  public T createOrReplace(T... items) {
+  public final T createOrReplace(T... items) {
     T itemToCreateOrReplace = getItem();
     if (items.length > 1) {
       throw new IllegalArgumentException("Too many items to create.");
@@ -423,16 +394,10 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       if (exception.getCode() != HttpURLConnection.HTTP_CONFLICT) {
         throw exception;
       }
-
       // Conflict; Do Replace
-      T itemFromServer = fromServer().get();
-      if (ResourceCompare.equals(itemFromServer, itemToCreateOrReplace)) {
-        // Nothing changed, ignore
-        return itemToCreateOrReplace;
-      } else {
-        KubernetesResourceUtil.setResourceVersion(itemToCreateOrReplace, KubernetesResourceUtil.getResourceVersion(itemFromServer));
-        return replace(itemToCreateOrReplace);
-      }
+      final T itemFromServer = fromServer().get();
+      KubernetesResourceUtil.setResourceVersion(itemToCreateOrReplace, KubernetesResourceUtil.getResourceVersion(itemFromServer));
+      return replace(itemToCreateOrReplace);
     }
   }
 
@@ -474,29 +439,28 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return this;
   }
 
-  // Deprecated as the underlying implementation does not align with the arguments anymore.
-  // It is possible to negate multiple values with the same key, e.g.:
-  // foo != bar , foo != baz
-  // To support this a multi-value map is needed, as a regular map would override the key with the new value.
+  /**
+   * @deprecated as the underlying implementation does not align with the arguments anymore.
+   *    It is possible to negate multiple values with the same key, e.g.:
+   *    foo != bar , foo != baz
+   *    To support this a multi-value map is needed, as a regular map would override the key with the new value.
+   */
   @Override
   @Deprecated
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabels(Map<String, String> labels) throws
-    KubernetesClientException {
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutLabels(Map<String, String> labels) {
     // Re-use "withoutLabel" to convert values from String to String[]
     labels.forEach(this::withoutLabel);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabelIn(String key, String... values) throws
-    KubernetesClientException {
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabelIn(String key, String... values) {
     labelsIn.put(key, values);
     return this;
   }
 
   @Override
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabelNotIn(String key, String... values) throws
-    KubernetesClientException {
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withLabelNotIn(String key, String... values) {
     labelsNotIn.put(key, values);
     return this;
   }
@@ -540,16 +504,17 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return this;
   }
 
-  // Deprecated as the underlying implementation does not align with the arguments fully.
-  // Method is created to have a similar API as `withoutLabels`, but should eventually be replaced with something
-  // better for the same reasons.
-  // It is possible to negate multiple values with the same key, e.g.:
-  // foo != bar , foo != baz
-  // To support this a multi-value map is needed, as a regular map would override the key with the new value.
+  /**
+   * @deprecated as the underlying implementation does not align with the arguments fully.
+   *    Method is created to have a similar API as `withoutLabels`, but should eventually be replaced
+   *    with something better for the same reasons.
+   *    It is possible to negate multiple values with the same key, e.g.:
+   *    foo != bar , foo != baz
+   *    To support this a multi-value map is needed, as a regular map would override the key with the new value.
+   */
   @Override
   @Deprecated
-  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutFields(Map<String, String> fields) throws
-    KubernetesClientException {
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withoutFields(Map<String, String> fields) {
     // Re-use "withoutField" to convert values from String to String[]
     labels.forEach(this::withoutField);
     return this;
@@ -655,7 +620,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return sb.toString();
   }
 
-  public L list() throws KubernetesClientException {
+  public L list() {
     try {
       return listRequestHelper(getResourceUrl(namespace, name));
     } catch (IOException e) {
@@ -700,9 +665,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     }
   }
 
-
+  @SafeVarargs
   @Override
-  public Boolean delete(T... items) {
+  public final Boolean delete(T... items) {
     return delete(Arrays.asList(items));
   }
 
@@ -710,25 +675,20 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   public Boolean delete(List<T> items) {
     boolean deleted = true;
     if (items != null) {
-      for (T item : items) {
-        if (item == null) {
+      for (T toDelete : items) {
+        if (toDelete == null) {
           continue;
         }
-        updateApiVersionResource(item);
+        updateApiVersion(toDelete);
 
         try {
-          R op;
-
-          if (item instanceof HasMetadata
-            && ((HasMetadata) item).getMetadata() != null
-            && ((HasMetadata) item).getMetadata().getName() != null
-            && !((HasMetadata) item).getMetadata().getName().isEmpty()) {
-            op = (R) inNamespace(checkNamespace(item)).withName(((HasMetadata) item).getMetadata().getName());
+          if (toDelete.getMetadata() != null
+            && toDelete.getMetadata().getName() != null
+            && !toDelete.getMetadata().getName().isEmpty()) {
+            deleted &= inNamespace(checkNamespace(toDelete)).withName(toDelete.getMetadata().getName()).delete();
           } else {
-            op = (R) withItem(item);
+            deleted &= withItem(toDelete).delete();
           }
-
-          deleted &= op.delete();
         } catch (KubernetesClientException e) {
           if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
             throw e;
@@ -756,7 +716,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   void deleteThis() {
     try {
       if (item != null) {
-        updateApiVersionResource(item);
+        updateApiVersion(item);
         handleDelete(item, gracePeriodSeconds, propagationPolicy, cascading);
       } else {
         handleDelete(getResourceUrl(), gracePeriodSeconds, propagationPolicy, cascading);
@@ -858,27 +818,27 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return Utils.isResourceNamespaced(getType());
   }
 
-  protected T handleResponse(Request.Builder requestBuilder) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+  protected T handleResponse(Request.Builder requestBuilder) throws ExecutionException, InterruptedException, IOException {
     return handleResponse(requestBuilder, getType());
   }
 
-  protected T handleCreate(T resource) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
-    updateApiVersionResource(resource);
+  protected T handleCreate(T resource) throws ExecutionException, InterruptedException, IOException {
+    updateApiVersion(resource);
     return handleCreate(resource, getType());
   }
 
-  protected T handleReplace(T updated) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
-    updateApiVersionResource(updated);
+  protected T handleReplace(T updated) throws ExecutionException, InterruptedException, IOException {
+    updateApiVersion(updated);
     return handleReplace(updated, getType());
   }
 
-  protected T handlePatch(T current, T updated) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
-    updateApiVersionResource(updated);
+  protected T handlePatch(T current, T updated) throws ExecutionException, InterruptedException, IOException {
+    updateApiVersion(updated);
     return handlePatch(current, updated, getType());
   }
 
   protected T handlePatch(T current, Map<String, Object> patchedUpdate) throws ExecutionException, InterruptedException, IOException {
-    updateApiVersionResource(current);
+    updateApiVersion(current);
     return handlePatch(current, patchedUpdate, getType());
   }
 
@@ -911,7 +871,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   protected T handleGet(URL resourceUrl) throws InterruptedException, ExecutionException, IOException {
     T answer = handleGet(resourceUrl, getType());
-    updateApiVersionResource(answer);
+    updateApiVersion(answer);
     return answer;
   }
 
@@ -1034,40 +994,17 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   /**
-   * Updates the list or single item if it has a missing or incorrect apiGroupVersion
-   *
-   * @param resource resource object
-   */
-  protected void updateApiVersionResource(Object resource) {
-    if (resource instanceof HasMetadata) {
-      HasMetadata hasMetadata = (HasMetadata) resource;
-      updateApiVersion(hasMetadata);
-    } else if (resource instanceof KubernetesResourceList) {
-      KubernetesResourceList list = (KubernetesResourceList) resource;
-      updateApiVersion(list);
-    }
-  }
-
-  /**
    * Updates the list items if they have missing or default apiGroupVersion values and the resource is currently
    * using API Groups with custom version strings
    *
    * @param list Kubernetes resource list
    */
-  protected void updateApiVersion(KubernetesResourceList list) {
+  protected void updateApiVersion(KubernetesResourceList<T> list) {
     String version = getApiVersion();
-    if (list != null && version != null && version.length() > 0) {
-      List items = list.getItems();
-      if (items != null) {
-        for (Object item : items) {
-          if (item instanceof HasMetadata) {
-            updateApiVersion((HasMetadata) item);
-          }
-        }
-      }
+    if (list != null && version != null && version.length() > 0 && list.getItems() != null) {
+      list.getItems().forEach(this::updateApiVersion);
     }
   }
-
 
   /**
    * Updates the resource if it has missing or default apiGroupVersion values and the resource is currently
@@ -1102,8 +1039,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public Boolean isReady() {
-    T i = get();
-    return i instanceof HasMetadata && Readiness.isReady((HasMetadata) i);
+    return Readiness.isReady(get());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -23,9 +23,6 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import java.net.HttpURLConnection;
 import java.util.function.Predicate;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,15 +55,12 @@ import io.fabric8.kubernetes.client.dsl.Waitable;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.handlers.KubernetesListHandler;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.kubernetes.client.utils.ResourceCompare;
 import okhttp3.OkHttpClient;
 
 public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl extends OperationSupport implements
   NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<HasMetadata, Boolean>,
   Waitable<HasMetadata, HasMetadata>,
   Readiable {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.class);
 
   private final String fallbackNamespace;
   private final String explicitNamespace;
@@ -153,16 +147,12 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
       }
 
       // Conflict; check deleteExisting flag otherwise replace
-      HasMetadata r = h.reload(client, config, meta.getMetadata().getNamespace(), meta);
       if (Boolean.TRUE.equals(deletingExisting)) {
         Boolean deleted = h.delete(client, config, namespaceToUse, propagationPolicy, meta);
         if (Boolean.FALSE.equals(deleted)) {
           throw new KubernetesClientException("Failed to delete existing item:" + meta);
         }
         return h.create(client, config, namespaceToUse, meta);
-      } else if (ResourceCompare.equals(r, meta)) {
-        LOGGER.debug("Item has not changed. Skipping");
-        return meta;
       } else {
         KubernetesResourceUtil.setResourceVersion(meta, resourceVersion);
         return h.replace(client, config, namespaceToUse, meta);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -62,7 +62,6 @@ public class ResourceTest {
   @Rule
   public KubernetesServer server = new KubernetesServer();
 
-
   @Test
   void testCreateOrReplace() {
     // Given
@@ -91,13 +90,13 @@ public class ResourceTest {
 
     @Test
     void testCreateWithExplicitNamespace() {
-        Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+      Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-        server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+      server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
 
-        KubernetesClient client = server.getClient();
-        HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
-        assertEquals(pod1, response);
+      KubernetesClient client = server.getClient();
+      HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
+      assertEquals(pod1, response);
     }
 
     @Test
@@ -105,7 +104,6 @@ public class ResourceTest {
       Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
       server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, pod1).once();
-      server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
       server.expect().delete().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
       server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
 
@@ -114,7 +112,7 @@ public class ResourceTest {
       assertEquals(pod1, response);
 
       RecordedRequest request = server.getLastRequest();
-      assertEquals(4, server.getMockServer().getRequestCount());
+      assertEquals(3, server.getMockServer().getRequestCount());
       assertEquals("/api/v1/namespaces/ns1/pods", request.getPath());
       assertEquals("POST", request.getMethod());
     }


### PR DESCRIPTION
## Description
fix #2445 : ConfigMap and other resources are replaced
- Reverted **behavior** of BaseOperation#createOrReplace method (and similar)
  to the previous behavior.
  API will always be hit, POST to try to create, and PUT in case POST fails.
  This reverts the behavior trying to mimic kubectl and not performing
  the second PUT request in case the resource is identical to the server version.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
