### PR TITLE
Fix #2699: Add support for `@EnableOpenShiftMockClient` for OpenShiftClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 #### Dependency Upgrade
 
 #### New Features
-- Update chaos-mesh extension to v1.1.1. Add PodIoChaos, JVMChaos, HTTPChaos and DNSChaos.
+* Update chaos-mesh extension to v1.1.1. Add PodIoChaos, JVMChaos, HTTPChaos and DNSChaos.
+* Fix #2699: Add support for `@EnableOpenShiftMockClient` for OpenShiftClient
+
 
 ### 5.1.1 (2021-02-24)
 

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
- * by annotating it with `@ExtendWith(KubernetesMockServerExtension.class)` or through
- * `@EnableKubernetesMockClient` annotation
+ * by annotating it with <code>@ExtendWith(KubernetesMockServerExtension.class)</code> or through
+ * <code>@EnableKubernetesMockClient</code> annotation
  */
 public class KubernetesMockServerExtension implements AfterEachCallback, AfterAllCallback, BeforeEachCallback, BeforeAllCallback {
 

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionClientAndServerStaticTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionClientAndServerStaticTests.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@EnableKubernetesMockClient
+class KubernetesMockServerExtensionClientAndServerStaticTests {
+  static KubernetesMockServer mockServer;
+  static KubernetesClient client;
+
+  @Test
+  void testExample() {
+    Assertions.assertNotNull(mockServer);
+    Assertions.assertNotNull(client);
+  }
+}

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionClientAndServerTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionClientAndServerTests.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@EnableKubernetesMockClient
+class KubernetesMockServerExtensionClientAndServerTests {
+  KubernetesMockServer mockServer;
+  KubernetesClient client;
+
+  @Test
+  void testExample() {
+    Assertions.assertNotNull(mockServer);
+    Assertions.assertNotNull(client);
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/APIServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/APIServiceTest.java
@@ -20,11 +20,10 @@ import io.fabric8.kubernetes.api.model.APIServiceBuilder;
 import io.fabric8.kubernetes.api.model.APIServiceList;
 import io.fabric8.kubernetes.api.model.APIServiceListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import org.junit.Rule;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
 import java.net.HttpURLConnection;
 
@@ -32,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableRuleMigrationSupport
+@EnableKubernetesMockClient
 class APIServiceTest {
-  @Rule
-  public KubernetesServer server = new KubernetesServer();
+  private KubernetesMockServer server;
+  private KubernetesClient client;
 
   @Test
   @DisplayName("Should load a yaml resource")
@@ -45,7 +44,6 @@ class APIServiceTest {
       .andReturn(HttpURLConnection.HTTP_OK, new APIServiceBuilder()
         .withNewMetadata().withName("as1").endMetadata().build())
       .once();
-    KubernetesClient client = server.getClient();
 
     // When
     APIService apiService = client.apiServices().withName("test-apiservice").get();
@@ -59,7 +57,6 @@ class APIServiceTest {
   @DisplayName("Should get a resource from APIServer")
   void load() {
     // Given
-    KubernetesClient client = server.getClient();
 
     // When
     APIService apiService = client.apiServices().load(getClass().getResourceAsStream("/test-apiservice.yml")).get();
@@ -80,7 +77,6 @@ class APIServiceTest {
         .addNewItem()
         .withNewMetadata().withName("as1").endMetadata().endItem().build())
       .once();
-    KubernetesClient client = server.getClient();
 
     // When
     APIServiceList apiServiceList = client.apiServices().list();
@@ -99,7 +95,6 @@ class APIServiceTest {
       .andReturn(HttpURLConnection.HTTP_OK, new APIServiceBuilder()
         .withNewMetadata().withName("v1alpha1.demo.fabric8.io").endMetadata().build())
       .once();
-    KubernetesClient client = server.getClient();
 
     // When
     Boolean isDeleted = client.apiServices().withName("v1alpha1.demo.fabric8.io").delete();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
@@ -20,24 +20,18 @@ import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.fabric8.openshift.api.model.BuildConfigList;
 import io.fabric8.openshift.client.OpenShiftClient;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableRuleMigrationSupport
+@EnableOpenShiftMockClient(crud = true)
 class BuildConfigCrudTest {
-
-  @Rule
-  public OpenShiftServer server = new OpenShiftServer(true, true);
+  OpenShiftClient client;
 
   @Test
   void testCrud() {
-    OpenShiftClient client = server.getOpenshiftClient();
-
     BuildConfig buildConfig = new BuildConfigBuilder()
       .withNewMetadata()
         .withName("bc2")

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildTest.java
@@ -16,21 +16,18 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.openshift.client.OpenShiftClient;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableRuleMigrationSupport
+@EnableOpenShiftMockClient
 class BuildTest {
-  @Rule
-  public OpenShiftServer server = new OpenShiftServer();
+  OpenShiftMockServer server;
+  OpenShiftClient openShiftClient;
 
   @Test
   void testLogWithoutTimestamps() {
     server.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/builds/test-build/log?pretty=false").andReturn(200, "test build output").times(2);
-    OpenShiftClient openShiftClient = server.getOpenshiftClient();
 
     String log = openShiftClient.builds().inNamespace("ns1").withName("test-build").getLog();
     assertEquals("test build output", log);
@@ -39,7 +36,6 @@ class BuildTest {
   @Test
   void testLogWithTimestamps() {
     server.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/builds/test-build/log?pretty=false&timestamps=true").andReturn(200, "test build output").times(2);
-    OpenShiftClient openShiftClient = server.getOpenshiftClient();
 
     String log = openShiftClient.builds().inNamespace("ns1").withName("test-build").usingTimestamps().getLog();
     assertEquals("test build output", log);

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/EnableOpenShiftMockClient.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/EnableOpenShiftMockClient.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation that is used for enabling OpenShiftMockServerExtension JUnit5 extension.
+ * You may set here two parameters of `OpenShiftServer`: crudMode and https
+ */
+@Target({ TYPE, METHOD, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@ExtendWith(OpenShiftMockServerExtension.class)
+public @interface EnableOpenShiftMockClient {
+
+  boolean https() default true;
+
+  boolean crud() default false;
+}

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
+import io.fabric8.mockwebserver.Context;
+import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import okhttp3.mockwebserver.MockWebServer;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+
+/**
+ * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
+ * by annotating it with `@ExtendWith(OpenShiftMockServerExtension.class)` or through
+ * `@EnableOpenShiftMockClient` annotation
+ */
+public class OpenShiftMockServerExtension extends KubernetesMockServerExtension {
+  private OpenShiftMockServer openShiftMockServer;
+  private NamespacedOpenShiftClient openShiftClient;
+
+  @Override
+  protected void destroy() {
+    openShiftMockServer.destroy();
+    openShiftClient.close();
+  }
+
+  @Override
+  protected Class<?> getClientType() {
+    return OpenShiftClient.class;
+  }
+
+  @Override
+  protected void createKubernetesClient(Class<?> testClass) {
+    EnableOpenShiftMockClient a = testClass.getAnnotation(EnableOpenShiftMockClient.class);
+    openShiftMockServer = a.crud()
+      ? new OpenShiftMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      : new OpenShiftMockServer(a.https());
+    openShiftMockServer.init();
+    openShiftClient = openShiftMockServer.createOpenShiftClient();
+  }
+
+  @Override
+  protected void setKubernetesClientField(Object instance, Field f) throws IllegalAccessException {
+    f.set(instance, openShiftClient);
+  }
+}

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
- * by annotating it with `@ExtendWith(OpenShiftMockServerExtension.class)` or through
- * `@EnableOpenShiftMockClient` annotation
+ * by annotating it with <code>@ExtendWith(OpenShiftMockServerExtension.class)</code> or through
+ * <code>@EnableOpenShiftMockClient</code> annotation
  */
 public class OpenShiftMockServerExtension extends KubernetesMockServerExtension {
   private OpenShiftMockServer openShiftMockServer;

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerStaticTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerStaticTests.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableOpenShiftMockClient
+class OpenShiftMockServerExtensionClientAndServerStaticTests {
+  private static OpenShiftMockServer openShiftMockServer;
+  private static OpenShiftClient openShiftClient;
+
+  @Test
+  void testMockServerAndClientAreInitialized() {
+    assertNotNull(openShiftMockServer);
+    assertNotNull(openShiftClient);
+  }
+}

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerTests.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableOpenShiftMockClient
+class OpenShiftMockServerExtensionClientAndServerTests {
+  private OpenShiftMockServer openShiftMockServer;
+  private OpenShiftClient openShiftClient;
+
+  @Test
+  void testMockServerAndClientAreInitialized() {
+    assertNotNull(openShiftMockServer);
+    assertNotNull(openShiftClient);
+  }
+}

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableOpenShiftMockClient(crud = true)
+class OpenShiftMockServerExtensionStaticTests {
+  static OpenShiftClient openShiftClient;
+
+  @Test
+  void testStaticOpenShiftClientGetsInitialized() {
+    assertNotNull(openShiftClient);
+  }
+}

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableOpenShiftMockClient(crud = true)
+class OpenShiftMockServerExtensionTests {
+  OpenShiftClient client;
+
+  @Test
+  void testOpenShiftClientGetsInitialized() {
+    assertNotNull(client);
+  }
+}


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #2699 
- Add OpenShiftMockServerExtension based on KubernetesMockServerExtension
- Refactor KubernetesMockServerExtension to set TestClass's KubernetesMockServer
  -  Right now KubernetesMockServerExtension only sets TestClass's KubernetesClient field if present. This is good for CRUD mode but for use cases where we want to set expectations; we can't use it. This PR also refactors KubernetesMockServerExtension to consider both KubernetesClient and KubernetesMockServer fields in TestClass and initialize them accordingly


I haven't updated all tests in `kubenetes-tests` to get rid of KubernetesServer `@Rule`. I think we can create an easy hack to replace it with this Junit5 extension
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
