### PR TITLE
Fix #2746: SharedInformerFactory should use a key based on OperationContext rather than Type in Map storing registered informers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 * Fix #2857: Fix the log of an unexpected error from an Informer's EventHandler
 * Fix #2853: Cannot change the type of the Service from ClusterIP to ExternalName with PATCH
 * Fix #2783: OpenIDConnectionUtils#persistKubeConfigWithUpdatedToken persists access token instead of refresh token
-* Fix #2871: Change longFileMode to LONGFILE_POSIX for creating tar in PodUpload, improve exception handling in PodUpload.
+* Fix #2871: Change longFileMode to LONGFILE\_POSIX for creating tar in PodUpload, improve exception handling in PodUpload.
+* Fix #2746: SharedInformerFactory should use key formed from OperationContext 
 
 #### Improvements
 * Fix #2781: RawCustomResourceOperationsImpl#delete now returns a boolean value for deletion status

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
@@ -28,8 +28,9 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.informers.impl.DefaultSharedIndexInformer;
+import io.fabric8.kubernetes.client.utils.Pluralize;
+import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
-import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,9 +46,9 @@ import okhttp3.OkHttpClient;
  * which is ported from offical go client https://github.com/kubernetes/client-go/blob/master/informers/factory.go
  */
 public class SharedInformerFactory extends BaseOperation {
-  private final Map<Type, SharedIndexInformer> informers = new HashMap<>();
+  private final Map<String, SharedIndexInformer> informers = new HashMap<>();
 
-  private final Map<Type, Future> startedInformers = new HashMap<>();
+  private final Map<String, Future> startedInformers = new HashMap<>();
 
   private final ExecutorService informerExecutor;
 
@@ -198,7 +199,7 @@ public class SharedInformerFactory extends BaseOperation {
       }
     }
     SharedIndexInformer<T> informer = new DefaultSharedIndexInformer<>(apiTypeClass, listerWatcher, resyncPeriodInMillis, context, eventListeners);
-    this.informers.put(apiTypeClass, informer);
+    this.informers.put(getInformerKey(context), informer);
     return informer;
   }
 
@@ -223,14 +224,21 @@ public class SharedInformerFactory extends BaseOperation {
 
   /**
    * Gets existing shared index informer, return null if the requesting informer
-   * is never constructed.
+   * is never constructed. If there are multiple SharedIndexInformer objects corresponding
+   * to a Kubernetes resource, then it returns the first one
    *
    * @param apiTypeClass API type class
    * @param <T> type of API type
    * @return SharedIndexInformer object
    */
   public synchronized <T> SharedIndexInformer<T> getExistingSharedIndexInformer(Class<T> apiTypeClass) {
-    return this.informers.get(apiTypeClass);
+    SharedIndexInformer<T> foundSharedIndexInformer = null;
+    for (Map.Entry<String, SharedIndexInformer> entry : this.informers.entrySet()) {
+      if (entry.getKey().contains(Pluralize.toPlural(apiTypeClass.getSimpleName().toLowerCase()))) {
+        foundSharedIndexInformer = (SharedIndexInformer<T>) entry.getValue();
+      }
+    }
+    return foundSharedIndexInformer;
   }
 
   /**
@@ -277,6 +285,33 @@ public class SharedInformerFactory extends BaseOperation {
 
   public void addSharedInformerEventListener(SharedInformerEventListener event) {
     this.eventListeners.add(event);
+  }
+
+  Map<String, SharedIndexInformer> getInformers() {
+    return this.informers;
+  }
+
+  static String getInformerKey(OperationContext operationContext) {
+    StringBuilder keyBuilder = new StringBuilder();
+    if (operationContext.getApiGroupName() == null) {
+      keyBuilder.append(operationContext.getApiGroupVersion());
+    } else {
+      keyBuilder.append(operationContext.getApiGroupName()).append("/").append(operationContext.getApiGroupVersion());
+    }
+    keyBuilder.append(getKeyStrForField(operationContext.getPlural()));
+    keyBuilder.append(getKeyStrForField(operationContext.getNamespace()));
+    keyBuilder.append(getKeyStrForField(operationContext.getName()));
+
+    return keyBuilder.toString();
+  }
+
+  private static String getKeyStrForField(String str) {
+    StringBuilder keyBuilder = new StringBuilder();
+    if (Utils.isNotNullOrEmpty(str)) {
+      keyBuilder.append("/");
+      keyBuilder.append(str);
+    }
+    return keyBuilder.toString();
   }
 
   private <T extends HasMetadata, L extends KubernetesResourceList<T>> BaseOperation<T, L, ?> getConfiguredBaseOperation(String namespace, OperationContext context, Class<T> apiTypeClass, Class<L> apiListTypeClass) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.informers;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+
+import static io.fabric8.kubernetes.client.informers.SharedInformerFactory.getInformerKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SharedInformerFactoryTest {
+  private OkHttpClient mockClient;
+  private Config config;
+  private ExecutorService executorService;
+  private static class TestCustomResourceSpec { }
+  private static class TestCustomResourceStatus { }
+
+  @Group("io.fabric8")
+  @Version("v1")
+  private static class TestCustomResource extends CustomResource<TestCustomResourceSpec, TestCustomResourceStatus> { }
+
+  @BeforeEach
+  void init() {
+    this.mockClient = Mockito.mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    this.config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    this.executorService = Mockito.mock(ExecutorService.class, Mockito.RETURNS_DEEP_STUBS);
+  }
+
+  @Test
+  void testGetInformerKey() {
+    assertThat(getInformerKey(new OperationContext()
+      .withApiGroupVersion("v1")
+      .withPlural("pods"))).isEqualTo("v1/pods");
+    assertThat(getInformerKey(new OperationContext()
+      .withApiGroupVersion("v1")
+      .withNamespace("ns1")
+      .withPlural("pods"))).isEqualTo("v1/pods/ns1");
+    assertThat(getInformerKey(new OperationContext()
+      .withApiGroupVersion("v1")
+      .withApiGroupName("io.fabric8")
+      .withPlural("testcustomresources"))).isEqualTo("io.fabric8/v1/testcustomresources");
+    assertThat(getInformerKey(new OperationContext()
+      .withApiGroupVersion("v1beta1")
+      .withApiGroupName("io.fabric8")
+      .withPlural("testcustomresources"))).isEqualTo("io.fabric8/v1beta1/testcustomresources");
+    assertThat(getInformerKey(new OperationContext()
+      .withApiGroupVersion("v1beta1")
+      .withApiGroupName("extensions")
+      .withPlural("deployments"))).isEqualTo("extensions/v1beta1/deployments");
+  }
+
+  @Test
+  void testInformersCreatedWithSameNameButDifferentCRDContext() {
+    // Given
+    SharedInformerFactory sharedInformerFactory = new SharedInformerFactory(executorService, mockClient, config);
+
+    // When
+    sharedInformerFactory.sharedIndexInformerForCustomResource(TestCustomResource.class, new OperationContext()
+      .withApiGroupVersion("v1")
+      .withPlural("testcustomresources"), 10 * 1000L);
+    sharedInformerFactory.sharedIndexInformerForCustomResource(TestCustomResource.class, new OperationContext()
+      .withApiGroupVersion("v1beta1")
+      .withPlural("testcustomresources"), 10 * 1000L);
+
+    // Then
+    assertThat(sharedInformerFactory.getInformers())
+      .hasSize(2);
+  }
+
+  @Test
+  void testGetExistingSharedIndexInformer() {
+    // Given
+    SharedInformerFactory sharedInformerFactory = new SharedInformerFactory(executorService, mockClient, config);
+
+    // When
+    sharedInformerFactory.sharedIndexInformerFor(Deployment.class, 10 * 1000L);
+    sharedInformerFactory.sharedIndexInformerFor(Pod.class, 10 * 1000L);
+
+    // Then
+    assertThat(sharedInformerFactory.getExistingSharedIndexInformer(Deployment.class)).isNotNull();
+    assertThat(sharedInformerFactory.getExistingSharedIndexInformer(Pod.class)).isNotNull();
+  }
+
+}


### PR DESCRIPTION
Fix #2746 

    SharedInformerFactory has `informers` and `startedInformers` Map fields
    which use `Type` as key. This limits us to use only one
    SharedIndexInformer corresponding to a particular type. We should make a
    key based on OperationContext's elements like apigroup, apiversion,
    namespace, name.

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
