### PR TITLE
Fix #2780: Refactor RawCustomResourceOperationsImpl#delete(String)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 #### Improvements
 * Fix #2781: RawCustomResourceOperationsImpl#delete now returns a boolean value for deletion status
+* Fix #2780: Refactor RawCustomResourceOperationsImpl#delete(String)
 
 #### Dependency Upgrade
 

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1798,67 +1798,67 @@ CustomResourceDefinitionContext customResourceDefinitionContext = new CustomReso
 ```
 Once you have built it, you can pass it to typeless DSL as argument `client.customResource(customResourceDefinitionContext)`. With this in place, you can do your standard `CustomResource` operations, but you would have to deal with Serialization/Deserialization part yourself. You can convert HashMap to some `JSON` object using JSON parsing libraries available on internet.
 - Load a `CustomResource` from yaml:
-```
+```java
 Map<String, Object> customResource = client.customResource(crdContext).load(new FileInputStream("cr.yaml"));
 ```
 - Get a `CustomResource` from Kubernetes API server:
-```
-Map<String, Object> customResourceObject = client.customResource(customResourceDefinitionContext).get(currentNamespace, "otter");
+```java
+Map<String, Object> customResourceObject = client.customResource(customResourceDefinitionContext).inNamespace(currentNamespace).withName("otter").get();
 ```
 - Create a `CustomResource`:
-```
+```java
 // Create via file
-Map<String, Object> object = client.customResource(customResourceDefinitionContext).create(currentNamespace, new FileInputStream("test-rawcustomresource.yml"));
+Map<String, Object> object = client.customResource(customResourceDefinitionContext).inNamespace(currentNamespace).create(new FileInputStream("test-rawcustomresource.yml"));
 
 // Create via raw JSON string
 
 String rawJsonCustomResourceObj = "{\"apiVersion\":\"jungle.example.com/v1\"," +
   "\"kind\":\"Animal\",\"metadata\": {\"name\": \"walrus\"}," +
   "\"spec\": {\"image\": \"my-awesome-walrus-image\"}}";
-Map<String, Object> object = client.customResource(customResourceDefinitionContext).create(currentNamespace, rawJsonCustomResourceObj);
+Map<String, Object> object = client.customResource(customResourceDefinitionContext).inNamespace(currentNamespace).create(rawJsonCustomResourceObj);
 ```
 - List `CustomResource`:
-```
-Map<String, Object> list = client.customResource(customResourceDefinitionContext).list(currentNamespace);
+```java
+Map<String, Object> list = client.customResource(customResourceDefinitionContext).inNamespace(currentNamespace).list();
 ```
 - List `CustomResource` with labels:
-```
+```java
 Map<String, Object> list = client.customResource(customResourceDefinitionContext).list(currentNamespace, Collections.singletonMap("foo", "bar"));
 ```
 - Update `CustomResource`:
-```
+```java
 Map<String, Object> object = client.customResource(customResourceDefinitionContext).get(currentNamespace, "walrus");
 ((HashMap<String, Object>)object.get("spec")).put("image", "my-updated-awesome-walrus-image");
 object = client.customResource(customResourceDefinitionContext).edit(currentNamespace, "walrus", new ObjectMapper().writeValueAsString(object));
 ```
 - Delete `CustomResource`:
-```
-client.customResource(customResourceDefinitionContext).delete(currentNamespace, "otter");
+```java
+client.customResource(customResourceDefinitionContext).inNamespace(currentNamespace).withName("otter").delete();
 ```
 - Update Status of `CustomResource`:
-```
-Map<String, Object> result = client.customResource(customResourceDefinitionContext).updateStatus("ns1", "example-hello", objectAsJsonString);
+```java
+Map<String, Object> result = client.customResource(customResourceDefinitionContext).inNamespace("ns1").withName("example-hello").updateStatus(objectAsJsonString);
 ```
 - Watch `CustomResource`:
-```
+```java
 
-  final CountDownLatch closeLatch = new CountDownLatch(1);
-  client.customResource(crdContext).watch(namespace, new Watcher<String>() {
+final CountDownLatch closeLatch = new CountDownLatch(1);
+client.customResource(crdContext).inNamespace(namespace).watch(new Watcher<String>() {
     @Override
     public void eventReceived(Action action, String resource) {
-      logger.info("{}: {}", action, resource);
+        logger.info("{}: {}", action, resource);
     }
 
     @Override
     public void onClose(KubernetesClientException e) {
-      logger.debug("Watcher onClose");
-      closeLatch.countDown();
-      if (e != null) {
-        logger.error(e.getMessage(), e);
-      }
+        logger.debug("Watcher onClose");
+        closeLatch.countDown();
+        if (e != null) {
+            logger.error(e.getMessage(), e);
+        }
     }
-  });
-  closeLatch.await(10, TimeUnit.MINUTES);
+});
+closeLatch.await(10, TimeUnit.MINUTES);
 ```
 
 ### CertificateSigningRequest

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,18 +55,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RawCustomResourceOperationsImplTest {
   private OkHttpClient mockClient;
   private Config config;
-  private CustomResourceDefinitionContext customResourceDefinitionContext;
+  private CustomResourceDefinitionContext namespacedCustomResourceDefinitionContext;
+  private CustomResourceDefinitionContext clusterCustomResourceDefinitionContext;
   private Response mockSuccessResponse;
 
   @BeforeEach
   public void setUp() throws IOException {
     this.mockClient = Mockito.mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
     this.config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
-    this.customResourceDefinitionContext = new CustomResourceDefinitionContext.Builder()
+    this.namespacedCustomResourceDefinitionContext = new CustomResourceDefinitionContext.Builder()
       .withGroup("test.fabric8.io")
       .withName("hellos.test.fabric8.io")
       .withPlural("hellos")
       .withScope("Namespaced")
+      .withVersion("v1alpha1")
+      .build();
+    this.clusterCustomResourceDefinitionContext = new CustomResourceDefinitionContext.Builder()
+      .withGroup("test.fabric8.io")
+      .withName("hellos.test.fabric8.io")
+      .withPlural("hellos")
+      .withScope("Cluster")
       .withVersion("v1alpha1")
       .build();
 
@@ -79,7 +88,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testCreateOrReplaceUrl() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     String resourceAsString = "{\"metadata\":{\"name\":\"myresource\",\"namespace\":\"myns\"}, \"kind\":\"raw\", \"apiVersion\":\"v1\"}";
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -116,7 +125,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceAndNameForNonExistentResource() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_NOT_FOUND, "{\"kind\":\"Status\",\"status\":\"Failure\"}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -132,7 +141,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceForNonExistentResource() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_NOT_FOUND, "{\"kind\":\"Status\",\"status\":\"Failure\"}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -148,7 +157,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceAndCascadingForNonExistentResource() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_NOT_FOUND, "{\"kind\":\"Status\",\"status\":\"Failure\"}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -164,7 +173,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceAndDeleteOptionsForNonExistentResource() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_NOT_FOUND, "{\"kind\":\"Status\",\"status\":\"Failure\"}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -180,7 +189,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceNameAndCascading() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_OK, "{\"kind\":\"Hello\",\"metadata\":{\"name\":\"Failure\"}}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -196,7 +205,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceNameAndCascadingForNonExistentResource() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_NOT_FOUND, "{\"kind\":\"Status\",\"status\":\"Failure\"}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -212,7 +221,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceNameAndPropagationPolicyForNonExistentResource() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_NOT_FOUND, "{\"kind\":\"Status\",\"status\":\"Failure\"}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -228,7 +237,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testDeleteWithNamespaceNameAndDeleteOptionsForNonExistentResource() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_NOT_FOUND, "{\"kind\":\"Status\",\"status\":\"Failure\"}");
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
@@ -244,21 +253,20 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testGetUrl() {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
 
     // When
     rawCustomResourceOperations.get("myns", "myresource");
 
     // Then
-    verify(mockClient).newCall(captor.capture());
-    assertEquals("/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos/myresource", captor.getValue().url().encodedPath());
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos/myresource", "GET");
   }
 
   @Test
   void testDeleteUrl() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
     ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
     mockDeletionCallWithResponse(HttpURLConnection.HTTP_OK, "{\"kind\":\"Status\",\"status\":\"Success\"}");
 
@@ -267,17 +275,16 @@ public class RawCustomResourceOperationsImplTest {
 
     // Then
     assertTrue(result);
-    verify(mockClient).newCall(captor.capture());
-    assertEquals("/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos/myresource", captor.getValue().url().encodedPath());
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos/myresource", "DELETE");
   }
 
   @Test
   void testFetchWatchUrlWithNamespace() throws MalformedURLException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
 
     // When
-    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl("test", null, null, new ListOptionsBuilder().withWatch(true).build()).build();
+    HttpUrl url = rawCustomResourceOperations.inNamespace("test").fetchWatchUrl(null, new ListOptionsBuilder().withWatch(true).build()).build();
 
     // Then
     assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/namespaces/test/hellos?watch=true", url.url().toString());
@@ -286,10 +293,10 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testFetchWatchUrlWithNamespaceAndName() throws MalformedURLException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
 
     // When
-    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl("test", "example-resource", null, new ListOptionsBuilder().withWatch(true).build()).build();
+    HttpUrl url = rawCustomResourceOperations.inNamespace("test").withName("example-resource").fetchWatchUrl(null, new ListOptionsBuilder().withWatch(true).build()).build();
 
     // Then
     assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/namespaces/test/hellos?fieldSelector=metadata.name%3Dexample-resource&watch=true", url.url().toString());
@@ -298,10 +305,10 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testFetchWatchUrlWithNamespaceAndNameAndResourceVersion() throws MalformedURLException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
 
     // When
-    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl("test", "example-resource", null, new ListOptionsBuilder().withResourceVersion("100069").withWatch(true).build()).build();
+    HttpUrl url = rawCustomResourceOperations.inNamespace("test").withName("example-resource").fetchWatchUrl(null, new ListOptionsBuilder().withResourceVersion("100069").withWatch(true).build()).build();
 
     // Then
     assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/namespaces/test/hellos?fieldSelector=metadata.name%3Dexample-resource&resourceVersion=100069&watch=true", url.url().toString());
@@ -310,10 +317,10 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testFetchWatchUrlWithoutAnything() throws MalformedURLException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
 
     // When
-    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl(null, null, null, new ListOptionsBuilder().withWatch(true).build()).build();
+    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl(null, new ListOptionsBuilder().withWatch(true).build()).build();
 
     // Then
     assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/hellos?watch=true", url.url().toString());
@@ -322,33 +329,33 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testFetchWatchUrlWithLabels() throws MalformedURLException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
 
     // When
     Map<String, String> labels = new HashMap<>();
     labels.put("foo", "bar");
     labels.put("foo1", "bar1");
 
-    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl(null, null, labels, new ListOptionsBuilder().withWatch(true).build()).build();
+    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl(labels, new ListOptionsBuilder().withWatch(true).build()).build();
 
     // Then
-    assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/hellos?labelSelector=" + Utils.toUrlEncoded("foo=bar") + "," + Utils.toUrlEncoded("foo1=bar1") + "&watch=true", url.url().toString());
+    assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/hellos?labelSelector=" + Utils.toUrlEncoded("foo=bar") + Utils.toUrlEncoded(",") + Utils.toUrlEncoded("foo1=bar1") + "&watch=true", url.url().toString());
   }
 
   @Test
   void testFetchWatchUrlWithLabelsWithNamespace() throws MalformedURLException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
 
     // When
     Map<String, String> labels = new HashMap<>();
     labels.put("foo", "bar");
     labels.put("foo1", "bar1");
 
-    HttpUrl url = rawCustomResourceOperations.fetchWatchUrl("test", null, labels, new ListOptionsBuilder().withWatch(true).build()).build();
+    HttpUrl url = rawCustomResourceOperations.inNamespace("test").fetchWatchUrl(labels, new ListOptionsBuilder().withWatch(true).build()).build();
 
     // Then
-    assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/namespaces/test/hellos?labelSelector=" + Utils.toUrlEncoded("foo=bar") + "," + Utils.toUrlEncoded("foo1=bar1") + "&watch=true", url.url().toString());
+    assertEquals("https://localhost:8443/apis/test.fabric8.io/v1alpha1/namespaces/test/hellos?labelSelector=" + Utils.toUrlEncoded("foo=bar") + Utils.toUrlEncoded(",") + Utils.toUrlEncoded("foo1=bar1") + "&watch=true", url.url().toString());
   }
 
   @Test
@@ -362,7 +369,7 @@ public class RawCustomResourceOperationsImplTest {
       .withWatchReconnectLimit(1)
       .withWatchReconnectInterval(10)
       .build();
-    RawCustomResourceOperationsImpl rawOp = new RawCustomResourceOperationsImpl(mockClient, config, customResourceDefinitionContext);
+    RawCustomResourceOperationsImpl rawOp = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
 
     // When
     Config configFromRawOp = rawOp.getConfig();
@@ -386,7 +393,7 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   private Response mockResponse(int code) {
-    return mockResponse(code, "");
+    return mockResponse(code, "{\"kind\":\"Status\",\"status\":\"Success\"}");
   }
 
   private Response mockResponse(int code, String body) {
@@ -399,4 +406,168 @@ public class RawCustomResourceOperationsImplTest {
       .build();
   }
 
+  @Test
+  void testDeleteWithNamespaceAndName() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.inNamespace("myns").withName("myresource").delete();
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos/myresource", "DELETE");
+  }
+
+  @Test
+  void testListWithLabels() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.list("myns", Collections.singletonMap("foo", "bar"));
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", "GET");
+    assertEquals("labelSelector=foo%3Dbar", captor.getValue().url().encodedQuery());
+  }
+
+  @Test
+  void testDeleteInSpecifiedNamespace() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.inNamespace("myns").delete();
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", "DELETE");
+  }
+
+  @Test
+  void testDeleteInAllNamespaces() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.inAnyNamespace().delete();
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/hellos", "DELETE");
+  }
+
+  @Test
+  void testClusterScopedDeletionWithName() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.withName("myresource").delete();
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/hellos/myresource", "DELETE");
+  }
+
+  @Test
+  void testClusterScopeDeletionAll() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.delete();
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/hellos", "DELETE");
+  }
+
+  @Test
+  void testDeleteByNamespaceOrNameWithNamespacedScopedCRD() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.delete("myns");
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", "DELETE");
+  }
+
+  @Test
+  void testDeleteByNamespaceOrNameWithCascadingWithNamespacedScopedCRD() throws IOException {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.delete("myns", true);
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", "DELETE");
+  }
+
+  @Test
+  void testDeleteByNamespaceOrNameWithDeleteOptionsWithNamespacedScopedCRD() throws IOException {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.delete("myns", new DeleteOptionsBuilder()
+      .withPropagationPolicy(DeletionPropagation.BACKGROUND.toString()).build());
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", "DELETE");
+  }
+
+  @Test
+  void testDeleteByNamespaceOrNameWithClusterScopedCRD() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.delete("myresource");
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/hellos/myresource", "DELETE");
+  }
+
+  @Test
+  void testDeleteByNamespaceOrNameWithCascadingWithClusterScopedCRD() throws IOException {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.delete("myresource", true);
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/hellos/myresource", "DELETE");
+  }
+
+  @Test
+  void testDeleteByNamespaceOrNameWithDeleteOptionsWithClusterScopedCRD() throws IOException {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.delete("myresource", new DeleteOptionsBuilder()
+      .withPropagationPolicy(DeletionPropagation.BACKGROUND.toString()).build());
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/hellos/myresource", "DELETE");
+  }
+
+  private void assertRequestCaptured(ArgumentCaptor<Request> captor, String url, String method) {
+    verify(mockClient).newCall(captor.capture());
+    assertEquals(url, captor.getValue().url().encodedPath());
+    assertEquals(method, captor.getValue().method());
+  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -420,6 +420,47 @@ public class RawCustomResourceOperationsImplTest {
   }
 
   @Test
+  void testGet() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.inNamespace("myns").withName("myresource").get();
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos/myresource", "GET");
+  }
+
+  @Test
+  void testListWithLimitAndContinue() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.inNamespace("myns").list(4, "eyJ2IjoibWV0YS5rOHMuaW8vdj");
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", "GET");
+    assertEquals("limit=4&continue=eyJ2IjoibWV0YS5rOHMuaW8vdj", captor.getValue().url().encodedQuery());
+  }
+
+  @Test
+  void testListWithListOptions() {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    rawCustomResourceOperations.inNamespace("myns").list(new ListOptionsBuilder().withLimit(4L).build());
+
+    // Then
+    assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/namespaces/myns/hellos", "GET");
+    assertEquals("limit=4", captor.getValue().url().encodedQuery());
+  }
+
+  @Test
   void testListWithLabels() {
     // Given
     RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, namespacedCustomResourceDefinitionContext);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawClusterScopedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RawClusterScopedCustomResourceIT.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import io.fabric8.commons.AssumingK8sVersionAtLeast;
+import io.fabric8.commons.ClusterEntity;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class RawClusterScopedCustomResourceIT {
+  @ArquillianResource
+  public KubernetesClient client;
+
+  @ArquillianResource
+  public Session session;
+
+  @ClassRule
+  public static final AssumingK8sVersionAtLeast assumingK8sVersion = new AssumingK8sVersionAtLeast("1", "16");
+
+  private final CustomResourceDefinitionContext customResourceDefinitionContext = new CustomResourceDefinitionContext.Builder()
+    .withVersion("v1alpha1")
+    .withScope("Cluster")
+    .withGroup("demos.fabric8.io")
+    .withPlural("satellites")
+    .build();
+
+  @BeforeClass
+  public static void initCrd() {
+    // Create a Custom Resource Definition Animals:
+    ClusterEntity.apply(RawCustomResourceIT.class.getResourceAsStream("/rawclusterscopedcustomresource-it.yml"));
+  }
+
+  @Test
+  public void testCrud() throws IOException {
+    // Create
+    Map<String, Object> satellite = createSatellite("moon", "earth", "1.7371e+3", "7.34767309e+22");
+    Map<String, Object> createdSatellite = client.customResource(customResourceDefinitionContext).create(satellite);
+
+    assertThat(createdSatellite)
+      .isNotNull()
+      .hasFieldOrPropertyWithValue("metadata.name", "moon");
+
+    // Get
+    Map<String, Object> satelliteFromServer = client.customResource(customResourceDefinitionContext).withName("moon").get();
+    assertThat(satelliteFromServer).isNotNull()
+      .hasFieldOrPropertyWithValue("metadata.name", "moon");
+
+    // List
+    Map<String, Object> satellites = client.customResource(customResourceDefinitionContext).list();
+    assertThat(satellites).isNotNull();
+    assertThat(satellites.get("items")).isInstanceOfAny(ArrayList.class);
+    assertThat((ArrayList<Object>)satellites.get("items")).hasSize(1);
+
+    // Delete
+    Boolean isDeleted = client.customResource(customResourceDefinitionContext).withName("moon").delete();
+    assertThat(isDeleted).isTrue();
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    ClusterEntity.remove(RawCustomResourceIT.class.getResourceAsStream("/rawclusterscopedcustomresource-it.yml"));
+  }
+
+  private Map<String, Object> createSatellite(String name, String planet, String radius, String mass) {
+    Map<String, Object> crAsMap = new HashMap<>();
+    crAsMap.put("apiVersion", "demos.fabric8.io/v1alpha1");
+    crAsMap.put("kind", "Satellite");
+
+    Map<String, Object> crMetadata = new HashMap<>();
+    crMetadata.put("name", name);
+    crMetadata.put("labels", Collections.singletonMap("foo", "bar"));
+    Map<String, Object> crSpec = new HashMap<>();
+    crSpec.put("planet", planet);
+    crSpec.put("radius", radius);
+    crSpec.put("mass", mass);
+
+    crAsMap.put("metadata", crMetadata);
+    crAsMap.put("spec", crSpec);
+
+    return crAsMap;
+  }
+}

--- a/kubernetes-itests/src/test/resources/rawclusterscopedcustomresource-it.yml
+++ b/kubernetes-itests/src/test/resources/rawclusterscopedcustomresource-it.yml
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: satellites.demos.fabric8.io
+spec:
+  group: demos.fabric8.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                planet:
+                  type: string
+                mass:
+                  type: string
+                radius:
+                  type: string
+  scope: Cluster
+  names:
+    plural: satellites
+    singular: satellite
+    kind: Satellite
+    shortNames:
+      - satellite

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -139,7 +139,7 @@ class CustomResourceTest {
     String jsonObject = "{\"metadata\":{\"continue\":\"\",\"resourceVersion\":\"539617\",\"selfLink\":\"test.fabric8.io/v1alpha1/namespaces/ns1/hellos/\"},\"apiVersion\":\"test.fabric8.io/v1alpha1\",\"kind\":\"HelloList\",\"items\":[{\"apiVersion\": \"test.fabric8.io/v1alpha1\",\"kind\": \"Hello\"," +
       "\"metadata\": {\"name\": \"example-hello\", \"labels\": {\"scope\":\"test\"}},\"spec\": {\"size\": 3},\"uid\":\"3525437a-6a56-11e9-8787-525400b18c1d\"}]}";
 
-    server.expect().get().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?labelSelector=org%3Dfabric8,scope%3Dtest").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
+    server.expect().get().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?labelSelector=org%3Dfabric8" + Utils.toUrlEncoded(",") + "scope%3Dtest").andReturn(HttpURLConnection.HTTP_CREATED, jsonObject).once();
     KubernetesClient client = server.getClient();
 
     Map<String, String> labels = new HashMap<>();


### PR DESCRIPTION
## Description
Fixes #2780

+ Move namespace and name to be member fields rather than being specified in method parameters so that they can be configured using `withName`, `inNamespace` methods
+ Right now these single argument delete methods are quite confusing. On first look user might think it's for deleting a Cluster Scoped Custom Resource. Hence, modifying it to behave differently based on Scope provided in CustomResourceDefinitionContext
- Added get(), list() methods to Raw CustomResource API in order
     to make it more consistent with KubernetesClient DSL
- Added an Integration test for Cluster scoped Custom resource


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
