### PR TITLE
fix: Replace double-checked locking idiom with initialization-on-demand holder idiom

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/Readiness.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/Readiness.java
@@ -49,15 +49,12 @@ public class Readiness {
   protected static final String READINESS_APPLICABLE_RESOURCES =
     "Node, Deployment, ReplicaSet, StatefulSet, Pod, ReplicationController";
 
-  private static Readiness instance;
+  private static class ReadinessHolder {
+    public static final Readiness INSTANCE = new Readiness();
+  }
 
   public static Readiness getInstance() {
-    if (instance == null) {
-      synchronized (Readiness.class) {
-        instance = new Readiness();
-      }
-    }
-    return instance;
+    return ReadinessHolder.INSTANCE;
   }
 
   /**

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadiness.java
@@ -27,15 +27,12 @@ public class OpenShiftReadiness extends Readiness {
   private static final String OPENSHIFT_READINESS_APPLICABLE_RESOURCES = READINESS_APPLICABLE_RESOURCES +
     ", " + "DeploymentConfig";
 
-  private static OpenShiftReadiness instance;
+  private static class OpenShiftReadinessHolder {
+    public static final OpenShiftReadiness INSTANCE = new OpenShiftReadiness();
+  }
 
   public static OpenShiftReadiness getInstance() {
-    if (instance == null) {
-      synchronized (OpenShiftReadiness.class) {
-        instance = new OpenShiftReadiness();
-      }
-    }
-    return instance;
+    return OpenShiftReadinessHolder.INSTANCE;
   }
 
   @Override


### PR DESCRIPTION
## Description
fix: Replace double-checked locking idiom with the more suitable initialization-on-demand holder idiom

Initial implementation of the singleton contained a typo (missing `volatile` variable declaration).
Since this pattern is [dangerous](https://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html) and [not](https://www.infoworld.com/article/2074979/double-checked-locking--clever--but-broken.html?page=2) [recommended](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2168), I replaced it with the more suitable (for this case) [Initialization-on-demand holder idiom](https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom).

cc: @Ladicek 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
