### PR TITLE
fix(#2596) Add buildable ref for container, port and volume

### DIFF
--- a/extensions/knative/model/src/test/java/io/fabric8/knative/ModelTest.java
+++ b/extensions/knative/model/src/test/java/io/fabric8/knative/ModelTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.knative;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.knative.serving.v1.*;
+
+class ModelTest {
+
+  @Test
+  void shouldHaveBuildableContainer()  {
+    Service service = new ServiceBuilder()
+      .withNewSpec()
+      .withNewTemplate()
+      .withNewSpec()
+      .addNewContainer()
+      .withNewImage("my-image")
+      .endContainer()
+      .endSpec()
+      .endTemplate()
+      .endSpec()
+      .build();
+                                
+  }
+}
+

--- a/extensions/tekton/model-v1beta1/src/test/java/io/fabric8/tekton/ModelTest.java
+++ b/extensions/tekton/model-v1beta1/src/test/java/io/fabric8/tekton/ModelTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tekton;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.tekton.pipeline.v1beta1.*;
+
+class ModelTest {
+
+  @Test
+  void shouldHaveBuildableContainer()  {
+    Task service = new TaskBuilder()
+      .withNewSpec()
+      .addNewVolume()
+        .withName("m2-cache")
+        .withNewNfs()
+          .withPath("my.nfs-server.com")
+          .withNewPath("/m2")
+        .endNfs()
+      .endVolume()
+      .addNewStep()
+        .withName("maven-build")
+        .withCommand("mvn")
+        .withArgs("clean", "install")
+        .withImage("maven:3.6.3-jdk11")
+        .addNewVolumeMount()
+          .withName("m2-cache")
+          .withMountPath("/m2-cache")
+        .endVolumeMount()
+        .addNewEnv()
+          .withName("FOO")
+          .withValue("BAR")
+        .endEnv()
+      .endStep()
+      .endSpec()
+      .build();
+  }
+}
+

--- a/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
+++ b/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sun.codemodel.*;
 import io.fabric8.kubernetes.model.annotation.ApiGroup;
 import io.fabric8.kubernetes.model.annotation.ApiVersion;
+import io.sundr.builder.annotations.Inline;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.builder.annotations.Inline;
 import io.sundr.transform.annotations.VelocityTransformation;
 import io.sundr.transform.annotations.VelocityTransformations;
 import lombok.EqualsAndHashCode;
@@ -53,7 +53,7 @@ public class ModelAnnotator extends AbstractAnnotator {
       clazz.annotate(EqualsAndHashCode.class);
 
       JAnnotationUse buildable = clazz.annotate(Buildable.class)
-        .param("editableEnabled", false)
+        .param("editableEnabled", true)
         .param("validationEnabled", false)
         .param("generateBuilderPackage", false)
         .param("builderPackage", "io.fabric8.kubernetes.api.builder");
@@ -63,8 +63,14 @@ public class ModelAnnotator extends AbstractAnnotator {
         .param("prefix", "Doneable")
         .param("value", "done");
 
-      buildable.paramArray("refs").annotate(BuildableReference.class)
-        .param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.ObjectMeta"));
+        JAnnotationArrayMember refs = buildable.paramArray("refs");
+        refs.annotate(BuildableReference.class).param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.ObjectMeta"));
+        refs.annotate(BuildableReference.class).param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.LabelSelector"));
+        refs.annotate(BuildableReference.class).param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.Container"));
+        refs.annotate(BuildableReference.class).param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.EnvVar"));
+        refs.annotate(BuildableReference.class).param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.ContainerPort"));
+        refs.annotate(BuildableReference.class).param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.Volume"));
+        refs.annotate(BuildableReference.class).param("value", new JCodeModel()._class("io.fabric8.kubernetes.api.model.VolumeMount"));
 
       if (isCRD(clazz, propertiesNode) || isCRDList(clazz, propertiesNode)) { // add CRD-specific annotations
         String apiVersion = getApiVersion(propertiesNode);


### PR DESCRIPTION
This is a backport from master. Since, we've already broken the model jar into pieces, it does make sense to add it on 4.x too.
