### PR TITLE
Fix #2651: SharedInformers should ignore resync on zero resyncPeriod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #2510 : Yaml containing aliases rejected due to FasterXML bug
+* Fix #2651: SharedInformers should ignore resync on zero resyncPeriod
 * Fix #2656: Binding operations can be instantiated
 
 #### Improvements

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
@@ -43,8 +43,6 @@ import java.util.function.Supplier;
 public class Controller<T extends HasMetadata, L extends KubernetesResourceList<T>> {
   private static final Logger log = LoggerFactory.getLogger(Controller.class);
 
-  private static final long DEFAULT_PERIOD = 5000L;
-
   /**
    * resync fifo internals in millis
    */
@@ -81,6 +79,9 @@ public class Controller<T extends HasMetadata, L extends KubernetesResourceList<
     this.apiTypeClass = apiTypeClass;
     this.processFunc = processFunc;
     this.resyncFunc = resyncFunc;
+    if (fullResyncPeriod < 0) {
+      throw new IllegalArgumentException("Invalid resync period provided, It should be a non-negative value");
+    }
     this.fullResyncPeriod = fullResyncPeriod;
     this.operationContext = context;
     this.eventListeners = eventListeners;
@@ -167,10 +168,6 @@ public class Controller<T extends HasMetadata, L extends KubernetesResourceList<
   }
 
   private void initReflector() {
-    if (fullResyncPeriod >= 0) {
-      reflector = new Reflector<>(apiTypeClass, listerWatcher, queue, operationContext, fullResyncPeriod, Executors.newSingleThreadScheduledExecutor());
-    } else {
-      reflector = new Reflector<>(apiTypeClass, listerWatcher, queue, operationContext, DEFAULT_PERIOD, Executors.newSingleThreadScheduledExecutor());
-    }
+      reflector = new Reflector<>(apiTypeClass, listerWatcher, queue, operationContext, fullResyncPeriod);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.client.informers.ListerWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,10 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private final AtomicBoolean isActive;
   private final AtomicBoolean isWatcherStarted;
   private final AtomicReference<Watch> watch;
+
+  public Reflector(Class<T> apiTypeClass, ListerWatcher<T, L> listerWatcher, Store store, OperationContext operationContext, long resyncPeriodMillis) {
+    this(apiTypeClass, listerWatcher, store, operationContext, resyncPeriodMillis, Executors.newSingleThreadScheduledExecutor());
+  }
 
   public Reflector(Class<T> apiTypeClass, ListerWatcher<T, L> listerWatcher, Store store, OperationContext operationContext, long resyncPeriodMillis, ScheduledExecutorService resyncExecutor) {
     this.apiTypeClass = apiTypeClass;

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ControllerTest {
   private DeltaFIFO<Pod> deltaFIFO = Mockito.mock(DeltaFIFO.class, Mockito.RETURNS_DEEP_STUBS);
@@ -48,16 +49,12 @@ class ControllerTest {
   }
 
   @Test
-  @DisplayName("Controller initialized with resync period less than zero should use default resync period")
+  @DisplayName("Controller initialized with resync period less than zero should throw exception")
   void testControllerCreationWithResyncPeriodLessThanZero() {
-    // Given + When
-    Controller<Pod, PodList> controller = new Controller<>(Pod.class, deltaFIFO, listerWatcher,
+    assertThrows(IllegalArgumentException.class, () -> new Controller<>(Pod.class, deltaFIFO, listerWatcher,
       simpleEntries -> { },
       () -> true,
-      -1000L, operationContext, eventListeners);
-
-    // Then
-    assertEquals(5000L, controller.getReflector().getResyncPeriodMillis());
+      -1000L, operationContext, eventListeners));
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.informers.cache;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.informers.ListerWatcher;
+import io.fabric8.kubernetes.client.informers.SharedInformerEventListener;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ControllerTest {
+  private DeltaFIFO<Pod> deltaFIFO = Mockito.mock(DeltaFIFO.class, Mockito.RETURNS_DEEP_STUBS);
+  private ListerWatcher<Pod, PodList> listerWatcher = Mockito.mock(ListerWatcher.class, Mockito.RETURNS_DEEP_STUBS);
+  private OperationContext operationContext = Mockito.mock(OperationContext.class, Mockito.RETURNS_DEEP_STUBS);
+  private ConcurrentLinkedQueue<SharedInformerEventListener> eventListeners = Mockito.mock(ConcurrentLinkedQueue.class, Mockito.RETURNS_DEEP_STUBS);
+
+  @Test
+  @DisplayName("Controller initialized with resync period greater than zero should use provided resync period")
+  void testControllerCreationWithResyncPeriodMoreThanZero() {
+    // Given + When
+    Controller<Pod, PodList> controller = new Controller<>(Pod.class, deltaFIFO, listerWatcher,
+      simpleEntries -> { },
+      () -> true,
+      1000L, operationContext, eventListeners);
+
+    // Then
+    assertEquals(1000L, controller.getReflector().getResyncPeriodMillis());
+  }
+
+  @Test
+  @DisplayName("Controller initialized with resync period less than zero should use default resync period")
+  void testControllerCreationWithResyncPeriodLessThanZero() {
+    // Given + When
+    Controller<Pod, PodList> controller = new Controller<>(Pod.class, deltaFIFO, listerWatcher,
+      simpleEntries -> { },
+      () -> true,
+      -1000L, operationContext, eventListeners);
+
+    // Then
+    assertEquals(5000L, controller.getReflector().getResyncPeriodMillis());
+  }
+
+  @Test
+  @DisplayName("Controller initialized with resync period 0 should use provided resync period")
+  void testControllerCreationWithResyncPeriodZero() {
+    // Given + When
+    Controller<Pod, PodList> controller = new Controller<>(Pod.class, deltaFIFO, listerWatcher,
+      simpleEntries -> { },
+      () -> true,
+      0L, operationContext, eventListeners);
+
+    // Then
+    assertEquals(0L, controller.getReflector().getResyncPeriodMillis());
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.informers.cache;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.informers.ListerWatcher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class ReflectorTest {
+  @Test
+  @DisplayName("Given Reflector with non zero resync period should invoke executorService")
+  void testScheduleResyncExecutionWithNonZeroResyncPeriod() {
+    // Given
+    ScheduledExecutorService executorService = Mockito.mock(ScheduledExecutorService.class, Mockito.RETURNS_DEEP_STUBS);
+    Reflector<Pod, PodList> reflector = getReflectorWithResyncPeriod(1000L, executorService);
+
+    // When
+    reflector.scheduleResyncExecution();
+
+    // Then
+    verify(executorService, times(1)).scheduleWithFixedDelay(any(), eq(0L), eq(1000L), eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  @DisplayName("Given Reflector with zero resync Period should not Then executorService is not invoked")
+  void testScheduleResyncExecutionWithZeroResyncPeriod() {
+    // Given
+    ScheduledExecutorService executorService = Mockito.mock(ScheduledExecutorService.class, Mockito.RETURNS_DEEP_STUBS);
+    Reflector<Pod, PodList> reflector = getReflectorWithResyncPeriod(0L, executorService);
+
+    // When
+    reflector.scheduleResyncExecution();
+
+    // Then
+    verify(executorService, times(0)).scheduleWithFixedDelay(any(), eq(0L), eq(1000L), eq(TimeUnit.MILLISECONDS));
+  }
+
+  private Reflector<Pod, PodList> getReflectorWithResyncPeriod(long resyncPeriodMillis, ScheduledExecutorService executorService) {
+    ListerWatcher<Pod, PodList> listerWatcher = Mockito.mock(ListerWatcher.class, Mockito.RETURNS_DEEP_STUBS);
+    Store store = Mockito.mock(Store.class, Mockito.RETURNS_DEEP_STUBS);
+    OperationContext operationContext = Mockito.mock(OperationContext.class, Mockito.RETURNS_DEEP_STUBS);
+    Reflector<Pod, PodList> reflector = new Reflector<>(Pod.class, listerWatcher, store, operationContext, resyncPeriodMillis, executorService);
+    return reflector;
+  }
+}


### PR DESCRIPTION
Fix #2651 

Refactor Reflector to ignore resync if resyncPeriod is set to zero

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
