### PR TITLE
Doc: Add documentation about customResource API change related to Namespaced interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,8 +131,16 @@ _**Note**_: Some classes have been moved to other packages:
 * Add support for Namespaced SharedInformers, fixed probelms with OperationContext argument
 * Fix #1821: ListOptions now supported when watching a Kubernetes Resource
 
-_**Note**_: Some classes have been renamed:
-- `io.fabric8.tekton.pipeline.v1beta1.WorkspacePipelineDeclaration` is now `io.fabric8.tekton.pipeline.v1beta1.PipelineWorkspaceDeclaration`
+_**Note**_:
+- Some classes have been renamed:
+   - `io.fabric8.tekton.pipeline.v1beta1.WorkspacePipelineDeclaration` is now `io.fabric8.tekton.pipeline.v1beta1.PipelineWorkspaceDeclaration`
+- Breaking changes in `KubernetesClient` `customResource()` typed API:
+  - We've introduced a major breaking change in customResource(...) typed API. We have introduced a new interface `io.fabric8.kubernetes.api.model.Namespaced` which needs to
+    be added to your Custom Types using typed API. For example, for a custom resource named `Animals` which is a [Namespaced](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) resource; It should be declared like this:
+    ```
+    public class Animals extends CustomResource implements Namespaced { ... }
+    ```
+    You can also checkout an example in our test suite for this: [PodSet.java](https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/PodSet.java#L22)
 
 ### 4.10.1 (2020-05-06)
 #### Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -158,100 +158,156 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     return new DefaultKubernetesClient(Serialization.unmarshal(is, Config.class));
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<ComponentStatus, ComponentStatusList, DoneableComponentStatus, Resource<ComponentStatus, DoneableComponentStatus>> componentstatuses() {
     return new ComponentStatusOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> load(InputStream is) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<>(), is, null, true, DeletionPropagation.BACKGROUND) {
     };
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(KubernetesResourceList item) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<>(), item, null, DeletionPropagation.BACKGROUND, true) {
     };
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(HasMetadata... items) {
     return resourceList(new KubernetesListBuilder().withItems(items).build());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(Collection<HasMetadata> items) {
     return resourceList(new KubernetesListBuilder().withItems(new ArrayList<>(items)).build());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> resourceList(String s) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<>(), s, null, DeletionPropagation.BACKGROUND, true) {
     };
   }
 
-
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<HasMetadata, Boolean> resource(HasMetadata item) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<>(), item, -1, DeletionPropagation.BACKGROUND, true, Waitable.DEFAULT_INITIAL_BACKOFF_MILLIS, Waitable.DEFAULT_BACKOFF_MULTIPLIER);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<HasMetadata, Boolean> resource(String s) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(httpClient, getConfiguration(), getNamespace(), null, false, false, new ArrayList<>(), s, -1, DeletionPropagation.BACKGROUND, true, Waitable.DEFAULT_INITIAL_BACKOFF_MILLIS, Waitable.DEFAULT_BACKOFF_MULTIPLIER);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<Binding, KubernetesResourceList<Binding>, DoneableBinding, Resource<Binding, DoneableBinding>> bindings() {
     return new BindingOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> endpoints() {
     return new EndpointsOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<Event, EventList, DoneableEvent, Resource<Event, DoneableEvent>> events() {
     return new EventOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NonNamespaceOperation<Namespace, NamespaceList, DoneableNamespace, Resource<Namespace, DoneableNamespace>> namespaces() {
     return new NamespaceOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NonNamespaceOperation<Node, NodeList, DoneableNode, Resource<Node, DoneableNode>> nodes() {
     return new NodeOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NonNamespaceOperation<PersistentVolume, PersistentVolumeList, DoneablePersistentVolume, Resource<PersistentVolume, DoneablePersistentVolume>> persistentVolumes() {
     return new PersistentVolumeOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<PersistentVolumeClaim, PersistentVolumeClaimList, DoneablePersistentVolumeClaim, Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim>> persistentVolumeClaims() {
     return new PersistentVolumeClaimOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> pods() {
     return new PodOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<ReplicationController, ReplicationControllerList, DoneableReplicationController, RollableScalableResource<ReplicationController, DoneableReplicationController>> replicationControllers() {
     return new ReplicationControllerOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<ResourceQuota, ResourceQuotaList, DoneableResourceQuota, Resource<ResourceQuota, DoneableResourceQuota>> resourceQuotas() {
     return new ResourceQuotaOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public SchedulingAPIGroupDSL scheduling() {
     return adapt(SchedulingAPIGroupClient.class);
@@ -262,61 +318,97 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     return new SecretOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> services() {
     return new ServiceOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<ServiceAccount, ServiceAccountList, DoneableServiceAccount, Resource<ServiceAccount, DoneableServiceAccount>> serviceAccounts() {
     return new ServiceAccountOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<APIService, APIServiceList, DoneableAPIService, Resource<APIService, DoneableAPIService>> apiServices() {
     return new APIServiceOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public KubernetesListMixedOperation lists() {
     return new KubernetesListOperationsImpl(httpClient, getConfiguration(), getNamespace());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> configMaps() {
     return new ConfigMapOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MixedOperation<LimitRange, LimitRangeList, DoneableLimitRange, Resource<LimitRange, DoneableLimitRange>> limitRanges() {
     return new LimitRangeOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NonNamespaceOperation<CustomResourceDefinition, CustomResourceDefinitionList, DoneableCustomResourceDefinition, Resource<CustomResourceDefinition, DoneableCustomResourceDefinition>> customResourceDefinitions() {
     return new CustomResourceDefinitionOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ApiextensionsAPIGroupDSL apiextensions() {
     return adapt(ApiextensionsAPIGroupClient.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, DoneableCertificateSigningRequest, Resource<CertificateSigningRequest, DoneableCertificateSigningRequest>> certificateSigningRequests() {
     return new CertificateSigningRequestOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public AuthorizationAPIGroupDSL authorization() {
     return adapt(AuthorizationAPIGroupClient.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public Createable<TokenReview, TokenReview, DoneableTokenReview> tokenReviews() {
     return new CreateOnlyResourceOperationsImpl<>(httpClient, getConfiguration(), "authentication.k8s.io", "v1", Utils.getPluralFromKind(TokenReview.class.getSimpleName()), TokenReview.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public <T extends HasMetadata, L extends KubernetesResourceList<T>, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return new CustomResourceOperationsImpl<>(new CustomResourceOperationContext().withOkhttpClient(httpClient).withConfig(getConfiguration())
@@ -327,6 +419,9 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
       .withDoneableType(doneClass));
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public <T extends HasMetadata, L extends KubernetesResourceList<T>, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResources(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return new CustomResourceOperationsImpl<>(new CustomResourceOperationContext().withOkhttpClient(httpClient).withConfig(getConfiguration())
@@ -337,16 +432,25 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
       .withDoneableType(doneClass));
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public RawCustomResourceOperationsImpl customResource(CustomResourceDefinitionContext customResourceDefinition) {
     return new RawCustomResourceOperationsImpl(httpClient, getConfiguration(), customResourceDefinition);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public <T extends HasMetadata, L extends KubernetesResourceList<T>, D extends Doneable<T>> MixedOperation<T, L, D, Resource<T, D>> customResource(CustomResourceDefinition crd, Class<T> resourceType, Class<L> listClass, Class<D> doneClass) {
     return customResources(crd, resourceType, listClass, doneClass);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NamespacedKubernetesClient inNamespace(String namespace)
   {
@@ -354,73 +458,124 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     return new DefaultKubernetesClient(httpClient, updated);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NamespacedKubernetesClient inAnyNamespace() {
     return inNamespace(null);
   }
 
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public FunctionCallable<NamespacedKubernetesClient> withRequestConfig(RequestConfig requestConfig) {
     return new WithRequestCallable<>(this, requestConfig);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ExtensionsAPIGroupDSL extensions() {
     return adapt(ExtensionsAPIGroupClient.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public VersionInfo getVersion() {
     return new ClusterOperationsImpl(httpClient, getConfiguration(), ClusterOperationsImpl.KUBERNETES_VERSION_ENDPOINT).fetchVersion();
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public V1APIGroupDSL v1() {
     return adapt(V1APIGroupClient.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public AdmissionRegistrationAPIGroupDSL admissionRegistration() {
     return adapt(AdmissionRegistrationAPIGroupClient.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public AppsAPIGroupDSL apps() {
     return adapt(AppsAPIGroupClient.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public AutoscalingAPIGroupDSL autoscaling() {
     return adapt(AutoscalingAPIGroupClient.class);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public NetworkAPIGroupDSL network() { return adapt(NetworkAPIGroupClient.class); }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public StorageAPIGroupDSL storage() { return adapt(StorageAPIGroupClient.class); }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public BatchAPIGroupDSL batch() { return adapt(BatchAPIGroupClient.class); }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public MetricAPIGroupDSL top() { return adapt(MetricAPIGroupClient.class); }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public PolicyAPIGroupDSL policy() { return adapt(PolicyAPIGroupClient.class); }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public RbacAPIGroupDSL rbac() { return adapt(RbacAPIGroupClient.class); }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public SettingsAPIGroupDSL settings() { return adapt(SettingsAPIGroupClient.class); }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public SharedInformerFactory informers() {
     return new SharedInformerFactory(ForkJoinPool.commonPool(), httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public SharedInformerFactory informers(ExecutorService executorService) {
     return new SharedInformerFactory(executorService, httpClient, getConfiguration());
@@ -442,6 +597,9 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     return new LeaseOperationsImpl(httpClient, getConfiguration());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public RunOperations run() {
     return new RunOperations(httpClient, getConfiguration(), getNamespace(), new RunConfigBuilder());

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -124,11 +124,19 @@ public interface KubernetesClient extends Client {
    * CustomResource into this and with it you would be able to instantiate a client
    * specific to CustomResource.
    *
+   * <p>
+   *   Note: your CustomResource POJO (T in this context) must implement
+   *   <a href="https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Namespaced.java">
+   *     io.fabric8.kubernetes.api.model.Namespaced
+   *   </a> if it is a Namespaced scoped resource.
+   * </p>
+   *
    * @param crdContext CustomResourceDefinitionContext describes the core fields used to search for CustomResources
    * @param resourceType Class for CustomResource
    * @param listClass Class for list object for CustomResource
    * @param doneClass Class for Doneable CustomResource object
-   * @param <T> T type represents CustomResource type
+   * @param <T> T type represents CustomResource type. If it's Namespaced resource, it must implement
+   *           io.fabric8.kubernetes.api.model.Namespaced
    * @param <L> L type represents CustomResourceList type
    * @param <D> D type represents DoneableCustomResource type
    * @return returns a MixedOperation object with which you can do basic CustomResource operations
@@ -140,6 +148,13 @@ public interface KubernetesClient extends Client {
    * CustomResource into this and with it you would be able to instantiate a client
    * specific to CustomResource.
    *
+   * <p>
+   *   Note: your CustomResource POJO (T in this context) must implement
+   *   <a href="https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Namespaced.java">
+   *     io.fabric8.kubernetes.api.model.Namespaced
+   *   </a> if it is a Namespaced scoped resource.
+   * </p>
+   *
    * @deprecated use {@link #customResources(CustomResourceDefinitionContext, Class, Class, Class)}, which takes a {@link CustomResourceDefinitionContext}
    * instead of a full {@link CustomResourceDefinition}.
    *
@@ -147,7 +162,8 @@ public interface KubernetesClient extends Client {
    * @param resourceType Class for CustomResource
    * @param listClass Class for list object for CustomResource
    * @param doneClass Class for Doneable CustomResource object
-   * @param <T> T type represents CustomResource type
+   * @param <T> T type represents CustomResource type. If it's Namespaced resource, it must implement
+   *            io.fabric8.kubernetes.api.model.Namespaced
    * @param <L> L type represents CustomResourceList type
    * @param <D> D type represents DoneableCustomResource type
    * @return returns a MixedOperation object with which you can do basic CustomResource operations
@@ -161,11 +177,19 @@ public interface KubernetesClient extends Client {
    * @deprecated use {@link #customResources(CustomResourceDefinitionContext, Class, Class, Class)}, which takes a {@link CustomResourceDefinitionContext}
    * instead of a full {@link CustomResourceDefinition}.
    *
+   * <p>
+   *   Note: your CustomResource POJO (T in this context) must implement
+   *   <a href="https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Namespaced.java">
+   *     io.fabric8.kubernetes.api.model.Namespaced
+   *   </a> if it is a Namespaced scoped resource.
+   * </p>
+   *
    * @param crd Custom Resource Definition
    * @param resourceType resource type Pojo
    * @param listClass list class Pojo
    * @param doneClass Done class Pojo
-   * @param <T> template argument for resource
+   * @param <T> template argument for resource. If it's Namespaced resource, it must implement
+   *            io.fabric8.kubernetes.api.model.Namespaced
    * @param <L> template argument for list
    * @param <D> template argument for doneable resource
    * @return Kubernetes client object for manipulating custom resource.


### PR DESCRIPTION
We changed `customResource()` typed API to require POJOs to implement `io.fabric8.kubernetes.api.model.Namespaced`
for Namespaced resources, but we didn't add any documentation about this breaking change. This PR tries to add
documentation regarding this in javadocs and CHANGELOG

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
