### PR TITLE
Reduce code smells in OperationContext class

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -98,7 +98,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   private static final String INVOLVED_OBJECT_API_VERSION = "involvedObject.apiVersion";
   private static final String INVOLVED_OBJECT_FIELD_PATH = "involvedObject.fieldPath";
 
-  private final Boolean cascading;
+  private final boolean cascading;
   private final T item;
 
   private final Map<String, String> labels;
@@ -110,7 +110,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   private final Map<String, String[]> fieldsNot;
 
   private final String resourceVersion;
-  private final Boolean reloadingFromServer;
+  private final boolean reloadingFromServer;
   private final long gracePeriodSeconds;
   private final DeletionPropagation propagationPolicy;
   private final long watchRetryInitialBackoffMillis;
@@ -125,7 +125,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     super(ctx);
     this.cascading = ctx.getCascading();
     this.item = (T) ctx.getItem();
-    this.reloadingFromServer = ctx.getReloadingFromServer();
+    this.reloadingFromServer = ctx.isReloadingFromServer();
     this.resourceVersion = ctx.getResourceVersion();
     this.gracePeriodSeconds = ctx.getGracePeriodSeconds();
     this.propagationPolicy = ctx.getPropagationPolicy();
@@ -166,8 +166,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     } catch (ExecutionException | IOException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("list"), e);
     }
-
-
  }
 
   protected URL fetchListUrl(URL url, ListOptions listOptions) throws MalformedURLException {
@@ -952,11 +950,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   public String getResourceVersion() {
     return resourceVersion;
-  }
-
-  @Deprecated
-  public Boolean getReloadingFromServer() {
-    return isReloadingFromServer();
   }
 
   public Boolean isReloadingFromServer() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationContext.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.dsl.base;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.Config;
@@ -42,7 +43,7 @@ public class OperationContext {
   protected boolean reloadingFromServer;
   /*
    * This field is added in order to distinguish whether namespace is picked from global
-   * Configuration(either your KUBECONFIG or /var/run/secrets/kubernetes.io/serviceaccount/namespace
+   * Configuration (either your KUBECONFIG or /var/run/secrets/kubernetes.io/serviceaccount/namespace)
    * if inside a Pod
    */
   protected boolean namespaceFromGlobalConfig;
@@ -61,32 +62,36 @@ public class OperationContext {
   protected Map<String, String> fields;
   protected Map<String, String[]> fieldsNot;
 
-
   public OperationContext() {
   }
 
-  public OperationContext(OkHttpClient client, Config config, String plural, String namespace, String name, String apiGroupName, String apiGroupVersion, boolean cascading, Object item, Map<String, String> labels, Map<String, String[]> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Map<String, String[]> fieldsNot, String resourceVersion, boolean reloadingFromServer, long gracePeriodSeconds, DeletionPropagation propagationPolicy, long watchRetryInitialBackoffMillis, double watchRetryBackoffMultiplier, boolean namespaceFromGlobalConfig) {
+  public OperationContext(OkHttpClient client, Config config, String plural, String namespace, String name,
+      String apiGroupName, String apiGroupVersion, boolean cascading, Object item, Map<String, String> labels,
+      Map<String, String[]> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn,
+      Map<String, String> fields, Map<String, String[]> fieldsNot, String resourceVersion, boolean reloadingFromServer,
+      long gracePeriodSeconds, DeletionPropagation propagationPolicy, long watchRetryInitialBackoffMillis,
+      double watchRetryBackoffMultiplier, boolean namespaceFromGlobalConfig) {
     this.client = client;
     this.config = config;
     this.plural = plural;
+    this.namespace = Utils.isNotNullOrEmpty(namespace) ? namespace : (config != null ? config.getNamespace() : null);
     this.name = name;
+    this.apiGroupName = ApiVersionUtil.apiGroup(item, apiGroupName);
+    this.apiGroupVersion = ApiVersionUtil.apiVersion(item, apiGroupVersion);
     this.cascading = cascading;
-    this.labels = labels != null ? labels : new HashMap<>();
-    this.labelsNot = labelsNot != null ? labelsNot : new HashMap<>();
-    this.labelsIn = labelsIn != null ? labelsIn : new HashMap<>();
-    this.labelsNotIn = labelsNotIn != null ? labelsNotIn : new HashMap<>();
-    this.fields = fields != null ? fields : new HashMap<>();
-    this.fieldsNot = fieldsNot != null ? fieldsNot : new HashMap<>();
+    this.item = item;
+    this.labels = Utils.getNonNullOrElse(labels, new HashMap<>());
+    this.labelsNot = Utils.getNonNullOrElse(labelsNot, new HashMap<>());
+    this.labelsIn = Utils.getNonNullOrElse(labelsIn, new HashMap<>());
+    this.labelsNotIn = Utils.getNonNullOrElse(labelsNotIn, new HashMap<>());
+    this.fields = Utils.getNonNullOrElse(fields, new HashMap<>());
+    this.fieldsNot = Utils.getNonNullOrElse(fieldsNot, new HashMap<>());
     this.resourceVersion = resourceVersion;
     this.reloadingFromServer = reloadingFromServer;
     this.gracePeriodSeconds = gracePeriodSeconds;
     this.propagationPolicy = propagationPolicy;
     this.watchRetryInitialBackoffMillis = watchRetryInitialBackoffMillis;
     this.watchRetryBackoffMultiplier = watchRetryBackoffMultiplier;
-    this.item = item;
-    this.apiGroupName =  ApiVersionUtil.apiGroup(item, apiGroupName);
-    this.apiGroupVersion = ApiVersionUtil.apiVersion(item, apiGroupVersion);
-    this.namespace = Utils.isNotNullOrEmpty(namespace) ? namespace : (config != null ? config.getNamespace() : null);
     this.namespaceFromGlobalConfig = namespaceFromGlobalConfig;
   }
 
@@ -154,7 +159,7 @@ public class OperationContext {
     return resourceVersion;
   }
 
-  public boolean getReloadingFromServer() {
+  public boolean isReloadingFromServer() {
     return reloadingFromServer;
   }
 
@@ -179,202 +184,275 @@ public class OperationContext {
   }
 
   public OperationContext withOkhttpClient(OkHttpClient client) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading, item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.client == client) {
+      return this;
+    }
+    return new OperationContext(client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withConfig(Config config) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.config == config) {
+      return this;
+    }
+    return new OperationContext(this.client, config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withPlural(String plural) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (Objects.equals(this.plural, plural)) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withNamespace(String namespace) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (Objects.equals(this.namespace, namespace)) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withName(String name) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (Objects.equals(this.name, name)) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
-
   public OperationContext withApiGroupName(String apiGroupName) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (Objects.equals(this.apiGroupName, apiGroupName)) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withApiGroupVersion(String apiGroupVersion) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (Objects.equals(this.apiGroupVersion, apiGroupVersion)) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withItem(Object item) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.item == item) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withCascading(boolean cascading) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.cascading == cascading) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withLabels(Map<String, String> labels) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.labels == labels) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withLabelsIn(Map<String, String[]> labelsIn) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.labelsIn == labelsIn) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withLabelsNot(Map<String, String[]> labelsNot) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.labelsNot == labelsNot) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withLabelsNotIn(Map<String, String[]> labelsNotIn) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.labelsNotIn == labelsNotIn) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withFields(Map<String, String> fields) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.fields == fields) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withFieldsNot(Map<String, String[]> fieldsNot) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.fieldsNot == fieldsNot) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withResourceVersion(String resourceVersion) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (Objects.equals(this.resourceVersion, resourceVersion)) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withReloadingFromServer(boolean reloadingFromServer) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.reloadingFromServer == reloadingFromServer) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withGracePeriodSeconds(long gracePeriodSeconds) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.gracePeriodSeconds == gracePeriodSeconds) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withPropagationPolicy(DeletionPropagation propagationPolicy) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.propagationPolicy == propagationPolicy) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withWatchRetryInitialBackoffMillis(long watchRetryInitialBackoffMillis) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.watchRetryInitialBackoffMillis == watchRetryInitialBackoffMillis) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withWatchRetryBackoffMultiplier(double watchRetryBackoffMultiplier) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.watchRetryBackoffMultiplier == watchRetryBackoffMultiplier) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier,
+        this.namespaceFromGlobalConfig);
   }
 
   public OperationContext withIsNamespaceConfiguredFromGlobalConfig(boolean namespaceFromGlobalConfig) {
-    return new OperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfig);
+    if (this.namespaceFromGlobalConfig == namespaceFromGlobalConfig) {
+      return this;
+    }
+    return new OperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.apiGroupName,
+        this.apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+        this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+        this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+        namespaceFromGlobalConfig);
   }
 
   /**
-   * Returns an OperationContext object merged with current object
+   * Returns an OperationContext object merged with current object.
    *
-   * @param operationContext object with modifications
+   * @param context object with modifications
    * @return a merged object between passed argument and current object
    */
-  public OperationContext withOperationContext(OperationContext operationContext) {
-    OkHttpClient clientCloned = getClient();
-    Config configCloned = getConfig();
-    Object itemCloned = getItem();
-    String resourceVersionCloned = getResourceVersion();
-    String pluralCloned = getPlural();
-    String apiGroupNameCloned = getApiGroupName();
-    String apiGroupVersionCloned = getApiGroupVersion();
-    String namespaceCloned = getNamespace();
-    String nameCloned = getName();
-    boolean cascadingCloned = getCascading();
-    boolean reloadingFromServerCloned = getReloadingFromServer();
-    boolean namespaceFromGlobalConfigCloned = isNamespaceFromGlobalConfig();
-    long gracePeriodSecondsCloned = getGracePeriodSeconds();
-    long watchRetryInitialBackoffMillis = getWatchRetryInitialBackoffMillis();
-    double watchRetryBackoffMultiplier = getWatchRetryBackoffMultiplier();
-    DeletionPropagation propagationPolicyCloned = getPropagationPolicy();
-    Map<String, String> labelsCloned = getLabels();
-    Map<String, String[]> labelsNotCloned = getLabelsNot();
-    Map<String, String[]> labelsInCloned = getLabelsIn();
-    Map<String, String[]> labelsNotInCloned = getLabelsNotIn();
-    Map<String, String> fieldsCloned = getFields();
-    Map<String, String[]> fieldsNotCloned = getFieldsNot();
-
-    if (operationContext.getApiGroupVersion() != null) {
-      apiGroupVersionCloned = operationContext.getApiGroupVersion();
-    }
-
-    if (operationContext.getClient() != null) {
-      clientCloned = operationContext.getClient();
-    }
-
-    if (operationContext.getConfig() != null) {
-      configCloned = operationContext.getConfig();
-    }
-
-    if (operationContext.getPlural() != null) {
-      pluralCloned = operationContext.getPlural();
-    }
-
-    if (operationContext.getNamespace() != null) {
-      namespaceCloned = operationContext.getNamespace();
-    }
-
-    if (operationContext.getName() != null) {
-      nameCloned = operationContext.getName();
-    }
-
-    if (operationContext.getApiGroupName() != null) {
-      apiGroupNameCloned = operationContext.getApiGroupName();
-    }
-
-    if (operationContext.getCascading()) {
-      cascadingCloned = operationContext.getCascading();
-    }
-
-    if (operationContext.getItem() != null) {
-      itemCloned = operationContext.getItem();
-    }
-
-    if (operationContext.getLabels() != null) {
-      labelsCloned = operationContext.getLabels();
-    }
-
-    if (operationContext.getLabelsNot() != null) {
-      labelsNotCloned = operationContext.getLabelsNot();
-    }
-
-    if (operationContext.getLabelsIn() != null) {
-      labelsInCloned = operationContext.getLabelsIn();
-    }
-
-    if (operationContext.getLabelsNotIn() != null) {
-      labelsNotInCloned = operationContext.getLabelsNotIn();
-    }
-
-    if (operationContext.getFields() != null) {
-      fieldsCloned = operationContext.getFields();
-    }
-
-    if (operationContext.getFieldsNot() != null) {
-      fieldsNotCloned = operationContext.getFieldsNot();
-    }
-
-    if (operationContext.getResourceVersion() != null) {
-      resourceVersionCloned = operationContext.getResourceVersion();
-    }
-
-    if (operationContext.getReloadingFromServer()) {
-      reloadingFromServerCloned = operationContext.getReloadingFromServer();
-    }
-
-    if (operationContext.getGracePeriodSeconds() > 0) {
-      gracePeriodSecondsCloned = operationContext.getGracePeriodSeconds();
-    }
-
-    if (operationContext.getPropagationPolicy() != null) {
-      propagationPolicyCloned = operationContext.getPropagationPolicy();
-    }
-
-    namespaceFromGlobalConfigCloned = operationContext.isNamespaceFromGlobalConfig();
-
-    return new OperationContext(clientCloned, configCloned, pluralCloned, namespaceCloned, nameCloned, apiGroupNameCloned, apiGroupVersionCloned, cascadingCloned, itemCloned, labelsCloned, labelsNotCloned, labelsInCloned, labelsNotInCloned, fieldsCloned, fieldsNotCloned, resourceVersionCloned, reloadingFromServerCloned, gracePeriodSecondsCloned, propagationPolicyCloned, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, namespaceFromGlobalConfigCloned);
+  public OperationContext withOperationContext(OperationContext context) {
+    return new OperationContext(Utils.getNonNullOrElse(context.getClient(), getClient()),
+        Utils.getNonNullOrElse(context.getConfig(), getConfig()),
+        Utils.getNonNullOrElse(context.getPlural(), getPlural()),
+        Utils.getNonNullOrElse(context.getNamespace(), getNamespace()),
+        Utils.getNonNullOrElse(context.getName(), getName()),
+        Utils.getNonNullOrElse(context.getApiGroupName(), getApiGroupName()),
+        Utils.getNonNullOrElse(context.getApiGroupVersion(), getApiGroupVersion()),
+        context.getCascading() ? context.getCascading() : getCascading(),
+        Utils.getNonNullOrElse(context.getItem(), getItem()),
+        Utils.getNonNullOrElse(context.getLabels(), getLabels()),
+        Utils.getNonNullOrElse(context.getLabelsNot(), getLabelsNot()),
+        Utils.getNonNullOrElse(context.getLabelsIn(), getLabelsIn()),
+        Utils.getNonNullOrElse(context.getLabelsNotIn(), getLabelsNotIn()),
+        Utils.getNonNullOrElse(context.getFields(), getFields()),
+        Utils.getNonNullOrElse(context.getFieldsNot(), getFieldsNot()),
+        Utils.getNonNullOrElse(context.getResourceVersion(), getResourceVersion()),
+        context.isReloadingFromServer() ? context.isReloadingFromServer() : isReloadingFromServer(),
+        context.getGracePeriodSeconds() > 0 ? context.getGracePeriodSeconds() : getGracePeriodSeconds(),
+        Utils.getNonNullOrElse(context.getPropagationPolicy(), getPropagationPolicy()),
+        getWatchRetryInitialBackoffMillis(), getWatchRetryBackoffMultiplier(),
+        context.isNamespaceFromGlobalConfig() ? context.isNamespaceFromGlobalConfig() : isNamespaceFromGlobalConfig());
   }
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
@@ -335,7 +335,7 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
       new RollingOperationContext(context.getClient(), context.getConfig(), context.getPlural(), context.getNamespace(),
         null, context.getApiGroupName(), context.getApiGroupVersion(), context.getCascading(), null, context.getLabels(),
         context.getLabelsNot(), context.getLabelsIn(), context.getLabelsNotIn(), context.getFields(), context.getFieldsNot(),
-        context.getResourceVersion(), context.getReloadingFromServer(), context.getGracePeriodSeconds(), context.getPropagationPolicy(),
+        context.getResourceVersion(), context.isReloadingFromServer(), context.getGracePeriodSeconds(), context.getPropagationPolicy(),
         context.getWatchRetryInitialBackoffMillis(), context.getWatchRetryBackoffMultiplier(), false, 0, null,
         context.isNamespaceFromGlobalConfig()), podLogWaitTimeout);
     ReplicaSetList rcList = rsOperations.withLabels(getDeploymentSelectorLabels(deployment)).list();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
@@ -341,7 +341,7 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
       new RollingOperationContext(context.getClient(), context.getConfig(), context.getPlural(), context.getNamespace(),
         null, context.getApiGroupName(), context.getApiGroupVersion(), context.getCascading(), null, context.getLabels(),
         context.getLabelsNot(), context.getLabelsIn(), context.getLabelsNotIn(), context.getFields(), context.getFieldsNot(),
-        context.getResourceVersion(), context.getReloadingFromServer(), context.getGracePeriodSeconds(), context.getPropagationPolicy(),
+        context.getResourceVersion(), context.isReloadingFromServer(), context.getGracePeriodSeconds(), context.getPropagationPolicy(),
         context.getWatchRetryInitialBackoffMillis(), context.getWatchRetryBackoffMultiplier(), false, 0, null,
       context.isNamespaceFromGlobalConfig()), podLogWaitTimeout);
     ReplicaSetList rcList = rsOperations.withLabels(getDeploymentSelectorLabels(deployment)).list();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/PodOperationUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/PodOperationUtil.java
@@ -58,7 +58,7 @@ public class PodOperationUtil {
       context.getConfig(), context.getPlural(), context.getNamespace(), null, null,
       "v1", context.getCascading(), context.getItem(), context.getLabels(), context.getLabelsNot(),
       context.getLabelsIn(), context.getLabelsNotIn(), context.getFields(), context.getFieldsNot(), context.getResourceVersion(),
-      context.getReloadingFromServer(), context.getGracePeriodSeconds(), context.getPropagationPolicy(),
+      context.isReloadingFromServer(), context.getGracePeriodSeconds(), context.getPropagationPolicy(),
       context.getWatchRetryInitialBackoffMillis(), context.getWatchRetryBackoffMultiplier(), context.isNamespaceFromGlobalConfig(), null, null, null, null, null,
       null, null, null, null, false, false, false, null, null,
       null, isPretty, null, null, null, null, null, podLogWaitTimeout));

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -47,71 +47,70 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class Utils {
-  
+
   private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
   private static final String ALL_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
   public static final String WINDOWS = "win";
   public static final String OS_NAME = "os.name";
   public static final String PATH_WINDOWS = "Path";
   public static final String PATH_UNIX = "PATH";
-  
+
   private Utils() {
   }
-  
+
   public static <T> T checkNotNull(T ref, String message) {
     if (ref == null) {
       throw new NullPointerException(message);
     }
     return ref;
   }
-  
+
   public static String getSystemPropertyOrEnvVar(String systemPropertyName, String envVarName, String defaultValue) {
     String answer = System.getProperty(systemPropertyName);
     if (isNotNullOrEmpty(answer)) {
       return answer;
     }
-    
+
     answer = System.getenv(envVarName);
     if (isNotNullOrEmpty(answer)) {
       return answer;
     }
-    
+
     return defaultValue;
   }
-  
+
   public static String convertSystemPropertyNameToEnvVar(String systemPropertyName) {
     return systemPropertyName.toUpperCase(Locale.ROOT).replaceAll("[.-]", "_");
   }
-  
+
   public static String getEnvVar(String envVarName, String defaultValue) {
     String answer = System.getenv(envVarName);
     return isNotNullOrEmpty(answer) ? answer : defaultValue;
   }
-  
+
   public static String getSystemPropertyOrEnvVar(String systemPropertyName, String defaultValue) {
     return getSystemPropertyOrEnvVar(systemPropertyName, convertSystemPropertyNameToEnvVar(systemPropertyName), defaultValue);
   }
-  
+
   public static String getSystemPropertyOrEnvVar(String systemPropertyName) {
     return getSystemPropertyOrEnvVar(systemPropertyName, (String) null);
   }
-  
+
   public static boolean getSystemPropertyOrEnvVar(String systemPropertyName, Boolean defaultValue) {
     String result = getSystemPropertyOrEnvVar(systemPropertyName, defaultValue.toString());
     return Boolean.parseBoolean(result);
   }
-  
+
   public static int getSystemPropertyOrEnvVar(String systemPropertyName, int defaultValue) {
     String result = getSystemPropertyOrEnvVar(systemPropertyName, Integer.toString(defaultValue));
     return Integer.parseInt(result);
   }
-  
+
   public static String join(final Object[] array) {
     return join(array, ',');
   }
-  
+
   public static String join(final Object[] array, final char separator) {
     if (array == null) {
       return null;
@@ -130,8 +129,7 @@ public class Utils {
     }
     return buf.toString();
   }
-  
-  
+
   /**
    * Wait until an other thread signals the completion of a task.
    * If an exception is passed, it will be propagated to the caller.
@@ -156,7 +154,7 @@ public class Utils {
       throw KubernetesClientException.launderThrowable(t);
     }
   }
-  
+
   /**
    * Closes the specified {@link ExecutorService}.
    * @param executorService   The executorService.
@@ -170,22 +168,22 @@ public class Utils {
     if (!executorService.isShutdown()) {
       executorService.shutdown();
     }
-    
+
     try {
       //Wait for clean termination
       if (executorService.awaitTermination(5, TimeUnit.SECONDS)) {
         return true;
       }
-      
+
       //If not already terminated (via shutdownNow) do shutdownNow.
       if (!executorService.isTerminated()) {
         executorService.shutdownNow();
       }
-      
+
       if (executorService.awaitTermination(5, TimeUnit.SECONDS)) {
         return true;
       }
-      
+
       if (LOGGER.isDebugEnabled()) {
         List<Runnable> tasks = executorService.shutdownNow();
         if (!tasks.isEmpty()) {
@@ -199,7 +197,7 @@ public class Utils {
     }
     return false;
   }
-  
+
   /**
    * Closes and flushes the specified {@link Closeable} items.
    * @param closeables  An {@link Iterable} of {@link Closeable} items.
@@ -211,7 +209,7 @@ public class Utils {
         if (c instanceof Flushable) {
           ((Flushable) c).flush();
         }
-        
+
         if (c != null) {
           c.close();
         }
@@ -220,7 +218,7 @@ public class Utils {
       }
     }
   }
-  
+
   /**
    * Closes and flushes the specified {@link Closeable} items.
    * @param closeables  An array of {@link Closeable} items.
@@ -228,7 +226,7 @@ public class Utils {
   public static void closeQuietly(Closeable... closeables) {
     closeQuietly(Arrays.asList(closeables));
   }
-  
+
   public static String coalesce(String... items) {
     for (String str : items) {
       if (str != null) {
@@ -237,7 +235,7 @@ public class Utils {
     }
     return null;
   }
-  
+
   public static String randomString(int length) {
     Random random = new Random();
     StringBuilder sb = new StringBuilder();
@@ -247,7 +245,7 @@ public class Utils {
     }
     return sb.toString();
   }
-  
+
   public static String randomString(String prefix, int length) {
     Random random = new Random();
     StringBuilder sb = new StringBuilder();
@@ -257,7 +255,7 @@ public class Utils {
     }
     return sb.toString();
   }
-  
+
   public static String filePath(URL path) {
     try {
       return Paths.get(path.toURI()).toString();
@@ -265,7 +263,7 @@ public class Utils {
       throw new RuntimeException(e);
     }
   }
-  
+
   /**
    * Replaces all occurrences of the from text with to text without any regular expressions
    *
@@ -283,7 +281,7 @@ public class Utils {
       idx = text.indexOf(from, idx);
       if (idx >= 0) {
         text = text.substring(0, idx) + to + text.substring(idx + from.length());
-        
+
         // lets start searching after the end of the `to` to avoid possible infinite recursion
         idx += to.length();
       } else {
@@ -292,42 +290,46 @@ public class Utils {
     }
     return text;
   }
-  
+
   public static boolean isNullOrEmpty(String str) {
     return str == null || str.isEmpty();
   }
-  
+
   public static boolean isNotNullOrEmpty(Map map) {
     return !(map == null || map.isEmpty());
   }
-  
+
   public static boolean isNotNullOrEmpty(String str) {
     return !isNullOrEmpty(str);
   }
-  
+
   public static boolean isNotNullOrEmpty(String[] array) {
     return !(array == null || array.length == 0);
   }
-  
+
   public static <T> boolean isNotNull(T... refList) {
     return Optional.ofNullable(refList)
       .map(refs -> Stream.of(refs).allMatch(Objects::nonNull))
       .orElse(false);
   }
-  
+
+  public static <T> T getNonNullOrElse(T obj, T defaultObj) {
+    return obj != null ? obj : defaultObj;
+  }
+
   public static String getProperty(Map<String, Object> properties, String propertyName, String defaultValue) {
     String answer = (String) properties.get(propertyName);
     if (!isNullOrEmpty(answer)) {
       return answer;
     }
-    
+
     return getSystemPropertyOrEnvVar(propertyName, defaultValue);
   }
-  
+
   public static String getProperty(Map<String, Object> properties, String propertyName) {
     return getProperty(properties, propertyName, null);
   }
-  
+
   /**
    * Converts string to URL encoded string.
    *
@@ -342,7 +344,7 @@ public class Utils {
     }
     return null;
   }
-  
+
   /**
    *  todo: we should unify this with {@link Pluralize}
    */
@@ -370,7 +372,7 @@ public class Utils {
     }
     return pluralBuffer.toString();
   }
-  
+
   /**
    * Reads @Namespaced annotation in resource class to check whether
    * resource is namespaced or not
@@ -381,7 +383,7 @@ public class Utils {
   public static boolean isResourceNamespaced(Class kubernetesResourceType) {
     return Namespaced.class.isAssignableFrom(kubernetesResourceType);
   }
-  
+
   public static String getAnnotationValue(Class kubernetesResourceType, Class annotationClass) {
     Annotation annotation = kubernetesResourceType.getAnnotation(annotationClass);
     if (annotation instanceof Group) {
@@ -391,7 +393,7 @@ public class Utils {
     }
     return null;
   }
-  
+
   /**
    * Interpolates a String containing variable placeholders with the values provided in the valuesMap.
    *
@@ -425,7 +427,7 @@ public class Utils {
       .reduce(Function.identity(), Function::andThen)
       .apply(Objects.requireNonNull(templateInput, "templateInput is required"));
   }
-  
+
   /**
    * Check whether platform is windows or not
    *
@@ -434,7 +436,7 @@ public class Utils {
   public static boolean isWindowsOperatingSystem() {
     return getOperatingSystemFromSystemProperty().toLowerCase().contains(WINDOWS);
   }
-  
+
   /**
    * Get system PATH variable
    *
@@ -443,7 +445,7 @@ public class Utils {
   public static String getSystemPathVariable() {
     return System.getenv(isWindowsOperatingSystem() ? PATH_WINDOWS : PATH_UNIX);
   }
-  
+
   /**
    * Returns prefixes needed to invoke specified command
    * in a subprocess.
@@ -461,9 +463,9 @@ public class Utils {
     }
     return platformPrefixParts;
   }
-  
+
   private static String getOperatingSystemFromSystemProperty() {
     return System.getProperty(OS_NAME);
   }
-  
+
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/OperationContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/OperationContextTest.java
@@ -105,7 +105,7 @@ class OperationContextTest {
     assertEquals("field", operationContext.getFields().get("test"));
     assertArrayEquals(new String[]{ "fieldsNot"}, operationContext.getFieldsNot().get("test"));
     assertEquals("234343", operationContext.getResourceVersion());
-    assertFalse(operationContext.getReloadingFromServer());
+    assertFalse(operationContext.isReloadingFromServer());
     assertEquals(0, operationContext.getGracePeriodSeconds());
     assertEquals(DeletionPropagation.BACKGROUND, operationContext.getPropagationPolicy());
     assertEquals(0, operationContext.getWatchRetryInitialBackoffMillis());


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Reduce some code smells from OperationContext class, and also use primitive booleans in BaseOperation.

There is a small improvement in the `with*` instantiation of OperationContext where if the same value is provided, the same instance is returned instead of creating an unnecessary copy.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
