### PR TITLE
fix: tidied 1109 test to show clearer intentions

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/FooBar.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/FooBar.java
@@ -24,7 +24,7 @@ import io.fabric8.kubernetes.model.annotation.Singular;
 @Group(FooBar.GROUP)
 @Version(FooBar.VERSION)
 @Singular(FooBar.SINGULAR)
-public class FooBar  extends CustomResource implements Namespaced {
+public class FooBar extends CustomResource implements Namespaced {
   public static final String GROUP = "baz.example.com";
   public static final String VERSION = "v1alpha1";
   public static final String SINGULAR = "foo-bar";


### PR DESCRIPTION
## Description
Tidied 1109 test to show clearer intentions 
- documented test cases
- Added extra verification to assert RAW HTTP path is as expected

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] ~~I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change~~
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~~I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly~~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] ~~I tested my code in Kubernetes~~
 - [ ] ~~I tested my code in OpenShift~~

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
