### PR TITLE
Add utility to get age of a resource

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -355,5 +356,15 @@ public class KubernetesResourceUtil {
    */
   public static boolean isResourceReady(HasMetadata item) {
     return Readiness.isReady(item);
+  }
+
+  /**
+   * Calculates age of a kubernetes resource
+   * @param kubernetesResource
+   * @return a positive duration indicating age of the kubernetes resource
+   */
+  public static Duration getAge(HasMetadata kubernetesResource) {
+    Instant instant = Instant.parse(kubernetesResource.getMetadata().getCreationTimestamp());
+    return Duration.between(instant, Instant.now()).abs();
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -184,5 +186,19 @@ class KubernetesResourceUtilTest {
 
     // Then
     assertFalse(result);
+  }
+
+  @Test
+  void testGetAge(){
+    // Given
+    Pod pod = new PodBuilder()
+      .withNewMetadata().withName("test").withCreationTimestamp("2020-11-03T13:22:22Z").endMetadata()
+      .build();
+
+    // When
+    Duration duration = KubernetesResourceUtil.getAge(pod);
+
+    // Then
+    assertFalse(duration.isNegative());
   }
 }


### PR DESCRIPTION
Signed-off-by: Arghya Sadhu <arghya88@gmail.com>

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Add utility method to get age of a kubernetes resource in `KubernetesResourceUtil`
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
Fixes #2590