### PR TITLE
Chore: Use Java 8 in Github Actions instead of Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Java 11
+      - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Build Project
         run: mvn clean install

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,10 +46,10 @@ jobs:
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force
-      - name: Setup Java 11
+      - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Install Kubernetes Client
         run: mvn -f pom.xml -B -DskipTests clean install
       - name: Install and Run Integration Tests
@@ -71,10 +71,10 @@ jobs:
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Java 11
+      - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Install Kubernetes Client
         run: mvn -f pom.xml -B -DskipTests clean install
       - name: Install and Run Integration Tests

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Java 11
+      - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Check Java Docs
         run: mvn clean install javadoc:jar -DskipTests -Pjavadoc-test

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Java 11
+      - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Check License Headers
         run: mvn -N license:check

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,9 +32,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Java 11
+      - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Maven Sonar
         run: mvn clean install sonar:sonar -Psonar


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
