### PR TITLE
Fix #2460: Querying for an event based on InvolvedObject fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix #2111: Support automatic refreshing for expired OIDC tokens
 * Fix #2314: Fetch logs should wait for the job's associated pod to be ready
 * Fix #2043: Support for Tekton Triggers
+* Fix #2460: Querying for an event based on InvolvedObject fields 
 
 ### 4.11.1 (2020-09-02)
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
@@ -16,8 +16,7 @@
 package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.api.model.ObjectReference;
 
 import java.util.Map;
 
@@ -48,5 +47,12 @@ public interface Filterable<T> {
   T withoutField(String key, String value);
 
   T withLabelSelector(LabelSelector selector);
+
+  /**
+   * Filter with the object that this event is about.
+   * @param objectReference {@link ObjectReference} for providing information of referred object
+   * @return filtered resource
+   */
+  T withInvolvedObject(ObjectReference objectReference);
 }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.base;
 
+import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +88,13 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   Resource<T, D> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseOperation.class);
+  private static final String INVOLVED_OBJECT_NAME = "involvedObject.name";
+  private static final String INVOLVED_OBJECT_NAMESPACE = "involvedObject.namespace";
+  private static final String INVOLVED_OBJECT_KIND = "involvedObject.kind";
+  private static final String INVOLVED_OBJECT_UID = "involvedObject.uid";
+  private static final String INVOLVED_OBJECT_RESOURCE_VERSION = "involvedObject.resourceVersion";
+  private static final String INVOLVED_OBJECT_API_VERSION = "involvedObject.apiVersion";
+  private static final String INVOLVED_OBJECT_FIELD_PATH = "involvedObject.fieldPath";
 
   private final Boolean cascading;
   private final T item;
@@ -513,6 +521,35 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     fields.put(key, value);
     return this;
   }
+
+  @Override
+  public FilterWatchListDeletable<T, L, Boolean, Watch, Watcher<T>> withInvolvedObject(ObjectReference objectReference) {
+    if (objectReference != null) {
+      if (objectReference.getName() != null) {
+        fields.put(INVOLVED_OBJECT_NAME, objectReference.getName());
+      }
+      if (objectReference.getNamespace() != null) {
+        fields.put(INVOLVED_OBJECT_NAMESPACE, objectReference.getNamespace());
+      }
+      if (objectReference.getKind() != null) {
+        fields.put(INVOLVED_OBJECT_KIND, objectReference.getKind());
+      }
+      if (objectReference.getUid() != null) {
+        fields.put(INVOLVED_OBJECT_UID, objectReference.getUid());
+      }
+      if (objectReference.getResourceVersion() != null) {
+        fields.put(INVOLVED_OBJECT_RESOURCE_VERSION, objectReference.getResourceVersion());
+      }
+      if (objectReference.getApiVersion() != null) {
+        fields.put(INVOLVED_OBJECT_API_VERSION, objectReference.getApiVersion());
+      }
+      if (objectReference.getFieldPath() != null) {
+        fields.put(INVOLVED_OBJECT_FIELD_PATH, objectReference.getFieldPath());
+      }
+    }
+    return this;
+  }
+
 
   /**
    * @deprecated as the underlying implementation does not align with the arguments fully.

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.utils;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -179,6 +180,9 @@ class PodOperationUtilTest {
 
       @Override
       public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withLabelSelector(LabelSelector selector) { return null; }
+
+      @Override
+      public FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> withInvolvedObject(ObjectReference objectReference) { return null; }
 
       @Override
       public PodList list() { return getMockPodList(controllerUid); }


### PR DESCRIPTION
Fix #2460

Added an `withInvolvedObject(ObjectReference objectReference)` method in Filterable
interface which would transform object references into fieldsSelector values

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
