### PR TITLE
Fix #2716: Add a property to disable BackwardCompatibilityInterceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix #2757: add `storage` and `served` to `Version` annotation
 * Fix #2759: add `ShortNames` annotation to specify short names for CRD generation
 * Fix #2694: Remove deprecated methods from KubernetesClient DSL
+* Fix #2716: Add a property to disable BackwardCompatibilityInterceptor
 
 #### Dependency Upgrade
 * update Tekton Triggers model to v0.11.1

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ System properties are preferred over environment variables. The following system
 | `kubernetes.truststore.passphrase` / `KUBERNETES_TRUSTSTORE_PASSPHRASE` | | |
 | `kubernetes.keystore.file` / `KUBERNETES_KEYSTORE_FILE` | | |
 | `kubernetes.keystore.passphrase` / `KUBERNETES_KEYSTORE_PASSPHRASE` | | |
+| `kubernetes.backwardsCompatibilityInterceptor.disable` / `KUBERNETES_BACKWARDS_COMPATIBILITY_INTERCEPTOR_DISABLE` | `Disable BackwardsCompatibilityInterceptor`| `false` |
 
 Alternatively you can use the `ConfigBuilder` to create a config object for the Kubernetes client:
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import okhttp3.Interceptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.KUBERNETES_BACKWARDS_COMPATIBILITY_INTERCEPTOR_DISABLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpClientUtilsTest {
+  @Test
+  void testCreateApplicableInterceptors() {
+    // Given
+    Config config = new ConfigBuilder().build();
+
+    // When
+    List<Interceptor> interceptorList = HttpClientUtils.createApplicableInterceptors(config);
+
+    // Then
+    assertThat(interceptorList)
+      .isNotNull()
+      .hasSize(4)
+      .hasAtLeastOneElementOfType(BackwardsCompatibilityInterceptor.class)
+      .hasAtLeastOneElementOfType(ImpersonatorInterceptor.class)
+      .hasAtLeastOneElementOfType(TokenRefreshInterceptor.class);
+  }
+
+  @Test
+  void testCreateApplicableInterceptorsWithBackwardsCompatibilityDisabled() {
+    // Given
+    Config config = new ConfigBuilder().build();
+    System.setProperty(KUBERNETES_BACKWARDS_COMPATIBILITY_INTERCEPTOR_DISABLE, "true");
+
+    // When
+    List<Interceptor> interceptorList = HttpClientUtils.createApplicableInterceptors(config);
+
+    // Then
+    assertThat(interceptorList)
+      .isNotNull()
+      .hasSize(3)
+      .noneMatch(i -> i instanceof BackwardsCompatibilityInterceptor)
+      .hasAtLeastOneElementOfType(ImpersonatorInterceptor.class)
+      .hasAtLeastOneElementOfType(TokenRefreshInterceptor.class);
+    System.clearProperty(KUBERNETES_BACKWARDS_COMPATIBILITY_INTERCEPTOR_DISABLE);
+  }
+}


### PR DESCRIPTION
Fix #2716 
Added a flag "kubernetes.disable.backwardsCompatibilityInterceptor"
which will skip addition of BackwardCompatibilityInterceptor in
OkHttpClient created in HttpClientUtils.createHTTPClient

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
