### PR TITLE
Fix #2703 : Add support for `certificates.k8s.io` v1 and v1beta1 API in KubernetesClient DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### New Features
 * Fix #2702 : Add support for discovery.k8s.io/v1beta1 EndpointSlice in KubernetesClient DSL
+* Fix #2703 : Add support for `certificates.k8s.io` v1 and v1beta1 API in KubernetesClient DSL
 
 _**Note**_: Breaking changes in the API
 - `client.settings()` DSL has been removed since PodPreset v1alpha1 API is no longer present in Kubernetes 1.20.x

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1862,7 +1862,7 @@ Map<String, Object> result = client.customResource(customResourceDefinitionConte
 ```
 
 ### CertificateSigningRequest
-Kubernetes Client provides using `CertificateSigningRequest` via the `client.certificateSigningRequests()` DSL interface. Here is an example of creating `CertificateSigningRequest` using Fabric8 Kubernetes Client:
+Kubernetes Client provides using `CertificateSigningRequest` via the `client.certificates().v1().certificateSigningRequests()` DSL interface. Here is an example of creating `CertificateSigningRequest` using Fabric8 Kubernetes Client:
 ```
 try (KubernetesClient client = new DefaultKubernetesClient()) {
     CertificateSigningRequest csr = new CertificateSigningRequestBuilder()
@@ -1874,7 +1874,7 @@ try (KubernetesClient client = new DefaultKubernetesClient()) {
             .endSpec()
             .build();
 
-    client.certificateSigningRequests().create(csr);
+    client.certificates().v1().certificateSigningRequests().create(csr);
 }
 ```
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CertificatesAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CertificatesAPIGroupClient.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.V1CertificatesAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.V1beta1CertificatesAPIGroupDSL;
+import okhttp3.OkHttpClient;
+
+public class CertificatesAPIGroupClient extends BaseClient implements CertificatesAPIGroupDSL {
+
+  public CertificatesAPIGroupClient() {
+    super();
+  }
+
+  public CertificatesAPIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public V1CertificatesAPIGroupDSL v1() {
+    return adapt(V1CertificatesAPIGroupClient.class);
+  }
+
+  @Override
+  public V1beta1CertificatesAPIGroupDSL v1beta1() {
+    return adapt(V1beta1CertificatesAPIGroupClient.class);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CertificatesAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CertificatesAPIGroupExtensionAdapter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+
+public class CertificatesAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<CertificatesAPIGroupClient> {
+  @Override
+  protected String getAPIGroupName() {
+    return "certificates";
+  }
+
+  @Override
+  public Class<CertificatesAPIGroupClient> getExtensionType() {
+    return CertificatesAPIGroupClient.class;
+  }
+
+  @Override
+  protected CertificatesAPIGroupClient newInstance(Client client) {
+    return new CertificatesAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -371,6 +371,11 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     return new CertificateSigningRequestOperationsImpl(httpClient, getConfiguration());
   }
 
+  @Override
+  public CertificatesAPIGroupDSL certificates() {
+    return adapt(CertificatesAPIGroupClient.class);
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -99,9 +99,18 @@ public interface KubernetesClient extends Client {
   /**
    * API entrypoint for using CertificateSigningRequest(certificates.k8s.io/v1beta1)
    *
+   * @deprecated Use `client.certificates().v1beta1().certificateSigningRequest` instead
    * @return {@link NonNamespaceOperation} for CertificateSigningRequest class
    */
+  @Deprecated
   NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests();
+
+  /**
+   * API entrypoint for certificates.k8s.io APIGroup
+   *
+   * @return {@link CertificatesAPIGroupDSL} for Certificate API resources
+   */
+  CertificatesAPIGroupDSL certificates();
 
   /**
    * Typed API for managing CustomResources. You would need to provide POJOs for

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1CertificatesAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1CertificatesAPIGroupClient.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.V1CertificatesAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.internal.certificates.v1.CertificateSigningRequestOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class V1CertificatesAPIGroupClient extends BaseClient implements V1CertificatesAPIGroupDSL {
+  public V1CertificatesAPIGroupClient() {
+    super();
+  }
+
+  public V1CertificatesAPIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests() {
+    return new CertificateSigningRequestOperationsImpl(httpClient, getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1CertificatesAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1CertificatesAPIGroupExtensionAdapter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+
+public class V1CertificatesAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<V1CertificatesAPIGroupClient> {
+  @Override
+  protected String getAPIGroupName() {
+    return "certificates/v1";
+  }
+
+  @Override
+  public Class<V1CertificatesAPIGroupClient> getExtensionType() {
+    return V1CertificatesAPIGroupClient.class;
+  }
+
+  @Override
+  protected V1CertificatesAPIGroupClient newInstance(Client client) {
+    return new V1CertificatesAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1CertificatesAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1CertificatesAPIGroupClient.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestList;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.V1beta1CertificatesAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.internal.certificates.v1beta1.CertificateSigningRequestOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class V1beta1CertificatesAPIGroupClient extends BaseClient implements V1beta1CertificatesAPIGroupDSL {
+  public V1beta1CertificatesAPIGroupClient() {
+    super();
+  }
+
+  public V1beta1CertificatesAPIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests() {
+    return new CertificateSigningRequestOperationsImpl(httpClient, getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1CertificatesAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1CertificatesAPIGroupExtensionAdapter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+
+public class V1beta1CertificatesAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<V1beta1CertificatesAPIGroupClient> {
+  @Override
+  protected String getAPIGroupName() {
+    return "certificates/v1beta1";
+  }
+
+  @Override
+  public Class<V1beta1CertificatesAPIGroupClient> getExtensionType() {
+    return V1beta1CertificatesAPIGroupClient.class;
+  }
+
+  @Override
+  protected V1beta1CertificatesAPIGroupClient newInstance(Client client) {
+    return new V1beta1CertificatesAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CertificatesAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CertificatesAPIGroupDSL.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.client.Client;
+
+public interface CertificatesAPIGroupDSL extends Client {
+  V1CertificatesAPIGroupDSL v1();
+  V1beta1CertificatesAPIGroupDSL v1beta1();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1CertificatesAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1CertificatesAPIGroupDSL.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
+import io.fabric8.kubernetes.client.Client;
+
+public interface V1CertificatesAPIGroupDSL extends Client {
+  NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1CertificatesAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1CertificatesAPIGroupDSL.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestList;
+import io.fabric8.kubernetes.client.Client;
+
+public interface V1beta1CertificatesAPIGroupDSL extends Client {
+  NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -80,6 +80,7 @@ import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AuthorizationAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AutoscalingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Createable;
 import io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
@@ -415,6 +416,11 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests() {
     return delegate.certificateSigningRequests();
+  }
+
+  @Override
+  public CertificatesAPIGroupDSL certificates() {
+    return delegate.certificates();
   }
 
   @Override

--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
@@ -41,3 +41,6 @@ io.fabric8.kubernetes.client.V1NetworkAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V1beta1NetworkAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.DiscoveryAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V1beta1DiscoveryAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.CertificatesAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.V1CertificatesAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.V1beta1CertificatesAPIGroupExtensionAdapter

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CertificateSigningRequestIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CertificateSigningRequestIT.java
@@ -48,20 +48,20 @@ public class CertificateSigningRequestIT {
 
   @Test
   public void get() {
-    CertificateSigningRequest certificateSigningRequest = client.certificateSigningRequests().withName("csr-get").get();
+    CertificateSigningRequest certificateSigningRequest = client.certificates().v1beta1().certificateSigningRequests().withName("csr-get").get();
     assertThat(certificateSigningRequest).isNotNull();
   }
 
   @Test
   public void list() {
-    CertificateSigningRequestList certificateSigningRequestList = client.certificateSigningRequests().list();
+    CertificateSigningRequestList certificateSigningRequestList = client.certificates().v1beta1().certificateSigningRequests().list();
     assertNotNull(certificateSigningRequestList);
     assertTrue(certificateSigningRequestList.getItems().size() >= 1);
   }
 
   @Test
   public void update() {
-    CertificateSigningRequest certificateSigningRequest = client.certificateSigningRequests().withName("csr-update").edit(c -> new CertificateSigningRequestBuilder(c)
+    CertificateSigningRequest certificateSigningRequest = client.certificates().v1beta1().certificateSigningRequests().withName("csr-update").edit(c -> new CertificateSigningRequestBuilder(c)
       .editOrNewMetadata().addToAnnotations("foo", "bar").endMetadata().build());
 
     assertNotNull(certificateSigningRequest);
@@ -70,7 +70,7 @@ public class CertificateSigningRequestIT {
 
   @Test
   public void delete() {
-    assertTrue(client.certificateSigningRequests().withName("csr-delete").delete());
+    assertTrue(client.certificates().v1beta1().certificateSigningRequests().withName("csr-delete").delete());
   }
 
   @AfterClass

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CertificateSigningRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CertificateSigningRequestTest.java
@@ -16,60 +16,119 @@
 package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
-import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestBuilder;
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestBuilder;
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
+import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
 import java.net.HttpURLConnection;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableRuleMigrationSupport
-class CertificateSigningRequestTest {
+class V1CertificateSigningRequestTest {
   @Rule
   public KubernetesServer server = new KubernetesServer();
 
+  private KubernetesClient client;
+
+  @BeforeEach
+  void initializeClient() {
+    client = server.getClient();
+  }
+
   @Test
   void testLoad() {
-    // Given
-    KubernetesClient client = server.getClient();
-
     // When
-    List<HasMetadata> resources = client.load(getClass().getResourceAsStream("/test-csr.yml")).get();
+    List<HasMetadata> resources = client.load(getClass().getResourceAsStream("/test-v1-csr.yml")).get();
 
     // Then
-    assertEquals(1, resources.size());
-    assertTrue(resources.get(0) instanceof CertificateSigningRequest);
+    assertThat(resources).hasSize(1);
+    assertThat(resources.get(0)).isInstanceOf(CertificateSigningRequest.class);
   }
 
   @Test
   void testCreate() {
     // Given
-    CertificateSigningRequest csr = new CertificateSigningRequestBuilder()
-      .withNewMetadata().withName("test-k8s-csr").endMetadata()
+    String name = "test-k8s-csr";
+    CertificateSigningRequest csr = getCertificateSigningRequest(name);
+    server.expect().post().withPath("/apis/certificates.k8s.io/v1/certificatesigningrequests")
+      .andReturn(HttpURLConnection.HTTP_OK, csr)
+      .once();
+
+    // When
+    csr = client.certificates().v1().certificateSigningRequests().create(csr);
+
+    // Then
+    assertThat(csr).isNotNull();
+    assertThat(csr.getMetadata().getName()).isEqualTo(name);
+  }
+
+  private CertificateSigningRequest getCertificateSigningRequest(String name) {
+    return new CertificateSigningRequestBuilder()
+      .withNewMetadata().withName(name).endMetadata()
       .withNewSpec()
       .addNewGroup("system:authenticated")
       .withRequest("RSBSRVFVRVNULS0tLS0KTUlJRWJqQ0NBbFlDQVFBd0tURVBNQTBHQTFVRUF3d0dhMmxrYjI1bk1SWXdGQVlEVlFRS0RBMWtZWFJoTFdWdQpaMmx1WldWeU1JSUNJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBc2dVZXl0S0F6ZDkyClN1S2pZL1RqbmRsZ0lkSFVVYWFxbHJIVW1nbTloKzY2RTJCNGs0TSt6Q0tOQmovemlMdWV6NFNUeHJ6SFk3RlUKNGUxWElBU3lMS0dmRGNPaks5NThURThwcXBRM21VdlpWMmxnK25BTVF5dlZUYWdZSmFId2JWUzVlNHgvRmpKcQoxTWpQZ1VoSGFXeEdIYTQrQnZYQU9Kdk5BdnV4alpZaVJET251dGxHVzloQkRKRlhoUk5jOGFKNnFiZWVBWnNiCmozWUFMaUcydWp1VmhoTUVRNEJxdFVHVGZCMzBQNGhRK2t2bWVKc2ZUU3Vsb2xiWFdIdVZGWnh1d0FJek5RbmQKMTd4VHd2cU04OGZFb3ZJazBJV0ZCWTk2aHRvaUVNdThZUms4SEZ6QkJralhsZGlkbVNNSHkwK0plcFRONmdQTQpEYVVsd1cxS0lCcW9TbnZNcjY4cFRVWEVhZVRjc040anMxTUIwK3FwR0JBS1puWWVxM0JmMkxVVFBNaG1VZ2VVCmFUTFlqODI2WVorZjJrOWJ1cngwK1NOSmVZbWoxVTl0N3A2YWM0dDIzZHVYQ1BzYkNrUFNKeGtrU3dudUlVVzkKdmJVVGtJNGtVMlFVMnE0NzRaMW1uMlkvejF2TEdQdEpsTDFYUVFVNEdsb2hrQkVkM1BsUTRtOGU1WGZSRkV6ZgpYZnhMRXFRczFTeEg1ekhjcnVaOWxJdnBkeEw5Tkc5WlR6M0tmT0tIbCtSUzdxMGdKaExac0RubUJKNXZab3p4CldXci9IRW9PamFYbGh0VitDN3M4TUg5Y0lKZENZNnpjcFVrZis1NmZ0Z1FuN0YrT1RYdDI0UVJQYWNFZnRFOTkKVERPb2luTGtOMm1kckxiMTgxQUZNUWJ0bTFLc1k2MENBd0VBQWFBQU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQwpBUUNQYU1WdDd4YWhkZlF1L1BySFVTTW5LK2I0SlJScEdEYlpWUXk4aUtkSmdHM0VrYnNBZ21qQmN4Q1IvL2t1CkVhU0plSGNWK20xVlFUTEp1ZFU3ZHFUeFBLOVFCNlB2aHlBbCttNnFaQkt1Q25VM1BKc2k5azBYSE5GWXBqRmYKVFNwTlpJSnRuanVEQWVtT05kcjJYMm1rODZmSmpWTEUvYnA1KzM5dFBkN0xjL3dZR2JoRU0xcExtUGpQK0Z6eQpzZnBiYW5PcmZFSG5NMmlsRFpGZURVSEpYL3F5Ykt1RC9BRmdoZk1Ua0x3ODNLNkNRdCtDQm05djRCeEtCS2xqCkdBWEQyUEhUTWlzektUbGpBM3czYUphanZzU0FwQXFCWnFocjB3QzdOb1dYM1h6S0p3ck9MaWVxemo3SXlpUGEKTEI5SmJveFpOQTdBSU5ucEdsa1hDZlRGT2RManZtQkVRQXV5Ym9wLzdqV2RiSzJHRkZKS2UwdlVlbWNUeGdHVwp5c0ZyV2pqMUlvdVBVNFZ6ck82QVBVQnZCZUFtdU1Bbm9yVng5emc4akhlT1pkd2RWdFRnOUwrK0VnWjlxK0htCjVtUlJGVHlZOWo4WVVvd2J6TzRlRUZnaVN0di84T1p0YmtOeDFROWFQWHJ3VUV1Q1I0SUthWG0wNlJUYXJOYXUKTWFsbk5oZm9WYi9Bc1R5d1ArNlc1dGErcTBpckR5cnVkZk5pRkFWbkRMZEU5a2hWZzVrU0lPRzhYbEZUMklwSQpkdVNpcUl0NlNUTlY3UmdaRzBGTFN5akxoc3laWnY2bitpUzl3Ky9OOFpoUzgvalViUUVidG1VTnNJU3Z5WS9JCmZqcHNZQUdleExvVW5mN2pDaUhkbTVhSnJ5SU1kdmZ2akJsMDhIVk5nWG1McVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K")
       .addNewUsage("client auth")
       .endSpec()
       .build();
-    server.expect().post().withPath("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests")
+  }
+
+  @Test
+  void get() {
+    // Given
+    String name = "test-k8s-csr";
+    CertificateSigningRequest csr = getCertificateSigningRequest(name);
+    server.expect().get().withPath("/apis/certificates.k8s.io/v1/certificatesigningrequests/" + name)
       .andReturn(HttpURLConnection.HTTP_OK, csr)
       .once();
-    KubernetesClient client = server.getClient();
 
     // When
-    csr = client.certificates().v1beta1().certificateSigningRequests().create(csr);
+    csr = client.certificates().v1().certificateSigningRequests().withName(name).get();
 
     // Then
-    assertNotNull(csr);
-    assertEquals("test-k8s-csr", csr.getMetadata().getName());
+    assertThat(csr).isNotNull();
+    assertThat(csr.getMetadata().getName()).isEqualTo(name);
+  }
+
+  @Test
+  void list() {
+    // Given
+    String name = "test-k8s-csr";
+    server.expect().get().withPath("/apis/certificates.k8s.io/v1/certificatesigningrequests")
+      .andReturn(HttpURLConnection.HTTP_OK, new CertificateSigningRequestListBuilder().withItems(getCertificateSigningRequest(name)).build())
+      .once();
+
+    // When
+    CertificateSigningRequestList csrList = client.certificates().v1().certificateSigningRequests().list();
+
+    // Then
+    assertThat(csrList).isNotNull();
+    assertThat(csrList.getItems()).hasSize(1);
+    assertThat(csrList.getItems().get(0).getMetadata().getName()).isEqualTo(name);
+  }
+
+  @Test
+  void delete() {
+    // Given
+    String name = "test-k8s-csr";
+    CertificateSigningRequest csr = getCertificateSigningRequest(name);
+    server.expect().delete().withPath("/apis/certificates.k8s.io/v1/certificatesigningrequests/" + name)
+      .andReturn(HttpURLConnection.HTTP_OK, csr)
+      .once();
+
+    // When
+    Boolean isDeleted = client.certificates().v1().certificateSigningRequests().withName(name).delete();
+
+    // Then
+    assertThat(isDeleted).isTrue();
   }
 }

--- a/kubernetes-tests/src/test/resources/test-v1-csr.yml
+++ b/kubernetes-tests/src/test/resources/test-v1-csr.yml
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: john
+spec:
+  groups:
+    - system:authenticated
+  request: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ1ZqQ0NBVDRDQVFBd0VURVBNQTBHQTFVRUF3d0dZVzVuWld4aE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRgpBQU9DQVE4QU1JSUJDZ0tDQVFFQTByczhJTHRHdTYxakx2dHhWTTJSVlRWMDNHWlJTWWw0dWluVWo4RElaWjBOCnR2MUZtRVFSd3VoaUZsOFEzcWl0Qm0wMUFSMkNJVXBGd2ZzSjZ4MXF3ckJzVkhZbGlBNVhwRVpZM3ExcGswSDQKM3Z3aGJlK1o2MVNrVHF5SVBYUUwrTWM5T1Nsbm0xb0R2N0NtSkZNMUlMRVI3QTVGZnZKOEdFRjJ6dHBoaUlFMwpub1dtdHNZb3JuT2wzc2lHQ2ZGZzR4Zmd4eW8ybmlneFNVekl1bXNnVm9PM2ttT0x1RVF6cXpkakJ3TFJXbWlECklmMXBMWnoyalVnald4UkhCM1gyWnVVV1d1T09PZnpXM01LaE8ybHEvZi9DdS8wYk83c0x0MCt3U2ZMSU91TFcKcW90blZtRmxMMytqTy82WDNDKzBERHk5aUtwbXJjVDBnWGZLemE1dHJRSURBUUFCb0FBd0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBR05WdmVIOGR4ZzNvK21VeVRkbmFjVmQ1N24zSkExdnZEU1JWREkyQTZ1eXN3ZFp1L1BVCkkwZXpZWFV0RVNnSk1IRmQycVVNMjNuNVJsSXJ3R0xuUXFISUh5VStWWHhsdnZsRnpNOVpEWllSTmU3QlJvYXgKQVlEdUI5STZXT3FYbkFvczFqRmxNUG5NbFpqdU5kSGxpT1BjTU1oNndLaTZzZFhpVStHYTJ2RUVLY01jSVUyRgpvU2djUWdMYTk0aEpacGk3ZnNMdm1OQUxoT045UHdNMGM1dVJVejV4T0dGMUtCbWRSeEgvbUNOS2JKYjFRQm1HCkkwYitEUEdaTktXTU0xMzhIQXdoV0tkNjVoVHdYOWl4V3ZHMkh4TG1WQzg0L1BHT0tWQW9FNkpsYWFHdTlQVmkKdjlOSjVaZlZrcXdCd0hKbzZXdk9xVlA3SVFjZmg3d0drWm89Ci0tLS0tRU5EIENFUlRJRklDQVRFIFJFUVVFU1QtLS0tLQo=
+  signerName: kubernetes.io/kube-apiserver-client
+  usages:
+    - client auth

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -90,6 +90,7 @@ import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AuthorizationAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AutoscalingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Createable;
 import io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
@@ -512,6 +513,11 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests() {
     return delegate.certificateSigningRequests();
+  }
+
+  @Override
+  public CertificatesAPIGroupDSL certificates() {
+    return delegate.certificates();
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -72,6 +72,7 @@ import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AuthorizationAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.AutoscalingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Createable;
 import io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
@@ -603,6 +604,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests() {
     return delegate.certificateSigningRequests();
+  }
+
+  @Override
+  public CertificatesAPIGroupDSL certificates() {
+    return delegate.certificates();
   }
 
   @Override


### PR DESCRIPTION
Fix #2703 

+ Added a new `client.certificates()` DSL to KubernetesClient
+ Mark `client.certificateSigningRequests()` as `@Deprecated`
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
