### PR TITLE
Fix #2612: add support for checking latest kubeconfig in Interceptor

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.AuthInfo;
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.internal.KubeConfigUtils;
 import io.fabric8.kubernetes.client.internal.SSLUtils;
 import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -30,8 +29,6 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import java.io.File;
-import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
@@ -152,7 +149,7 @@ public class HttpClientUtils {
             }
             return chain.proceed(request);
           }).addInterceptor(new ImpersonatorInterceptor(config))
-            .addInterceptor(new OIDCTokenRefreshInterceptor(config))
+            .addInterceptor(new TokenRefreshInterceptor(config))
             .addInterceptor(new BackwardsCompatibilityInterceptor());
 
             Logger reqLogger = LoggerFactory.getLogger(HttpLoggingInterceptor.class);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
@@ -53,7 +53,7 @@ public class TokenRefreshInterceptor implements Interceptor {
       if (currentAuthInfo != null && currentAuthInfo.getAuthProvider() != null) {
         response.close();
         String newAccessToken;
-        if (currentAuthInfo.getAuthProvider().toLowerCase().equals("oidc")) {
+        if (currentAuthInfo.getAuthProvider().getName().toLowerCase().equals("oidc")) {
           newAccessToken = OpenIDConnectionUtils.resolveOIDCTokenFromAuthConfig(currentAuthInfo.getAuthProvider().getConfig());
         } else {
           Config newestConfig = Config.autoConfigure(currentContextName);


### PR DESCRIPTION
## Description
Fixes #2612. 

When using a Kubernetes provider that uses OAuth tokens, such as GKE, the existing token will expire after some amount of time, and the client will receive 401 HTTP_UNAUTHORIZED. Instead of assuming this is related to only OIDC tokens, make OIDCTokenRefreshInterceptor more generic and if the auth provider is not OIDC, try to load the latest kubeconfig from disk and use the token provided there. This solves the issue for providers like GKE if the user ensures their kubeconfig location contains a valid token.

Also fixes a response leak in the interceptor.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
