### PR TITLE
Fix #2687: RawCustomResourceOperationsImpl ignores provided Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.1-SNAPSHOT
 
 #### Bugs
+* Fix #2687: RawCustomResourceOperationsImpl ignores config
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -60,16 +60,13 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
   
   private static final String METADATA = "metadata";
   private static final String RESOURCE_VERSION = "resourceVersion";
-  private OkHttpClient client;
-  private Config config;
-  private CustomResourceDefinitionContext customResourceDefinition;
-  private ObjectMapper objectMapper;
+  private final CustomResourceDefinitionContext customResourceDefinition;
+  private final ObjectMapper objectMapper;
 
-  private enum HttpCallMethod { GET, POST, PUT, DELETE };
+  private enum HttpCallMethod { GET, POST, PUT, DELETE }
 
   public RawCustomResourceOperationsImpl(OkHttpClient client, Config config, CustomResourceDefinitionContext customResourceDefinition) {
-    this.client = client;
-    this.config = config;
+    super(client, config);
     this.customResourceDefinition = customResourceDefinition;
     this.objectMapper = Serialization.jsonMapper();
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -45,6 +45,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class RawCustomResourceOperationsImplTest {
   private OkHttpClient mockClient;
   private Config config;
@@ -146,7 +148,7 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   @Test
-  public void testFetchWatchUrlWithNamespace() throws MalformedURLException {
+  void testFetchWatchUrlWithNamespace() throws MalformedURLException {
     // Given
     RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
 
@@ -158,7 +160,7 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   @Test
-  public void testFetchWatchUrlWithNamespaceAndName() throws MalformedURLException {
+  void testFetchWatchUrlWithNamespaceAndName() throws MalformedURLException {
     // Given
     RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
 
@@ -170,7 +172,7 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   @Test
-  public void testFetchWatchUrlWithNamespaceAndNameAndResourceVersion() throws MalformedURLException {
+  void testFetchWatchUrlWithNamespaceAndNameAndResourceVersion() throws MalformedURLException {
     // Given
     RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
 
@@ -182,7 +184,7 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   @Test
-  public void testFetchWatchUrlWithoutAnything() throws MalformedURLException {
+  void testFetchWatchUrlWithoutAnything() throws MalformedURLException {
     // Given
     RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
 
@@ -194,7 +196,7 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   @Test
-  public void testFetchWatchUrlWithLabels() throws MalformedURLException {
+  void testFetchWatchUrlWithLabels() throws MalformedURLException {
     // Given
     RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
 
@@ -210,7 +212,7 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   @Test
-  public void testFetchWatchUrlWithLabelsWithNamespace() throws MalformedURLException {
+  void testFetchWatchUrlWithLabelsWithNamespace() throws MalformedURLException {
     // Given
     RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
 
@@ -223,5 +225,31 @@ public class RawCustomResourceOperationsImplTest {
 
     // Then
     assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/namespaces/test/hellos?labelSelector=" + Utils.toUrlEncoded("foo=bar") + "," + Utils.toUrlEncoded("foo1=bar1") + "&watch=true", url.url().toString());
+  }
+
+  @Test
+  void testGetConfigShouldNotReturnNull() {
+    // Given
+    Config config = new ConfigBuilder()
+      .withRequestTimeout(5)
+      .withWebsocketTimeout(10L)
+      .withWebsocketPingInterval(10L)
+      .withConnectionTimeout(10)
+      .withWatchReconnectLimit(1)
+      .withWatchReconnectInterval(10)
+      .build();
+    RawCustomResourceOperationsImpl rawOp = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+
+    // When
+    Config configFromRawOp = rawOp.getConfig();
+
+    // Then
+    assertThat(configFromRawOp).isNotNull();
+    assertThat(configFromRawOp.getRequestTimeout()).isEqualTo(5);
+    assertThat(configFromRawOp.getWebsocketTimeout()).isEqualTo(10L);
+    assertThat(configFromRawOp.getWebsocketPingInterval()).isEqualTo(10L);
+    assertThat(configFromRawOp.getConnectionTimeout()).isEqualTo(10L);
+    assertThat(configFromRawOp.getWatchReconnectInterval()).isEqualTo(10);
+    assertThat(configFromRawOp.getWatchReconnectLimit()).isEqualTo(1);
   }
 }

--- a/kubernetes-itests/src/test/resources/rawcustomresourceit-crud-inputstream.yml
+++ b/kubernetes-itests/src/test/resources/rawcustomresourceit-crud-inputstream.yml
@@ -14,23 +14,9 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: jungle.example.com/v1
+kind: Animal
 metadata:
-  name: animals.jungle.example.com
+  name: hippo
 spec:
-  group: jungle.example.com
-  version: v1
-  versions:
-    - name: v1
-      served: true
-      storage: true
-  scope: Namespaced
-  subresources:
-    status: {}
-  names:
-    plural: animals
-    singular: animals
-    kind: Animal
-    shortNames:
-    - al
+  image: "Hippopotamidae"


### PR DESCRIPTION
Fix #2687 

Removed colliding variables from parent OperationSupport class and added
a call to super in constructor

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
