### PR TITLE
Fix #2717: Remove edit() methods from RawCustomResourceOperationsImpl taking InputStream arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #2717: Remove edit() methods from RawCustomResourceOperationsImpl taking InputStream arguments
 
 #### Dependency Upgrade
 * update Tekton Triggers model to v0.11.1

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -287,31 +287,6 @@ public class RawCustomResourceOperationsImpl extends OperationSupport {
   }
 
   /**
-   * Edit a custom resource object which is a non-namespaced object.
-   *
-   * @param name name of the custom resource
-   * @param objectAsStream new object as a file input stream
-   * @return Object as HashMap
-   * @throws IOException in case of network/serialization failures or failures from Kubernetes API
-   */
-  public Map<String, Object> edit(String name, InputStream objectAsStream) throws IOException {
-    return validateAndSubmitRequest(null, name, IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
-  }
-
-  /**
-   * Edit a custom resource object which is a namespaced object.
-   *
-   * @param namespace desired namespace
-   * @param name name of the custom resource
-   * @param objectAsStream new object as a file input stream
-   * @return Object as HashMap
-   * @throws IOException in case of network/serialization failures or failures from Kubernetes API
-   */
-  public Map<String, Object> edit(String namespace, String name, InputStream objectAsStream) throws IOException {
-    return validateAndSubmitRequest(namespace, name, IOHelpers.readFully(objectAsStream), HttpCallMethod.PUT);
-  }
-
-  /**
    * Update status related to a CustomResource, this method does a PUT request on /status endpoint related
    * to the CustomResource
    *

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawCustomResourceIT.java
@@ -151,7 +151,7 @@ public class RawCustomResourceIT {
   }
 
   @Test
-  public void testCrudUsingInputStream() throws IOException {
+  public void testCreateReadDeleteUsingInputStream() throws IOException {
     // Create
     String name = "hippo";
     InputStream hippoInputStream = getClass().getResourceAsStream("/rawcustomresourceit-crud-inputstream.yml");
@@ -161,13 +161,6 @@ public class RawCustomResourceIT {
     // Read
     hippoCr = client.customResource(customResourceDefinitionContext).get(currentNamespace, name);
     assertAnimal(hippoCr, name, "Hippopotamidae");
-
-    // Update
-    ((Map<String, Object>)hippoCr.get("spec")).put("image", "river-hippo");
-    File updatedHippoManifest = Files.createTempFile("hippo", "yml").toFile();
-    FileUtils.writeStringToFile(updatedHippoManifest, Serialization.jsonMapper().writeValueAsString(hippoCr));
-    hippoCr = client.customResource(customResourceDefinitionContext).edit(currentNamespace, name, new FileInputStream(updatedHippoManifest));
-    assertAnimal(hippoCr, name, "river-hippo");
 
     // Delete
     Map<String, Object> deletionStatusMap = client.customResource(customResourceDefinitionContext).delete(currentNamespace, name);


### PR DESCRIPTION
As discussed in #2717, it's not a good idea to take InputStream for
edit() methods which simply does a PATCH to Kubernetes APIServer.

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
