### PR TITLE
Fix #2510: Yaml containing aliases rejected due to FasterXML bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.0-SNAPSHOT
 
 #### Bugs
+Fix #2510 : Yaml containing aliases rejected due to FasterXML bug
 
 #### Improvements
 

--- a/kubernetes-client/src/test/resources/test-pod-manifest-with-aliases.yml
+++ b/kubernetes-client/src/test/resources/test-pod-manifest-with-aliases.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-with-alias
+spec:
+  nodeSelector:
+    workload: build
+  tolerations:
+    - key: nodeType
+      operator: Equal
+      value: build
+      effect: NoSchedule
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+  containers:
+    - name: ubuntu
+      image: ubuntu:bionic
+      imagePullPolicy: Always
+      command:
+        - cat
+      tty: true
+      resources:
+        requests: &id001
+          cpu: 100m
+    - name: python3
+      image: python:3.7
+      imagePullPolicy: Always
+      command:
+        - cat
+      tty: true
+      resources:
+        requests: *id001


### PR DESCRIPTION
Fix #2510 
    Modify the way we deserialize Yaml objects. Load them into raw HashMap
    using SnakeYAML and then use Jackson to convert them to JSON and finally
    the required object


## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
