### PR TITLE
Issue-2766: Replace occurrences of Function<T, T> with UnaryOperator<T>

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Pluralize.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Pluralize.java
@@ -22,12 +22,13 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Pluralize implements UnaryOperator<String> {
+public class Pluralize implements UnaryOperator<String>
+{
 
   private static Pluralize INSTANCE = null;
   private static final Object LOCK = new Object();
   private static final List<String> UNCOUNTABLE = Arrays.asList("equipment", "fish", "information", "money", "rice", "series", "sheep", "species");
-  private static final List<UnaryOperator<String>> PLURALS = Arrays.<Function<String, String>>asList(
+  private static final List<UnaryOperator<String>> PLURALS = Arrays.<UnaryOperator<String>>asList(
             //Irregulars
             new StringReplace("(p)eople$", "$1erson"),
             new StringReplace("(m)en$", "$1an"),

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Pluralize.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Pluralize.java
@@ -18,15 +18,16 @@ package io.fabric8.kubernetes.client.utils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Pluralize implements Function<String, String> {
+public class Pluralize implements UnaryOperator<String> {
 
   private static Pluralize INSTANCE = null;
   private static final Object LOCK = new Object();
   private static final List<String> UNCOUNTABLE = Arrays.asList("equipment", "fish", "information", "money", "rice", "series", "sheep", "species");
-  private static final List<Function<String, String>> PLURALS = Arrays.<Function<String, String>>asList(
+  private static final List<UnaryOperator<String>> PLURALS = Arrays.<Function<String, String>>asList(
             //Irregulars
             new StringReplace("(p)eople$", "$1erson"),
             new StringReplace("(m)en$", "$1an"),
@@ -87,7 +88,7 @@ public class Pluralize implements Function<String, String> {
             return word;
         }
 
-        for (Function<String, String> function : PLURALS) {
+        for (UnaryOperator<String> function : PLURALS) {
             String result = function.apply(word);
             if (result != null) {
                 return result;
@@ -112,7 +113,7 @@ public class Pluralize implements Function<String, String> {
         return false;
     }
 
-  private static class StringReplace implements Function<String, String> {
+  private static class StringReplace implements UnaryOperator<String> {
 
     private final String target;
     private final String replacement;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Pluralize.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Pluralize.java
@@ -17,7 +17,6 @@ package io.fabric8.kubernetes.client.utils;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
## Description
Replace occurrences of Function<T, T> with UnaryOperator<T>. Imports are also reorganized in the touched class.
Fixes #2766 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
