### PR TITLE
Fix isReady call for DeploymentConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Bugs
 
+* Fix #2537: Checking for Readiness of DeploymentConfig
+
 #### Improvements
 
 #### Dependency Upgrade

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -323,7 +323,27 @@ class DeploymentConfigTest {
     assertNotNull(deploymentConfig);
     assertEquals(1, deploymentConfig.getStatus().getAvailableReplicas().intValue());
     assertTrue(deploymentConfig.getStatus().getConditions().stream().anyMatch(c -> c.getType().equals("Available")));
-    assertTrue(client.deploymentConfigs().inNamespace("ns1").withName("dc1").isReady());
+  }
+
+  @Test
+  void testIsReady() {
+    // Given
+    DeploymentConfig deploymentConfig = getDeploymentConfig().withNewStatus()
+      .addNewCondition()
+      .withType("Available")
+      .endCondition()
+      .withReplicas(1).withAvailableReplicas(1)
+      .endStatus().build();
+    server.expect().get().withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs/dc1")
+      .andReturn(HttpURLConnection.HTTP_OK, deploymentConfig)
+      .always();
+    OpenShiftClient client = server.getOpenshiftClient();
+
+    // When
+    boolean result =  client.deploymentConfigs().inNamespace("ns1").withName("dc1").isReady();
+
+    // Then
+    assertTrue(result);
   }
 
   private DeploymentConfigBuilder getDeploymentConfig() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -323,6 +323,7 @@ class DeploymentConfigTest {
     assertNotNull(deploymentConfig);
     assertEquals(1, deploymentConfig.getStatus().getAvailableReplicas().intValue());
     assertTrue(deploymentConfig.getStatus().getConditions().stream().anyMatch(c -> c.getType().equals("Available")));
+    assertTrue(client.deploymentConfigs().inNamespace("ns1").withName("dc1").isReady());
   }
 
   private DeploymentConfigBuilder getDeploymentConfig() {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -103,6 +103,11 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
   }
 
   @Override
+  public Boolean isReady() {
+    return OpenShiftReadiness.isReady(get());
+  }
+
+  @Override
   public T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
     return waitUntilCondition(resource -> Objects.nonNull(resource) && OpenShiftReadiness.isReady(resource), amount, timeUnit);
   }


### PR DESCRIPTION
## Description

This PR fixes the issue described in #2537 where the `isReady()` method does not work for DeploymentConfig because it calls `Readiness.isReady()` instead of `OpenShiftReadiness.isReady()` This PR adds override into `OpenShiftOperation` which uses `OpenShiftReadiness` for OpenShift resources. As a test I added it to the existing `waitUntilReady` test.

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift