### PR TITLE
Automatically instantiate spec and status fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 #### Dependency Upgrade
 
 #### New Features
+                        
+### 5.0.1
+
+#### Improvements
+* Fix #2744: Automatically instantiates spec and status fields on `CustomResource` when possible. 
+  `initSpec` and `initStatus` methods are also provided to allow for overriding of the default implementation.
 
 ### 5.0.0 (2020-12-30)
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -245,7 +245,6 @@ public abstract class CustomResource<S, T> implements HasMetadata {
   }
   
   private final static String TYPE_NAME = CustomResource.class.getTypeName();
-  private final static String OBJECT_TYPE_NAME = Object.class.getTypeName();
   private final static String VOID_TYPE_NAME = Void.class.getTypeName();
   private Instantiator[] instantiators = new Instantiator[2];
   
@@ -261,18 +260,16 @@ public abstract class CustomResource<S, T> implements HasMetadata {
     final Instantiator instantiator = instantiators[genericTypeIndex];
     if (instantiator == null) {
       instantiators[genericTypeIndex] = Instantiator.NULL;
-      // this should work because CustomResource is an abstract class
+      
+      // walk the type hierarchy until we reach CustomResource or a ParameterizedType
       Type genericSuperclass = getClass().getGenericSuperclass();
       String typeName = genericSuperclass.getTypeName();
-      do {
-        if (genericSuperclass instanceof ParameterizedType) {
-          break;
-        }
+      while (!TYPE_NAME.equals(typeName) && !(genericSuperclass instanceof ParameterizedType)) {
         genericSuperclass = ((Class) genericSuperclass).getGenericSuperclass();
         typeName = genericSuperclass.getTypeName();
-      } while (!TYPE_NAME.equals(typeName)
-        && !OBJECT_TYPE_NAME.equals(typeName));
-      
+      }
+  
+      // this works because CustomResource is an abstract class
       if (genericSuperclass instanceof ParameterizedType) {
         final Type[] types = ((ParameterizedType) genericSuperclass).getActualTypeArguments();
         if (types.length != 2) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -74,10 +75,10 @@ public abstract class CustomResource<S, T> implements HasMetadata {
   private ObjectMeta metadata = new ObjectMeta();
 
   @JsonProperty("spec")
-  private S spec;
+  protected S spec;
 
   @JsonProperty("status")
-  private T status;
+  protected T status;
 
   private final String singular;
   private final String crdName;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -100,6 +100,27 @@ public abstract class CustomResource<S, T> implements HasMetadata {
     this.singular = getSingular(clazz);
     this.plural = getPlural(clazz);
     this.crdName = getCRDName(clazz);
+    this.spec = initSpec();
+    this.status = initStatus();
+  }
+  
+  protected S initSpec() {
+    return (S)genericInit(0, "spec");
+  }
+  
+  private Object genericInit(int genericTypeIndex, String fieldName) {
+    try {
+      // this should work because CustomResource is an abstract class
+      String className = ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[genericTypeIndex].getTypeName();
+      Class<?> clazz = Class.forName(className);
+      return clazz.getConstructor().newInstance();
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Cannot instantiate " + fieldName, e);
+    }
+  }
+  
+  protected T initStatus() {
+    return (T)genericInit(1, "status");
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -280,7 +280,7 @@ public abstract class CustomResource<S, T> implements HasMetadata {
         String className = types[genericTypeIndex].getTypeName();
         if (!VOID_TYPE_NAME.equals(className)) {
           Class<?> clazz = Class.forName(className);
-          instantiators[genericTypeIndex] = () -> clazz.getConstructor().newInstance();
+          instantiators[genericTypeIndex] = () -> clazz.getDeclaredConstructor().newInstance();
         }
       }
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Locale;
@@ -280,7 +281,11 @@ public abstract class CustomResource<S, T> implements HasMetadata {
         String className = types[genericTypeIndex].getTypeName();
         if (!VOID_TYPE_NAME.equals(className)) {
           Class<?> clazz = Class.forName(className);
-          instantiators[genericTypeIndex] = () -> clazz.getDeclaredConstructor().newInstance();
+          instantiators[genericTypeIndex] = () -> {
+            final Constructor<?> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+          };
         }
       }
     }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
@@ -59,15 +59,8 @@ class CustomResourceTest {
   }
   
   @Test
-  void directInitShouldWork() {
-    final CustomResource<String, Foo> cr = new CustomResource<String, Foo>(){};
-    assertEquals("", cr.getSpec());
-    assertEquals(new Foo(), cr.getStatus());
-  }
-  
-  @Test
   void untypedCustomResourceInitShouldWork() {
-    final CustomResource cr = new CustomResource() {};
+    final CustomResource cr = new Untyped();
     assertNull(cr.getSpec());
     assertNull(cr.getStatus());
   }
@@ -109,6 +102,10 @@ class CustomResourceTest {
       return obj instanceof Foo;
     }
   }
+  
+  @Group("example.com")
+  @Version("v1")
+  private static class Untyped extends CustomResource{}
   
   @Group("example.com")
   @Version("v1")

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
@@ -19,31 +19,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CustomResourceTest {
   private static class MissingApiVersion extends CustomResource {
   }
-  
-  private static class CRSpec {
-    public CRSpec() {
-    }
-  
-    @Override
-    public boolean equals(Object obj) {
-      return obj instanceof CRSpec;
-    }
-  }
-  private static class CRStatus {
-    public CRStatus() {
-    }
-  
-    @Override
-    public boolean equals(Object obj) {
-      return obj instanceof CRStatus;
-    }
-  }
-  private static class CR extends CustomResource<CRSpec,CRStatus>{}
   
   @Test
   void missingGroupAndVersionShouldFail() {
@@ -76,9 +57,74 @@ class CustomResourceTest {
   }
   
   @Test
-  void defaultInitSpecShouldWork() {
-    CR cr = new CR();
-    assertEquals(new CRSpec(), cr.getSpec());
-    assertEquals(new CRStatus(), cr.getStatus());
+  void directInitShouldWork() {
+    final CustomResource<String, Foo> cr = new CustomResource<String, Foo>(){};
+    assertEquals("", cr.getSpec());
+    assertEquals(new Foo(), cr.getStatus());
+  }
+  
+  @Test
+  void untypedCustomResourceInitShouldWork() {
+    final CustomResource cr = new CustomResource() {};
+    assertNull(cr.getSpec());
+    assertNull(cr.getStatus());
+  }
+  
+  @Test
+  void subclassInitShouldWork() {
+    final CRC cr = new CRC();
+    assertEquals("", cr.getSpec());
+    assertEquals(new Foo(), cr.getStatus());
+  }
+  
+  @Test
+  void subclassWithOverriddenInitShouldWork() {
+    final CRI cri = new CRI();
+    assertEquals("", cri.getSpec());
+    assertEquals(7, cri.getStatus());
+  }
+  
+  @Test
+  void subclassWithVoidStatusShouldWork() {
+    final CRV crv = new CRV();
+    assertEquals("", crv.getSpec());
+    assertNull(crv.getStatus());
+  }
+  
+  @Test
+  void deeperSubclassShouldWork() {
+    final CRGG cr = new CRGG();
+    assertEquals("", cr.getSpec());
+    assertEquals(new Foo(), cr.getStatus());
+  }
+  
+  private static class Foo {
+    public Foo() {
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof Foo;
+    }
+  }
+  
+  private static class CRV extends CustomResource<String, Void> {
+  }
+  
+  private static class CRI extends CustomResource<String, Integer> {
+    
+    @Override
+    protected Integer initStatus() {
+      return 7;
+    }
+  }
+  
+  private static class CRC extends CustomResource<String, Foo> {
+  }
+  
+  private static class CRG extends CRC {
+  }
+  
+  private static class CRGG extends CRG {
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.kubernetes.client;
 
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -108,9 +110,13 @@ class CustomResourceTest {
     }
   }
   
+  @Group("example.com")
+  @Version("v1")
   private static class CRV extends CustomResource<String, Void> {
   }
   
+  @Group("example.com")
+  @Version("v1")
   private static class CRI extends CustomResource<String, Integer> {
     
     @Override
@@ -119,12 +125,18 @@ class CustomResourceTest {
     }
   }
   
+  @Group("example.com")
+  @Version("v1")
   private static class CRC extends CustomResource<String, Foo> {
   }
   
+  @Group("example.com")
+  @Version("v1")
   private static class CRG extends CRC {
   }
   
+  @Group("example.com")
+  @Version("v1")
   private static class CRGG extends CRG {
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
@@ -25,6 +25,26 @@ class CustomResourceTest {
   private static class MissingApiVersion extends CustomResource {
   }
   
+  private static class CRSpec {
+    public CRSpec() {
+    }
+  
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof CRSpec;
+    }
+  }
+  private static class CRStatus {
+    public CRStatus() {
+    }
+  
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof CRStatus;
+    }
+  }
+  private static class CR extends CustomResource<CRSpec,CRStatus>{}
+  
   @Test
   void missingGroupAndVersionShouldFail() {
     assertThrows(IllegalArgumentException.class, MissingApiVersion::new);
@@ -53,5 +73,12 @@ class CustomResourceTest {
     assertEquals(custom.getPlural() + "." + Custom.GROUP, custom.getCRDName());
     assertEquals(Custom.VERSION, custom.getVersion());
     assertEquals(Custom.GROUP, custom.getGroup());
+  }
+  
+  @Test
+  void defaultInitSpecShouldWork() {
+    CR cr = new CR();
+    assertEquals(new CRSpec(), cr.getSpec());
+    assertEquals(new CRStatus(), cr.getStatus());
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client;
 
+import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CustomResourceTest {
   private static class MissingApiVersion extends CustomResource {
@@ -100,6 +102,13 @@ class CustomResourceTest {
     assertEquals("", cr.getStatus());
   }
   
+  @Test
+  void interfaceTypeShouldFail() {
+    final IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, CRInterface::new);
+    assertTrue(exception.getMessage().contains(KubernetesResource.class.getName()));
+  }
+  
   private static class Foo {
     public Foo() {
     }
@@ -143,15 +152,17 @@ class CustomResourceTest {
   
   @Group("example.com")
   @Version("v1")
-  private static class CRG extends CRC {
-  }
+  private static class CRG extends CRC {}
   
   @Group("example.com")
   @Version("v1")
-  private static class CRGG extends CRG {
-  }
+  private static class CRGG extends CRG {}
   
   @Group("example.com")
   @Version("v1")
   private static class CRImplicit extends CustomResource<Bar, String> {}
+  
+  @Group("example.com")
+  @Version("v1")
+  private static class CRInterface extends CustomResource<String, KubernetesResource> {}
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/CustomResourceTest.java
@@ -93,6 +93,13 @@ class CustomResourceTest {
     assertEquals(new Foo(), cr.getStatus());
   }
   
+  @Test
+  void implicitConstructorShouldWork() {
+    final CRImplicit cr = new CRImplicit();
+    assertEquals(new Bar(), cr.getSpec());
+    assertEquals("", cr.getStatus());
+  }
+  
   private static class Foo {
     public Foo() {
     }
@@ -100,6 +107,13 @@ class CustomResourceTest {
     @Override
     public boolean equals(Object obj) {
       return obj instanceof Foo;
+    }
+  }
+  
+  private static class Bar {
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof Bar;
     }
   }
   
@@ -136,4 +150,8 @@ class CustomResourceTest {
   @Version("v1")
   private static class CRGG extends CRG {
   }
+  
+  @Group("example.com")
+  @Version("v1")
+  private static class CRImplicit extends CustomResource<Bar, String> {}
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleRelease.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd/EntandoBundleRelease.java
@@ -23,5 +23,5 @@ import io.fabric8.kubernetes.model.annotation.Version;
 
 @Version("v1alpha1")
 @Group("demo.fabric8.io")
-public class EntandoBundleRelease extends CustomResource<EntandoBundleReleaseSpec, KubernetesResource> implements Namespaced {
+public class EntandoBundleRelease extends CustomResource<EntandoBundleReleaseSpec, Void> implements Namespaced {
 }


### PR DESCRIPTION
## Description
Makes typical use cases automatic, provide `initSpec` and  `initStatus` method on `CustomResource` to let user provide their own custom implementation if the default doesn't work for their use case. Fixes #2744.
 
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
