### PR TITLE
fix: improve matcher to make it more DNS-spec compliant

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
@@ -21,8 +21,10 @@ import java.util.regex.Pattern;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public interface HasMetadata extends KubernetesResource {
-  String DNS_NAME_REGEXP = "(?!-)[A-Za-z0-9-]{1,63}(?<!-)";
-  Matcher DOMAIN_NAME_MATCHER = Pattern.compile("^(" + DNS_NAME_REGEXP + "\\.)+[A-Za-z]{2,6}/" + DNS_NAME_REGEXP).matcher("");
+  String DNS_LABEL_START = "(?!-)[A-Za-z0-9-]{";
+  String DNS_LABEL_END = ",63}(?<!-)";
+  String DNS_LABEL_REGEXP = DNS_LABEL_START + 1 + DNS_LABEL_END;
+  Matcher FINALIZER_NAME_MATCHER = Pattern.compile("^(" + DNS_LABEL_REGEXP + "\\.)+" + DNS_LABEL_START + 2 + DNS_LABEL_END + "/" + DNS_LABEL_REGEXP).matcher("");
   
   ObjectMeta getMetadata();
   
@@ -71,7 +73,7 @@ public interface HasMetadata extends KubernetesResource {
     if (isMarkedForDeletion() || hasFinalizer(finalizer)) {
       return false;
     }
-    if (DOMAIN_NAME_MATCHER.reset(finalizer).matches()) {
+    if (FINALIZER_NAME_MATCHER.reset(finalizer).matches()) {
       return getMetadata().getFinalizers().add(finalizer);
     } else {
       throw new IllegalArgumentException("Invalid finalizer name: '" + finalizer + "'. Must consist of a domain name, a forward slash and the valid kubernetes name.");

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
@@ -55,6 +55,8 @@ class HasMetadataTest {
     assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer("/"));
     assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer("-fabric8.io/finalizer"));
     assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer("fabric8.i/finalizer"));
+    assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer("fabric8./finalizer"));
+    assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer("fabric8.label12345678901234567890123456789012345678901234567890qwertyuiopasdfghjkl/finalizer"));
     assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer(".io/finalizer"));
     assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer("fabric8.io/-finalizer"));
     assertThrows(IllegalArgumentException.class, () -> hasMetadata.addFinalizer("fabric8.io/finalizer-"));


### PR DESCRIPTION
## Description
Fix the name of the finalizer name matcher. Breaks interface but since it was just introduced in 5.0.0-alpha-1, it's a good time to fix it before it's used. 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
