### PR TITLE
Fix #2467: OpenShiftClient cannot replace existing resource with API version =! v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix: #2442: Wrong resource kind in `ProjectRequestHandler` causes ClassCastException when handling Project resources.
+* Fix #2467: OpenShiftClient cannot replace existing resource with API version =! v1
 
 #### Improvements
 * Fix #2473: Removed unused ValidationMessages.properties

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
@@ -24,6 +24,7 @@ import okhttp3.Response;
 import okio.Buffer;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -134,7 +135,7 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
     Response response = chain.proceed(request);
     if (isOpenshiftApiRequest(request)) {
       return handleOpenshiftRequests(request, response, chain);
-    } else if (!response.isSuccessful() && responseCodeToTransformations.keySet().contains(response.code())) {
+    } else if (!response.isSuccessful() && responseCodeToTransformations.containsKey(response.code())) {
       String url = request.url().toString();
       Matcher matcher = getMatcher(url);
       ResourceKey key = getKey(matcher);
@@ -170,7 +171,7 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
   }
 
   private static Response handleOpenshiftRequests(Request request, Response response, Chain chain) throws IOException{
-    if (!response.isSuccessful()) {
+    if (!response.isSuccessful() && response.code() == HttpURLConnection.HTTP_NOT_FOUND) {
       ResourceKey target = getResourceKeyFromRequest(request);
       if (target != null) {
         String requestUrl = request.url().toString();

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
@@ -89,4 +89,19 @@ public class DeploymentConfigIT {
     assertTrue(bDeleted);
   }
 
+  @Test
+  public void createOrReplace() {
+    // Given
+    DeploymentConfig deploymentConfig = client.deploymentConfigs().inNamespace(session.getNamespace()).withName("dc-createorreplace").get();
+
+    // When
+    deploymentConfig.getSpec().getTemplate().getSpec().getContainers().get(0).setImage("openshift/hello-openshift:v3.8");
+    deploymentConfig = client.deploymentConfigs().inNamespace(session.getNamespace()).createOrReplace(deploymentConfig);
+
+    // Then
+    assertNotNull(deploymentConfig);
+    assertEquals("dc-createorreplace", deploymentConfig.getMetadata().getName());
+    assertEquals("openshift/hello-openshift:v3.8", deploymentConfig.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+  }
+
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/ImageStreamIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/ImageStreamIT.java
@@ -90,4 +90,19 @@ public class ImageStreamIT {
     assertTrue(bDeleted);
   }
 
+  @Test
+  public void createOrReplace() {
+    // Given
+    ImageStream imageStream = client.imageStreams().inNamespace(session.getNamespace()).withName("is-createorreplace").get();
+
+    // When
+    imageStream.getSpec().setDockerImageRepository("docker.io/openshift/ruby-centos-2");
+    imageStream = client.imageStreams().inNamespace(session.getNamespace()).createOrReplace(imageStream);
+
+    // Then
+    assertNotNull(imageStream);
+    assertEquals("is-createorreplace", imageStream.getMetadata().getName());
+    assertEquals("docker.io/openshift/ruby-centos-2", imageStream.getSpec().getDockerImageRepository());
+  }
+
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/RouteIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/RouteIT.java
@@ -30,6 +30,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static junit.framework.TestCase.assertNotNull;
@@ -92,6 +93,23 @@ public class RouteIT {
     await().atMost(30, TimeUnit.SECONDS).until(route1Ready);
     boolean bDeleted = client.routes().inNamespace(currentNamespace).withName("route-delete").delete();
     assertTrue(bDeleted);
+  }
+
+  @Test
+  public void createOrReplace() {
+    // Given
+    Route route = client.routes().inNamespace(currentNamespace).withName("route-createorreplace").get();
+
+    // When
+    route.getMetadata().setAnnotations(Collections.singletonMap("foo", "bar"));
+    route.getSpec().setHost("test.fabric8.io");
+    route = client.routes().inNamespace(currentNamespace).createOrReplace(route);
+
+    // Then
+    assertNotNull(route);
+    assertEquals("route-createorreplace", route.getMetadata().getName());
+    assertEquals("bar", route.getMetadata().getAnnotations().get("foo"));
+    assertEquals("test.fabric8.io", route.getSpec().getHost());
   }
 
 }

--- a/kubernetes-itests/src/test/resources/buildconfig-it.yml
+++ b/kubernetes-itests/src/test/resources/buildconfig-it.yml
@@ -130,3 +130,33 @@ spec:
     to:
       kind: "ImageStreamTag"
       name: "origin-ruby-sample:latest"
+---
+kind: "BuildConfig"
+apiVersion: "v1"
+metadata:
+  name: bc-createorreplace
+spec:
+  triggers:
+    - type: "GitHub"
+      github:
+        secret: "secret101"
+    - type: "Generic"
+      generic:
+        secret: "secret101"
+    - type: "ImageChange"
+  source:
+    type: "Git"
+    git:
+      uri: "https://github.com/openshift/ruby-hello-world"
+    dockerfile: "FROM openshift/ruby-22-centos7\nUSER example"
+  strategy:
+    type: "Source"
+    sourceStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: "ruby-20-centos7:latest"
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "origin-ruby-sample:latest"
+

--- a/kubernetes-itests/src/test/resources/deploymentconfig-it.yml
+++ b/kubernetes-itests/src/test/resources/deploymentconfig-it.yml
@@ -142,3 +142,35 @@ spec:
           name: "origin-ruby-sample:latest"
   strategy:
     type: "Rolling"
+---
+kind: "DeploymentConfig"
+apiVersion: "v1"
+metadata:
+  name: dc-createorreplace
+spec:
+  template:
+    metadata:
+      labels:
+        name: "frontend"
+    spec:
+      containers:
+        - name: "helloworld"
+          image: "openshift/origin-ruby-sample"
+          ports:
+            - containerPort: 8080
+              protocol: "TCP"
+  replicas: 5
+  selector:
+    name: "frontend"
+  triggers:
+    - type: "ConfigChange"
+    - type: "ImageChange"
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - "helloworld"
+        from:
+          kind: "ImageStreamTag"
+          name: "origin-ruby-sample:latest"
+  strategy:
+    type: "Rolling"

--- a/kubernetes-itests/src/test/resources/imagestream-it.yml
+++ b/kubernetes-itests/src/test/resources/imagestream-it.yml
@@ -42,3 +42,10 @@ metadata:
   name: "is-delete"
 spec:
   dockerImageRepository: "docker.io/openshift/ruby-20-centos7"
+---
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: "is-createorreplace"
+spec:
+  dockerImageRepository: "docker.io/openshift/ruby-20-centos7"

--- a/kubernetes-itests/src/test/resources/route-it.yml
+++ b/kubernetes-itests/src/test/resources/route-it.yml
@@ -54,3 +54,13 @@ spec:
   to:
     kind: Service
     name: service-name
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: route-createorreplace
+spec:
+  host: www.example.com
+  to:
+    kind: Service
+    name: service-name


### PR DESCRIPTION
Fix #2467 
BackwardCompatibilityInterceptor should only convert openshift4 to openshift3 requests
on receiving 404

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
