### PR TITLE
Fix #2837: Add Support for `events.k8s.io` APIGroup DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Fix #2837: Add Support for `events.k8s.io` APIGroup DSL
 
 ### 5.2.1 (2021-03-16)
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -67,6 +67,7 @@ import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Createable;
 import io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.EventingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
@@ -440,6 +441,11 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public DiscoveryAPIGroupDSL discovery() {
     return adapt(DiscoveryAPIGroupClient.class);
+  }
+
+  @Override
+  public EventingAPIGroupDSL events() {
+    return adapt(EventingAPIGroupClient.class);
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/EventingAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/EventingAPIGroupClient.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.client.dsl.EventingAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.V1EventingAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.V1beta1EventingAPIGroupDSL;
+import okhttp3.OkHttpClient;
+
+public class EventingAPIGroupClient extends BaseClient implements EventingAPIGroupDSL {
+  public EventingAPIGroupClient() {
+    super();
+  }
+
+  public EventingAPIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+
+  @Override
+  public V1EventingAPIGroupDSL v1() {
+    return adapt(V1EventingAPIGroupClient.class);
+  }
+
+  @Override
+  public V1beta1EventingAPIGroupDSL v1beta1() {
+    return adapt(V1beta1EventingAPIGroupClient.class);
+  }
+}
+

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/EventingAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/EventingAPIGroupExtensionAdapter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+
+public class EventingAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<EventingAPIGroupClient> {
+
+  @Override
+  protected String getAPIGroupName() {
+    return "events";
+  }
+
+  @Override
+  public Class<EventingAPIGroupClient> getExtensionType() {
+    return EventingAPIGroupClient.class;
+  }
+
+  @Override
+  protected EventingAPIGroupClient newInstance(Client client) {
+    return new EventingAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -166,6 +166,15 @@ public interface KubernetesClient extends Client {
   DiscoveryAPIGroupDSL discovery();
 
   /**
+   * Event API entrypoint for APIGroup events.k8s.io
+   *
+   * <b>Note:</b> This should not be confused with v1.Event
+   *
+   * @return {@link EventingAPIGroupDSL} with which you can access Events API resources objects.
+   */
+  EventingAPIGroupDSL events();
+
+  /**
    * Extensions API entrypoint for APIGroup extensions/v1beta1
    *
    * @return ExtensionsAPIGroupDSL with which you can access entrypoints for extension objects

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1EventingAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1EventingAPIGroupClient.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.events.v1.Event;
+import io.fabric8.kubernetes.api.model.events.v1.EventList;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.V1EventingAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.internal.events.v1.EventOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class V1EventingAPIGroupClient extends BaseClient implements V1EventingAPIGroupDSL {
+  public V1EventingAPIGroupClient() {
+    super();
+  }
+
+  public V1EventingAPIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public MixedOperation<Event, EventList, Resource<Event>> events() {
+    return new EventOperationsImpl(httpClient, getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1EventingAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1EventingAPIGroupExtensionAdapter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+
+public class V1EventingAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<V1EventingAPIGroupClient> {
+  @Override
+  protected String getAPIGroupName() {
+    return "events.k8s.io/v1";
+  }
+
+  @Override
+  public Class<V1EventingAPIGroupClient> getExtensionType() {
+    return V1EventingAPIGroupClient.class;
+  }
+
+  @Override
+  protected V1EventingAPIGroupClient newInstance(Client client) {
+    return new V1EventingAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1EventingAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1EventingAPIGroupClient.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.events.v1beta1.Event;
+import io.fabric8.kubernetes.api.model.events.v1beta1.EventList;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.V1beta1EventingAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.internal.events.v1beta1.EventOperationsImpl;
+import okhttp3.OkHttpClient;
+
+public class V1beta1EventingAPIGroupClient extends BaseClient implements V1beta1EventingAPIGroupDSL {
+  public V1beta1EventingAPIGroupClient() {
+    super();
+  }
+
+  public V1beta1EventingAPIGroupClient(OkHttpClient httpClient, final Config config) {
+    super(httpClient, config);
+  }
+
+  @Override
+  public MixedOperation<Event, EventList, Resource<Event>> events() {
+    return new EventOperationsImpl(httpClient, getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1EventingAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1EventingAPIGroupExtensionAdapter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import okhttp3.OkHttpClient;
+
+public class V1beta1EventingAPIGroupExtensionAdapter  extends APIGroupExtensionAdapter<V1beta1EventingAPIGroupClient> {
+  @Override
+  protected String getAPIGroupName() {
+    return "events.k8s.io/v1beta1";
+  }
+
+  @Override
+  public Class<V1beta1EventingAPIGroupClient> getExtensionType() {
+    return V1beta1EventingAPIGroupClient.class;
+  }
+
+  @Override
+  protected V1beta1EventingAPIGroupClient newInstance(Client client) {
+    return new V1beta1EventingAPIGroupClient(client.adapt(OkHttpClient.class), client.getConfiguration());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EventingAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EventingAPIGroupDSL.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.client.Client;
+
+public interface EventingAPIGroupDSL extends Client {
+  V1EventingAPIGroupDSL v1();
+  V1beta1EventingAPIGroupDSL v1beta1();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1EventingAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1EventingAPIGroupDSL.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.api.model.events.v1.Event;
+import io.fabric8.kubernetes.api.model.events.v1.EventList;
+
+public interface V1EventingAPIGroupDSL {
+  /**
+   * DSL Entrypoint for `events.k8s.io/v1` Event Object
+   *
+   * @return {@link MixedOperation} for Event class
+   */
+  MixedOperation<Event, EventList, Resource<Event>> events();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1EventingAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1EventingAPIGroupDSL.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.api.model.events.v1beta1.Event;
+import io.fabric8.kubernetes.api.model.events.v1beta1.EventList;
+
+public interface V1beta1EventingAPIGroupDSL {
+  /**
+   * DSL Entrypoint for `events.k8s.io/v1beta1` Event Object
+   *
+   * @return {@link MixedOperation} for Event class
+   */
+  MixedOperation<Event, EventList, Resource<Event>> events();
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -78,6 +78,7 @@ import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Createable;
 import io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.EventingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
@@ -437,6 +438,11 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   @Override
   public DiscoveryAPIGroupDSL discovery() {
     return delegate.discovery();
+  }
+
+  @Override
+  public EventingAPIGroupDSL events() {
+    return delegate.events();
   }
 
   @Override

--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
@@ -26,6 +26,9 @@ io.fabric8.kubernetes.client.V2beta1AutoscalingAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V2beta2AutoscalingAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.BatchAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.ExtensionsAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.EventingAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.V1EventingAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.V1beta1EventingAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.MetricAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.NetworkAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.PolicyAPIGroupExtensionAdapter

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/MockOkhttpClientUtils.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/MockOkhttpClientUtils.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+public class MockOkhttpClientUtils {
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.events.v1.Event;
+import io.fabric8.kubernetes.api.model.events.v1.EventBuilder;
+import io.fabric8.kubernetes.api.model.events.v1.EventList;
+import io.fabric8.kubernetes.api.model.events.v1.EventListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient
+class V1EventsTest {
+  private KubernetesClient client;
+  private KubernetesMockServer server;
+
+  @Test
+  void testList() {
+    // Given
+    server.expect().get().withPath("/apis/events.k8s.io/v1/namespaces/default/events")
+      .andReturn(HttpURLConnection.HTTP_OK, new EventListBuilder()
+        .addToItems(new EventBuilder().withNewMetadata().withName("event1").endMetadata().build())
+        .build())
+      .once();
+
+    // When
+    EventList eventList = client.events().v1().events().inNamespace("default").list();
+
+    // Then
+    assertThat(eventList).isNotNull();
+    assertThat(eventList.getItems()).hasSize(1);
+    assertThat(eventList.getItems().get(0)).hasFieldOrPropertyWithValue("metadata.name", "event1");
+  }
+
+  @Test
+  void testGet() {
+    // Given
+    server.expect().get().withPath("/apis/events.k8s.io/v1/namespaces/default/events/event1")
+      .andReturn(HttpURLConnection.HTTP_OK, new EventBuilder()
+        .withNewMetadata().withName("event1").endMetadata()
+        .build())
+      .once();
+
+    // When
+    Event e1 = client.events().v1().events().inNamespace("default").withName("event1").get();
+
+    // Then
+    assertThat(e1)
+      .isNotNull()
+      .hasFieldOrPropertyWithValue("metadata.name", "event1");
+  }
+
+
+  @Test
+  void testDelete() {
+    // Given
+    server.expect().delete().withPath("/apis/events.k8s.io/v1/namespaces/default/events/e1")
+      .andReturn(HttpURLConnection.HTTP_OK, new StatusBuilder().withStatus("Success").build())
+      .once();
+
+    // When
+    Boolean isDeleted = client.events().v1().events().inNamespace("default").withName("e1").delete();
+
+    // Then
+    assertThat(isDeleted).isTrue();
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.events.v1beta1.Event;
+import io.fabric8.kubernetes.api.model.events.v1beta1.EventBuilder;
+import io.fabric8.kubernetes.api.model.events.v1beta1.EventList;
+import io.fabric8.kubernetes.api.model.events.v1beta1.EventListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient
+class V1beta1EventsTest {
+  private KubernetesClient client;
+  private KubernetesMockServer server;
+
+  @Test
+  void testList() {
+    // Given
+    server.expect().get().withPath("/apis/events.k8s.io/v1beta1/namespaces/default/events")
+      .andReturn(HttpURLConnection.HTTP_OK, new EventListBuilder()
+        .addToItems(new EventBuilder().withNewMetadata().withName("event1").endMetadata().build())
+        .build())
+      .once();
+
+    // When
+    EventList eventList = client.events().v1beta1().events().inNamespace("default").list();
+
+    // Then
+    assertThat(eventList).isNotNull();
+    assertThat(eventList.getItems()).hasSize(1);
+    assertThat(eventList.getItems().get(0)).hasFieldOrPropertyWithValue("metadata.name", "event1");
+  }
+
+  @Test
+  void testGet() {
+    // Given
+    server.expect().get().withPath("/apis/events.k8s.io/v1beta1/namespaces/default/events/event1")
+      .andReturn(HttpURLConnection.HTTP_OK, new EventBuilder()
+        .withNewMetadata().withName("event1").endMetadata()
+        .build())
+      .once();
+
+    // When
+    Event e1 = client.events().v1beta1().events().inNamespace("default").withName("event1").get();
+
+    // Then
+    assertThat(e1)
+      .isNotNull()
+      .hasFieldOrPropertyWithValue("metadata.name", "event1");
+  }
+
+  @Test
+  void testDelete() {
+    // Given
+    server.expect().delete().withPath("/apis/events.k8s.io/v1beta1/namespaces/default/events/e1")
+      .andReturn(HttpURLConnection.HTTP_OK, new StatusBuilder().withStatus("Success").build())
+      .once();
+
+    // When
+    Boolean isDeleted = client.events().v1beta1().events().inNamespace("default").withName("e1").delete();
+
+    // Then
+    assertThat(isDeleted).isTrue();
+  }
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -89,6 +89,7 @@ import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Createable;
 import io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.EventingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.InOutCreateable;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
@@ -477,6 +478,11 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public DiscoveryAPIGroupDSL discovery() {
     return delegate.discovery();
+  }
+
+  @Override
+  public EventingAPIGroupDSL events() {
+    return delegate.events();
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -71,6 +71,7 @@ import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Createable;
 import io.fabric8.kubernetes.client.dsl.DiscoveryAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.EventingAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.InOutCreateable;
@@ -570,6 +571,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public DiscoveryAPIGroupDSL discovery() {
     return delegate.discovery();
+  }
+
+  @Override
+  public EventingAPIGroupDSL events() {
+    return delegate.events();
   }
 
   @Override


### PR DESCRIPTION
Fix #2837 
+ Add support for v1() and v1beta1() models for `events.k8s.io` APIGroup

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
