### PR TITLE
fix: make inferListType return CustomResourceList if no custom list exist

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -36,7 +36,7 @@ public class CustomResourceList<T extends HasMetadata> implements KubernetesReso
   private String apiVersion;
 
   @JsonProperty("items")
-  private List<T> items = new ArrayList<T>();
+  private List<T> items = new ArrayList<>();
 
   @JsonProperty("kind")
   private String kind;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -75,7 +75,7 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
 
   public static <T extends HasMetadata> Class<KubernetesResourceList<T>> inferListType(Class<T> customResource) {
     try {
-		return (Class<KubernetesResourceList<T>>) Class.forName(customResource.getCanonicalName() + "List");
+      return (Class<KubernetesResourceList<T>>) Class.forName(customResource.getName() + "List");
     } catch (ClassNotFoundException e) {
       throw KubernetesClientException.launderThrowable(e);
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -73,11 +74,11 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
     return resourceNamespaced;
   }
 
-  public static <T extends HasMetadata> Class<KubernetesResourceList<T>> inferListType(Class<T> customResource) {
+  public static <T extends HasMetadata> Class<? extends KubernetesResourceList> inferListType(Class<T> customResource) {
     try {
       return (Class<KubernetesResourceList<T>>) Class.forName(customResource.getName() + "List");
     } catch (ClassNotFoundException e) {
-      throw KubernetesClientException.launderThrowable(e);
+      return CustomResourceList.class;
     }
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
@@ -22,6 +22,9 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefin
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 
@@ -33,6 +36,7 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class CustomResourceOperationsImplTest {
@@ -42,6 +46,8 @@ public class CustomResourceOperationsImplTest {
 
   public static class MyCustomResourceList extends CustomResourceList<MyCustomResource> {
   }
+  
+  public static class Bar extends CustomResource {}
 
   private final CustomResourceDefinition crd = new CustomResourceDefinitionBuilder()
     .withNewMetadata()
@@ -60,11 +66,25 @@ public class CustomResourceOperationsImplTest {
   .build();
 
   @Test
+  void shouldBeAbleToReturnOperationsWithoutSpecificList() {
+    final MixedOperation<Bar, CustomResourceList, Resource<Bar>> operation = new DefaultKubernetesClient().customResources(Bar.class, CustomResourceList.class);
+    assertNotNull(operation);
+  }
+  
+  @Test
   public void shouldRegisterWithKubernetesDeserializer() throws IOException {
     assertForContext(new CustomResourceOperationContext()
       .withCrd(crd)
       .withType(MyCustomResource.class)
       .withListType(MyCustomResourceList.class));
+  }
+  
+  @Test
+  public void shouldWorkWithPlainCustomResourceList() throws IOException {
+    assertForContext(new CustomResourceOperationContext()
+      .withCrd(crd)
+      .withType(MyCustomResource.class)
+      .withListType(CustomResourceList.class));
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -105,6 +106,7 @@ public class CustomResourceOperationsImplTest {
   void canProperlyInferListType() {
     assertEquals(MyCustomResourceList.class, CustomResourceOperationsImpl.inferListType(MyCustomResource.class));
     assertEquals(FooList.class, CustomResourceOperationsImpl.inferListType(Foo.class));
+    assertEquals(CustomResourceList.class, CustomResourceOperationsImpl.inferListType(Bar.class));
   }
 
   private void assertForContext(CustomResourceOperationContext context) throws IOException {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImplTest.java
@@ -80,6 +80,12 @@ public class CustomResourceOperationsImplTest {
       .withType(MyCustomResource.class)
       .withListType(MyCustomResourceList.class));
   }
+  
+  @Test
+  void canProperlyInferListType() {
+    assertEquals(MyCustomResourceList.class, CustomResourceOperationsImpl.inferListType(MyCustomResource.class));
+    assertEquals(FooList.class, CustomResourceOperationsImpl.inferListType(Foo.class));
+  }
 
   private void assertForContext(CustomResourceOperationContext context) throws IOException {
     // CustomResourceOperationsImpl constructor invokes KubernetesDeserializer::registerCustomKind

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/Foo.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/Foo.java
@@ -1,13 +1,12 @@
 /**
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,8 +17,5 @@ package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.client.CustomResource;
 
-/**
- * @author <a href="claprun@redhat.com">Christophe Laprun</a>
- */
 public class Foo extends CustomResource {
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/Foo.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/Foo.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.client.CustomResource;
+
+/**
+ * @author <a href="claprun@redhat.com">Christophe Laprun</a>
+ */
+public class Foo extends CustomResource {
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/FooList.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/FooList.java
@@ -1,13 +1,12 @@
 /**
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
- * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,8 +17,5 @@ package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.client.CustomResourceList;
 
-/**
- * @author <a href="claprun@redhat.com">Christophe Laprun</a>
- */
 public class FooList extends CustomResourceList<Foo> {
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/FooList.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/FooList.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+/**
+ * @author <a href="claprun@redhat.com">Christophe Laprun</a>
+ */
+public class FooList extends CustomResourceList<Foo> {
+}


### PR DESCRIPTION
## Description
Currently, when the client is asked to retrieve a `MixedOperation` instance to deal with custom resources based solely on the custom resource's class, it will try to infer a `KubernetesList` implementation associated with that custom resource class. However, this currently requires users to provide such an implementation which should be named as the custom resource class with the `List` suffix in the same package. This kind of defeats the purpose of only requiring the custom resource class. This change makes it so that, if a custom list implementation satisfying the above criteria is not found, `CustomResourceList.class` is returned, which should work adequately as a default.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
