### PR TITLE
add missing OpenShiftReadiness.isReadinessApplicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _**Note**_: Breaking changes in the API
 
 * `NetworkPolicy` moved to `io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy` from
   `io.fabric8.kubernetes.api.model.networking.NetworkPolicy`
+* Fix #2557: add missing `OpenShiftReadiness.isReadinessApplicable`
 
 ### 4.12.0 (2020-10-02)
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
@@ -23,6 +23,12 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import io.fabric8.openshift.api.model.DeploymentConfigStatus;
 
 public class OpenShiftReadiness extends Readiness {
+  public static boolean isReadinessApplicable(Class<? extends HasMetadata> itemClass) {
+    return Readiness.isReadinessApplicable(itemClass)
+      || DeploymentConfig.class.isAssignableFrom(itemClass)
+      ;
+  }
+
   public static boolean isReady(HasMetadata item) {
     if (Readiness.isReadiableKubernetesResource(item)) {
       return Readiness.isReady(item);


### PR DESCRIPTION
This is to make `OpenShiftReadiness` a drop-in replacement
for `Readiness` for OpenShift users.

Fixes #2557.

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
