### PR TITLE
Allow specifying PropagationPolicy when using deleteExisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #2656: Binding operations can be instantiated
 
 #### Improvements
+* Fix: Allow specifying PropagationPolicy when using deleteExisting
 * Fix: CustomResourceDefinitionContext.fromCrd support for v1 CustomResourceDefinition
 * Fix #2642: Update kubernetes-examples to use apps/v1 Deployment rather than extensions/v1beta1
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
@@ -18,5 +18,5 @@ package io.fabric8.kubernetes.client.dsl;
 /**
  * Created by iocanel on 9/15/16.
  */
-public interface CascadingDeletable extends Deletable, Cascading<Deletable> {
+public interface CascadingDeletable<T> extends Deletable, Cascading<Deletable>, Recreateable<Applicable<T>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ListVisitFromServerGetDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ListVisitFromServerGetDeleteRecreateWaitApplicable.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
 public interface ListVisitFromServerGetDeleteRecreateWaitApplicable<T> extends Visitable<ListVisitFromServerGetDeleteRecreateWaitApplicable<T>>,
   FromServerGettable<List<T>>,
   RecreateApplicable<List<T>, T>,
-  CascadingDeletable,
+  CascadingDeletable<List<T>>,
   Waitable<List<T>, T>,
-  GracePeriodConfigurable<CascadingDeletable>,
-  PropagationPolicyConfigurable<CascadingDeletable> {
+  GracePeriodConfigurable<CascadingDeletable<List<T>>>,
+  PropagationPolicyConfigurable<CascadingDeletable<List<T>>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetWatchDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/VisitFromServerGetWatchDeleteRecreateWaitApplicable.java
@@ -25,9 +25,9 @@ import io.fabric8.kubernetes.client.Watcher;
 
 public interface VisitFromServerGetWatchDeleteRecreateWaitApplicable<T> extends Visitable<VisitFromServerGetWatchDeleteRecreateWaitApplicable<T>>,
   FromServerGettable<T>, RecreateApplicable<T, T>,
-  CascadingDeletable,
+  CascadingDeletable<T>,
   Watchable<Watcher<T>>,
   Waitable<T, T>,
-  GracePeriodConfigurable<CascadingDeletable>,
-  PropagationPolicyConfigurable<CascadingDeletable> {
+  GracePeriodConfigurable<CascadingDeletable<T>>,
+  PropagationPolicyConfigurable<CascadingDeletable<T>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -200,12 +200,12 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
   }
 
   @Override
-  public CascadingDeletable withGracePeriod(long gracePeriodSeconds) {
+  public CascadingDeletable<HasMetadata> withGracePeriod(long gracePeriodSeconds) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(client, config, fallbackNamespace, explicitNamespace, fromServer, true, visitors, item, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }
 
   @Override
-  public CascadingDeletable withPropagationPolicy(DeletionPropagation propagationPolicy) {
+  public CascadingDeletable<HasMetadata> withPropagationPolicy(DeletionPropagation propagationPolicy) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl(client, config, fallbackNamespace, explicitNamespace, fromServer, true, visitors, item, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -382,12 +382,12 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
         return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(client, config, fallbackNamespace, explicitNamespace, fromServer, true, newVisitors, item, null, null, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
     }
 
-  @Override public CascadingDeletable withGracePeriod(long gracePeriodSeconds)
+  @Override public CascadingDeletable<List<HasMetadata>> withGracePeriod(long gracePeriodSeconds)
   {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(client, config, fallbackNamespace, explicitNamespace, fromServer, true, visitors, item, null, null, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }
 
-  @Override public CascadingDeletable withPropagationPolicy(DeletionPropagation propagationPolicy)
+  @Override public CascadingDeletable<List<HasMetadata>> withPropagationPolicy(DeletionPropagation propagationPolicy)
   {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(client, config, fallbackNamespace, explicitNamespace, fromServer, true, visitors, item, null, null, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/DeleteAndCreateHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/DeleteAndCreateHelper.java
@@ -23,15 +23,25 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import okhttp3.OkHttpClient;
 
+import java.net.HttpURLConnection;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DeleteAndCreateHelper<T extends HasMetadata> {
+  private static final Logger LOG = LoggerFactory.getLogger(DeleteAndCreateHelper.class);
+
   private final UnaryOperator<T> createTask;
+  private final Function<T, Boolean> awaitDeleteTask;
   private final Function<T, Boolean> deleteTask;
 
-  public DeleteAndCreateHelper(UnaryOperator<T> createTask, Function<T, Boolean> deleteTask) {
+  public DeleteAndCreateHelper(UnaryOperator<T> createTask, Function<T, Boolean> deleteTask, Function<T, Boolean> awaitDeleteTask) {
     this.createTask = createTask;
+    this.awaitDeleteTask = awaitDeleteTask;
     this.deleteTask = deleteTask;
   }
 
@@ -40,15 +50,40 @@ public class DeleteAndCreateHelper<T extends HasMetadata> {
     if (Boolean.FALSE.equals(deleted)) {
       throw new KubernetesClientException("Failed to delete existing item:" + item.getMetadata().getName());
     }
-    return createTask.apply(item);
+    try {
+      return createTask.apply(item);
+    } catch (KubernetesClientException e) {
+      // depending on the grace period, the object might not actually be deleted by the time we try to create
+      // if that's the case, give it some time.
+      if (e.getCode() == HttpURLConnection.HTTP_CONFLICT) {
+        if (Boolean.FALSE.equals(awaitDeleteTask.apply(item))) {
+          throw new KubernetesClientException("Timed out waiting for item to be deleted before recreating: " + item.getMetadata().getName(), e);
+        }
+        return createTask.apply(item);
+      }
+      throw e;
+    }
   }
 
   public static HasMetadata deleteAndCreateItem(OkHttpClient client, Config config, HasMetadata meta, ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h, String namespaceToUse, DeletionPropagation propagationPolicy) {
     DeleteAndCreateHelper<HasMetadata> deleteAndCreateHelper = new DeleteAndCreateHelper<>(
       m -> h.create(client, config, namespaceToUse, m),
-      m -> h.delete(client, config, namespaceToUse, propagationPolicy, m)
+      m -> h.delete(client, config, namespaceToUse, propagationPolicy, m),
+      waitUntilDeletedOrInterrupted(client, config, h, namespaceToUse)
     );
 
     return deleteAndCreateHelper.deleteAndCreate(meta);
+  }
+
+  private static <T extends HasMetadata> Function<T, Boolean> waitUntilDeletedOrInterrupted(OkHttpClient client, Config config, ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h, String namespaceToUse) {
+    return m -> {
+      try {
+        return h.waitUntilCondition(client, config, namespaceToUse, m, Objects::isNull, 30 , TimeUnit.SECONDS) == null;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        LOG.warn("interrupted waiting for item to be deleted, assuming not deleted");
+        return false;
+      }
+    };
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/DeleteAndCreateHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/DeleteAndCreateHelper.java
@@ -34,7 +34,8 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteAndCreateHelper<T extends HasMetadata> {
   private static final Logger LOG = LoggerFactory.getLogger(DeleteAndCreateHelper.class);
-
+  private static final int MAX_WAIT_SECONDS = 30;
+  
   private final UnaryOperator<T> createTask;
   private final Function<T, Boolean> awaitDeleteTask;
   private final Function<T, Boolean> deleteTask;
@@ -86,7 +87,7 @@ public class DeleteAndCreateHelper<T extends HasMetadata> {
   private static <T extends HasMetadata> Function<T, Boolean> waitUntilDeletedOrInterrupted(OkHttpClient client, Config config, ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h, String namespaceToUse) {
     return m -> {
       try {
-        return h.waitUntilCondition(client, config, namespaceToUse, m, Objects::isNull, 30 , TimeUnit.SECONDS) == null;
+        return h.waitUntilCondition(client, config, namespaceToUse, m, Objects::isNull, MAX_WAIT_SECONDS , TimeUnit.SECONDS) == null;
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         LOG.warn("interrupted waiting for item to be deleted, assuming not deleted");

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -140,7 +140,7 @@ class ResourceTest {
     DeleteOptions deleteOptions = Serialization.unmarshal(deleteRequest.getBody().readUtf8(), DeleteOptions.class);
     assertEquals("Foreground", deleteOptions.getPropagationPolicy());
 
-    RecordedRequest postRequest = server.getLastRequest();
+    RecordedRequest postRequest = server.getMockServer().takeRequest();
     assertEquals("/api/v1/namespaces/ns1/pods", postRequest.getPath());
     assertEquals("POST", postRequest.getMethod());
   }


### PR DESCRIPTION
## Description
As the title says, this is something the API supports but kubernetes-client's generics were just not set up properly to allow crafting such a request. This updates the generics to support that use-case. Added an IT and unit test for the new functionality.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
