### PR TITLE
correct spelling on curd (crud) mode

### DIFF
--- a/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeServer.java
+++ b/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeServer.java
@@ -33,7 +33,10 @@ public class KnativeServer extends ExternalResource {
   private KnativeClient client;
 
   private boolean https;
-  private boolean curdMode;
+  // In this mode the mock web server will store, read, update and delete
+  // kubernetes resources using an in memory map and will appear as a real api
+  // server.
+  private boolean crudMode;
 
   public KnativeServer() {
     this(true, false);
@@ -43,13 +46,13 @@ public class KnativeServer extends ExternalResource {
     this(https, false);
   }
 
-  public KnativeServer(boolean https, boolean curdMode) {
+  public KnativeServer(boolean https, boolean crudMode) {
     this.https = https;
-    this.curdMode = curdMode;
+    this.crudMode = crudMode;
   }
 
   public void before() {
-    mock = curdMode
+    mock = crudMode
       ? new KnativeMockServer(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new KubernetesCrudDispatcher(), true)
       : new KnativeMockServer(https);
     mock.init();

--- a/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogServer.java
+++ b/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogServer.java
@@ -33,7 +33,10 @@ public class ServiceCatalogServer extends ExternalResource {
   private ServiceCatalogClient client;
 
   private boolean https;
-  private boolean curdMode;
+  // In this mode the mock web server will store, read, update and delete
+  // kubernetes resources using an in memory map and will appear as a real api
+  // server.
+  private boolean crudMode;
 
   public ServiceCatalogServer() {
     this(true, false);
@@ -43,13 +46,13 @@ public class ServiceCatalogServer extends ExternalResource {
     this(https, false);
   }
 
-  public ServiceCatalogServer(boolean https, boolean curdMode) {
+  public ServiceCatalogServer(boolean https, boolean crudMode) {
     this.https = https;
-    this.curdMode = curdMode;
+    this.crudMode = crudMode;
   }
 
   public void before() {
-    mock = curdMode
+    mock = crudMode
       ? new ServiceCatalogMockServer(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new KubernetesCrudDispatcher(), true)
       : new ServiceCatalogMockServer(https);
     mock.init();

--- a/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonServer.java
+++ b/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonServer.java
@@ -33,7 +33,10 @@ public class TektonServer extends ExternalResource {
   private TektonClient client;
 
   private boolean https;
-  private boolean curdMode;
+  // In this mode the mock web server will store, read, update and delete
+  // kubernetes resources using an in memory map and will appear as a real api
+  // server.
+  private boolean crudMode;
 
   public TektonServer() {
     this(true, false);
@@ -43,13 +46,13 @@ public class TektonServer extends ExternalResource {
     this(https, false);
   }
 
-  public TektonServer(boolean https, boolean curdMode) {
+  public TektonServer(boolean https, boolean crudMode) {
     this.https = https;
-    this.curdMode = curdMode;
+    this.crudMode = crudMode;
   }
 
   public void before() {
-    mock = curdMode
+    mock = crudMode
       ? new TektonMockServer(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new KubernetesCrudDispatcher(), true)
       : new TektonMockServer(https);
     mock.init();

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
@@ -37,7 +37,10 @@ public class OpenShiftServer extends ExternalResource {
   private NamespacedOpenShiftClient client;
 
   private boolean https;
-  private boolean curdMode;
+  // In this mode the mock web server will store, read, update and delete
+  // kubernetes resources using an in memory map and will appear as a real api
+  // server.
+  private boolean crudMode;
 
   public OpenShiftServer() {
     this(true, false);
@@ -47,13 +50,13 @@ public class OpenShiftServer extends ExternalResource {
     this(https, false);
   }
 
-  public OpenShiftServer(boolean https, boolean curdMode) {
+  public OpenShiftServer(boolean https, boolean crudMode) {
     this.https = https;
-    this.curdMode = curdMode;
+    this.crudMode = crudMode;
   }
 
   public void before() {
-    mock = curdMode
+    mock = crudMode
       ? new OpenShiftMockServer(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new KubernetesCrudDispatcher(), true)
       : new OpenShiftMockServer(https);
     mock.init();


### PR DESCRIPTION
Rename 'curdMode' to 'crudMode' and add a comment what it does.
This is the same PR as #1107 but generalized to all other mocks.
Fixes #1106.