### PR TITLE
fix: kind for CustomResourceDefinition is `CustomResourceDefinition`

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
@@ -58,16 +58,14 @@ public class CustomResourceDefinitionContext {
   public String getKind() {
     return kind;
   }
-  
+
   public static CustomResourceDefinitionBuilder v1beta1CRDFromCustomResourceType(Class<? extends CustomResource> customResource) {
     try {
       final CustomResource instance = customResource.getDeclaredConstructor().newInstance();
-    
-      final String kind = instance.getKind();
+
       final String version = instance.getVersion();
-  
+
       return new CustomResourceDefinitionBuilder()
-        .withKind(kind)
         .withNewMetadata()
         .withName(instance.getCRDName())
         .endMetadata()
@@ -77,7 +75,7 @@ public class CustomResourceDefinitionContext {
         .addNewVersion().withName(version).endVersion()
         .withScope(instance.getScope())
         .withNewNames()
-        .withKind(kind)
+        .withKind(instance.getKind())
         .withPlural(instance.getPlural())
         .withSingular(instance.getSingular())
         .endNames()
@@ -86,15 +84,11 @@ public class CustomResourceDefinitionContext {
       throw KubernetesClientException.launderThrowable(e);
     }
   }
-  
+
   public static io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder v1CRDFromCustomResourceType(Class<? extends CustomResource> customResource) {
     try {
       final CustomResource instance = customResource.getDeclaredConstructor().newInstance();
-    
-      String kind = instance.getKind();
-  
       return new io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder()
-        .withKind(kind)
         .withNewMetadata()
         .withName(instance.getCRDName())
         .endMetadata()
@@ -103,7 +97,7 @@ public class CustomResourceDefinitionContext {
         .addNewVersion().withName(instance.getVersion()).endVersion()
         .withScope(instance.getScope())
         .withNewNames()
-        .withKind(kind)
+        .withKind(instance.getKind())
         .withPlural(instance.getPlural())
         .withSingular(instance.getSingular())
         .endNames()
@@ -112,7 +106,7 @@ public class CustomResourceDefinitionContext {
       throw KubernetesClientException.launderThrowable(e);
     }
   }
-  
+
   public static CustomResourceDefinitionContext fromCustomResourceType(Class<? extends HasMetadata> customResource) {
     try {
       final CustomResource instance = (CustomResource) customResource.getDeclaredConstructor().newInstance();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrud1109Test.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrud1109Test.java
@@ -49,7 +49,6 @@ class CustomResourceCrud1109Test {
   @DisplayName("Generated customResourceDefinition has dashes in singular and plural but not in kind")
   void testGeneratedCRDHasDashesInNamesButNotInKind() {
     assertThat(customResourceDefinition)
-      .hasFieldOrPropertyWithValue("kind", "FooBar")
       .hasFieldOrPropertyWithValue("spec.names.kind", "FooBar")
       .hasFieldOrPropertyWithValue("spec.names.singular", "foo-bar")
       .hasFieldOrPropertyWithValue("spec.names.plural", "foo-bars");


### PR DESCRIPTION
## Description
fix: kind for CustomResourceDefinition is `CustomResourceDefinition`

- Current behavior is to override the CustomResourceDefinition kind field value
  with that of the CR it's defining which is not OK.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
