### PR TITLE
Fixes around exceptional cases in watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.0-SNAPSHOT
 
 #### Bugs
+* Fix: Reliability improvements to watchers
 * Fix #2592: ConcurrentModificationException in CRUD KubernetesMockServer
 * Fix #2519: Generated schemas contains a valid meta-schema URI reference (`http://json-schema.org/draft-05/schema#`)
 * Fix #2631: Handle null values when getting current context on OIDC interceptors

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/WaitForConditionWatcher.java
@@ -48,6 +48,8 @@ public class WaitForConditionWatcher<T extends HasMetadata> implements Watcher<T
       case DELETED:
         if (condition.test(null)) {
           future.complete(null);
+        } else {
+          future.completeExceptionally(new WatcherException("Unexpected deletion of watched resource, will never satisfy condition"));
         }
         break;
       case ERROR:


### PR DESCRIPTION
## Description
These changes have been running for us internally for 6 months or so, but I never got a chance to upstream them. We'd like to bring our fork more in-line with mainstream, so here is a group of changes related to watcher reliability:

- _If the target of a watch is deleted, it will never satisfy the watch condition_
We saw this case where you are watching a resource hoping it will hit a particular condition, if the resource gets deleted while you are waiting the watcher will simply go on forever until the timeout. This change makes it fail much faster in the case where it will never succeed.

- _Path segment based filters have spotty support in newer kube api versions. Field selector seems to work everywhere_
It looks like this was added [3.5 years ago](https://github.com/fabric8io/kubernetes-client/pull/816) because field selectors weren't working. The patch to make CRDs support field selectors was then added [a few months later](https://github.com/kubernetes/kubernetes/pull/53345). If you take a look at the API spec (even for the really old v1.11 [here](https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#read-pod-v1-core)), the read API url we are using here does not support the `watch` query param. If you want to watch an object, you need to use either the Watch API (with `/api/v1/watch` path) or the List API, which _does_ support the `watch` query param. We noticed that watches for specific resources were not working correctly for us, instead they were spamming our API servers because they were actually short polling (basically just a get that returns instantly). Note that I linked to the Pods API, but the same seems to be true for CustomResources (or as the original PR called them, API Groups). You can test this out pretty easily:

```
kubectl proxy
# then in another terminal:

# this returns instantly, with no watch:
curl http://127.0.0.1:8001/apis/zk.hubspot.com/v1/namespaces/zk/zookeeperclusters/zk-test-qa\?watch=1

# this properly watches only the resource in question:
 curl http://127.0.0.1:8001/apis/zk.hubspot.com/v1/namespaces/zk/zookeeperclusters/\?watch=1\&fieldSelector=metadata.name=zk-test-qa

# this similarly works:
curl http://127.0.0.1:8001/apis/zk.hubspot.com/v1/watch/namespaces/zk/zookeeperclusters/\?watch=1\&fieldSelector=metadata.name=zk-test-qa

# this watches ALL resources of the type, as you'd expect:
curl http://127.0.0.1:8001/apis/zk.hubspot.com/v1/namespaces/zk/zookeeperclusters/\?watch=1
```

This is obviously a CRD we have internally, you can create your own CRD of any type to test it. It also works the same on standard APIs. I chose to simply remove this apiGroup handling here so that we always use the fieldSelector filtering. It's possible that another change we could make is to move over to the `/watch` API, but that would be more complicated because we'd need to use a different URL than what we have available from `getNamespacedUrl()`. I could hook that up if you want, but it mean somewhat wider scope changes. I'd prefer to handle that separately/later if possible.

- _Handle unsuccessful watch statuses better -- we should either be retrying, or passing an error event back to the user. Throwing an exception will result in a transparent failure that no user can handle, because it happens in a thread_
We noticed this issue where our watchers were failing silently with no real feedback. This is because the client was throwing a failure exception in the callback which does not get executed in the main thread. So the exception really goes nowhere. I refactored  callback so that when `!isSuccessful()` we do the same status handling that we do in the case of a successful response, we just pass in the unsuccessful Status object. This way the watcher will receive an appropriate event and the caller can be notified that the watch failed.

- _long polls return a response once data is available. we should only backoff in exceptional cases, otherwise immediately connect so we can receive followup data in a more timely manner_
Another situation we saw is we some watch events would not make their way to us in a timely manner. This was because the WatchHTTPManager was always backing off after processing a response body. The way long polling works is, when data is ready, the connection immediately returns a response with the data in the body. At that point, the long poll needs to be reinitialized. This is not an error state, the long poll should _immediately_ be reinitialized. So I updated the onResponse callback and scheduleReconnect to only backoff in the case of errors.


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
