### PR TITLE
Fix #2672: WaitUntilReady for Service resource throws IllegalArgumentException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #2748: Pass custom headers in kubernetes-client to watch api by modify WatchConnectionManager
 * Fix #2745: Filtering Operations can't configure PropagationPolicy
+* Fix #2672: WaitUntilReady for Service resource throws IllegalArgumentException
 
 #### Improvements
 * Fix #2717: Remove edit() methods from RawCustomResourceOperationsImpl taking InputStream arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
     suffixed with the specification version, e.g. `mycrplural.group.example.com-v1.yml`
   - The CRD files are generated in the `target/META-INF/fabric8` directory of your project
 
-_**Note**_: Breaking changes in the API
+#### _**Note**_: Breaking changes in the API
 ##### DSL Changes:
 - `client.settings()` DSL has been removed since PodPreset v1alpha1 API is no longer present in Kubernetes 1.20.x
 - `client.customResourceDefinitions()` has been removed. Use `client.apiextensions().v1beta1().customResourceDefinitions()` instead

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -254,7 +254,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     throw new KubernetesClientException("Cannot edit read-only resources");
   }
 
-  @Override 
+  @Override
   public <V> T edit(final Class<V> visitorType, final Visitor<V> visitor) {
     return edit(new TypedVisitor<V>() {
         @Override
@@ -1085,14 +1085,18 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return apiVersion != null && apiVersion.indexOf('/') > 0;
   }
 
+  public Readiness getReadiness() {
+    return Readiness.getInstance();
+  }
+
   @Override
-  public Boolean isReady() {
-    return Readiness.isReady(get());
+  public final Boolean isReady() {
+    return getReadiness().isReady(get());
   }
 
   @Override
   public T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
-    return waitUntilCondition(resource -> Objects.nonNull(resource) && Readiness.isReady(resource), amount, timeUnit);
+    return waitUntilCondition(resource -> Objects.nonNull(resource) && getReadiness().isReady(resource), amount, timeUnit);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -242,9 +242,13 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
     return h.watch(client, config, meta.getMetadata().getNamespace(), meta, options, watcher);
   }
 
+  protected Readiness getReadiness() {
+    return Readiness.getInstance();
+  }
+
   @Override
-  public Boolean isReady() {
-    return Readiness.isReady(get());
+  public final Boolean isReady() {
+    return getReadiness().isReady(get());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -206,7 +206,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
   @Override
   public Boolean isReady() {
     for (final HasMetadata meta : acceptVisitors(get(), visitors)) {
-      if (!isResourceReady(meta)) {
+      if (!getReadiness().isReady(meta)) {
         return false;
       }
     }
@@ -403,11 +403,11 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(client, config, fallbackNamespace, explicitNamespace, fromServer, true, visitors, item, null, null, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }
 
-  protected boolean isResourceReady(HasMetadata meta) {
-    return Readiness.isReady(meta);
+  protected Readiness getReadiness() {
+    return Readiness.getInstance();
   }
 
-  protected <T> List<HasMetadata> asHasMetadata(T item, Boolean enableProccessing) {
+  protected <T> List<HasMetadata> asHasMetadata(T item, Boolean enableProcessing) {
     List<HasMetadata> result = new ArrayList<>();
     if (item instanceof KubernetesList) {
       result.addAll(((KubernetesList) item).getItems());
@@ -417,7 +417,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
       result.add((HasMetadata) item);
     }  else if (item instanceof String) {
       try (InputStream is = new ByteArrayInputStream(((String)item).getBytes(StandardCharsets.UTF_8))) {
-        return asHasMetadata(unmarshal(is), enableProccessing);
+        return asHasMetadata(unmarshal(is), enableProcessing);
       } catch (IOException e) {
         throw KubernetesClientException.launderThrowable(e);
       }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/Readiness.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/Readiness.java
@@ -38,8 +38,6 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 public class Readiness {
@@ -48,6 +46,7 @@ public class Readiness {
   private static final String NODE_READY = "Ready";
   private static final String TRUE = "True";
   private static final Logger logger = LoggerFactory.getLogger(Readiness.class);
+  private static final String READINESS_APPLICABLE_RESOURCES = "Node, Deployment, ReplicaSet, StatefulSet, Pod, ReplicationController";
 
   public static boolean isReadinessApplicable(Class<? extends HasMetadata> itemClass) {
     return Deployment.class.isAssignableFrom(itemClass)
@@ -65,28 +64,19 @@ public class Readiness {
     if (isReadiableKubernetesResource(item)) {
       return isKubernetesResourceReady(item);
     } else {
-      return handleNonReadinessApplicableResource(item, getReadinessApplicableResourcesList());
+      return handleNonReadinessApplicableResource(item, getReadinessApplicableResources());
     }
   }
 
-  public static boolean handleNonReadinessApplicableResource(HasMetadata item, List<String> readinessApplicableResources) {
+  public static boolean handleNonReadinessApplicableResource(HasMetadata item, String readinessApplicableResourcesStr) {
     boolean doesItemExist = Objects.nonNull(item);
-    String readinessApplicableResourcesStr = String.join(",", readinessApplicableResources);
     logger.warn("{} is not a Readiableresource. It needs to be one of [{}]",
       doesItemExist ? item.getKind() : "Unknown", readinessApplicableResourcesStr);
     return doesItemExist;
   }
 
-  public static List<String> getReadinessApplicableResourcesList() {
-    List<String> readinessApplicableResources = new ArrayList<>();
-    readinessApplicableResources.add("Node");
-    readinessApplicableResources.add("Deployment");
-    readinessApplicableResources.add("ReplicaSet");
-    readinessApplicableResources.add("StatefulSet");
-    readinessApplicableResources.add("Pod");
-    readinessApplicableResources.add("ReplicationController");
-
-    return readinessApplicableResources;
+  public static String getReadinessApplicableResources() {
+    return READINESS_APPLICABLE_RESOURCES;
   }
 
   private static boolean isKubernetesResourceReady(HasMetadata item) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessWatcher.java
@@ -38,7 +38,7 @@ public class ReadinessWatcher<T extends HasMetadata> implements Watcher<T> {
   public void eventReceived(Action action, T resource) {
     switch (action) {
       case MODIFIED:
-        if (Readiness.isReady(resource)) {
+        if (Readiness.getInstance().isReady(resource)) {
           reference.set(resource);
           latch.countDown();
         }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -356,7 +356,7 @@ public class KubernetesResourceUtil {
    * @return boolean value indicating it's status
    */
   public static boolean isResourceReady(HasMetadata item) {
-    return Readiness.isReady(item);
+    return Readiness.getInstance().isReady(item);
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessTest.java
@@ -15,56 +15,63 @@
  */
 package io.fabric8.kubernetes.client.internal.readiness;
 
-import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ReadinessTest {
+class ReadinessTest {
+
+  private Readiness readiness;
+
+  @BeforeEach
+  void setUp() {
+    readiness = Readiness.getInstance();
+  }
 
   @Test
-  public void testStatefulSetReadinessNoSpecNoStatus() {
+  void testStatefulSetReadinessNoSpecNoStatus() {
     StatefulSet statefulSet = new StatefulSet();
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
-  public void testStatefulSetReadinessNoSpec() {
+  void testStatefulSetReadinessNoSpec() {
     StatefulSetStatus status = new StatefulSetStatus();
 
     StatefulSet statefulSet = new StatefulSet();
     statefulSet.setStatus(status);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
 
     status.setReadyReplicas(1);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
-  public void testStatefulSetReadinessNoStatus() {
+  void testStatefulSetReadinessNoStatus() {
     StatefulSetSpec spec = new StatefulSetSpec();
     spec.setReplicas(1);
 
     StatefulSet statefulSet = new StatefulSet();
     statefulSet.setSpec(spec);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
 
   }
 
   @Test
-  public void testStatefulSetReadinessNotEnoughReadyReplicas() {
+  void testStatefulSetReadinessNotEnoughReadyReplicas() {
     StatefulSetStatus status = new StatefulSetStatus();
     status.setReadyReplicas(1);
     status.setReplicas(2);
@@ -76,12 +83,12 @@ public class ReadinessTest {
     statefulSet.setStatus(status);
     statefulSet.setSpec(spec);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
-  public void testStatefulSetReadiness() {
+  void testStatefulSetReadiness() {
     StatefulSetStatus status = new StatefulSetStatus();
     status.setReadyReplicas(2);
     status.setReplicas(2);
@@ -93,17 +100,17 @@ public class ReadinessTest {
     statefulSet.setStatus(status);
     statefulSet.setSpec(spec);
 
-    assertTrue(Readiness.isReady(statefulSet));
+    assertTrue(readiness.isReady(statefulSet));
     assertTrue(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
   void testReadinessWithNonNullResource() {
-    assertTrue(Readiness.isReady(new ServiceBuilder().withNewMetadata().withName("svc1").endMetadata().build()));
+    assertTrue(readiness.isReady(new ServiceBuilder().withNewMetadata().withName("svc1").endMetadata().build()));
   }
 
   @Test
   void testReadinessNullResource() {
-    assertFalse(Readiness.isReady(null));
+    assertFalse(readiness.isReady(null));
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.kubernetes.client.internal.readiness;
 
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
@@ -93,5 +95,15 @@ public class ReadinessTest {
 
     assertTrue(Readiness.isReady(statefulSet));
     assertTrue(Readiness.isStatefulSetReady(statefulSet));
+  }
+
+  @Test
+  void testReadinessWithNonNullResource() {
+    assertTrue(Readiness.isReady(new ServiceBuilder().withNewMetadata().withName("svc1").endMetadata().build()));
+  }
+
+  @Test
+  void testReadinessNullResource() {
+    assertFalse(Readiness.isReady(null));
   }
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeploymentIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeploymentIT.java
@@ -90,7 +90,7 @@ public class DeploymentIT {
     await().atMost(120, TimeUnit.SECONDS).until(deploymentReady);
     Deployment deploymentOne = client.apps().deployments()
       .inNamespace(session.getNamespace()).withName("deployment-wait").get();
-    assertTrue(Readiness.isDeploymentReady(deploymentOne));
+    assertTrue(Readiness.getInstance().isDeploymentReady(deploymentOne));
   }
 
   @Test

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -166,7 +166,7 @@ public class PodIT {
     // cant evict because only one left
     assertFalse(client.pods().inNamespace(session.getNamespace()).withName(pod1.getMetadata().getName()).evict());
     // ensure it really is still up
-    assertTrue(Readiness.isReady(client.pods().inNamespace(session.getNamespace()).withName(pod1.getMetadata().getName()).fromServer().get()));
+    assertTrue(Readiness.getInstance().isReady(client.pods().inNamespace(session.getNamespace()).withName(pod1.getMetadata().getName()).fromServer().get()));
 
     // create another pod to satisfy PDB
     client.pods().inNamespace(session.getNamespace()).createOrReplace(pod3);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceIT.java
@@ -26,7 +26,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
-import org.assertj.core.internal.bytebuddy.build.ToStringPlugin;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -223,6 +222,22 @@ public class ServiceIT {
     assertEquals("serviceit-externalname-createorreplace", service.getMetadata().getName());
     assertEquals("ExternalName", service.getSpec().getType());
     assertEquals("his.database.example.com", service.getSpec().getExternalName());
+  }
+
+  @Test
+  public void waitUntilReady() throws InterruptedException {
+    // Given
+    String svcName = "service-wait-until-ready";
+
+    // When
+    Service service = client.services().inNamespace(session.getNamespace())
+      .withName(svcName)
+      .waitUntilReady(10, TimeUnit.SECONDS);
+
+    // Then
+    assertNotNull(service);
+    assertEquals(svcName, service.getMetadata().getName());
+    assertTrue(client.pods().inNamespace(session.getNamespace()).withName(svcName).delete());
   }
 
   @AfterClass

--- a/kubernetes-itests/src/test/resources/service-it.yml
+++ b/kubernetes-itests/src/test/resources/service-it.yml
@@ -95,3 +95,32 @@ spec:
       protocol: TCP
       port: 443
       targetPort: 9377
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-wait-until-ready
+spec:
+  selector:
+    app: service-wait-until-ready
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: service-wait-until-ready
+  labels:
+    app: service-wait-until-ready
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      command: ["sleep", "36000"]
+      ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.client.OpenShiftConfig;
@@ -30,8 +31,6 @@ import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>>
   extends HasMetadataOperation<T, L, R> {
@@ -102,13 +101,8 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
   }
 
   @Override
-  public Boolean isReady() {
-    return OpenShiftReadiness.isReady(get());
-  }
-
-  @Override
-  public T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
-    return waitUntilCondition(resource -> Objects.nonNull(resource) && OpenShiftReadiness.isReady(resource), amount, timeUnit);
+  public Readiness getReadiness() {
+    return OpenShiftReadiness.getInstance();
   }
 
   private void updateApiVersion() {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 import okhttp3.OkHttpClient;
 
@@ -35,7 +36,7 @@ public class OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicab
   }
 
   @Override
-  public Boolean isReady() {
-    return OpenShiftReadiness.isReady(get());
+  protected Readiness getReadiness() {
+    return OpenShiftReadiness.getInstance();
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -54,8 +54,9 @@ public class OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicab
     super(client, config, namespace, explicitNamespace, fromServer, deletingExisting, visitors, item, inputStream, parameters, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }
 
-  protected boolean isResourceReady(HasMetadata meta) {
-    return OpenShiftReadiness.isReady(meta);
+  @Override
+  protected OpenShiftReadiness getReadiness() {
+    return OpenShiftReadiness.getInstance();
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
@@ -22,6 +22,9 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import io.fabric8.openshift.api.model.DeploymentConfigStatus;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class OpenShiftReadiness extends Readiness {
   public static boolean isReadinessApplicable(Class<? extends HasMetadata> itemClass) {
     return Readiness.isReadinessApplicable(itemClass)
@@ -35,7 +38,7 @@ public class OpenShiftReadiness extends Readiness {
     } else if (item instanceof DeploymentConfig) {
       return isDeploymentConfigReady((DeploymentConfig) item);
     } else {
-      throw new IllegalArgumentException("Item needs to be one of [Node, Deployment, ReplicaSet, StatefulSet, Pod, DeploymentConfig, ReplicationController], but was: [" + (item != null ? item.getKind() : "Unknown (null)") + "]");
+      return handleNonReadinessApplicableResource(item, getOpenShiftReadinessApplicableResourcesList());
     }
   }
 
@@ -55,5 +58,12 @@ public class OpenShiftReadiness extends Readiness {
 
     return spec.getReplicas().intValue() == status.getReplicas() &&
       spec.getReplicas() <= status.getAvailableReplicas();
+  }
+
+  private static List<String> getOpenShiftReadinessApplicableResourcesList() {
+    List<String> openShiftReadinessApplicableResources = new ArrayList<>(Readiness.getReadinessApplicableResourcesList());
+    openShiftReadinessApplicableResources.add("DeploymentConfig");
+
+    return openShiftReadinessApplicableResources;
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
@@ -22,10 +22,8 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import io.fabric8.openshift.api.model.DeploymentConfigStatus;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class OpenShiftReadiness extends Readiness {
+  private static final String OPENSHIFT_READINESS_APPLICABLE_RESOURCES = "DeploymentConfig";
   public static boolean isReadinessApplicable(Class<? extends HasMetadata> itemClass) {
     return Readiness.isReadinessApplicable(itemClass)
       || DeploymentConfig.class.isAssignableFrom(itemClass)
@@ -38,7 +36,7 @@ public class OpenShiftReadiness extends Readiness {
     } else if (item instanceof DeploymentConfig) {
       return isDeploymentConfigReady((DeploymentConfig) item);
     } else {
-      return handleNonReadinessApplicableResource(item, getOpenShiftReadinessApplicableResourcesList());
+      return handleNonReadinessApplicableResource(item, getOpenShiftReadinessApplicableResources());
     }
   }
 
@@ -60,10 +58,7 @@ public class OpenShiftReadiness extends Readiness {
       spec.getReplicas() <= status.getAvailableReplicas();
   }
 
-  private static List<String> getOpenShiftReadinessApplicableResourcesList() {
-    List<String> openShiftReadinessApplicableResources = new ArrayList<>(Readiness.getReadinessApplicableResourcesList());
-    openShiftReadinessApplicableResources.add("DeploymentConfig");
-
-    return openShiftReadinessApplicableResources;
+  private static String getOpenShiftReadinessApplicableResources() {
+    return Readiness.getReadinessApplicableResources() + ", " + OPENSHIFT_READINESS_APPLICABLE_RESOURCES;
   }
 }

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadinessTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadinessTest.java
@@ -15,15 +15,25 @@
  */
 package io.fabric8.openshift.client.internal.readiness;
 
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OpenShiftReadinessTest {
+
+  private Readiness readiness;
+
+  @BeforeEach
+  void setUp() {
+    readiness = OpenShiftReadiness.getInstance();
+  }
+
   @Test
   void testOpenShiftReadinessWithDeploymentConfig() {
     DeploymentConfig dc = new DeploymentConfigBuilder()
@@ -31,16 +41,16 @@ class OpenShiftReadinessTest {
       .withNewStatus().withAvailableReplicas(2).withReplicas(2).endStatus()
       .build();
 
-    assertTrue(OpenShiftReadiness.isReady(dc));
+    assertTrue(readiness.isReady(dc));
   }
 
   @Test
   void testOpenShiftReadinessWithNonReadinessApplicableResource() {
-    assertTrue(OpenShiftReadiness.isReady(new ImageStreamBuilder().withNewMetadata().withName("is1").endMetadata().build()));
+    assertTrue(readiness.isReady(new ImageStreamBuilder().withNewMetadata().withName("is1").endMetadata().build()));
   }
 
   @Test
   void testOpenShiftReadinessWithNullResource() {
-    assertFalse(OpenShiftReadiness.isReady(null));
+    assertFalse(readiness.isReady(null));
   }
 }

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadinessTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadinessTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.internal.readiness;
+
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenShiftReadinessTest {
+  @Test
+  void testOpenShiftReadinessWithDeploymentConfig() {
+    DeploymentConfig dc = new DeploymentConfigBuilder()
+      .withNewSpec().withReplicas(2).endSpec()
+      .withNewStatus().withAvailableReplicas(2).withReplicas(2).endStatus()
+      .build();
+
+    assertTrue(OpenShiftReadiness.isReady(dc));
+  }
+
+  @Test
+  void testOpenShiftReadinessWithNonReadinessApplicableResource() {
+    assertTrue(OpenShiftReadiness.isReady(new ImageStreamBuilder().withNewMetadata().withName("is1").endMetadata().build()));
+  }
+
+  @Test
+  void testOpenShiftReadinessWithNullResource() {
+    assertFalse(OpenShiftReadiness.isReady(null));
+  }
+}


### PR DESCRIPTION
Fix #2672 

Use `waitUntilCondition(Objects::nonNull, amount, timeUnit)` instead of waitUntilReady for `Service` resource

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
