### PR TITLE
Fail on invalid formats

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -100,8 +100,6 @@ public class Quantity  implements Serializable {
     this.format = format;
   }
 
-  private static Set<String> validFormats = new HashSet<String>(Arrays.asList("Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "n", "u", "m", "k", "M", "G", "T", "P", "E", ""));
-
   public static BigDecimal getAmountInBytes(Quantity quantity) throws ArithmeticException {
     String value = "";
     if (quantity.getAmount() != null && quantity.getFormat() != null) {
@@ -124,8 +122,6 @@ public class Quantity  implements Serializable {
     if ((formatStr.matches(AT_LEAST_ONE_DIGIT_REGEX)) && formatStr.length() > 1) {
       int exponent = Integer.parseInt(formatStr.substring(1));
       return new BigDecimal("10").pow(exponent, MathContext.DECIMAL64).multiply(new BigDecimal(amountFormatPair.getAmount()));
-    } else if (!validFormats.contains(quantity.getFormat())) {
-      throw new IllegalArgumentException("Invalid quantity format passed to parse");
     }
 
     BigDecimal digit = new BigDecimal(amountFormatPair.getAmount());
@@ -179,6 +175,10 @@ public class Quantity  implements Serializable {
       case "E":
         multiple = decimalFactor.pow(18, MathContext.DECIMAL64);
         break;
+      case "":
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid quantity format passed to parse");
     }
 
     return digit.multiply(multiple);

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -29,11 +29,8 @@ import io.sundr.builder.annotations.Buildable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.io.Serializable;
 
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -29,8 +29,11 @@ import io.sundr.builder.annotations.Buildable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.io.Serializable;
 
 
@@ -47,7 +50,7 @@ public class Quantity  implements Serializable {
 
   private static final String AT_LEAST_ONE_DIGIT_REGEX = ".*\\d+.*";
   private String amount;
-  private String format;
+  private String format = "";
   private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
   /**
@@ -76,7 +79,9 @@ public class Quantity  implements Serializable {
    */
   public Quantity(String amount, String format) {
     this.amount = amount;
-    this.format = format;
+    if (format != null) {
+      this.format = format;
+    }
   }
 
   public String getAmount() {
@@ -94,6 +99,8 @@ public class Quantity  implements Serializable {
   public void setFormat(String format) {
     this.format = format;
   }
+
+  private static Set<String> validFormats = new HashSet<String>(Arrays.asList("Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "n", "u", "m", "k", "M", "G", "T", "P", "E", ""));
 
   public static BigDecimal getAmountInBytes(Quantity quantity) throws ArithmeticException {
     String value = "";
@@ -117,6 +124,8 @@ public class Quantity  implements Serializable {
     if ((formatStr.matches(AT_LEAST_ONE_DIGIT_REGEX)) && formatStr.length() > 1) {
       int exponent = Integer.parseInt(formatStr.substring(1));
       return new BigDecimal("10").pow(exponent, MathContext.DECIMAL64).multiply(new BigDecimal(amountFormatPair.getAmount()));
+    } else if (!validFormats.contains(quantity.getFormat())) {
+      throw new IllegalArgumentException("Invalid quantity format passed to parse");
     }
 
     BigDecimal digit = new BigDecimal(amountFormatPair.getAmount());

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
@@ -160,5 +160,7 @@ public class QuantityTest {
     assertThrows(IllegalArgumentException.class, () -> new Quantity(""));
     assertThrows(IllegalArgumentException.class, () -> new Quantity(null));
     assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity()));
+    assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity("4MiB")));
+    assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity("4megabyte")));
   }
 }


### PR DESCRIPTION
## Description
`Quantity.getAmountInBytes` should fail in case an invalid format is passed instead of ignoring it.

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
