### PR TITLE
Chore: Allow e2e workflows to use Maven Cache

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,8 +29,24 @@ env:
   IT_DIR: kubernetes-itests
 
 jobs:
+  buildWithoutTests:
+    name: BuildWithoutTests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Install Kubernetes Client
+        run: mvn -f pom.xml -B -DskipTests clean install
+
   minikube:
     name: K8S
+    needs: BuildWithoutTests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -46,18 +62,23 @@ jobs:
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force
+      - name: Cache .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
           java-version: '8'
-      - name: Install Kubernetes Client
-        run: mvn -f pom.xml -B -DskipTests clean install
       - name: Install and Run Integration Tests
         run: |
           cd $IT_DIR
           mvn test -Dtest="io.fabric8.kubernetes.**"
   openshift:
     name: OpenShift
+    needs: BuildWithoutTests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -71,12 +92,16 @@ jobs:
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java 8
         uses: actions/setup-java@v1
         with:
           java-version: '8'
-      - name: Install Kubernetes Client
-        run: mvn -f pom.xml -B -DskipTests clean install
       - name: Install and Run Integration Tests
         run: |
           cd $IT_DIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Improvements
 * Fix #2507: Add a test for creating a Job with generateName
 * Fix #2509: Reversed order + Add Kubernetes 1.16.0 + OpenShift 4.5.14 to Compatibility matrix
+* Add cache in github actions for integration tests
 
 #### Dependency Upgrade
 * Fix #2513: Update Kubernetes Model to v1.19.1

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/JobIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/JobIT.java
@@ -54,6 +54,7 @@ public class JobIT {
     ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
     LogWatch logWatch = client.batch().jobs().inNamespace(session.getNamespace())
       .withName(job.getMetadata().getName())
+      .withLogWaitTimeout(30)
       .watchLog(baos);
 
     await().atMost(5, TimeUnit.SECONDS).until(() -> baos.toString().length() > 0);


### PR DESCRIPTION
I've seen it many times that our e2e tests fail at Install Kubernetes Client
step, maybe we can move it to a separate job which e2e tests can reuse rather
than building client again everytime.

Also, increased log wait timeout to 30 seconds for JobIT's log test

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
