### PR TITLE
fix: Binding operations can be instantiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### 5.0-SNAPSHOT
 
 #### Bugs
-Fix #2510 : Yaml containing aliases rejected due to FasterXML bug
+* Fix #2510 : Yaml containing aliases rejected due to FasterXML bug
+* Fix #2656: Binding operations can be instantiated
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImpl.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.Binding;
 import io.fabric8.kubernetes.api.model.BindingBuilder;
@@ -40,7 +41,7 @@ public class BindingOperationsImpl extends HasMetadataOperation<Binding, Kuberne
       .withApiGroupVersion("v1")
       .withPlural("bindings"));
     this.type = Binding.class;
-    this.listType = (Class<KubernetesResourceList<Binding>>)new TypeReference<KubernetesResourceList<Binding>>(){}.getType();
+    this.listType = (Class<KubernetesResourceList<Binding>>) TypeFactory.rawClass(new TypeReference<KubernetesResourceList<Binding>>(){}.getType());
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImplTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal.core.v1;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BindingOperationsImplTest {
+
+  @Test
+  void canBeInstantiated() {
+    // When
+    final BindingOperationsImpl result = new BindingOperationsImpl(null, null);
+    // Then
+    assertThat(result).isNotNull();
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/BindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/BindingTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.Binding;
+import io.fabric8.kubernetes.api.model.BindingBuilder;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableRuleMigrationSupport
+class BindingTest {
+
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  @DisplayName("create, with created response, should return created resource")
+  @Test
+  void createOK() {
+    server.expect().post().withPath("/api/v1/namespaces/default/bindings")
+      .andReturn(201, "{\"metadata\": {\"name\": \"binding-name\"}}")
+      .once();
+    // When
+    final Binding result = server.getClient().bindings().inNamespace("default").create(new BindingBuilder()
+      .withNewMetadata().withName("binding-name").endMetadata()
+      .withNewTarget().withKind("Node").withApiVersion("v1").withName("node-name").endTarget()
+      .build());
+    // Then
+    assertThat(result)
+      .isNotNull()
+      .hasFieldOrPropertyWithValue("metadata.name", "binding-name");
+  }
+}


### PR DESCRIPTION
## Description
fix #2656: Binding operations can be instantiated

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~~I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly~~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
