### PR TITLE
Fix #2488: Unable to derive module descriptors for Kubernetes Model Jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #2474: Config.fromKubeconfig throws NullPointerException
 * Fix #2399: Cannot change the type of the Service from ClusterIP to ExternalName
 * Fix #2479: KuberentesDeserializer works on OSGi runtime environments
+* Fix #2488: Unable to derive module descriptors for kubernetes-model jars
 
 #### Improvements
 * Enable user to select custom address and port for KubernetesMockServer

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-events/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-events/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-networking/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-policy/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-scheduling/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-settings/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-settings/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider

--- a/kubernetes-model-generator/openshift-model/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
+++ b/kubernetes-model-generator/openshift-model/src/main/resources/META-INF/services/io.fabric8.kubernetes.api.KubernetesResourceMappingProvider
@@ -1,1 +1,0 @@
-io.fabric8.kubernetes.internal.InternalResourceMappingProvider


### PR DESCRIPTION
Fix #2488

Remove unused io.fabric8.kubernetes.api.KubernetesResourceMappingProvider from kubernetes model packages

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
