### PR TITLE
#2871: Change longFileMode to LONGFILE_POSIX for creating tar in PodU…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #2857: Fix the log of an unexpected error from an Informer's EventHandler
 * Fix #2853: Cannot change the type of the Service from ClusterIP to ExternalName with PATCH
 * Fix #2783: OpenIDConnectionUtils#persistKubeConfigWithUpdatedToken persists access token instead of refresh token
+* Fix #2871: Change longFileMode to LONGFILE_POSIX for creating tar in PodUpload, improve exception handling in PodUpload.
 
 #### Improvements
 * Fix #2781: RawCustomResourceOperationsImpl#delete now returns a boolean value for deletion status

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -119,9 +119,18 @@ class PodUploadTest {
 
   @Test
   void testUploadDirectoryHappyScenarioShouldUploadDirectory() throws Exception {
+    uploadDirectoryAndVerify("/upload");
+  }
+
+  @Test
+  void testUploadDirectoryLongFileNameShouldUploadDirectory() throws Exception {
+    uploadDirectoryAndVerify("/upload_long");
+  }
+
+  private void uploadDirectoryAndVerify(String resourcePath) throws IOException, InterruptedException {
     when(mockContext.getDir()).thenReturn("/mock/dir");
     when(mockPathToUpload.toFile())
-      .thenReturn(new File(PodUpload.class.getResource("/upload").getFile()));
+      .thenReturn(new File(PodUpload.class.getResource(resourcePath).getFile()));
     when(mockClient.newWebSocket(any(), any())).thenAnswer(newWebSocket -> {
       final PodUploadWebSocketListener wsl = newWebSocket.getArgument(1, PodUploadWebSocketListener.class);
       // Set ready status

--- a/kubernetes-client/src/test/resources/upload_long/very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_directory_name/upload-sample.txt
+++ b/kubernetes-client/src/test/resources/upload_long/very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_directory_name/upload-sample.txt
@@ -1,0 +1,17 @@
+====
+    Copyright (C) 2015 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+====
+
+This is a file to test uploads


### PR DESCRIPTION

## Description
 Changed longFileMode to LONGFILE_POSIX for creating tar in PodUpload, improved exception handling in PodUpload as RuntimeExceptions currently get ignored

Fix https://github.com/fabric8io/kubernetes-client/issues/2871

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
