### PR TITLE
refactor: Watcher.onClose has dedicated WatcherException as parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #2614: Watcher.onClose has dedicated WatcherException as parameter.
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Watcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Watcher.java
@@ -15,14 +15,23 @@
  */
 package io.fabric8.kubernetes.client;
 
+import org.slf4j.LoggerFactory;
+
 public interface Watcher<T> {
 
   void eventReceived(Action action, T resource);
 
   /**
-   * Run when the watcher finally closes.
+   * Invoked when the watcher is gracefully closed.
+   */
+  default void onClose() {
+    LoggerFactory.getLogger(Watcher.class).debug("Watcher closed");
+  }
+
+  /**
+   * Invoked when the watcher closes due to an Exception.
    *
-   * @param cause What caused the watcher to be closed. Null means normal close.
+   * @param cause What caused the watcher to be closed.
    */
   void onClose(WatcherException cause);
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Watcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Watcher.java
@@ -24,7 +24,7 @@ public interface Watcher<T> {
    *
    * @param cause What caused the watcher to be closed. Null means normal close.
    */
-  void onClose(KubernetesClientException cause);
+  void onClose(WatcherException cause);
 
   enum Action {
     ADDED, MODIFIED, DELETED, ERROR

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/WatcherException.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/WatcherException.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import java.net.HttpURLConnection;
+
+public class WatcherException extends Exception {
+
+  public WatcherException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public WatcherException(String message) {
+    super(message);
+  }
+
+  public KubernetesClientException asClientException() {
+    final Throwable cause = getCause();
+    return cause instanceof KubernetesClientException ?
+      (KubernetesClientException) cause : new KubernetesClientException(getMessage(), cause);
+  }
+
+  public boolean isHttpGone() {
+    final KubernetesClientException cause = asClientException();
+    return cause.getCode() == HttpURLConnection.HTTP_GONE
+      || (cause.getStatus() != null && cause.getStatus().getCode() == HttpURLConnection.HTTP_GONE);
+  }
+
+  public boolean isShouldRetry() {
+    return getCause() == null || !isHttpGone();
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.dsl.base;
 
 import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,6 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.WaitForConditionWatcher.WatchException;
 import io.fabric8.kubernetes.client.dsl.internal.DefaultOperationInfo;
 import io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager;
 import io.fabric8.kubernetes.client.dsl.internal.WatchHTTPManager;
@@ -1104,7 +1104,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         return watcher.getFuture().get(remainingNanosToWait, NANOSECONDS);
       } catch (ExecutionException e) {
         Throwable cause = e.getCause();
-        if (cause instanceof WatchException && ((WatchException) cause).isShouldRetry()) {
+        if (cause instanceof WatcherException && ((WatcherException) cause).isShouldRetry()) {
           LOG.debug("retryable watch exception encountered, retrying after {} millis", currentBackOff, cause);
           Thread.sleep(currentBackOff);
           currentBackOff *= watchRetryBackoffMultiplier;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcher.java
@@ -15,13 +15,12 @@
  */
 package io.fabric8.kubernetes.client.dsl.base;
 
-import java.net.HttpURLConnection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 
 public class WaitForConditionWatcher<T extends HasMetadata> implements Watcher<T> {
 
@@ -52,34 +51,14 @@ public class WaitForConditionWatcher<T extends HasMetadata> implements Watcher<T
         }
         break;
       case ERROR:
-        future.completeExceptionally(new WatchException("Action.ERROR received"));
+        future.completeExceptionally(new WatcherException("Action.ERROR received"));
         break;
     }
   }
 
   @Override
-  public void onClose(KubernetesClientException cause) {
-    future.completeExceptionally(new WatchException("Watcher closed", cause));
+  public void onClose(WatcherException cause) {
+    future.completeExceptionally(cause == null ? new WatcherException("Watcher closed") : cause);
   }
 
-  public static class WatchException extends Exception {
-
-    public WatchException(String message, KubernetesClientException cause) {
-      super(message, cause);
-    }
-
-    public WatchException(String message) {
-      super(message);
-    }
-
-    public boolean isShouldRetry() {
-      return getCause() == null || !isHttpGone();
-    }
-
-    private boolean isHttpGone() {
-      KubernetesClientException cause = ((KubernetesClientException) getCause());
-      return cause.getCode() == HttpURLConnection.HTTP_GONE
-        || (cause.getStatus() != null && cause.getStatus().getCode() == HttpURLConnection.HTTP_GONE);
-    }
-  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcher.java
@@ -58,7 +58,11 @@ public class WaitForConditionWatcher<T extends HasMetadata> implements Watcher<T
 
   @Override
   public void onClose(WatcherException cause) {
-    future.completeExceptionally(cause == null ? new WatcherException("Watcher closed") : cause);
+    future.completeExceptionally(cause);
   }
 
+  @Override
+  public void onClose() {
+    future.completeExceptionally(new WatcherException("Watcher closed"));
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -63,6 +63,14 @@ public abstract class AbstractWatchManager<T> implements Watch {
     watcher.onClose(cause);
   }
 
+  final void closeEvent() {
+    if (forceClosed.getAndSet(true)) {
+      logger.debug("Ignoring duplicate firing of onClose event");
+      return;
+    }
+    watcher.onClose();
+  }
+
   static void closeWebSocket(WebSocket webSocket) {
     if (webSocket != null) {
       logger.debug("Closing websocket {}", webSocket);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import okhttp3.OkHttpClient;
+import okhttp3.WebSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public abstract class AbstractWatchManager<T> implements Watch {
+
+  private static final Logger logger = LoggerFactory.getLogger(AbstractWatchManager.class);
+
+  final Watcher<T> watcher;
+  final int reconnectLimit;
+  final int reconnectInterval;
+  final int maxIntervalExponent;
+  final ListOptions listOptions;
+  final AtomicReference<String> resourceVersion;
+  final OkHttpClient clonedClient;
+
+  private final AtomicBoolean forceClosed;
+
+  AbstractWatchManager(
+    Watcher<T> watcher, ListOptions listOptions, int reconnectLimit, int reconnectInterval, int maxIntervalExponent,
+    OkHttpClient clonedClient
+  ) {
+    this.watcher = watcher;
+    this.listOptions = listOptions;
+    this.reconnectLimit = reconnectLimit;
+    this.reconnectInterval = reconnectInterval;
+    this.maxIntervalExponent = maxIntervalExponent;
+    this.clonedClient = clonedClient;
+    this.resourceVersion = new AtomicReference<>(listOptions.getResourceVersion());
+    this.forceClosed = new AtomicBoolean();
+  }
+
+  final void closeEvent(WatcherException cause) {
+    if (forceClosed.getAndSet(true)) {
+      logger.debug("Ignoring duplicate firing of onClose event");
+      return;
+    }
+    watcher.onClose(cause);
+  }
+
+  static void closeWebSocket(WebSocket webSocket) {
+    if (webSocket != null) {
+      logger.debug("Closing websocket {}", webSocket);
+      try {
+        if (!webSocket.close(1000, null)) {
+          logger.warn("Failed to close websocket");
+        }
+      } catch (IllegalStateException e) {
+        logger.error("Called close on already closed websocket: {} {}", e.getClass(), e.getMessage());
+      }
+    }
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamedRunnable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamedRunnable.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import java.util.Objects;
+
+abstract class NamedRunnable implements Runnable {
+  private final String name;
+
+  NamedRunnable(String name) {
+    this.name = Objects.requireNonNull(name);
+  }
+
+  private void tryToSetName(String value) {
+    try {
+      Thread.currentThread().setName(value);
+    } catch (SecurityException ignored) {
+      // Ignored
+    }
+  }
+
+  public final void run() {
+    String oldName = Thread.currentThread().getName();
+    tryToSetName(this.name + "|" + oldName);
+    try {
+      execute();
+    } finally {
+      tryToSetName(oldName);
+    }
+  }
+
+  protected abstract void execute();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawWatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawWatchConnectionManager.java
@@ -254,7 +254,7 @@ public class RawWatchConnectionManager extends AbstractWatchManager<String> {
   @Override
   public void close() {
     logger.debug("Force closing the watch {}", this);
-    closeEvent(null);
+    closeEvent();
     closeWebSocket(webSocketRef.getAndSet(null));
     if (!executor.isShutdown()) {
       try {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -331,7 +331,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   @Override
   public void close() {
     logger.debug("Force closing the watch {}", this);
-    closeEvent(null);
+    closeEvent();
     closeWebSocket(webSocketRef.getAndSet(null));
     if (!executor.isShutdown()) {
       try {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -86,7 +86,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   }
 
   private void runWatch() {
-    logger.debug("Connecting websocket ... {}", this);
+    logger.debug("Connecting websocket to {}...", requestUrl);
 
     HttpUrl.Builder httpUrlBuilder = HttpUrl.get(requestUrl).newBuilder();
 
@@ -208,8 +208,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
           if (object instanceof HasMetadata) {
             @SuppressWarnings("unchecked")
             T obj = (T) object;
-            // Dirty cast - should always be valid though
-            resourceVersion.set(((HasMetadata) obj).getMetadata().getResourceVersion());
+            resourceVersion.set(obj.getMetadata().getResourceVersion());
             Watcher.Action action = Watcher.Action.valueOf(event.getType());
             watcher.eventReceived(action, obj);
           } else if (object instanceof KubernetesResourceList) {
@@ -237,7 +236,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
             }
 
             watcher.eventReceived(Action.ERROR, null);
-            logger.error("Error received: {}", status.toString());
+            logger.error("Error received: {}", status);
           } else {
             logger.error("Unknown message received: {}", message);
           }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -81,4 +81,9 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
     onClose.run();
   }
 
+  @Override
+  public void onClose() {
+    log.info("Watch gracefully closed");
+    onClose.run();
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -16,13 +16,12 @@
 package io.fabric8.kubernetes.client.informers.cache;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.HttpURLConnection;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -70,16 +69,14 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
   }
 
   @Override
-  public void onClose(KubernetesClientException exception) {
+  public void onClose(WatcherException exception) {
     log.error("Watch closing");
     Optional.ofNullable(exception)
       .map(e -> {
         log.debug("Exception received during watch", e);
         return exception;
       })
-      .map(KubernetesClientException::getStatus)
-      .map(Status::getCode)
-      .filter(c -> c.equals(HttpURLConnection.HTTP_GONE))
+      .filter(WatcherException::isHttpGone)
       .ifPresent(c -> onHttpGone.run());
     onClose.run();
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessWatcher.java
@@ -20,12 +20,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 
 public class ReadinessWatcher<T extends HasMetadata> implements Watcher<T> {
-
 
   private final CountDownLatch latch = new CountDownLatch(1);
   private final AtomicReference<T> reference = new AtomicReference<>();
@@ -49,7 +48,7 @@ public class ReadinessWatcher<T extends HasMetadata> implements Watcher<T> {
   }
 
   @Override
-  public void onClose(KubernetesClientException e) {
+  public void onClose(WatcherException e) {
 
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/WatcherToggle.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/WatcherToggle.java
@@ -16,8 +16,8 @@
 
 package io.fabric8.kubernetes.client.utils;
 
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 
 import java.util.Objects;
 
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public class WatcherToggle<T> implements Watcher<T> {
 
-  private Watcher<T> delegate;
+  private final Watcher<T> delegate;
 
   private boolean enabled;
 
@@ -51,7 +51,7 @@ public class WatcherToggle<T> implements Watcher<T> {
   }
 
   @Override
-  public void onClose(KubernetesClientException cause) {
+  public void onClose(WatcherException cause) {
     if (enabled) {
       delegate.onClose(cause);
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/WatcherToggle.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/WatcherToggle.java
@@ -56,4 +56,11 @@ public class WatcherToggle<T> implements Watcher<T> {
       delegate.onClose(cause);
     }
   }
+
+  @Override
+  public void onClose() {
+    if (enabled) {
+      delegate.onClose();
+    }
+  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationWatchTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationWatchTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.base;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager;
+import io.fabric8.kubernetes.client.dsl.internal.WatchHTTPManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings({"rawtypes", "FieldCanBeLocal"})
+class BaseOperationWatchTest {
+
+  private Watcher<Pod> watcher;
+  private OperationContext operationContext;
+  private BaseOperation<Pod, PodList, PodResource<Pod>> baseOperation;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    watcher = mock(Watcher.class);
+    operationContext = mock(OperationContext.class, RETURNS_DEEP_STUBS);
+    baseOperation = new BaseOperation<>(operationContext);
+  }
+
+  @Test
+  @DisplayName("watch, with exception on connection open, should throw Exception and close WatchConnectionManager")
+  void watchWithExceptionOnOpen() {
+    try (final MockedConstruction<WatchConnectionManager> m = mockConstruction(WatchConnectionManager.class, (mock, context) -> {
+      // Given
+      doThrow(new KubernetesClientException("Mocked Connection Error")).when(mock).waitUntilReady();
+    })) {
+      // When
+      final KubernetesClientException result = assertThrows(KubernetesClientException.class,
+        () -> {
+          baseOperation.watch(watcher);
+          fail();
+        });
+      // Then
+      assertThat(result).hasMessage("Mocked Connection Error");
+      assertThat(m.constructed())
+        .hasSize(1)
+        .element(0)
+        .matches(wcm -> {
+          verify(wcm, times(1)).close();
+          return true;
+        });
+    }
+  }
+
+  @Test
+  @DisplayName("watch, with retryable exception on connection open, should close initial WatchConnectionManager and retry")
+  void watchWithRetryableExceptionOnOpen() {
+    try (
+      final MockedConstruction<WatchConnectionManager> m = mockConstruction(WatchConnectionManager.class, (mock, context) -> {
+        // Given
+        doThrow(new KubernetesClientException(new StatusBuilder().withCode(503).build())).when(mock).waitUntilReady();
+      });
+      final MockedConstruction<WatchHTTPManager> mHttp = mockConstruction(WatchHTTPManager.class)
+    ) {
+      // When
+      final Watch result = baseOperation.watch(watcher);
+      // Then
+      assertThat(result).isInstanceOf(WatchHTTPManager.class).isSameAs(mHttp.constructed().get(0));
+      assertThat(m.constructed())
+        .hasSize(1)
+        .element(0)
+        .matches(wcm -> {
+          verify(wcm, times(1)).close();
+          return true;
+        });
+    }
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcherTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcherTest.java
@@ -26,13 +26,13 @@ import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 
+import io.fabric8.kubernetes.client.WatcherException;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher.Action;
-import io.fabric8.kubernetes.client.dsl.base.WaitForConditionWatcher.WatchException;
 
 class WaitForConditionWatcherTest {
 
@@ -111,8 +111,8 @@ class WaitForConditionWatcherTest {
       watcher.getFuture().get();
       fail("should have thrown exception");
     } catch (ExecutionException e) {
-      assertEquals(e.getCause().getClass(), WatchException.class);
-      assertEquals(e.getCause().getMessage(), "Action.ERROR received");
+      assertEquals(WatcherException.class, e.getCause().getClass());
+      assertEquals("Action.ERROR received", e.getCause().getMessage());
     }
     assertFalse(condition.isCalled());
   }
@@ -121,15 +121,15 @@ class WaitForConditionWatcherTest {
   void itCompletesExceptionallyWithRetryOnCloseNonGone() throws Exception {
     TrackingPredicate condition = condition(ss -> true);
     WaitForConditionWatcher<ConfigMap> watcher = new WaitForConditionWatcher<>(condition);
-    watcher.onClose(new KubernetesClientException("test", 500, null));
+    watcher.onClose(new WatcherException("Watcher closed", new KubernetesClientException("test", 500, null)));
     assertTrue(watcher.getFuture().isDone());
     try {
       watcher.getFuture().get();
       fail("should have thrown exception");
     } catch (ExecutionException e) {
-      assertEquals(e.getCause().getClass(), WatchException.class);
-      assertEquals(e.getCause().getMessage(), "Watcher closed");
-      assertTrue(((WatchException) e.getCause()).isShouldRetry());
+      assertEquals(WatcherException.class, e.getCause().getClass());
+      assertEquals("Watcher closed", e.getCause().getMessage());
+      assertTrue(((WatcherException) e.getCause()).isShouldRetry());
     }
     assertFalse(condition.isCalled());
   }
@@ -138,15 +138,15 @@ class WaitForConditionWatcherTest {
   void itCompletesExceptionallyWithNoRetryOnCloseGone() throws Exception {
     TrackingPredicate condition = condition(ss -> true);
     WaitForConditionWatcher<ConfigMap> watcher = new WaitForConditionWatcher<>(condition);
-    watcher.onClose(new KubernetesClientException("test", HttpURLConnection.HTTP_GONE, null));
+    watcher.onClose(new WatcherException("Watcher closed", new KubernetesClientException("test", HttpURLConnection.HTTP_GONE, null)));
     assertTrue(watcher.getFuture().isDone());
     try {
       watcher.getFuture().get();
       fail("should have thrown exception");
     } catch (ExecutionException e) {
-      assertEquals(e.getCause().getClass(), WatchException.class);
-      assertEquals(e.getCause().getMessage(), "Watcher closed");
-      assertFalse(((WatchException) e.getCause()).isShouldRetry());
+      assertEquals(WatcherException.class, e.getCause().getClass());
+      assertEquals("Watcher closed", e.getCause().getMessage());
+      assertFalse(((WatcherException) e.getCause()).isShouldRetry());
     }
     assertFalse(condition.isCalled());
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import okhttp3.OkHttpClient;
+import okhttp3.WebSocket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class AbstractWatchManagerTest {
+
+  @Test
+  @DisplayName("closeEvent, is idempotent, multiple calls only close watcher once")
+  void closeEventIsIdempotent() {
+    // Given
+    final AtomicInteger closeCount = new AtomicInteger();
+    final Watcher<Object> watcher = new WatcherAdapter<Object>() {
+
+      @Override
+      public void onClose(WatcherException cause) {
+        closeCount.addAndGet(1);
+      }
+    };
+    final WatchManager<Object> awm = new WatchManager<>(
+      watcher, mock(ListOptions.class, RETURNS_DEEP_STUBS), 0, 0, 0,
+      mock(OkHttpClient.class));
+    // When
+    for (int it = 0; it < 10; it++) {
+      awm.closeEvent(null);
+    }
+    // Then
+    assertThat(closeCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("closeWebSocket, closes web socket with 1000 code (Normal Closure)")
+  void closeWebSocket() {
+    // Given
+    final WebSocket webSocket = mock(WebSocket.class);
+    // When
+    AbstractWatchManager.closeWebSocket(webSocket);
+    // Then
+    verify(webSocket, times(1)).close(1000, null);
+  }
+
+  private static class WatcherAdapter<T> implements Watcher<T> {
+    @Override
+    public void eventReceived(Action action, T resource) {
+
+    }
+    @Override
+    public void onClose(WatcherException cause) {
+
+    }
+  }
+
+  private static final class WatchManager<T> extends AbstractWatchManager<T> {
+    public WatchManager(Watcher<T> watcher, ListOptions listOptions, int reconnectLimit, int reconnectInterval, int maxIntervalExponent, OkHttpClient clonedClient) {
+      super(watcher, listOptions, reconnectLimit, reconnectInterval, maxIntervalExponent, clonedClient);
+    }
+    @Override
+    public void close() {
+
+    }
+  }
+}

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -171,12 +172,12 @@ public class CRDExample {
         }
 
         @Override
-        public void onClose(KubernetesClientException cause) {
+        public void onClose(WatcherException cause) {
         }
       });
 
       System.in.read();
-      
+
     } catch (KubernetesClientException e) {
       logger.error(e.getMessage(), e);
     } catch (Exception e) {

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CronJobExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CronJobExample.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 public class CronJobExample {
   private static final Logger logger = LoggerFactory.getLogger(CronJobExample.class);
 
-  public static void main(String args[]) throws InterruptedException {
+  public static void main(String[] args) {
     String master = "https://localhost:8443/";
     if (args.length == 1) {
       master = args[0];
@@ -86,7 +86,7 @@ public class CronJobExample {
         }
 
         @Override
-        public void onClose(KubernetesClientException e) {
+        public void onClose(WatcherException e) {
           // Ignore
         }
       })) {

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/FullExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/FullExample.java
@@ -22,21 +22,18 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ResourceQuota;
 import io.fabric8.kubernetes.api.model.ResourceQuotaBuilder;
-import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.client.APIGroupNotAvailableException;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.internal.SerializationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.fabric8.kubernetes.client.Watcher.Action.ERROR;
 
 public class FullExample {
 
@@ -57,7 +54,7 @@ public class FullExample {
                 }
 
                 @Override
-                public void onClose(KubernetesClientException e) {
+                public void onClose(WatcherException e) {
                     if (e != null) {
                         e.printStackTrace();
                         logger.error(e.getMessage(), e);

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/RawCustomResourceExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/RawCustomResourceExample.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +73,7 @@ public class RawCustomResourceExample {
         }
 
         @Override
-        public void onClose(KubernetesClientException e) {
+        public void onClose(WatcherException e) {
           logger.debug("Watcher onClose");
           closeLatch.countDown();
           if (e != null) {

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/WatchExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/WatchExample.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,7 @@ public class WatchExample {
         }
 
         @Override
-        public void onClose(KubernetesClientException e) {
+        public void onClose(WatcherException e) {
           logger.debug("Watcher onClose");
           if (e != null) {
             logger.error(e.getMessage(), e);

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodWatchEquivalent.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodWatchEquivalent.java
@@ -18,8 +18,8 @@ package io.fabric8.kubernetes.examples.kubectl.equivalents;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,14 +42,14 @@ public class PodWatchEquivalent {
                 @Override
                 public void eventReceived(Action action, Pod pod) {
                     logger.info("{} {}", action.name(), pod.getMetadata().getName());
-                    switch (action.name()) {
-                        case "ADDED":
+                    switch (action) {
+                        case ADDED:
                             logger.info("{} got added", pod.getMetadata().getName());
                             break;
-                        case "DELETED":
+                        case DELETED:
                             logger.info("{} got deleted", pod.getMetadata().getName());
                             break;
-                        case "MODIFIED":
+                      case MODIFIED:
                             logger.info("{} got modified",  pod.getMetadata().getName());
                             break;
                         default:
@@ -58,7 +58,7 @@ public class PodWatchEquivalent {
                 }
 
                 @Override
-                public void onClose(KubernetesClientException e) {
+                public void onClose(WatcherException e) {
                     logger.info( "Closed");
                     isWatchClosed.countDown();
                 }

--- a/kubernetes-examples/src/main/java/io/fabric8/openshift/examples/WatchBuildConfigs.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/openshift/examples/WatchBuildConfigs.java
@@ -19,6 +19,7 @@ package io.fabric8.openshift.examples;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -36,7 +37,7 @@ public class WatchBuildConfigs {
         }
 
         @Override
-        public void onClose(KubernetesClientException cause) {
+        public void onClose(WatcherException cause) {
           System.out.println("Watch Closed: " + cause);
           if (cause != null) {
             cause.printStackTrace();

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
@@ -71,7 +71,7 @@ public class WatchIT {
       }
 
       @Override
-      public void onClose(KubernetesClientException e) {
+      public void onClose(WatcherException e) {
         closeLatch.countDown();
         logger.info("watch closed...");
       }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
@@ -71,7 +71,12 @@ public class WatchIT {
       }
 
       @Override
-      public void onClose(WatcherException e) {
+      public void onClose(WatcherException cause) {
+
+      }
+
+      @Override
+      public void onClose() {
         closeLatch.countDown();
         logger.info("watch closed...");
       }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -19,7 +19,6 @@ package io.fabric8.kubernetes.client.mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -37,6 +36,7 @@ import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.client.WatcherException;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Rule;
 import org.junit.jupiter.api.Assertions;
@@ -294,7 +294,7 @@ class CustomResourceTest {
           @Override
           public void eventReceived(Action action, String resource) { anyEventReceived.countDown(); }
           @Override
-          public void onClose(KubernetesClientException cause) { }
+          public void onClose(WatcherException cause) { }
         });
 
     // Then
@@ -323,7 +323,7 @@ class CustomResourceTest {
           @Override
           public void eventReceived(Action action, String resource) { anyEventReceieved.countDown(); }
           @Override
-          public void onClose(KubernetesClientException cause) { }
+          public void onClose(WatcherException cause) { }
         });
 
     // Then
@@ -352,7 +352,7 @@ class CustomResourceTest {
           @Override
           public void eventReceived(Action action, String resource) { anyEventReceived.countDown(); }
           @Override
-          public void onClose(KubernetesClientException cause) { }
+          public void onClose(WatcherException cause) { }
         });
 
     // Then
@@ -383,7 +383,7 @@ class CustomResourceTest {
           @Override
           public void eventReceived(Action action, String resource) { anyEventReceived.countDown(); }
           @Override
-          public void onClose(KubernetesClientException cause) { }
+          public void onClose(WatcherException cause) { }
         });
 
     // Then
@@ -416,7 +416,7 @@ class CustomResourceTest {
           @Override
           public void eventReceived(Action action, String resource) { anyEventReceived.countDown(); }
           @Override
-          public void onClose(KubernetesClientException cause) { }
+          public void onClose(WatcherException cause) { }
         });
 
     // Then

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
@@ -22,9 +22,9 @@ import io.fabric8.kubernetes.api.model.EventListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.Rule;
@@ -72,7 +72,7 @@ class EventTest {
       }
 
       @Override
-      public void onClose(KubernetesClientException cause) {
+      public void onClose(WatcherException cause) {
 
       }
     });

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -100,34 +100,10 @@ class PodCrudTest {
   void testPodWatchOnName() throws InterruptedException {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
-    final CountDownLatch deleteLatch = new CountDownLatch(1);
-    final CountDownLatch closeLatch = new CountDownLatch(1);
-    final CountDownLatch editLatch = new CountDownLatch(2);
-    final CountDownLatch addLatch = new CountDownLatch(1);
+    final LatchedWatcher lw = new LatchedWatcher(1, 2, 1, 1, 1);
 
     pod1 = client.pods().inNamespace("ns1").create(pod1);
-    Watch watch = client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName()).watch(new Watcher<Pod>() {
-      @Override
-      public void eventReceived(Action action, Pod resource) {
-        switch (action) {
-          case DELETED:
-            deleteLatch.countDown();
-            break;
-          case MODIFIED:
-            editLatch.countDown();
-            break;
-          case ADDED:
-            addLatch.countDown();
-            break;
-          default:
-            throw new AssertionFailedError(action.toString().concat(" isn't recognised."));
-        }
-      }
-      @Override
-      public void onClose(WatcherException cause) {
-        closeLatch.countDown();
-      }
-    });
+    Watch watch = client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName()).watch(lw);
 
     pod1 = client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName())
       .patch(new PodBuilder().withNewMetadataLike(pod1.getMetadata()).endMetadata().build());
@@ -141,13 +117,13 @@ class PodCrudTest {
     client.pods().inNamespace("ns1").create(new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build());
 
     assertEquals(1, client.pods().inNamespace("ns1").list().getItems().size());
-    assertTrue(addLatch.await(1, TimeUnit.MINUTES));
-    assertTrue(editLatch.await(1, TimeUnit.MINUTES));
-    assertTrue(deleteLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.addLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.editLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.deleteLatch.await(1, TimeUnit.MINUTES));
 
     watch.close();
 
-    assertTrue(closeLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.closeLatch.await(1, TimeUnit.MINUTES));
   }
 
   @Test
@@ -155,35 +131,10 @@ class PodCrudTest {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
 
-    final CountDownLatch deleteLatch = new CountDownLatch(3);
-    final CountDownLatch closeLatch = new CountDownLatch(1);
-    final CountDownLatch addLatch = new CountDownLatch(3);
-    final CountDownLatch editLatch = new CountDownLatch(2);
+    final LatchedWatcher lw = new LatchedWatcher();
 
     client.pods().inNamespace("ns1").create(pod1);
-    Watch watch = client.pods().inNamespace("ns1").watch(new Watcher<Pod>() {
-      @Override
-      public void eventReceived(Action action, Pod resource) {
-        switch (action) {
-          case DELETED:
-            deleteLatch.countDown();
-            break;
-          case ADDED:
-            addLatch.countDown();
-            break;
-          case MODIFIED:
-            editLatch.countDown();
-            break;
-          default:
-            throw new AssertionFailedError(action.toString());
-        }
-      }
-      @Override
-      public void onClose(WatcherException cause) {
-        closeLatch.countDown();
-      }
-    });
-
+    Watch watch = client.pods().inNamespace("ns1").watch(lw);
 
     client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName())
       .patch(new PodBuilder().withNewMetadataLike(pod1.getMetadata()).endMetadata().build());
@@ -201,7 +152,7 @@ class PodCrudTest {
     assertEquals(0, client.pods().inNamespace("ns1").list().getItems().size());
 
     watch.close();
-    assertTrue(closeLatch.await(2, TimeUnit.MINUTES));
+    assertTrue(lw.closeLatch.await(1, TimeUnit.MINUTES));
   }
 
   @Test
@@ -209,37 +160,12 @@ class PodCrudTest {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("test", "watch").endMetadata().build();
 
-    final CountDownLatch deleteLatch = new CountDownLatch(1);
-    final CountDownLatch closeLatch = new CountDownLatch(1);
-    final CountDownLatch addLatch = new CountDownLatch(2);
-    final CountDownLatch editLatch = new CountDownLatch(1);
+    final LatchedWatcher lw = new LatchedWatcher(2, 1, 1, 1, 1);
 
     client.pods().inNamespace("ns1").create(pod1);
     Watch watch = client.pods().inNamespace("ns1")
       .withLabels(new HashMap<String, String>() {{ put("test", "watch");}})
-      .watch(new Watcher<Pod>() {
-        @Override
-        public void eventReceived(Action action, Pod resource) {
-          switch (action) {
-            case DELETED:
-              deleteLatch.countDown();
-              break;
-            case ADDED:
-              addLatch.countDown();
-              break;
-            case MODIFIED:
-              editLatch.countDown();
-              break;
-            default:
-              throw new AssertionFailedError(action.toString());
-          }
-        }
-
-        @Override
-        public void onClose(WatcherException cause) {
-          closeLatch.countDown();
-        }
-    });
+      .watch(lw);
 
     Map<String, String> m = pod1.getMetadata().getLabels();
     m.put("foo", "bar");
@@ -253,8 +179,8 @@ class PodCrudTest {
       .build());
 
     assertEquals(1, client.pods().inNamespace("ns1").list().getItems().size());
-    assertTrue(deleteLatch.await(1, TimeUnit.MINUTES));
-    assertTrue(editLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.deleteLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.editLatch.await(1, TimeUnit.MINUTES));
 
     Pod pod2 = client.pods().inNamespace("ns1").create(new PodBuilder()
       .withNewMetadata().withName("pod2").addToLabels("foo", "bar").endMetadata()
@@ -271,60 +197,82 @@ class PodCrudTest {
 
     assertEquals(2, client.pods().inNamespace("ns1").list().getItems().size());
     assertEquals(2, client.pods().inNamespace("ns1").withLabel("test", "watch").list().getItems().size());
-    assertTrue(addLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.addLatch.await(1, TimeUnit.MINUTES));
 
     watch.close();
-    assertTrue(closeLatch.await(1, TimeUnit.MINUTES));
+    assertTrue(lw.closeLatch.await(1, TimeUnit.MINUTES));
   }
 
   @Test
-  void testPodWatchClientSocketError() throws InterruptedException {
+  void testPodWatchTryWithResources() throws InterruptedException {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
 
-    final CountDownLatch deleteLatch = new CountDownLatch(1);
-    final CountDownLatch closeLatch = new CountDownLatch(1);
-    final CountDownLatch editLatch = new CountDownLatch(1);
-    final CountDownLatch addLatch = new CountDownLatch(1);
+    final LatchedWatcher lw = new LatchedWatcher();
 
     client.pods().inNamespace("ns1").create(pod1);
 
-    try (Watch watch = client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName()).watch(new Watcher<Pod>() {
-        @Override
-        public void eventReceived(Action action, Pod resource) {
-          switch (action) {
-            case DELETED:
-              deleteLatch.countDown();
-              break;
-            case MODIFIED:
-              editLatch.countDown();
-              break;
-            case ADDED:
-              addLatch.countDown();
-              break;
-            default:
-              throw new AssertionFailedError(action.toString().concat(" isn't recognised."));
-          }
-        }
-
-        @Override
-        public void onClose(WatcherException e) {
-            closeLatch.countDown();
-        }
-      })) {
-        client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName())
+    try (
+      Watch watch = client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName()).watch(lw)
+    ) {
+      client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName())
         .patch(new PodBuilder().withNewMetadataLike(pod1.getMetadata()).endMetadata().build());
 
-        client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName()).delete();
+      client.pods().inNamespace("ns1").withName(pod1.getMetadata().getName()).delete();
 
-        client.pods().inNamespace("ns1").create(new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build());
+      client.pods().inNamespace("ns1").create(new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build());
 
-        assertEquals(1, client.pods().inNamespace("ns1").list().getItems().size());
-        assertTrue(addLatch.await(1, TimeUnit.SECONDS));
-        assertTrue(editLatch.await(1, TimeUnit.SECONDS));
-        assertTrue(deleteLatch.await(1, TimeUnit.SECONDS));
-      } finally {
-        assertTrue(closeLatch.await(3, TimeUnit.SECONDS));
+      assertEquals(1, client.pods().inNamespace("ns1").list().getItems().size());
+      assertTrue(lw.addLatch.await(1, TimeUnit.SECONDS));
+      assertTrue(lw.editLatch.await(1, TimeUnit.SECONDS));
+      assertTrue(lw.deleteLatch.await(1, TimeUnit.SECONDS));
+    }
+    assertTrue(lw.closeLatch.await(3, TimeUnit.SECONDS));
+  }
+
+    private static final class LatchedWatcher implements Watcher<Pod> {
+      final CountDownLatch addLatch;
+      final CountDownLatch editLatch;
+      final CountDownLatch deleteLatch;
+      final CountDownLatch closeErrorLatch;
+      final CountDownLatch closeLatch;
+
+      public LatchedWatcher() {
+        this(1, 1, 1, 1, 1);
+      }
+      public LatchedWatcher(int addLatch, int editLatch, int deleteLatch, int closeErrorLatch, int closeLatch) {
+        this.addLatch = new CountDownLatch(addLatch);
+        this.editLatch = new CountDownLatch(editLatch);
+        this.deleteLatch = new CountDownLatch(deleteLatch);
+        this.closeErrorLatch = new CountDownLatch(closeErrorLatch);
+        this.closeLatch = new CountDownLatch(closeLatch);
+      }
+
+      @Override
+      public void eventReceived(Action action, Pod resource) {
+        switch (action) {
+          case DELETED:
+            deleteLatch.countDown();
+            break;
+          case MODIFIED:
+            editLatch.countDown();
+            break;
+          case ADDED:
+            addLatch.countDown();
+            break;
+          default:
+            throw new AssertionFailedError(action.toString().concat(" isn't recognised."));
+        }
+      }
+
+      @Override
+      public void onClose(WatcherException e) {
+        closeErrorLatch.countDown();
+      }
+
+      @Override
+      public void onClose() {
+        closeLatch.countDown();
       }
     }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -21,9 +21,9 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import junit.framework.AssertionFailedError;
 import org.junit.Rule;
@@ -41,13 +41,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @EnableRuleMigrationSupport
-public class PodCrudTest {
+class PodCrudTest {
 
   @Rule
   public KubernetesServer server = new KubernetesServer(true, true);
 
   @Test
-  public void testCrud() { KubernetesClient client = server.getClient();
+  void testCrud() { KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
     Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").addToLabels("testKey", "testValue").endMetadata().build();
     Pod pod3 = new PodBuilder().withNewMetadata().withName("pod3").endMetadata().build();
@@ -97,7 +97,7 @@ public class PodCrudTest {
   }
 
   @Test
-  public void testPodWatchOnName() throws InterruptedException {
+  void testPodWatchOnName() throws InterruptedException {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
     final CountDownLatch deleteLatch = new CountDownLatch(1);
@@ -124,7 +124,7 @@ public class PodCrudTest {
         }
       }
       @Override
-      public void onClose(KubernetesClientException cause) {
+      public void onClose(WatcherException cause) {
         closeLatch.countDown();
       }
     });
@@ -151,7 +151,7 @@ public class PodCrudTest {
   }
 
   @Test
-  public void testPodWatchOnNamespace() throws InterruptedException {
+  void testPodWatchOnNamespace() throws InterruptedException {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
 
@@ -179,7 +179,7 @@ public class PodCrudTest {
         }
       }
       @Override
-      public void onClose(KubernetesClientException cause) {
+      public void onClose(WatcherException cause) {
         closeLatch.countDown();
       }
     });
@@ -205,7 +205,7 @@ public class PodCrudTest {
   }
 
   @Test
-  public void testPodWatchOnLabels() throws InterruptedException {
+  void testPodWatchOnLabels() throws InterruptedException {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("test", "watch").endMetadata().build();
 
@@ -236,7 +236,7 @@ public class PodCrudTest {
         }
 
         @Override
-        public void onClose(KubernetesClientException cause) {
+        public void onClose(WatcherException cause) {
           closeLatch.countDown();
         }
     });
@@ -278,7 +278,7 @@ public class PodCrudTest {
   }
 
   @Test
-  public void testPodWatchClientSocketError() throws InterruptedException {
+  void testPodWatchClientSocketError() throws InterruptedException {
     KubernetesClient client = server.getClient();
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
 
@@ -308,7 +308,7 @@ public class PodCrudTest {
         }
 
         @Override
-        public void onClose(KubernetesClientException e) {
+        public void onClose(WatcherException e) {
             closeLatch.countDown();
         }
       })) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -43,6 +43,7 @@ import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.PortForward;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -359,7 +360,7 @@ class PodTest {
       }
 
       @Override
-      public void onClose(KubernetesClientException cause) {
+      public void onClose(WatcherException cause) {
       }
     };
     // When

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -33,6 +33,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.Watchable;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 
@@ -86,8 +87,8 @@ class WatchTest {
       }
 
       @Override
-      public void onClose(KubernetesClientException cause) {
-        assertEquals(410, cause.getCode());
+      public void onClose(WatcherException cause) {
+        assertTrue(cause.isHttpGone());
         closeLatch.countDown();
       }
     };
@@ -115,7 +116,7 @@ class WatchTest {
       }
 
       @Override
-      public void onClose(KubernetesClientException cause) {
+      public void onClose(WatcherException cause) {
         assertNull("Close event should be invoked by try-with-resources successful completion, not by exception", cause);
         closeLatch.countDown();
       }
@@ -151,7 +152,7 @@ class WatchTest {
       public void eventReceived(Action action, Pod resource) { eventReceivedLatch.countDown(); }
 
       @Override
-      public void onClose(KubernetesClientException cause) { }
+      public void onClose(WatcherException cause) { }
     });
 
     // Then
@@ -181,8 +182,8 @@ class WatchTest {
       }
 
       @Override
-      public void onClose(KubernetesClientException cause) {
-        assertEquals(410, cause.getCode());
+      public void onClose(WatcherException cause) {
+        assertTrue(cause.isHttpGone());
         closeLatch.countDown();
       }
     };
@@ -211,7 +212,7 @@ class WatchTest {
       }
 
       @Override
-      public void onClose(KubernetesClientException cause) {
+      public void onClose(WatcherException cause) {
         closeLatch.countDown();
       }
     });
@@ -257,7 +258,7 @@ class WatchTest {
       }
 
       @Override
-      public void onClose(KubernetesClientException cause) {
+      public void onClose(WatcherException cause) {
       }
     });
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -117,7 +117,11 @@ class WatchTest {
 
       @Override
       public void onClose(WatcherException cause) {
-        assertNull("Close event should be invoked by try-with-resources successful completion, not by exception", cause);
+        fail("Close event should be invoked by try-with-resources successful completion, not by exception");
+      }
+
+      @Override
+      public void onClose() {
         closeLatch.countDown();
       }
     };
@@ -213,6 +217,11 @@ class WatchTest {
 
       @Override
       public void onClose(WatcherException cause) {
+        fail();
+      }
+
+      @Override
+      public void onClose() {
         closeLatch.countDown();
       }
     });


### PR DESCRIPTION
## Description

refactor: `Watcher#onClose` has dedicated `WatcherException` as parameter.

 - Refactored common parts of Watcher implementations into `AbstractWatchManager`

#### Watcher interface refactor

I've refactored the `Watcher` interface and the methods calling it.

The interface now provides a dedicated default argument-less `onClose()` method. This method should always be called upon Watcher completion. Implementations should override this method in case operations (e.g. cleanup) should be performed once the Watcher is closed.

The previous `onClose(WatcherException cause)` is kept and only invoked whenever an exception occurs during the Watcher life-cycle (once the watch connection is open and established).

To be clear, Exceptions that happen during Watch initiation should be captured with code like (this has not changed):
```java
try (
  Watch watch = kubernetesClient.pods().watch(new WatcherImpl())
) {
   // ...
} catch (Exception exception) {
  // act upon exceptions that may happen synchronously when opening the watch
}
```

Maybe further improvements can be performed or [method signatures](https://github.com/fabric8io/kubernetes-client/blob/10d55aa5a022b176bc06667abac809a579b31bfd/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Watchable.java#L29) changed so that they throw checked exceptions.



Fixes: #2614

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
