### PR TITLE
Register CustomResource to KubernetesDeserializer with only the class

### DIFF
--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1619,36 +1619,12 @@ package io.fabric8.kubernetes.client.mock.crd;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
 
-public class CronTab extends CustomResource implements Namespaced {
-    private CronTabSpec spec;
-    private CronTabStatus status;
-
-    @Override
-    public ObjectMeta getMetadata() {
-        return super.getMetadata();
-    }
-
-    public CronTabSpec getSpec() {
-        return spec;
-    }
-
-    public void setSpec(CronTabSpec spec) {
-        this.spec = spec;
-    }
-
-    public CronTabStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(CronTabStatus status) {
-        this.status = status;
-    }
-
-    @Override
-    public String getApiVersion() {
-        return "stable.example.com/v1";
-    }
+@Group("stable.example.com")
+@Version("v1")
+public class CronTab extends CustomResource<CronTabSpec, CronTabStatus> implements Namespaced {
 
     @Override
     public String toString() {
@@ -1679,7 +1655,7 @@ MixedOperation<CronTab, CronTabList, Resource<CronTab>> cronTabClient = client
 ```
 - Register your `CustomResource` to `KubernetesDeserializer`:
 ```
-KubernetesDeserializer.registerCustomKind("stable.example.com/v1", "CronTab", CronTab.class);
+KubernetesDeserializer.registerCustomKind(CronTab.class);
 ```
 - Get `CustomResource` from Kubernetes APIServer:
 ```

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
@@ -116,7 +116,7 @@ public class CRDExample {
         System.out.println("Created CRD " + dummyCRD.getMetadata().getName());
       }
 
-      KubernetesDeserializer.registerCustomKind(HasMetadata.getApiVersion(Dummy.class), dummyCRD.getKind(), Dummy.class);
+      KubernetesDeserializer.registerCustomKind(Dummy.class);
 
       // lets create a client for the CRD
       NonNamespaceOperation<Dummy, DummyList, Resource<Dummy>> dummyClient = client.customResources(dummyCRD, Dummy.class, DummyList.class);

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -105,6 +105,13 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
     /**
      * Registers a Custom Resource Definition Kind
      */
+    public static void registerCustomKind(Class<? extends HasMetadata> clazz) {
+        registerCustomKind(HasMetadata.getApiVersion(clazz), HasMetadata.getKind(clazz), clazz);
+    }
+
+    /**
+     * Registers a Custom Resource Definition Kind
+     */
     public static void registerCustomKind(String kind, Class<? extends KubernetesResource> clazz) {
         registerCustomKind(null, kind, clazz);
     }


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

Provide a new method `registerCustomKind(Class<? extends HasMetadata> clazz)` that only needs the class to infer the ApiVersion and Kind using HasMetadata information.

This simplifies the registration of CustomResources now that `@Group` and `@Version` annotations are required.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
