### PR TITLE
Revert BackwardCompatibilityInterceptor's behavior of changing /apis to /oapi URLs

### DIFF
--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
@@ -90,14 +90,6 @@ public class DeploymentConfigIT {
   }
 
   @Test
-  public void testWaitUntilReady() throws InterruptedException {
-    DeploymentConfig deploymentConfig = client.deploymentConfigs().inNamespace(session.getNamespace()).withName("dc-waituntilready").waitUntilReady(15, TimeUnit.MINUTES);
-    assertNotNull(deploymentConfig);
-    assertEquals(1, deploymentConfig.getStatus().getAvailableReplicas().intValue());
-    assertTrue(deploymentConfig.getStatus().getConditions().stream().anyMatch(c -> c.getType().equals("Available")));
-  }
-
-  @Test
   public void createOrReplace() {
     // Given
     DeploymentConfig deploymentConfig = client.deploymentConfigs().inNamespace(session.getNamespace()).withName("dc-createorreplace").get();

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
@@ -91,7 +91,7 @@ public class DeploymentConfigIT {
 
   @Test
   public void testWaitUntilReady() throws InterruptedException {
-    DeploymentConfig deploymentConfig = client.deploymentConfigs().inNamespace(session.getNamespace()).withName("dc-waituntilready").waitUntilReady(2, TimeUnit.MINUTES);
+    DeploymentConfig deploymentConfig = client.deploymentConfigs().inNamespace(session.getNamespace()).withName("dc-waituntilready").waitUntilReady(15, TimeUnit.MINUTES);
     assertNotNull(deploymentConfig);
     assertEquals(1, deploymentConfig.getStatus().getAvailableReplicas().intValue());
     assertTrue(deploymentConfig.getStatus().getConditions().stream().anyMatch(c -> c.getType().equals("Available")));

--- a/kubernetes-itests/src/test/resources/deploymentconfig-it.yml
+++ b/kubernetes-itests/src/test/resources/deploymentconfig-it.yml
@@ -174,25 +174,3 @@ spec:
           name: "origin-ruby-sample:latest"
   strategy:
     type: "Rolling"
----
-kind: "DeploymentConfig"
-apiVersion: "v1"
-metadata:
-  name: dc-waituntilready
-spec:
-  template:
-    metadata:
-      labels:
-        name: "frontend"
-    spec:
-      containers:
-        - name: "helloworld"
-          image: "openshift/hello-openshift:latest"
-          ports:
-            - containerPort: 8080
-              protocol: "TCP"
-  replicas: 1
-  selector:
-    name: "frontend"
-  triggers:
-    - type: ConfigChange

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
@@ -201,23 +201,6 @@ public class BuildConfigTest {
     assertTrue(deleted);
   }
 
-  @Test
-  void testCreateOrReplaceOpenShift3() {
-    // Given
-    BuildConfig buildConfig = getBuildConfig();
-    server.expect().post().withPath("/oapi/v1/namespaces/ns1/buildconfigs")
-      .andReturn(HttpURLConnection.HTTP_OK, buildConfig)
-      .once();
-    OpenShiftClient client = server.getOpenshiftClient();
-
-    // When
-    buildConfig = client.buildConfigs().inNamespace("ns1").createOrReplace(buildConfig);
-
-    // Then
-    assertNotNull(buildConfig);
-    assertEquals("ruby-sample-build", buildConfig.getMetadata().getName());
-  }
-
   private BuildConfig getBuildConfig() {
     return new BuildConfigBuilder()
       .withNewMetadata().withName("ruby-sample-build").endMetadata()

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @EnableRuleMigrationSupport
-public class DeploymentConfigTest {
+class DeploymentConfigTest {
   @Rule
   public OpenShiftServer server = new OpenShiftServer();
 
@@ -250,23 +250,6 @@ public class DeploymentConfigTest {
      }).build();
    assertNotNull(dc2);
    assertTrue(visitedContainer.get());
-  }
-
-  @Test
-  void testCreateOrReplaceOnOpenShift3() {
-    // Given
-    DeploymentConfig deploymentConfig = getDeploymentConfig().build();
-    server.expect().post().withPath("/oapi/v1/namespaces/ns1/deploymentconfigs")
-      .andReturn(HttpURLConnection.HTTP_OK, deploymentConfig)
-      .once();
-    OpenShiftClient client = server.getOpenshiftClient();
-
-    // When
-    deploymentConfig = client.deploymentConfigs().inNamespace("ns1").createOrReplace(deploymentConfig);
-
-    // Then
-    assertNotNull(deploymentConfig);
-    assertEquals("dc1", deploymentConfig.getMetadata().getName());
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -263,23 +263,6 @@ public class TemplateTest {
   }
 
   @Test
-  void testCreateOrReplaceOpenShift3() {
-    // Given
-    Template template = getTemplateBuilder().build();
-    server.expect().post().withPath("/oapi/v1/namespaces/ns1/templates")
-      .andReturn(HttpURLConnection.HTTP_OK, template)
-      .once();
-
-    OpenShiftClient client = server.getOpenshiftClient();
-
-    // When
-    template = client.templates().inNamespace("ns1").createOrReplace(template);
-
-    // Then
-    assertNotNull(template);
-  }
-
-  @Test
   void testCreateOrReplaceOpenShif4() {
     // Given
     Template template = getTemplateBuilder().build();

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -41,6 +41,7 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
 
   public OpenShiftOperation(OperationContext ctx) {
     super(wrap(ctx));
+    updateApiVersion();
   }
 
   static OperationContext wrap(OperationContext context) {
@@ -106,7 +107,15 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
     return waitUntilCondition(resource -> Objects.nonNull(resource) && OpenShiftReadiness.isReady(resource), amount, timeUnit);
   }
 
-  protected Class<? extends Config> getConfigType()  {
+  private void updateApiVersion() {
+    if (apiGroupName != null && apiGroupVersion != null) {
+      this.apiVersion = apiGroupName + "/" + apiGroupVersion;
+    } else if (apiGroupVersion != null) {
+      this.apiVersion = apiGroupVersion;
+    }
+  }
+
+  protected Class<? extends Config> getConfigType() {
     return OpenShiftConfig.class;
   }
 }


### PR DESCRIPTION
Revert #2373

This commit reverts 293ab9d445291de389d438f4a857928722230dba which was added in order
to fix #2373. This behavior was causing problems with Strimzi's Kubernetes Client
upgrade: https://github.com/strimzi/strimzi-kafka-operator/pull/3553 . On bisecting
the failing test, I found this commit as culprit. Git bisect log:
```
kubernetes-client : $ git bisect log
git bisect start
# bad: [ea09419284b32e6da70aadfaf9022485f2bec594] Merge pull request #2478 from rohanKanojia/pr/migrate-github-actions-java8
git bisect bad ea09419284b32e6da70aadfaf9022485f2bec594
# good: [c5fe5488dc15ed3d4795a3b3d676549c24c2e744] Post v4.10.3 release chores
git bisect good c5fe5488dc15ed3d4795a3b3d676549c24c2e744
# bad: [262e35f09be835bf5f3b5fbc4c16791224fbc390] Merge pull request #2381 from rohanKanojia/pr/issue2308
git bisect bad 262e35f09be835bf5f3b5fbc4c16791224fbc390
# bad: [d13a86480f699735dcc8e0ece90c24d4e49079e8] Merge pull request #2393 from rohanKanojia/pr/fix-failing-resource-it
git bisect bad d13a86480f699735dcc8e0ece90c24d4e49079e8
# good: [f1d695d59ce50a9067639df0b79855f03096adc8] Merge pull request #2371 from manusa/fix/mockserver-post
git bisect good f1d695d59ce50a9067639df0b79855f03096adc8
# good: [0b1e0668788aaf2d7f0e706f111ca67456cbb36c] Merge pull request #2361 from fabric8io/dependabot/maven/org.jboss-jandex-2.2.1.Final
git bisect good 0b1e0668788aaf2d7f0e706f111ca67456cbb36c
# bad: [14cae945ee20ce1ac980d492e53d388aa93eb371] Merge pull request #2372 from rohanKanojia/pr/issue2292
git bisect bad 14cae945ee20ce1ac980d492e53d388aa93eb371
# bad: [f6d4e8fedd2d7c36a5608e5f3a4fd73070e51559] Merge pull request #2375 from rohanKanojia/pr/issue2373
git bisect bad f6d4e8fedd2d7c36a5608e5f3a4fd73070e51559
# bad: [293ab9d445291de389d438f4a857928722230dba] Fix #2373: Unable to create a Template on OCP3
git bisect bad 293ab9d445291de389d438f4a857928722230dba
# first bad commit: [293ab9d445291de389d438f4a857928722230dba] Fix #2373: Unable to create a Template on OCP3
```

Handling OpenShift old /oapi requests seem to be handled in OpenShiftOperation where we check `config.isOpenshiftApiGroupsEnabled()` to modify OperationContext.

#2373 can be fixed by adding apiVersion in OpenShiftOperation.

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
