### PR TITLE
add a method which directly takes a namespace and name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix #2656: Binding operations can be instantiated
 
 #### Improvements
+* Fix: Adds a convenience method for referring to Cache keys by namespace and name rather than item
 * Fix: CustomResourceDefinitionContext.fromCrd support for v1 CustomResourceDefinition
 * Fix #2642: Update kubernetes-examples to use apps/v1 Deployment rather than extensions/v1beta1
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.informers.cache;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.utils.ReflectUtils;
+import io.fabric8.kubernetes.client.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -400,13 +401,23 @@ public class Cache<T> implements Indexer<T> {
           throw new RuntimeException("Object is bad :" + obj);
         }
       }
-      if ((metadata.getNamespace() != null) && !metadata.getNamespace().isEmpty()) {
-        return metadata.getNamespace() + "/" + metadata.getName();
-      }
-      return metadata.getName();
+
+      return namespaceKeyFunc(metadata.getNamespace(), metadata.getName());
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Default index function that indexes based on an object's namespace and name.
+   *
+   * @see #metaNamespaceKeyFunc
+   */
+  public static String namespaceKeyFunc(String objectNamespace, String objectName) {
+    if (Utils.isNullOrEmpty(objectNamespace)) {
+      return objectName;
+    }
+    return objectNamespace + "/" + objectName;
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
@@ -88,6 +88,13 @@ class CacheTest {
 
     cache.add(testPodObj);
     assertEquals("default/test-pod4", Cache.metaNamespaceKeyFunc(testPodObj));
+    assertEquals("default/test-pod4", Cache.namespaceKeyFunc("default", "test-pod4"));
+  }
+
+  @Test
+  void testEmptyNamespaceKey() {
+    assertEquals("test-pod4", Cache.namespaceKeyFunc("", "test-pod4"));
+    assertEquals("test-pod4", Cache.namespaceKeyFunc(null, "test-pod4"));
   }
 
   @Test


### PR DESCRIPTION
## Description
We sometimes need to index into the Cache/Indexers when we know a namespace/name rather than have a HasMetadata on hand. We could generate this ourself, but I felt it was more safe to provide a convenience method. This way if the cache key format ever changes in the future, anyone looking up directly by namespace/name will also be automatically updated to sync with those passing in a HasMetadata.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
