### PR TITLE
fix: CustomResourceDefinitionContext.fromCrd support for v1 CustomResourceDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 * Fix #2519: Generated schemas contains a valid meta-schema URI reference (`http://json-schema.org/draft-05/schema#`)
 * Fix #2631: Handle null values when getting current context on OIDC interceptors
 * Fix #2510 : Yaml containing aliases rejected due to FasterXML bug
-* Fix #2510 : Yaml containing aliases rejected due to FasterXML bug
 * Fix #2656: Binding operations can be instantiated
 
 #### Improvements
+* Fix: CustomResourceDefinitionContext.fromCrd support for v1 CustomResourceDefinition
 
 #### Dependency Upgrade
 
@@ -56,7 +56,6 @@
 * Fix #2537: Checking for Readiness of DeploymentConfig
 * Fix #2300: Remove job extensions/v1beta1 from backward compatibiliy interceptor
 * Fix #2514: SharedIndexInformer watches only pods of its own namespace when run in the cluster
-
 
 #### Improvements
 * Fix #2507: Add a test for creating a Job with generateName

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.base;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomResourceDefinitionContextTest {
+
+  @Test
+  @DisplayName("formCrd, with v1 CRD, should infer correct properties")
+  void fromCrdV1() {
+    // Given
+    final io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition crd =
+      new io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder()
+        .withNewMetadata().withName("foobar.the-foo.com").endMetadata()
+        .withNewSpec()
+        .withGroup("the-foo.com")
+        .withScope("Namespaced")
+        .withNewNames().withNewSingular("foobar").withNewPlural("foobars").withKind("Foobar").endNames()
+        .addNewVersion().withName("v1beta1").endVersion()
+        .addNewVersion().withName("v1alpha1").endVersion()
+        .addNewVersion().withName("v1").endVersion()
+        .endSpec()
+        .build();
+    // When
+    final CustomResourceDefinitionContext result = CustomResourceDefinitionContext.fromCrd(crd);
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("group", "the-foo.com")
+      .hasFieldOrPropertyWithValue("version", "v1")
+      .hasFieldOrPropertyWithValue("scope", "Namespaced")
+      .hasFieldOrPropertyWithValue("name", "foobar.the-foo.com")
+      .hasFieldOrPropertyWithValue("plural", "foobars")
+      .hasFieldOrPropertyWithValue("kind", "Foobar");
+  }
+
+
+  @Test
+  @DisplayName("formCrd, with v1beta1 CRD with versions, should infer correct properties")
+  void fromCrdV1beta1() {
+    // Given
+    final io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition crd =
+      new io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder()
+        .withNewMetadata().withName("foobar.the-foo.com").endMetadata()
+        .withNewSpec()
+        .withGroup("the-foo.com")
+        .withScope("Namespaced")
+        .withNewNames().withNewSingular("foobar").withNewPlural("foobars").withKind("Foobar").endNames()
+        .addNewVersion().withName("v1beta1").endVersion()
+        .addNewVersion().withName("v1alpha1").endVersion()
+        .addNewVersion().withName("v1").endVersion()
+        .endSpec()
+        .build();
+    // When
+    final CustomResourceDefinitionContext result = CustomResourceDefinitionContext.fromCrd(crd);
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("group", "the-foo.com")
+      .hasFieldOrPropertyWithValue("version", "v1")
+      .hasFieldOrPropertyWithValue("scope", "Namespaced")
+      .hasFieldOrPropertyWithValue("name", "foobar.the-foo.com")
+      .hasFieldOrPropertyWithValue("plural", "foobars")
+      .hasFieldOrPropertyWithValue("kind", "Foobar");
+  }
+
+  @Test
+  @DisplayName("formCrd, with v1beta1 CRD with spec.version, should infer correct properties")
+  void fromCrdV1beta1OldVersionStyle() {
+    // Given
+    final io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition crd =
+      new io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder()
+        .withNewMetadata().withName("foobar.the-foo.com").endMetadata()
+        .withNewSpec()
+        .withGroup("the-foo.com")
+        .withScope("Namespaced")
+        .withNewNames().withNewSingular("foobar").withNewPlural("foobars").withKind("Foobar").endNames()
+        .withVersion("v1")
+        .endSpec()
+        .build();
+    // When
+    final CustomResourceDefinitionContext result = CustomResourceDefinitionContext.fromCrd(crd);
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("group", "the-foo.com")
+      .hasFieldOrPropertyWithValue("version", "v1")
+      .hasFieldOrPropertyWithValue("scope", "Namespaced")
+      .hasFieldOrPropertyWithValue("name", "foobar.the-foo.com")
+      .hasFieldOrPropertyWithValue("plural", "foobars")
+      .hasFieldOrPropertyWithValue("kind", "Foobar");
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
@@ -52,7 +52,7 @@ class CustomResourceDefinitionContextTest {
 
 
   @Test
-  @DisplayName("formCrd, with v1beta1 CRD with versions, should infer correct properties")
+  @DisplayName("fromCrd, with v1beta1 CRD with versions, should infer correct properties")
   void fromCrdV1beta1() {
     // Given
     final io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition crd =
@@ -80,7 +80,7 @@ class CustomResourceDefinitionContextTest {
   }
 
   @Test
-  @DisplayName("formCrd, with v1beta1 CRD with spec.version, should infer correct properties")
+  @DisplayName("fromCrd, with v1beta1 CRD with spec.version, should infer correct properties")
   void fromCrdV1beta1OldVersionStyle() {
     // Given
     final io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition crd =

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CustomResourceDefinitionContextTest {
 
   @Test
-  @DisplayName("formCrd, with v1 CRD, should infer correct properties")
+  @DisplayName("fromCrd, with v1 CRD, should infer correct properties")
   void fromCrdV1() {
     // Given
     final io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition crd =


### PR DESCRIPTION
## Description
fix: CustomResourceDefinitionContext.fromCrd support for v1 CustomResourceDefinition

Relates to #2611

CC: @adietish 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
