### PR TITLE
Fix #2802: Kubernetes Mock Server Crud Mode should reject invalid Kubernetes resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.2-SNAPSHOT
 
 #### Bugs
+* Fix #2802: NullPointerException in HasMetadataOperation patch/replace when using KubernetesMockServer
 * Fix #2828: Remove automatic instantiation of CustomResource spec and status as this feature was causing more issues than it was solving
 * Fix #2857: Fix the log of an unexpected error from an Informer's EventHandler
 * Fix #2853: Cannot change the type of the Service from ClusterIP to ExternalName with PATCH

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -266,7 +266,7 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
     return null;
   }
 
-  private static HasMetadata toKubernetesResource(String s) {
+  static HasMetadata toKubernetesResource(String s) {
     try (InputStream stream = new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8.name()))) {
       return Serialization.unmarshal(stream);
     } catch (Exception e) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SecretCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SecretCrudTest.java
@@ -20,6 +20,9 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretList;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -27,6 +30,8 @@ import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -79,6 +84,24 @@ public class SecretCrudTest {
 
     secret2 = client.secrets().inNamespace("ns2").withName("secret2").edit(s -> new SecretBuilder(s).removeFromData("one").build());
     assertNotNull(secret2);
-    assertEquals(null, secret2.getData());
+    assertNull(secret2.getData());
+  }
+
+  @Test
+  void testSecretWithNoMetadataCreateFails() {
+    // Given
+    Secret invalidSecret = new SecretBuilder()
+      .addToData("key.json", "{\"foo\":\"bar\"}")
+      .build();
+    KubernetesClient client = server.getClient();
+
+    // When + Then
+    NonNamespaceOperation<Secret, SecretList, Resource<Secret>> secretOp = client.secrets().inNamespace("foo");
+    KubernetesClientException kubernetesClientException = assertThrows(KubernetesClientException.class, () -> secretOp.create(invalidSecret));
+    assertEquals(422, kubernetesClientException.getCode());
+    assertEquals("Secret is invalid", kubernetesClientException.getStatus().getMessage());
+    assertEquals(1, kubernetesClientException.getStatus().getDetails().getCauses().size());
+    assertEquals("ValueRequired", kubernetesClientException.getStatus().getDetails().getCauses().get(0).getReason());
+    assertEquals("Required value: metadata is required", kubernetesClientException.getStatus().getDetails().getCauses().get(0).getMessage());
   }
 }


### PR DESCRIPTION
Fix #2802 

Right now when a resource with no metadata is created, instead of throwing KubernetesClientException, we're throwing a
NullPointerException here:
  KubernetesAttributesExtractor.extractMetadataAttributes:L154

KubernetesMockServer should validate whether object sent in the request body contains metadata or not

Note that this doesn't solve your issue when you're using
KubernetesMockServer in expectations mode since you set what you'll be
getting as response to be received by yourself

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
