### PR TITLE
Fix Kubernetes Discovery ApiVersion in Model generator script

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-discovery/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-discovery/cmd/generate/generate.go
@@ -69,7 +69,7 @@ func main() {
     {"k8s.io/apimachinery/pkg/version", "", "io.fabric8.kubernetes.api.model.version", "kubernetes_apimachinery_pkg_version_", false},
     {"k8s.io/apimachinery/pkg/apis/meta/v1", "", "io.fabric8.kubernetes.api.model", "kubernetes_apimachinery_", false},
     {"k8s.io/api/core/v1", "", "io.fabric8.kubernetes.api.model", "kubernetes_core_", false},
-    {"k8s.io/api/discovery/v1beta1", "", "io.fabric8.kubernetes.api.model.discovery", "kubernetes_discovery_", true},
+    {"k8s.io/api/discovery/v1beta1", "discovery.k8s.io", "io.fabric8.kubernetes.api.model.discovery", "kubernetes_discovery_", true},
   }
 
   typeMap := map[reflect.Type]reflect.Type{

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/kube-schema.json
@@ -854,7 +854,7 @@
         },
         "apiVersion": {
           "type": "string",
-          "default": "discovery/v1beta1",
+          "default": "discovery.k8s.io/v1beta1",
           "required": true
         },
         "endpoints": {
@@ -893,7 +893,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "discovery/v1beta1",
+          "default": "discovery.k8s.io/v1beta1",
           "required": true
         },
         "items": {

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/validation-schema.json
@@ -854,7 +854,7 @@
         },
         "apiVersion": {
           "type": "string",
-          "default": "discovery/v1beta1",
+          "default": "discovery.k8s.io/v1beta1",
           "required": true
         },
         "endpoints": {
@@ -893,7 +893,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "discovery/v1beta1",
+          "default": "discovery.k8s.io/v1beta1",
           "required": true
         },
         "items": {
@@ -1193,7 +1193,7 @@
         },
         "apiVersion": {
           "type": "string",
-          "default": "discovery/v1beta1",
+          "default": "discovery.k8s.io/v1beta1",
           "required": true
         },
         "endpoints": {
@@ -1226,7 +1226,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "discovery/v1beta1",
+          "default": "discovery.k8s.io/v1beta1",
           "required": true
         },
         "items": {

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/test/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/EndpointSliceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/test/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/EndpointSliceTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model.discovery.v1beta1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.fabric8.kubernetes.api.model.discovery.EndpointSlice;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSliceBuilder;
+import io.fabric8.kubernetes.model.util.Helper;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EndpointSliceTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void loadTest() throws Exception {
+    // given
+    final String originalJson = Helper.loadJson("/valid-endpointslice.json");
+
+    // when
+    final EndpointSlice endpointSlice = mapper.readValue(originalJson, EndpointSlice.class);
+    final String serializedJson = mapper.writeValueAsString(endpointSlice);
+
+    // then
+    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
+      .isEqualTo(originalJson);
+  }
+
+  @Test
+  void testBuilder() {
+    // Given + When      
+    EndpointSlice endpointSlice = new EndpointSliceBuilder()
+                    .withNewMetadata()
+                    .withName("example-abc")
+                    .addToLabels("kubernetes.io/service-name", "example")
+                    .endMetadata()
+                    .withAddressType("IPv4")
+                    .addNewPort()
+                    .withName("http")
+                    .withPort(80)
+                    .endPort()
+                    .addNewEndpoint()
+                    .withAddresses("10.1.2.3")
+                    .withNewConditions().withReady(true).endConditions()
+                    .withHostname("pod-1")
+                    .addToTopology("kubernetes.io/hostname", "node-1")
+                    .addToTopology("topology.kubernetes.io/zone", "us-west2-a")
+                    .endEndpoint()
+                    .build();
+
+    // Then
+    assertEquals("discovery.k8s.io/v1beta1", endpointSlice.getApiVersion());
+    assertEquals("example-abc", endpointSlice.getMetadata().getName());
+    assertEquals("example", endpointSlice.getMetadata().getLabels().get("kubernetes.io/service-name"));
+    assertEquals("IPv4", endpointSlice.getAddressType());
+    assertEquals(1, endpointSlice.getPorts().size());
+    assertEquals(1, endpointSlice.getEndpoints().size());
+    assertEquals("pod-1", endpointSlice.getEndpoints().get(0).getHostname());
+    assertEquals("node-1", endpointSlice.getEndpoints().get(0).getTopology().get("kubernetes.io/hostname"));
+    assertEquals("us-west2-a", endpointSlice.getEndpoints().get(0).getTopology().get("topology.kubernetes.io/zone"));
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/test/resources/valid-endpointslice.json
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/test/resources/valid-endpointslice.json
@@ -1,0 +1,33 @@
+{
+  "apiVersion": "discovery.k8s.io/v1beta1",
+  "kind": "EndpointSlice",
+  "metadata": {
+    "name": "example-abc",
+    "labels": {
+      "kubernetes.io/service-name": "example"
+    }
+  },
+  "addressType": "IPv4",
+  "ports": [
+    {
+      "name": "http",
+      "protocol": "TCP",
+      "port": 80
+    }
+  ],
+  "endpoints": [
+    {
+      "addresses": [
+        "10.1.2.3"
+      ],
+      "conditions": {
+        "ready": true
+      },
+      "hostname": "pod-1",
+      "topology": {
+        "kubernetes.io/hostname": "node-1",
+        "topology.kubernetes.io/zone": "us-west2-a"
+      }
+    }
+  ]
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EndpointSliceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EndpointSliceTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.discovery.EndpointSlice;
+import io.fabric8.kubernetes.api.model.discovery.EndpointSliceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.net.HttpURLConnection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableRuleMigrationSupport
+class EndpointSliceTest {
+  @Rule
+  public KubernetesServer server = new KubernetesServer();
+
+  private KubernetesClient client;
+
+  @BeforeEach
+  void init() {
+    this.client = server.getClient();
+  }
+
+  @Test
+  void resourceCreate() {
+    // Given
+    EndpointSlice endpointSlice = getEndpointSlice();
+    server.expect().post().withPath("/apis/discovery.k8s.io/v1beta1/namespaces/ns1/endpointslices")
+      .andReturn(HttpURLConnection.HTTP_OK, endpointSlice)
+      .once();
+
+    // When
+    EndpointSlice endpointSliceCreated = client.resource(endpointSlice).inNamespace("ns1").createOrReplace();
+
+    // Then
+    assertNotNull(endpointSliceCreated);
+    assertEquals("example-abc", endpointSliceCreated.getMetadata().getName());
+    assertEquals("discovery.k8s.io/v1beta1", endpointSliceCreated.getApiVersion());
+    assertEquals("example-abc", endpointSliceCreated.getMetadata().getName());
+    assertEquals("example", endpointSliceCreated.getMetadata().getLabels().get("kubernetes.io/service-name"));
+    assertEquals("IPv4", endpointSliceCreated.getAddressType());
+    assertEquals(1, endpointSliceCreated.getPorts().size());
+    assertEquals(1, endpointSliceCreated.getEndpoints().size());
+    assertEquals("pod-1", endpointSliceCreated.getEndpoints().get(0).getHostname());
+    assertEquals("node-1", endpointSliceCreated.getEndpoints().get(0).getTopology().get("kubernetes.io/hostname"));
+    assertEquals("us-west2-a", endpointSliceCreated.getEndpoints().get(0).getTopology().get("topology.kubernetes.io/zone"));
+  }
+
+  private EndpointSlice getEndpointSlice() {
+    return new EndpointSliceBuilder()
+      .withNewMetadata()
+      .withName("example-abc")
+      .addToLabels("kubernetes.io/service-name", "example")
+      .endMetadata()
+      .withAddressType("IPv4")
+      .addNewPort()
+      .withName("http")
+      .withPort(80)
+      .endPort()
+      .addNewEndpoint()
+      .withAddresses("10.1.2.3")
+      .withNewConditions().withReady(true).endConditions()
+      .withHostname("pod-1")
+      .addToTopology("kubernetes.io/hostname", "node-1")
+      .addToTopology("topology.kubernetes.io/zone", "us-west2-a")
+      .endEndpoint()
+      .build();
+  }
+}

--- a/platforms/karaf/itests/src/test/resources/deserializer_test.yaml
+++ b/platforms/karaf/itests/src/test/resources/deserializer_test.yaml
@@ -76,7 +76,7 @@ metadata:
   name: test-pod
 ---
 kind: EndpointSlice
-apiVersion: discovery/v1beta1
+apiVersion: discovery.k8s.io/v1beta1
 metadata:
   name: test-endpointslice-v1beta1
 ---


### PR DESCRIPTION
Kubernetes Discovery apiVersion is `discovery.k8s.io` not discovery

Related to #2702 
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
