### PR TITLE
Fix #2745: Filtering Operations can't configure PropagationPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #2748: Pass custom headers in kubernetes-client to watch api by modify WatchConnectionManager
+* Fix #2745: Filtering Operations can't configure PropagationPolicy
 
 #### Improvements
 * Fix #2717: Remove edit() methods from RawCustomResourceOperationsImpl taking InputStream arguments

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
@@ -16,9 +16,11 @@
 package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.GracePeriodConfigurable;
+import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
 
 public interface WatchListDeletable<T, L> extends VersionWatchAndWaitable<T>, Listable<L>, Deletable,
                                                         GracePeriodConfigurable<Deletable>,
+                                                        PropagationPolicyConfigurable<EditReplacePatchDeletable<T>>,
                                                         StatusUpdatable<T>
 {
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.api.model.ObjectReference;
@@ -25,6 +26,7 @@ import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Deletable;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
@@ -137,6 +139,9 @@ class PodOperationUtilTest {
 
   private FilterWatchListDeletable<Pod, PodList> getMockPodFilterOperation(String controllerUid) {
     return new FilterWatchListDeletable<Pod, PodList>() {
+      @Override
+      public EditReplacePatchDeletable<Pod> withPropagationPolicy(DeletionPropagation propagationPolicy) { return null; }
+
       @Override
       public Deletable withGracePeriod(long gracePeriodSeconds) { return null; }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
@@ -15,9 +15,6 @@
  */
 package io.fabric8.kubernetes.client.mock;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
@@ -26,7 +23,9 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceListBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.batch.JobBuilder;
@@ -36,14 +35,20 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.mock.crd.PodSet;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.util.Map;
+import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Rule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableRuleMigrationSupport
 class PropagationPolicyTest {
@@ -413,6 +418,67 @@ class PropagationPolicyTest {
     // Then
     assertTrue(isDeleted);
     assertDeleteOptionsInLastRecordedRequest(DeletionPropagation.BACKGROUND.toString(), server.getLastRequest());
+  }
+
+  @Test
+  void testFilterWithLabelDeletion() throws InterruptedException {
+    // Given
+    KubernetesClient kubernetesClient = setMockExpectationsForFilterDeletionAndGetClient("labelSelector=myLabel");
+
+    // When
+    Boolean isDeleted = kubernetesClient.services().inNamespace("myNameSpace").withLabel("myLabel").withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
+
+    // Then
+    assertTrue(isDeleted);
+    RecordedRequest recordedRequest = server.getLastRequest();
+    assertEquals("DELETE", recordedRequest.getMethod());
+    assertDeleteOptionsInLastRecordedRequest(DeletionPropagation.BACKGROUND.toString(), recordedRequest);
+  }
+
+  @Test
+  void testFilterWithLabelsDeletion() throws InterruptedException {
+    // Given
+    KubernetesClient kubernetesClient = setMockExpectationsForFilterDeletionAndGetClient("labelSelector=" + Utils.toUrlEncoded("foo=bar"));
+
+    // When
+    Boolean isDeleted = kubernetesClient.services().inNamespace("myNameSpace").withLabels(Collections.singletonMap("foo", "bar")).withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
+
+    // Then
+    assertTrue(isDeleted);
+    RecordedRequest recordedRequest = server.getLastRequest();
+    assertEquals("DELETE", recordedRequest.getMethod());
+    assertDeleteOptionsInLastRecordedRequest(DeletionPropagation.BACKGROUND.toString(), recordedRequest);
+  }
+
+  @Test
+  void testFilterWithFieldDeletion() throws InterruptedException {
+    // Given
+    KubernetesClient kubernetesClient = setMockExpectationsForFilterDeletionAndGetClient("fieldSelector=" + Utils.toUrlEncoded("status.phase=Running"));
+
+    // When
+    Boolean isDeleted = kubernetesClient.services().inNamespace("myNameSpace").withField("status.phase", "Running").withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
+
+    // Then
+    assertTrue(isDeleted);
+    RecordedRequest recordedRequest = server.getLastRequest();
+    assertEquals("DELETE", recordedRequest.getMethod());
+    assertDeleteOptionsInLastRecordedRequest(DeletionPropagation.BACKGROUND.toString(), recordedRequest);
+
+  }
+
+  private KubernetesClient setMockExpectationsForFilterDeletionAndGetClient(String filter) {
+    Service svc1 = new ServiceBuilder().withNewMetadata().withName("svc1").endMetadata().build();
+    Service svc2 = new ServiceBuilder().withNewMetadata().withName("svc2").endMetadata().build();
+    server.expect().get().withPath("/api/v1/namespaces/myNameSpace/services?" + filter)
+      .andReturn(HttpURLConnection.HTTP_OK, new ServiceListBuilder().addToItems(svc1, svc2).build())
+      .once();
+    server.expect().delete().withPath("/api/v1/namespaces/myNameSpace/services/svc1")
+      .andReturn(HttpURLConnection.HTTP_OK, svc1)
+      .once();
+    server.expect().delete().withPath("/api/v1/namespaces/myNameSpace/services/svc2")
+      .andReturn(HttpURLConnection.HTTP_OK, svc2)
+      .once();
+    return server.getClient();
   }
 
   private void assertDeleteOptionsInLastRecordedRequest(String propagationPolicy, RecordedRequest recordedRequest) {


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #2745 
Add `PropagationPolicyConfigurable<EditReplacePatchDeletable<T>>` to `WatchListDeletable` interface so that it's available in all `Filterable<T>` methods

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
