### PR TITLE
fix: KuberentesDeserializer works on OSGi runtime environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ### 4.11-SNAPSHOT
 
 #### Bugs
-* Fix: #2442: Wrong resource kind in `ProjectRequestHandler` causes ClassCastException when handling Project resources.
+* Fix #2442: Wrong resource kind in `ProjectRequestHandler` causes ClassCastException when handling Project resources.
 * Fix #2467: OpenShiftClient cannot replace existing resource with API version =! v1
-* Fix: #2474: Config.fromKubeconfig throws NullPointerException
+* Fix #2474: Config.fromKubeconfig throws NullPointerException
 * Fix #2399: Cannot change the type of the Service from ClusterIP to ExternalName
+* Fix #2479: KuberentesDeserializer works on OSGi runtime environments
 
 #### Improvements
 * Fix #2473: Removed unused ValidationMessages.properties

--- a/extensions/knative/client/pom.xml
+++ b/extensions/knative/client/pom.xml
@@ -29,6 +29,14 @@
   <name>Fabric8 :: Knative :: Client</name>
 
   <properties>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)"
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.ResourceHandler
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.knative.client.*,

--- a/extensions/service-catalog/client/pom.xml
+++ b/extensions/service-catalog/client/pom.xml
@@ -30,6 +30,14 @@
 
   <properties>
     <useIncrementalCompilation>false</useIncrementalCompilation>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)"
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.ResourceHandler
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.servicecatalog.client.*,

--- a/extensions/tekton/client/pom.xml
+++ b/extensions/tekton/client/pom.xml
@@ -29,6 +29,14 @@
   <name>Fabric8 :: Tekton :: Client</name>
 
   <properties>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)"
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.ResourceHandler
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.tekton.client.*,

--- a/extensions/volumesnapshot/client/pom.xml
+++ b/extensions/volumesnapshot/client/pom.xml
@@ -31,6 +31,14 @@
 
   <properties>
     <useIncrementalCompilation>false</useIncrementalCompilation>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)"
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.ResourceHandler
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.volumesnapshot.client.*,

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -29,9 +29,21 @@
   <name>Fabric8 :: Kubernetes :: Java Client</name>
 
   <properties>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.processor)",
+      osgi.serviceloader;
+      filter:="(osgi.serviceloader=io.fabric8.kubernetes.client.ResourceHandler)";
+      cardinality:=multiple
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.ResourceHandler
+    </osgi.provide-capability>
     <osgi.import>
       !android.util*,
-      *
+      *,
+      io.fabric8.openshift.client.handlers;resolution:=optional,
     </osgi.import>
     <osgi.export>
       io.fabric8.kubernetes.client*;-noimport:=true,
@@ -329,6 +341,8 @@
                 <Export-Package>${osgi.export}</Export-Package>
                 <Import-Package>${osgi.import}</Import-Package>
                 <DynamicImport-Package>${osgi.dynamic.import}</DynamicImport-Package>
+                <Require-Capability>${osgi.require-capability}</Require-Capability>
+                <Provide-Capability>${osgi.provide-capability}</Provide-Capability>
                 <Private-Package>${osgi.private}</Private-Package>
                 <Require-Bundle>${osgi.bundles}</Require-Bundle>
                 <Bundle-Activator>${osgi.activator}</Bundle-Activator>

--- a/kubernetes-model-generator/kubernetes-model-core/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-core/pom.xml
@@ -99,7 +99,47 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-            <Import-Package>*</Import-Package>
+            <!-- To enable deserialization type inference in OSGi, all KubernetesDeserializer$Mapping#PACKAGES must be included in this list -->
+            <Import-Package>
+              *,
+              io.fabric8.kubernetes.api.model.admission,
+              io.fabric8.kubernetes.api.model.admissionregistration.v1,
+              io.fabric8.kubernetes.api.model.admissionregistration.v1beta1,
+              io.fabric8.kubernetes.api.model.authentication,
+              io.fabric8.kubernetes.api.model.authorization.v1,
+              io.fabric8.kubernetes.api.model.authorization.v1beta1,
+              io.fabric8.kubernetes.api.model.apiextensions.v1,
+              io.fabric8.kubernetes.api.model.apiextensions.v1beta1,
+              io.fabric8.kubernetes.api.model.apps,
+              io.fabric8.kubernetes.api.model.autoscaling.v1,
+              io.fabric8.kubernetes.api.model.autoscaling.v2beta1,
+              io.fabric8.kubernetes.api.model.autoscaling.v2beta2,
+              io.fabric8.kubernetes.api.model.batch,
+              io.fabric8.kubernetes.api.model.certificates,
+              io.fabric8.kubernetes.api.model.coordination.v1,
+              io.fabric8.kubernetes.api.model.discovery,
+              io.fabric8.kubernetes.api.model.events,
+              io.fabric8.kubernetes.api.model.extensions,
+              io.fabric8.kubernetes.api.model.metrics.v1beta1,
+              io.fabric8.kubernetes.api.model.networking,
+              io.fabric8.kubernetes.api.model.networking.v1beta1,
+              io.fabric8.kubernetes.api.model.policy,
+              io.fabric8.kubernetes.api.model.rbac,
+              io.fabric8.kubernetes.api.model.scheduling,
+              io.fabric8.kubernetes.api.model.settings,
+              io.fabric8.kubernetes.api.model.storage,
+              io.fabric8.kubernetes.api.model.storage.v1beta1,
+              io.fabric8.openshift.api.model;resolution:=optional,
+              io.fabric8.openshift.api.model.runtime;resolution:=optional,
+              io.fabric8.openshift.api.model.console.v1;resolution:=optional,
+              io.fabric8.openshift.api.model.monitoring.v1;resolution:=optional,
+              io.fabric8.openshift.api.model.operator;resolution:=optional,
+              io.fabric8.openshift.api.model.operator.v1;resolution:=optional,
+              io.fabric8.openshift.api.model.operator.v1alpha1;resolution:=optional,
+              io.fabric8.openshift.api.model.operatorhub.manifests;resolution:=optional,
+              io.fabric8.openshift.api.model.operatorhub.v1;resolution:=optional,
+              io.fabric8.openshift.api.model.operatorhub.v1alpha1;resolution:=optional,
+            </Import-Package>
             <Private-Package>io.fabric8.kubernetes.internal</Private-Package>
             <Export-Package>
               io.fabric8.kubernetes.api,

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -131,24 +131,26 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
         // specific version will default to first available Class in one of these packages:
         private static final String[] PACKAGES = {
                 "io.fabric8.kubernetes.api.model.",
-                "io.fabric8.kubernetes.api.model.admission",
+                "io.fabric8.kubernetes.api.model.admission.",
                 "io.fabric8.kubernetes.api.model.admissionregistration.v1.",
                 "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.",
+                "io.fabric8.kubernetes.api.model.authentication.",
+                "io.fabric8.kubernetes.api.model.authorization.v1.",
+                "io.fabric8.kubernetes.api.model.authorization.v1beta1.",
                 "io.fabric8.kubernetes.api.model.apiextensions.v1.",
                 "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.",
                 "io.fabric8.kubernetes.api.model.apps.",
-                "io.fabric8.kubernetes.api.model.authentication.",
-                "io.fabric8.kubernetes.api.model.authorization.",
-                "io.fabric8.kubernetes.api.model.autoscaling.",
                 "io.fabric8.kubernetes.api.model.autoscaling.v1.",
+                "io.fabric8.kubernetes.api.model.autoscaling.",
                 "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.",
                 "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.",
                 "io.fabric8.kubernetes.api.model.batch.",
                 "io.fabric8.kubernetes.api.model.certificates.",
-                "io.fabric8.kubernetes.api.model.coordination.",
                 "io.fabric8.kubernetes.api.model.coordination.v1.",
+                "io.fabric8.kubernetes.api.model.coordination.",
                 "io.fabric8.kubernetes.api.model.discovery.",
                 "io.fabric8.kubernetes.api.model.events.",
+                "io.fabric8.kubernetes.api.model.metrics.v1beta1.",
                 "io.fabric8.kubernetes.api.model.networking.",
                 "io.fabric8.kubernetes.api.model.networking.v1beta1.",
                 "io.fabric8.kubernetes.api.model.policy.",
@@ -156,15 +158,19 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
                 "io.fabric8.kubernetes.api.model.storage.",
                 "io.fabric8.kubernetes.api.model.scheduling.",
                 "io.fabric8.kubernetes.api.model.settings.",
+                "io.fabric8.kubernetes.api.model.storage.",
+                "io.fabric8.kubernetes.api.model.storage.v1beta1.",
                 "io.fabric8.openshift.api.model.",
+                "io.fabric8.openshift.api.model.runtime.",
                 "io.fabric8.openshift.api.model.console.v1.",
                 "io.fabric8.openshift.api.model.monitoring.v1.",
+                "io.fabric8.openshift.api.model.operator.",
                 "io.fabric8.openshift.api.model.operator.v1.",
                 "io.fabric8.openshift.api.model.operator.v1alpha1.",
                 "io.fabric8.openshift.api.model.imageregistry.v1.",
+                "io.fabric8.openshift.api.model.operatorhub.manifests.",
                 "io.fabric8.openshift.api.model.operatorhub.v1.",
                 "io.fabric8.openshift.api.model.operatorhub.v1alpha1.",
-                "io.fabric8.openshift.api.model.operatorhub.manifests.",
                 "io.fabric8.kubernetes.api.model.extensions."
         };
 
@@ -173,24 +179,24 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
         Mapping() {
         	registerAllProviders();
         }
-        
+
         public Class<? extends KubernetesResource> getForKey(String key) {
-        	if (key == null) {
-        		return null;
-        	}
-        	Class<? extends KubernetesResource> clazz = mappings.get(key);
-        	if (clazz != null) {
-        		return clazz; 
-        	} 
-    		clazz = getInternalTypeForName(key);
-    		if (clazz != null) {
-				mappings.put(key, clazz);
-			}
-    		return clazz;
+            if (key == null) {
+                return null;
+            }
+            Class<? extends KubernetesResource> clazz = mappings.get(key);
+            if (clazz != null) {
+                return clazz;
+            }
+            clazz = getInternalTypeForName(key);
+            if (clazz != null) {
+                mappings.put(key, clazz);
+            }
+            return clazz;
         }
 
         public void registerKind(String apiVersion, String kind, Class<? extends KubernetesResource> clazz) {
-        	mappings.put(createKey(apiVersion, kind), clazz);
+          mappings.put(createKey(apiVersion, kind), clazz);
         }
 
         public void registerProvider(KubernetesResourceMappingProvider provider) {

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -29,6 +29,14 @@
   <name>Fabric8 :: Openshift :: Java Client</name>
 
   <properties>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)"
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.ResourceHandler
+    </osgi.provide-capability>
     <osgi.import>
       !org.junit*,
       *
@@ -209,6 +217,8 @@
                 <Export-Package>${osgi.export}</Export-Package>
                 <Import-Package>${osgi.import}</Import-Package>
                 <DynamicImport-Package>${osgi.dynamic.import}</DynamicImport-Package>
+                <Require-Capability>${osgi.require-capability}</Require-Capability>
+                <Provide-Capability>${osgi.provide-capability}</Provide-Capability>
                 <Private-Package>${osgi.private}</Private-Package>
                 <Require-Bundle>${osgi.bundles}</Require-Bundle>
                 <Bundle-Activator>${osgi.activator}</Bundle-Activator>

--- a/platforms/karaf/features/src/main/resources/feature.xml
+++ b/platforms/karaf/features/src/main/resources/feature.xml
@@ -30,8 +30,15 @@
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.conscrypt-openjdk/${conscrypt-openjdk-uber.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${okhttp.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${okio.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/${aries-spifly.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:org.ow2.asm/asm/${asm.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:org.ow2.asm/asm-analysis/${asm.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:org.ow2.asm/asm-commons/${asm.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:org.ow2.asm/asm-tree/${asm.bundle.version}</bundle>
+    <bundle dependency='true'>mvn:org.ow2.asm/asm-util/${asm.bundle.version}</bundle>
     <bundle dependency='true'>mvn:io.fabric8/kubernetes-model-common/${project.version}</bundle>
     <bundle>mvn:io.fabric8/zjsonpatch/${zjsonpatch.version}</bundle>
+
     <bundle>mvn:io.fabric8/kubernetes-model-core/${project.version}</bundle>
     <bundle>mvn:io.fabric8/kubernetes-model-rbac/${project.version}</bundle>
     <bundle>mvn:io.fabric8/kubernetes-model-admissionregistration/${project.version}</bundle>

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/FeatureInstallationTest.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/FeatureInstallationTest.java
@@ -15,29 +15,22 @@
  */
 package io.fabric8.kubernetes.karaf.itests;
 
-import java.io.File;
-import javax.inject.Inject;
-
+import org.apache.karaf.features.Feature;
 import org.apache.karaf.features.FeaturesService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.ops4j.pax.exam.karaf.container.internal.JavaVersionUtil;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption;
-import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
-import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureSecurity;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertTrue;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 
 @RunWith(PaxExam.class)
@@ -51,67 +44,25 @@ public class FeatureInstallationTest extends TestBase {
     public void testKubernetesClientFeature() throws Exception {
         featuresService.addRepository(getFeaturesFile().toURI());
         featuresService.installFeature("kubernetes-client");
+        assertTrue(Stream.of(featuresService.listInstalledFeatures())
+          .map(Feature::getName).anyMatch(name -> name.equals("kubernetes-client")));
     }
 
     @Test
     public void testOpenshiftClient() throws Exception {
         featuresService.addRepository(getFeaturesFile().toURI());
         featuresService.installFeature("openshift-client");
+        assertTrue(Stream.of(featuresService.listInstalledFeatures())
+          .map(Feature::getName).anyMatch(name -> name.equals("openshift-client")));
     }
 
     @Configuration
     public Option[] config() {
-        MavenArtifactUrlReference karafUrl = maven().groupId("org.apache.karaf").artifactId("apache-karaf-minimal").versionAsInProject().type("tar.gz");
-        if (JavaVersionUtil.getMajorVersion() >= 9) {
-            return new Option[]{
-                                karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
-                                configureSecurity().disableKarafMBeanServerBuilder(),
-                                keepRuntimeFolder(),
-                                editConfigurationFilePut("etc/system.properties", "features.xml", System.getProperty("features.xml")),
-                                editConfigurationFileExtend(
-                                    "etc/org.ops4j.pax.url.mvn.cfg",
-                                    "org.ops4j.pax.url.mvn.repositories",
-                                  "https://repo1.maven.org/maven2/"),
-                                logLevel(LogLevelOption.LogLevel.INFO),new VMOption("--add-reads=java.xml=java.logging"),
-                                new VMOption("--add-exports=java.base/"
-                                    + "org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED"),
-                                new VMOption("--patch-module"),
-                                new VMOption("java.base=lib/endorsed/org.apache.karaf.specs.locator-" 
-                                + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
-                                new VMOption("--patch-module"),
-                                new VMOption("java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-" 
-                                + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.security=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.net=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.lang=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.util=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.naming/javax.naming.spi=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"),
-                                new VMOption("--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED"),
-                                new VMOption("-classpath"),
-                                new VMOption("lib/jdk9plus/*" + File.pathSeparator + "lib/boot/*")
-                            };
-        } else {
-            return new Option[]{
-                karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
-                configureSecurity().disableKarafMBeanServerBuilder(),
-                keepRuntimeFolder(),
-                editConfigurationFilePut("etc/system.properties", "features.xml", System.getProperty("features.xml")),
-                editConfigurationFileExtend(
-                    "etc/org.ops4j.pax.url.mvn.cfg",
-                    "org.ops4j.pax.url.mvn.repositories",
-                  "https://repo1.maven.org/maven2/"),
-                logLevel(LogLevelOption.LogLevel.INFO),
-            };
-        }
+      return baseConfiguration(
+        null,
+        Collections.singletonList(
+          editConfigurationFilePut("etc/system.properties", "features.xml", System.getProperty("features.xml"))
+        )
+      );
     }
 }

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/KubernetesDeserializerTest.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/KubernetesDeserializerTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.karaf.itests;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class KubernetesDeserializerTest extends TestBase {
+
+  @Inject
+  KubernetesClient kubernetesClient;
+
+  @Inject
+  OpenShiftClient openShiftClient;
+
+  @Test
+  public void canDeserializeModelsFromDifferentKubernetesModules() {
+    // When
+    final List<HasMetadata> result = kubernetesClient.load(
+      KubernetesDeserializerTest.class.getResourceAsStream("/deserializer_test.yaml")
+    ).get();
+    // Then
+    assertEquals(23, result.size());
+  }
+
+  @Test
+  public void canDeserializeModelsFromDifferentOpenShiftModules() {
+    // When
+    final List<HasMetadata> result = openShiftClient.load(
+      KubernetesDeserializerTest.class.getResourceAsStream("/deserializer_openshift_test.yaml")
+    ).get();
+    // Then
+    assertEquals(8, result.size());
+  }
+
+  @Configuration
+  public Option[] config() {
+    return baseConfiguration(
+      features(getFeaturesFile().toURI().toString(), "scr", "openshift-client")
+    );
+  }
+}

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/PropertiesOverrideTest.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/PropertiesOverrideTest.java
@@ -16,11 +16,6 @@
 
 package io.fabric8.kubernetes.karaf.itests;
 
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import javax.inject.Inject;
-
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import org.junit.Assert;
@@ -31,23 +26,17 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.ProbeBuilder;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.ops4j.pax.exam.karaf.container.internal.JavaVersionUtil;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption;
-import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
-import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 
-import static org.ops4j.pax.exam.CoreOptions.maven;
+import javax.inject.Inject;
+
+import java.util.Arrays;
+
 import static org.ops4j.pax.exam.CoreOptions.systemProperty;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureSecurity;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -64,7 +53,7 @@ public class PropertiesOverrideTest extends TestBase {
 
     //Need to check this for class loading errors
     @Test
-    public void testNamspacedClients() throws Exception {
+    public void testNamespacedClients() {
         Assert.assertNotNull(kubernetesClient);
         Assert.assertNotNull(openShiftClient);
 
@@ -85,65 +74,14 @@ public class PropertiesOverrideTest extends TestBase {
     }
 
     @Configuration
-    public Option[] config() throws URISyntaxException, MalformedURLException {
-        MavenArtifactUrlReference karafUrl = maven().groupId("org.apache.karaf").artifactId("apache-karaf-minimal").versionAsInProject().type("tar.gz");
-        if (JavaVersionUtil.getMajorVersion() >= 9) {
-            return new Option[]{
-                                karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
-                                configureSecurity().disableKarafMBeanServerBuilder(),
-                                features(getFeaturesFile().toURI().toURL().toString(), "scr", "openshift-client"),
-                                editConfigurationFileExtend(
-                                    "etc/org.ops4j.pax.url.mvn.cfg",
-                                    "org.ops4j.pax.url.mvn.repositories",
-                                  "https://repo1.maven.org/maven2/"),
-                                keepRuntimeFolder(),
-                                systemProperty("kubernetes.namespace").value("my-namespace"),
-                                systemProperty("kubernetes.master").value("http://my.kube.master:8443"),
-                                systemProperty("kubernetes.auth.tryKubeConfig").value("false"),
-                                logLevel(LogLevelOption.LogLevel.DEBUG),
-                                new VMOption("--add-exports=java.base/"
-                                    + "org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED"),
-                                new VMOption("--patch-module"),
-                                new VMOption("java.base=lib/endorsed/org.apache.karaf.specs.locator-" 
-                                + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
-                                new VMOption("--patch-module"),
-                                new VMOption("java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-" 
-                                + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.security=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.net=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.lang=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.util=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.naming/javax.naming.spi=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"),
-                                new VMOption("--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED"),
-                                new VMOption("-classpath"),
-                                new VMOption("lib/jdk9plus/*" + File.pathSeparator + "lib/boot/*")
-            };
-            
-        } else {
-            return new Option[]{
-                karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
-                configureSecurity().disableKarafMBeanServerBuilder(),
-                features(getFeaturesFile().toURI().toURL().toString(), "scr", "openshift-client"),
-                editConfigurationFileExtend(
-                    "etc/org.ops4j.pax.url.mvn.cfg",
-                    "org.ops4j.pax.url.mvn.repositories",
-                  "https://repo1.maven.org/maven2/"),
-                keepRuntimeFolder(),
-                systemProperty("kubernetes.namespace").value("my-namespace"),
-                systemProperty("kubernetes.master").value("http://my.kube.master:8443"),
-                systemProperty("kubernetes.auth.tryKubeConfig").value("false"),
-                logLevel(LogLevelOption.LogLevel.DEBUG),
-            };
-        }
+    public Option[] config() {
+        return baseConfiguration(
+          features(getFeaturesFile().toURI().toString(), "scr", "openshift-client"),
+          Arrays.asList(
+            systemProperty("kubernetes.namespace").value("my-namespace"),
+            systemProperty("kubernetes.master").value("http://my.kube.master:8443"),
+            systemProperty("kubernetes.auth.tryKubeConfig").value("false")
+          )
+        );
     }
 }

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/ServiceTest.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/ServiceTest.java
@@ -16,11 +16,6 @@
 
 package io.fabric8.kubernetes.karaf.itests;
 
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import javax.inject.Inject;
-
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import org.junit.Assert;
@@ -31,22 +26,14 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.ProbeBuilder;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.ops4j.pax.exam.karaf.container.internal.JavaVersionUtil;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption;
-import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
-import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureSecurity;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import javax.inject.Inject;
+
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -62,14 +49,14 @@ public class ServiceTest extends TestBase {
     NamespacedOpenShiftClient openShiftClient;
 
     @Test
-    public void testServiceAvailability() throws Exception {
+    public void testServiceAvailability() {
         Assert.assertNotNull(kubernetesClient);
         Assert.assertNotNull(openShiftClient);
     }
 
     //Need to check this for class loading errors
     @Test
-    public void testNamspacedClients() throws Exception {
+    public void testNamespacedClients() {
         Assert.assertNotNull(kubernetesClient);
         Assert.assertNotNull(openShiftClient);
 
@@ -87,58 +74,9 @@ public class ServiceTest extends TestBase {
     }
 
     @Configuration
-    public Option[] config() throws URISyntaxException, MalformedURLException {
-        MavenArtifactUrlReference karafUrl = maven().groupId("org.apache.karaf").artifactId("apache-karaf-minimal").versionAsInProject().type("tar.gz");
-        if (JavaVersionUtil.getMajorVersion() >= 9) { 
-            return new Option[]{
-                                karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
-                                configureSecurity().disableKarafMBeanServerBuilder(),
-                                features(getFeaturesFile().toURI().toString(), "scr", "openshift-client"),
-                                editConfigurationFileExtend(
-                                    "etc/org.ops4j.pax.url.mvn.cfg",
-                                    "org.ops4j.pax.url.mvn.repositories",
-                                  "https://repo1.maven.org/maven2/"),
-                                keepRuntimeFolder(),
-                                logLevel(LogLevelOption.LogLevel.INFO),
-                                new VMOption("--add-exports=java.base/"
-                                    + "org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED"),
-                                new VMOption("--patch-module"),
-                                new VMOption("java.base=lib/endorsed/org.apache.karaf.specs.locator-" 
-                                + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
-                                new VMOption("--patch-module"),
-                                new VMOption("java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-" 
-                                + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.security=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.net=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.lang=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.base/java.util=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.naming/javax.naming.spi=ALL-UNNAMED"),
-                                new VMOption("--add-opens"),
-                                new VMOption("java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED"),
-                                new VMOption("--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"),
-                                new VMOption("--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED"),
-                                new VMOption("-classpath"),
-                                new VMOption("lib/jdk9plus/*" + File.pathSeparator + "lib/boot/*")
-                            };
-        } else {
-            return new Option[]{
-                karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
-                configureSecurity().disableKarafMBeanServerBuilder(),
-                features(getFeaturesFile().toURI().toString(), "scr", "openshift-client"),
-                editConfigurationFileExtend(
-                    "etc/org.ops4j.pax.url.mvn.cfg",
-                    "org.ops4j.pax.url.mvn.repositories",
-                  "https://repo1.maven.org/maven2/"),
-                keepRuntimeFolder(),
-                logLevel(LogLevelOption.LogLevel.INFO)
-            };
-        }
+    public Option[] config() {
+        return baseConfiguration(
+          features(getFeaturesFile().toURI().toString(), "scr", "openshift-client")
+        );
     }
 }

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
@@ -15,21 +15,98 @@
  */
 package io.fabric8.kubernetes.karaf.itests;
 
-import org.junit.Assert;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.karaf.container.internal.JavaVersionUtil;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.extra.VMOption;
 
 import java.io.File;
-import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureSecurity;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 public class TestBase {
 
-    private static final String FEATURES_XML = "features.xml";
+  private static final String FEATURES_XML = "features.xml";
 
-    static File getFeaturesFile() throws URISyntaxException {
-        String featuresXml = System.getProperty(FEATURES_XML);
-        Assert.assertNotNull(featuresXml);
-        File featuresFile = new File(featuresXml);
-        Assert.assertNotNull(featuresFile.exists());
-        return featuresFile;
+  Option[] baseConfiguration(Option features) {
+    return baseConfiguration(features, Collections.emptyList());
+  }
+
+  Option[] baseConfiguration(Option features, List<Option> extraOptions) {
+    MavenArtifactUrlReference karafUrl = maven().groupId("org.apache.karaf").artifactId("apache-karaf-minimal").versionAsInProject().type("tar.gz");
+    final List<Option> ret = new ArrayList<>();
+    if (JavaVersionUtil.getMajorVersion() >= 9) {
+      ret.addAll(Arrays.asList(
+        karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
+        configureSecurity().disableKarafMBeanServerBuilder(),
+        features,
+        editConfigurationFileExtend(
+          "etc/org.ops4j.pax.url.mvn.cfg",
+          "org.ops4j.pax.url.mvn.repositories",
+          "https://repo1.maven.org/maven2/"),
+        keepRuntimeFolder(),
+        logLevel(LogLevelOption.LogLevel.INFO),
+        new VMOption("--add-exports=java.base/"
+          + "org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED"),
+        new VMOption("--patch-module"),
+        new VMOption("java.base=lib/endorsed/org.apache.karaf.specs.locator-"
+          + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
+        new VMOption("--patch-module"),
+        new VMOption("java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-"
+          + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
+        new VMOption("--add-opens"),
+        new VMOption("java.base/java.security=ALL-UNNAMED"),
+        new VMOption("--add-opens"),
+        new VMOption("java.base/java.net=ALL-UNNAMED"),
+        new VMOption("--add-opens"),
+        new VMOption("java.base/java.lang=ALL-UNNAMED"),
+        new VMOption("--add-opens"),
+        new VMOption("java.base/java.util=ALL-UNNAMED"),
+        new VMOption("--add-opens"),
+        new VMOption("java.naming/javax.naming.spi=ALL-UNNAMED"),
+        new VMOption("--add-opens"),
+        new VMOption("java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED"),
+        new VMOption("--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED"),
+        new VMOption("--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED"),
+        new VMOption("--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"),
+        new VMOption("--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED"),
+        new VMOption("-classpath"),
+        new VMOption("lib/jdk9plus/*" + File.pathSeparator + "lib/boot/*")
+      ));
+    } else {
+      ret.addAll(Arrays.asList(
+        karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
+        configureSecurity().disableKarafMBeanServerBuilder(),
+        features,
+        editConfigurationFileExtend(
+          "etc/org.ops4j.pax.url.mvn.cfg",
+          "org.ops4j.pax.url.mvn.repositories",
+          "https://repo1.maven.org/maven2/"),
+        keepRuntimeFolder(),
+        logLevel(LogLevelOption.LogLevel.INFO)
+      ));
     }
+    ret.addAll(extraOptions);
+    return ret.toArray(new Option[0]);
+  }
 
+  static File getFeaturesFile() {
+    String featuresXml = System.getProperty(FEATURES_XML);
+    assertNotNull(featuresXml);
+    File featuresFile = new File(featuresXml);
+    assertTrue(featuresFile.exists());
+    return featuresFile;
+  }
 }

--- a/platforms/karaf/itests/src/test/resources/deserializer_openshift_test.yaml
+++ b/platforms/karaf/itests/src/test/resources/deserializer_openshift_test.yaml
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod
+---
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: test-deploymentconfig-v1
+---
+kind: ConsoleLink
+apiVersion: console.openshift.io/v1
+metadata:
+  name: test-consolelink-v1
+---
+kind: PodMonitor
+apiVersion: monitoring.coreos.com/v1
+metadata:
+  name: test-podmonitor-v1
+---
+kind: Authentication
+apiVersion: operator.openshift.io/v1
+metadata:
+  name: test-authentication-v1
+---
+kind: ImageContentSourcePolicy
+apiVersion: operator.openshift.io/v1alpha1
+metadata:
+  name: test-imagecontentsourcepolicy-v1alpha1
+---
+kind: OperatorGroup
+apiVersion: operators.coreos.com/v1
+metadata:
+  name: test-operatorgroup-v1
+---
+kind: CatalogSource
+apiVersion: operators.coreos.com/v1alpha1
+metadata:
+  name: test-catalogsource-v1alpha1

--- a/platforms/karaf/itests/src/test/resources/deserializer_test.yaml
+++ b/platforms/karaf/itests/src/test/resources/deserializer_test.yaml
@@ -1,0 +1,131 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+kind: MutatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1
+metadata:
+  name: test-mutatingwebhookconfiguration
+---
+kind: MutatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1beta1
+metadata:
+  name: test-mutatingwebhookconfiguration-v1beta1
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1
+metadata:
+  name: test-customresourcedefinition-v1
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: test-customresourcedefinition-v1beta1
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: test-deployment
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v1
+metadata:
+  name: test-horizontalpodautoscaler-v1
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta1
+metadata:
+  name: test-horizontalpodautoscaler-v2beta1
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta2
+metadata:
+  name: test-horizontalpodautoscaler-v2beta2
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: test-cronjob-v1beta1
+---
+kind: CertificateSigningRequest
+apiVersion: certificates.k8s.io/v1beta1
+metadata:
+  name: test-certificatesigningrequest-v1beta1
+---
+kind: Lease
+apiVersion: coordination.k8s.io/v1
+metadata:
+  name: test-lease-v1
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod
+---
+kind: EndpointSlice
+apiVersion: discovery/v1beta1
+metadata:
+  name: test-endpointslice-v1beta1
+---
+kind: Event
+apiVersion: events.k8s.io/v1beta1
+metadata:
+  name: test-event-v1beta1
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: test-deployment-extensions-v1beta1
+---
+kind: NodeMetrics
+apiVersion: metrics.k8s.io/v1beta1
+metadata:
+  name: test-nodemetrics-v1beta1
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: test-networkpolicy-v1
+---
+kind: PodSecurityPolicy
+apiVersion: policy/v1beta1
+metadata:
+  name: test-podsecuritypolicy-v1beta1
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-role-v1
+---
+kind: PriorityClass
+apiVersion: scheduling.k8s.io/v1beta1
+metadata:
+  name: test-priorityclass-v1beta1
+---
+kind: PodPreset
+apiVersion: settings.k8s.io/v1alpha1
+metadata:
+  name: test-podpreset-v1alpha1
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: test-storageclass-v1
+---
+kind: CSINode
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: test-csinode-v1beta1

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,8 @@
     <generex.bundle.version>1.0.1_1</generex.bundle.version>
     <automaton.version>1.11-8</automaton.version>
     <automaton.bundle.version>1.11-8_1</automaton.bundle.version>
+    <aries-spifly.bundle.version>1.3.0</aries-spifly.bundle.version>
+    <asm.bundle.version>8.0.1</asm.bundle.version>
     <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
     <junit.version>5.7.0</junit.version>
     <junit.compatible-with-arquillian.version>4.13</junit.compatible-with-arquillian.version>
@@ -158,6 +160,8 @@
     <osgi.export />
     <osgi.private />
     <osgi.dynamic.import />
+    <osgi.require-capability />
+    <osgi.provide-capability />
     <osgi.bundles />
     <osgi.activator />
     <osgi.export.service />
@@ -646,6 +650,8 @@
             <Export-Package>${osgi.export}</Export-Package>
             <Import-Package>${osgi.import}</Import-Package>
             <DynamicImport-Package>${osgi.dynamic.import}</DynamicImport-Package>
+            <Require-Capability>${osgi.require-capability}</Require-Capability>
+            <Provide-Capability>${osgi.provide-capability}</Provide-Capability>
             <Private-Package>${osgi.private}</Private-Package>
             <Require-Bundle>${osgi.bundles}</Require-Bundle>
             <Bundle-Activator>${osgi.activator}</Bundle-Activator>


### PR DESCRIPTION
## Description
fix #2479 : KuberentesDeserializer works on OSGi runtime environments

- Added specific imports (kubernetes-client) & exports for model modules
- Support for Java ServiceLoader API exported Handlers (OpenShift Client only) + tests
- Refactored Apache Karaf tests

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
