### PR TITLE
Fix #2781: RawCustomResourceOperationsImpl#delete should return a boolean value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #2781: RawCustomResourceOperationsImpl#delete now returns a boolean value for deletion status
 
 #### Dependency Upgrade
 

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawCustomResourceIT.java
@@ -146,8 +146,8 @@ public class RawCustomResourceIT {
     assertAnimal(bison, "bison", "bison-bonasus");
 
     // Delete
-    Map<String, Object> deletionStatusMap = client.customResource(customResourceDefinitionContext).delete(currentNamespace, name);
-    assertDeletionStatus(deletionStatusMap, "Success");
+    boolean isDeleted = client.customResource(customResourceDefinitionContext).delete(currentNamespace, name);
+    assertTrue(isDeleted);
   }
 
   @Test
@@ -163,8 +163,8 @@ public class RawCustomResourceIT {
     assertAnimal(hippoCr, name, "Hippopotamidae");
 
     // Delete
-    Map<String, Object> deletionStatusMap = client.customResource(customResourceDefinitionContext).delete(currentNamespace, name);
-    assertDeletionStatus(deletionStatusMap, "Success");
+    boolean isDeleted = client.customResource(customResourceDefinitionContext).delete(currentNamespace, name);
+    assertTrue(isDeleted);
   }
 
   @Test
@@ -189,8 +189,8 @@ public class RawCustomResourceIT {
     assertAnimal(rhinoCr, name, "rhinoceros");
 
     // Delete
-    Map<String, Object> deletionStatusMap = client.customResource(customResourceDefinitionContext).delete(currentNamespace, name);
-    assertDeletionStatus(deletionStatusMap, "Success");
+    boolean isDeleted = client.customResource(customResourceDefinitionContext).delete(currentNamespace, name);
+    assertTrue(isDeleted);
   }
 
   @Test
@@ -238,6 +238,12 @@ public class RawCustomResourceIT {
     assertEquals("endangered", ((Map<String, Object>)deer.get("status")).get("conservationStatus").toString());
   }
 
+  @Test
+  public void testDeleteNonExistingResource() throws IOException {
+    boolean isDeleted = client.customResource(customResourceDefinitionContext).delete(currentNamespace, "idontexist");
+    assertFalse(isDeleted);
+  }
+
   @AfterClass
   public static void cleanup() {
     ClusterEntity.remove(RawCustomResourceIT.class.getResourceAsStream("/test-rawcustomresource-definition.yml"));
@@ -248,12 +254,6 @@ public class RawCustomResourceIT {
     assertFalse(animal.isEmpty());
     assertThat(((HashMap<String, String>)animal.get("metadata")).get("name")).isEqualTo(name);
     assertThat(((HashMap<String, String>)animal.get("spec")).get("image")).isEqualTo(image);
-  }
-
-  private void assertDeletionStatus(Map<String, Object> deletionStatusAsMap, String status) {
-    Status deletionStatus = Serialization.jsonMapper().convertValue(deletionStatusAsMap, Status.class);
-    assertNotNull(deletionStatus);
-    assertEquals(status, deletionStatus.getStatus());
   }
 
   private Map<String, Object> createNewAnimal(String name, String image) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
@@ -391,7 +391,7 @@ class PropagationPolicyTest {
     KubernetesClient client = server.getClient();
 
     // When
-    Map<String, Object> result = client.customResource(new CustomResourceDefinitionContext.Builder()
+    boolean result = client.customResource(new CustomResourceDefinitionContext.Builder()
       .withGroup("test.fabric8.io")
       .withName("hellos.test.fabric8.io")
       .withPlural("hellos")
@@ -401,6 +401,7 @@ class PropagationPolicyTest {
       .delete("ns1", "example-hello");
 
     // Then
+    assertTrue(result);
     assertDeleteOptionsInLastRecordedRequest(DeletionPropagation.BACKGROUND.toString(), server.getLastRequest());
   }
 


### PR DESCRIPTION
Fix #2781 

Align RawCustomResource delete API to return a boolean value indicating
status for deletion just like we have in regular DSL. Right now we're
just throwing an exception in case item doesn't exist in server.

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
