### PR TITLE
Fix #2855: .withPropagationPolicy and .withGracePeriod DSL methods can't be combined resource() deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #2828: Remove automatic instantiation of CustomResource spec and status as this feature was causing more issues than it was solving
 * Fix #2857: Fix the log of an unexpected error from an Informer's EventHandler
 * Fix #2853: Cannot change the type of the Service from ClusterIP to ExternalName with PATCH
+* Fix #2855: `.withPropagationPolicy` and `.withGracePeriod` DSL methods can't be combined for Resource API deletion operations
 * Fix #2783: OpenIDConnectionUtils#persistKubeConfigWithUpdatedToken persists access token instead of refresh token
 * Fix #2871: Change longFileMode to LONGFILE\_POSIX for creating tar in PodUpload, improve exception handling in PodUpload.
 * Fix #2746: SharedInformerFactory should use key formed from OperationContext 

--- a/extensions/chaosmesh/client/src/main/resources/resource-handler.vm
+++ b/extensions/chaosmesh/client/src/main/resources/resource-handler.vm
@@ -85,8 +85,8 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ${model.name} item, boolean dryRun) {
-    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).delete();
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ${model.name} item, boolean dryRun) {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
   }
 
   @Override

--- a/extensions/knative/client/src/main/resources/resource-handler.vm
+++ b/extensions/knative/client/src/main/resources/resource-handler.vm
@@ -86,8 +86,8 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ${model.name} item, boolean dryRun) {
-    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).delete();
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ${model.name} item, boolean dryRun) {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
   }
 
   @Override

--- a/extensions/service-catalog/client/src/main/resources/resource-handler.vm
+++ b/extensions/service-catalog/client/src/main/resources/resource-handler.vm
@@ -85,8 +85,8 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ${model.name} item, boolean dryRun) {
-    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).delete();
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ${model.name} item, boolean dryRun) {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
   }
 
   @Override

--- a/extensions/tekton/client/src/main/resources/resource-handler.vm
+++ b/extensions/tekton/client/src/main/resources/resource-handler.vm
@@ -85,8 +85,8 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ${model.name} item, boolean dryRun) {
-    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).delete();
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ${model.name} item, boolean dryRun) {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
   }  
 
   @Override

--- a/extensions/volumesnapshot/client/src/main/resources/resource-handler.vm
+++ b/extensions/volumesnapshot/client/src/main/resources/resource-handler.vm
@@ -85,8 +85,8 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ${model.name} item, boolean dryRun) {
-    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).delete();
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ${model.name} item, boolean dryRun) {
+    return new ${model.name}OperationsImpl(client, config).withItem(item).inNamespace(namespace).withName(item.getMetadata().getName()).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
@@ -122,11 +122,12 @@ public interface ResourceHandler<T, V extends VisitableBuilder<T, V>> {
    * @param config        The client config.
    * @param namespace     The target namespace.
    * @param propagationPolicy  Whether and how garbage collection will be performed.
+   * @param gracePeriodSeconds The duration in seconds before the object should be deleted.
    * @param item          The resource to delete.
    * @param dryRun        enable dry run
    * @return              The true if the resource was successfully deleted.
    */
-  Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, T item, boolean dryRun);
+  Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, T item, boolean dryRun);
 
 
     /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CascadingDeletable.java
@@ -15,8 +15,15 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import io.fabric8.kubernetes.client.GracePeriodConfigurable;
+import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
+
 /**
  * Created by iocanel on 9/15/16.
  */
-public interface CascadingDeletable<T> extends Deletable, Cascading<Deletable>, Recreateable<Applicable<T>> {
+public interface CascadingDeletable<T> extends Deletable,
+  Cascading<Deletable>,
+  GracePeriodConfigurable<CascadingDeletable<T>>,
+  PropagationPolicyConfigurable<CascadingDeletable<T>>,
+  Recreateable<Applicable<T>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -27,6 +27,7 @@ import java.util.function.UnaryOperator;
 
 public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>> extends BaseOperation< T, L, R> {
   public static final DeletionPropagation DEFAULT_PROPAGATION_POLICY = DeletionPropagation.BACKGROUND;
+  public static final long DEFAULT_GRACE_PERIOD_IN_SECONDS = -1L;
 
   public HasMetadataOperation(OperationContext ctx) {
     super(ctx);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -77,8 +77,8 @@ public class OperationSupport {
     this(new OperationContext().withOkhttpClient(client).withConfig(config));
   }
 
-  public OperationSupport(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace).withPropagationPolicy(propagationPolicy));
+  public OperationSupport(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodInSeconds) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config).withNamespace(namespace).withPropagationPolicy(propagationPolicy).withGracePeriodSeconds(gracePeriodInSeconds));
   }
 
   public OperationSupport(OperationContext ctx) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -139,7 +139,7 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
     ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(meta);
     String namespaceToUse = meta.getMetadata().getNamespace();
     if (Boolean.TRUE.equals(deletingExisting)) {
-      return deleteAndCreateItem(client, config, meta, h, namespaceToUse, propagationPolicy, dryRun);
+      return deleteAndCreateItem(client, config, meta, h, namespaceToUse, propagationPolicy, gracePeriodSeconds, dryRun);
     }
     return createOrReplaceItem(client, config, meta, h, namespaceToUse, dryRun);
   }
@@ -154,7 +154,7 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
     //First pass check before deleting
     HasMetadata meta = acceptVisitors(asHasMetadata(item), visitors);
     ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(meta);
-    return h.delete(client, config, meta.getMetadata().getNamespace(), propagationPolicy, meta, dryRun);
+    return h.delete(client, config, meta.getMetadata().getNamespace(), propagationPolicy, gracePeriodSeconds, meta, dryRun);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -319,7 +319,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
         //Second pass do delete
         for (HasMetadata meta :  acceptVisitors(asHasMetadata(item, true), visitors)) {
             ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h = handlerOf(meta);
-            if (!h.delete(client, config, meta.getMetadata().getNamespace(), propagationPolicy, meta, dryRun)) {
+            if (!h.delete(client, config, meta.getMetadata().getNamespace(), propagationPolicy, gracePeriodSeconds, meta, dryRun)) {
                 return false;
             }
         }
@@ -449,7 +449,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
 
   private HasMetadata createOrReplaceOrDeleteExisting(HasMetadata meta, ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h, String namespaceToUse, boolean dryRun) {
       if (Boolean.TRUE.equals(deletingExisting)) {
-        return deleteAndCreateItem(client, config, meta, h, namespaceToUse, propagationPolicy, dryRun);
+        return deleteAndCreateItem(client, config, meta, h, namespaceToUse, propagationPolicy, gracePeriodSeconds, dryRun);
       }
       return createOrReplaceItem(client, config, meta, h, namespaceToUse, dryRun);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesListHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/handlers/KubernetesListHandler.java
@@ -37,6 +37,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.DEFAULT_GRACE_PERIOD_IN_SECONDS;
+import static io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.DEFAULT_PROPAGATION_POLICY;
+
 @Component
 @org.apache.felix.scr.annotations.Service
 public class KubernetesListHandler implements ResourceHandler<KubernetesList, KubernetesListBuilder> {
@@ -57,7 +60,7 @@ public class KubernetesListHandler implements ResourceHandler<KubernetesList, Ku
 
   @Override
   public KubernetesList create(OkHttpClient client, Config config, String namespace, KubernetesList item, boolean dryRun) {
-    return new KubernetesListOperationsImpl(client, config, namespace, null, DeletionPropagation.BACKGROUND, false, false, item, null, dryRun).create();
+    return new KubernetesListOperationsImpl(client, config, namespace, null, DEFAULT_PROPAGATION_POLICY, DEFAULT_GRACE_PERIOD_IN_SECONDS, false, false, item, null, dryRun).create();
   }
 
   @Override
@@ -96,8 +99,8 @@ public class KubernetesListHandler implements ResourceHandler<KubernetesList, Ku
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, KubernetesList item, boolean dryRun) {
-    return new KubernetesListOperationsImpl(client, config, namespace, null, propagationPolicy, false, false, item, null, dryRun).delete(item);
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, KubernetesList item, boolean dryRun) {
+    return new KubernetesListOperationsImpl(client, config, namespace, null, propagationPolicy, gracePeriodSeconds, false, false, item, null, dryRun).delete(item);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/DeleteAndCreateHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/DeleteAndCreateHelper.java
@@ -74,10 +74,10 @@ public class DeleteAndCreateHelper<T extends HasMetadata> {
     }
   }
 
-  public static HasMetadata deleteAndCreateItem(OkHttpClient client, Config config, HasMetadata meta, ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h, String namespaceToUse, DeletionPropagation propagationPolicy, boolean dryRun) {
+  public static HasMetadata deleteAndCreateItem(OkHttpClient client, Config config, HasMetadata meta, ResourceHandler<HasMetadata, HasMetadataVisitiableBuilder> h, String namespaceToUse, DeletionPropagation propagationPolicy, long gracePeriodSeconds, boolean dryRun) {
     DeleteAndCreateHelper<HasMetadata> deleteAndCreateHelper = new DeleteAndCreateHelper<>(
       m -> h.create(client, config, namespaceToUse, m, dryRun),
-      m -> h.delete(client, config, namespaceToUse, propagationPolicy, m, dryRun),
+      m -> h.delete(client, config, namespaceToUse, propagationPolicy, gracePeriodSeconds, m, dryRun),
       waitUntilDeletedOrInterrupted(client, config, h, namespaceToUse)
     );
 

--- a/kubernetes-client/src/main/resources/resource-handler.vm
+++ b/kubernetes-client/src/main/resources/resource-handler.vm
@@ -87,8 +87,8 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ${model.name} item, boolean dryRun) {
-    return new ${model.name}OperationsImpl(client, config, namespace).withItem(item).dryRun(dryRun).withPropagationPolicy(propagationPolicy).delete();
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ${model.name} item, boolean dryRun) {
+    return new ${model.name}OperationsImpl(client, config, namespace).withItem(item).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
   }
 
 @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/ProjectRequestHandler.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/handlers/ProjectRequestHandler.java
@@ -68,7 +68,7 @@ public class ProjectRequestHandler implements ResourceHandler<ProjectRequest, Pr
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ProjectRequest item, boolean dryRun) {
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ProjectRequest item, boolean dryRun) {
     throw new UnsupportedOperationException();
   }
 

--- a/openshift-client/src/main/resources/resource-handler.vm
+++ b/openshift-client/src/main/resources/resource-handler.vm
@@ -87,8 +87,8 @@ public class ${model.name}Handler implements ResourceHandler<${model.name}, ${mo
   }
 
   @Override
-  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, ${model.name} item, boolean dryRun) {
-    return new ${model.name}OperationsImpl(client, OpenShiftConfig.wrap(config)).withItem(item).dryRun(dryRun).withPropagationPolicy(propagationPolicy).delete();
+  public Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, ${model.name} item, boolean dryRun) {
+    return new ${model.name}OperationsImpl(client, OpenShiftConfig.wrap(config)).withItem(item).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
   }
 
   @Override


### PR DESCRIPTION
## Description
Fix #2885 

+ Add gracePeriodSeconds parameter in ResourceHandler#delete
+ Modified CascadingDeletable interface so that it includes
GracePeriodConfigurable and PropagationPolicyConfiguratble

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
