### PR TITLE
Fix #2146: Add Support for specifying CustomResourceDefinitionContext while initializing KubernetesServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 #### New Features
 * Fix #2340: Adding support for Knative Eventing Contrib 
 * Fix #2111: Support automatic refreshing for expired OIDC tokens
+* Fix #2146: Add Support for specifying CustomResourceDefinitionContext while initializing KubernetesServer
 * Fix #2314: Fetch logs should wait for the job's associated pod to be ready
 * Fix #2043: Support for Tekton Triggers
 * Fix #2460: Querying for an event based on InvolvedObject fields 

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudAttributesExtractor.java
@@ -16,9 +16,21 @@
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.mockwebserver.crud.AttributeSet;
 
+import java.util.Collections;
+import java.util.List;
+
 public class KubernetesCrudAttributesExtractor extends KubernetesAttributesExtractor {
+  public KubernetesCrudAttributesExtractor() {
+    super(Collections.emptyList());
+  }
+
+  public KubernetesCrudAttributesExtractor(List<CustomResourceDefinitionContext> crdContexts) {
+    super(crdContexts);
+  }
+
     @Override
     public AttributeSet extract(HasMetadata hasMetadata) {
         return extractMetadataAttributes(hasMetadata);

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.server.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.crud.Attribute;
@@ -30,6 +31,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -52,7 +54,11 @@ public class KubernetesCrudDispatcher extends CrudDispatcher {
   private final Set<WatchEventsListener> watchEventListeners = new CopyOnWriteArraySet<>();
 
   public KubernetesCrudDispatcher() {
-    this(new KubernetesCrudAttributesExtractor(), new KubernetesResponseComposer());
+    this(Collections.emptyList());
+  }
+
+  public KubernetesCrudDispatcher(List<CustomResourceDefinitionContext> crdContexts) {
+    this(new KubernetesCrudAttributesExtractor(crdContexts), new KubernetesResponseComposer());
   }
 
   public KubernetesCrudDispatcher(KubernetesCrudAttributesExtractor attributeExtractor, ResponseComposer responseComposer) {

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.server.mock;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Optional;
 
@@ -91,7 +92,7 @@ public class KubernetesMockServerExtension implements AfterEachCallback, AfterAl
   private void createKubernetesClient(Class<?> testClass) {
     EnableKubernetesMockClient a = testClass.getAnnotation(EnableKubernetesMockClient.class);
     mock = a.crud()
-      ? new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), a.https())
+      ? new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
       : new KubernetesMockServer(a.https());
     mock.init();
     client = mock.createClient();

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import okhttp3.mockwebserver.MockWebServer;
@@ -23,7 +24,9 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.rules.ExternalResource;
 
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 public class KubernetesServer extends ExternalResource {
 
@@ -36,6 +39,7 @@ public class KubernetesServer extends ExternalResource {
   private boolean crudMode;
   private final InetAddress address;
   private int port;
+  private List<CustomResourceDefinitionContext> crdContextList;
 
   public KubernetesServer() {
     this(true);
@@ -46,19 +50,24 @@ public class KubernetesServer extends ExternalResource {
   }
 
   public KubernetesServer(boolean https, boolean crudMode) {
-    this(https, crudMode, InetAddress.getLoopbackAddress(), 0);
+    this(https, crudMode, InetAddress.getLoopbackAddress(), 0, Collections.emptyList());
   }
 
-  public KubernetesServer(boolean https, boolean crudMode, InetAddress address, int port) {
+  public KubernetesServer(boolean https, boolean crudMode, List<CustomResourceDefinitionContext> crdContextList) {
+    this(https, crudMode, InetAddress.getLoopbackAddress(), 0, crdContextList);
+  }
+
+  public KubernetesServer(boolean https, boolean crudMode, InetAddress address, int port, List<CustomResourceDefinitionContext> crdContextList) {
     this.https = https;
     this.crudMode = crudMode;
     this.address = address;
     this.port = port;
+    this.crdContextList = crdContextList;
   }
 
   public void before() {
     mock = crudMode
-      ? new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), https)
+      ? new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(crdContextList), https)
       : new KubernetesMockServer(https);
     mock.init(address, port);
     client = mock.createClient();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudWithCRDContextTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudWithCRDContextTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.mock.crd.EntandoBundleRelease;
+import io.fabric8.kubernetes.client.mock.crd.EntandoBundleReleaseList;
+import io.fabric8.kubernetes.client.mock.crd.DoneableEntandoBundleRelease;
+import io.fabric8.kubernetes.client.mock.crd.EntandoBundleReleaseSpec;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@EnableRuleMigrationSupport
+class CustomResourceCrudWithCRDContextTest {
+  @Rule
+  public KubernetesServer kubernetesServer = new KubernetesServer(true, true, Collections.singletonList(new CustomResourceDefinitionContext.Builder()
+    .withScope("Namespaced")
+    .withPlural("entandobundlereleases")
+    .withVersion("v1alpha1")
+    .withGroup("demo.fabric8.io")
+    .withKind("EntandoBundleRelease")
+    .build()));
+
+  @Test
+  void testCreateAndGet() {
+    // Given
+    CustomResourceDefinitionContext crdContext = new CustomResourceDefinitionContext.Builder()
+      .withScope("Namespaced")
+      .withPlural("entandobundlereleases")
+      .withVersion("v1alpha1")
+      .withGroup("demo.fabric8.io")
+      .withKind("EntandoBundleRelease")
+      .build();
+    KubernetesClient client = kubernetesServer.getClient();
+    KubernetesDeserializer.registerCustomKind("demo.fabric8.io/v1alpha1", "EntandoBundleRelease", EntandoBundleRelease.class);
+    MixedOperation<EntandoBundleRelease, EntandoBundleReleaseList, DoneableEntandoBundleRelease, Resource<EntandoBundleRelease, DoneableEntandoBundleRelease>> ebrClient = client
+      .customResources(crdContext, EntandoBundleRelease.class, EntandoBundleReleaseList.class, DoneableEntandoBundleRelease.class);
+
+    // When
+    ebrClient.inNamespace("ns1").create(getMockedEntandoBundleRelease());
+    EntandoBundleRelease ebr1 = ebrClient.inNamespace("ns1").withName("ebr1").get();
+
+    // Then
+    assertNotNull(ebr1);
+    assertEquals("ebr1", ebr1.getMetadata().getName());
+  }
+
+  private EntandoBundleRelease getMockedEntandoBundleRelease() {
+    EntandoBundleReleaseSpec entandoBundleReleaseSpec = new EntandoBundleReleaseSpec();
+    entandoBundleReleaseSpec.setDatabaseType("MySQL");
+    EntandoBundleRelease entandoBundleRelease = new EntandoBundleRelease();
+    entandoBundleRelease.setMetadata(new ObjectMetaBuilder()
+      .withName("ebr1")
+      .build());
+    entandoBundleRelease.setSpec(entandoBundleReleaseSpec);
+    return entandoBundleRelease;
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/DoneableEntandoBundleRelease.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/DoneableEntandoBundleRelease.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+
+public class DoneableEntandoBundleRelease extends CustomResourceDoneable<EntandoBundleRelease> {
+  public DoneableEntandoBundleRelease(EntandoBundleRelease resource, Function function) { super(resource, function); }
+}
+

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleRelease.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleRelease.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class EntandoBundleRelease extends CustomResource implements Namespaced {
+  private EntandoBundleReleaseSpec spec;
+
+  @Override
+  public String getApiVersion() {
+    return "demo.fabric8.io/v1alpha1";
+  }
+
+  @Override
+  public ObjectMeta getMetadata() {
+    return super.getMetadata();
+  }
+
+  public EntandoBundleReleaseSpec getSpec() {
+    return spec;
+  }
+
+  public void setSpec(EntandoBundleReleaseSpec spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public String toString() {
+    return "EntandoBundleRelease{"+
+      "apiVersion='" + getApiVersion() + "'" +
+      ", metadata=" + getMetadata() +
+      ", spec=" + spec +
+      "}";
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleReleaseList.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleReleaseList.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class EntandoBundleReleaseList extends CustomResourceList<EntandoBundleRelease> {
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleReleaseSpec.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleReleaseSpec.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock.crd;
+
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(
+  using = JsonDeserializer.None.class
+)
+public class EntandoBundleReleaseSpec {
+  private String databaseType;
+
+  public String getDatabaseType() {
+    return databaseType;
+  }
+
+  public void setDatabaseType(String databaseType) {
+    this.databaseType = databaseType;
+  }
+
+  @Override
+  public String toString() {
+    return "EntandoBundleReleaseSpec{" +
+      " type='" + databaseType + "'" +
+      "}";
+  }
+}


### PR DESCRIPTION
Fix #2146 

Kubernetes Mock Server would now accept an extra optional parameter of list of CustomResourceDefinitionContext:
```
KubernetesServer(boolean https, boolean crudMode, List<CustomResourceDefinitionContext> crdContextList);
```

This CustomResourceDefinitionContext list would be propagated to KubernetesAttributeExtractor and would be
used while resolving Kind from Plural names

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
