### PR TITLE
fix: simple enums are now supported when generating CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Apiextensions DSL should use NonNamespaceOperation for CustomResourceDefinitions
+* Fix #2819: simple enums are now supported when generating CRDs
 * CNFE when initialzing CustomResource instances
 
 #### Improvements

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -64,16 +64,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/crd-generator/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.crd.generator;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.fabric8.crd.generator.utils.Types;
 import io.fabric8.kubernetes.api.model.Duration;
 import io.fabric8.kubernetes.api.model.IntOrString;
@@ -183,7 +185,18 @@ public abstract class AbstractJsonSchema<T, B> {
         if (typeRef instanceof ClassRef) { // Handle complex types
           ClassRef classRef = (ClassRef) typeRef;
           TypeDef def = classRef.getDefinition();
-          return internalFrom(def);
+
+          // check if we're dealing with an enum
+          if(def.isEnum()) {
+            final JsonNode[] enumValues = def.getProperties().stream()
+              .map(Property::getName)
+              .map(JsonNodeFactory.instance::textNode)
+              .toArray(JsonNode[]::new);
+            return enumProperty(enumValues);
+          } else {
+            return internalFrom(def);
+          }
+
         }
         return null;
       }
@@ -214,4 +227,5 @@ public abstract class AbstractJsonSchema<T, B> {
    */
   protected abstract T singleProperty(String typeName);
 
+  protected abstract T enumProperty(JsonNode... enumValues);
 }

--- a/crd-generator/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -190,6 +190,7 @@ public abstract class AbstractJsonSchema<T, B> {
           if(def.isEnum()) {
             final JsonNode[] enumValues = def.getProperties().stream()
               .map(Property::getName)
+              .filter(n -> !n.startsWith("$"))
               .map(JsonNodeFactory.instance::textNode)
               .toArray(JsonNode[]::new);
             return enumProperty(enumValues);

--- a/crd-generator/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.generator.v1;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.generator.AbstractJsonSchema;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsBuilder;
@@ -77,13 +78,16 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
 
   @Override
   protected JSONSchemaProps singleProperty(String typeName) {
-    return new JSONSchemaPropsBuilder()
-      .withType(typeName)
-      .build();
+    return new JSONSchemaPropsBuilder().withType(typeName).build();
   }
 
   @Override
   protected JSONSchemaProps mappedProperty(TypeRef ref) {
     return JSON_SCHEMA_INT_OR_STRING;
+  }
+
+  @Override
+  protected JSONSchemaProps enumProperty(JsonNode... enumValues) {
+    return new JSONSchemaPropsBuilder().withType("string").withEnum(enumValues).build();
   }
 }

--- a/crd-generator/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.generator.v1beta1;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.generator.AbstractJsonSchema;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsBuilder;
@@ -86,5 +87,10 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   @Override
   protected JSONSchemaProps mappedProperty(TypeRef ref) {
     return JSON_SCHEMA_INT_OR_STRING;
+  }
+
+  @Override
+  protected JSONSchemaProps enumProperty(JsonNode... enumValues) {
+    return new JSONSchemaPropsBuilder().withType("string").withEnum(enumValues).build();
   }
 }

--- a/crd-generator/src/test/java/io/fabric8/crd/example/person/Address.java
+++ b/crd-generator/src/test/java/io/fabric8/crd/example/person/Address.java
@@ -20,4 +20,9 @@ public class Address {
   private int number;
   private String zip;
   private String country;
+  private Type type;
+
+  public enum Type {
+    home, work;
+  }
 }

--- a/crd-generator/src/test/java/io/fabric8/crd/example/person/Person.java
+++ b/crd-generator/src/test/java/io/fabric8/crd/example/person/Person.java
@@ -26,5 +26,9 @@ public class Person {
   private int birthYear;
   private List<String> hobbies;
   private List<Address> addresses;
+  private Type type;
 
+  public enum Type {
+    crazy, crazier;
+  }
 }

--- a/crd-generator/src/test/java/io/fabric8/crd/generator/utils/TypesTest.java
+++ b/crd-generator/src/test/java/io/fabric8/crd/generator/utils/TypesTest.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.crd.generator.utils;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.fabric8.crd.example.webserver.WebServerWithStatusProperty;
 import io.sundr.codegen.functions.ClassTo;

--- a/crd-generator/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -15,12 +15,18 @@
  */
 package io.fabric8.crd.generator.v1;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.example.person.Person;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 import io.sundr.codegen.functions.ClassTo;
 import io.sundr.codegen.model.TypeDef;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class JsonSchemaTest {
@@ -30,6 +36,22 @@ class JsonSchemaTest {
     TypeDef person = ClassTo.TYPEDEF.apply(Person.class);
     JSONSchemaProps schema = JsonSchema.from(person);
     assertNotNull(schema);
+    final Map<String, JSONSchemaProps> properties = schema.getProperties();
+    assertEquals(7, properties.size());
+    final List<String> personTypes = properties.get("type").getEnum().stream().map(JsonNode::asText)
+      .collect(Collectors.toList());
+    assertEquals(2, personTypes.size());
+    assertTrue(personTypes.contains("crazy"));
+    assertTrue(personTypes.contains("crazier"));
+    final Map<String, JSONSchemaProps> addressProperties = properties.get("addresses").getItems()
+      .getSchema().getProperties();
+    assertEquals(5, addressProperties.size());
+    final List<String> addressTypes = addressProperties.get("type").getEnum().stream()
+      .map(JsonNode::asText)
+      .collect(Collectors.toList());
+    assertEquals(2, addressTypes.size());
+    assertTrue(addressTypes.contains("home"));
+    assertTrue(addressTypes.contains("work"));
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Core versions -->
-    <sundrio.version>0.24.2</sundrio.version>
+    <sundrio.version>0.24.3</sundrio.version>
     <okhttp.version>3.12.12</okhttp.version>
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
`Types.applyTypeArguments` doesn't crash when encountering differing
cardinality between type definition and actual arguments, which was the
case when encountering an enum property. Such properties are now
generated by enumerating their cases name and recording them in the
validation schema. Not sure if that actually covers all cases.

Fixes #2819.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
