### PR TITLE
Edit a CustomResource should result in a patch

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -1080,9 +1080,6 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
 
   private String getPatchDiff(String namespace, String customResourceName, Map<String, Object> customResource) throws IOException {
     Map<String, Object> oldObject = get(namespace, customResourceName);
-    String resourceVersion = ((Map<String, Object>)oldObject.get(METADATA)).get(RESOURCE_VERSION).toString();
-
-    ((Map<String, Object>)customResource.get(METADATA)).put(RESOURCE_VERSION, resourceVersion);
 
     // Exclude changes to the status
     oldObject.put("status", null);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -383,8 +383,6 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
    * @throws IOException in case of network/serializatino failures or failures from Kubernetes API
    */
   public Map<String, Object> edit(Map<String, Object> object) throws IOException {
-    // Append resourceVersion in object metadata in order to
-    // avoid : https://github.com/fabric8io/kubernetes-client/issues/1724
     String objectAsString = getPatchDiff(namespace, name, object);
     return validateAndSubmitRequest(objectAsString, HttpCallMethod.PATCH);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -1085,9 +1085,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
 
     JsonNode newone = JsonDiff.asJson(PatchUtils.patchMapper().valueToTree(oldObject), PatchUtils.patchMapper().valueToTree(customResource));
 
-    String patch = objectMapper.writeValueAsString(newone);
-
-    return patch;
+    return objectMapper.writeValueAsString(newone);
   }
 
   private DeleteOptions fetchDeleteOptions(boolean cascading, String propagationPolicy) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -52,7 +52,6 @@ import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.internal.PatchUtils;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import io.fabric8.kubernetes.client.utils.IOHelpers;
-import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.client.utils.WatcherToggle;
 import io.fabric8.zjsonpatch.JsonDiff;
@@ -96,7 +95,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
   private RawCustomResourceOperationsImpl(OkHttpClient client, Config config, CustomResourceDefinitionContext crdContext, String namespace, String name, long gracePeriodInSeconds, boolean cascading, String deletionPropagation, ListOptions listOptions, boolean dryRun) {
     super(client, config);
     this.customResourceDefinition = crdContext;
-    this.objectMapper = new ObjectMapper();
+    this.objectMapper = PatchUtils.patchMapper();
     this.namespace = namespace;
     this.name = name;
     this.gracePeriodInSeconds = gracePeriodInSeconds;

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -666,7 +666,7 @@ public class RawCustomResourceOperationsImplTest {
     Map<String, Object> res = rawCustomResourceOperations.edit(jsonString);
 
     // Then
-    assertNotEquals(res, null);
+    assertNotEquals(null, res);
   }
 
   private void assertRequestCaptured(ArgumentCaptor<Request> captor, String url, String method) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -15,10 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -30,6 +27,8 @@ import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.DeleteOptionsBuilder;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -655,6 +654,30 @@ public class RawCustomResourceOperationsImplTest {
     // Then
     assertThat(unstructuredConfigMap).isNotNull();
     assertRequestCaptured(captor, "/api/v1/namespaces/default/configmaps/game-config", "GET");
+  }
+
+  @Test
+  void testEditCR() throws IOException {
+    // Given
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext) {
+      public Map<String, Object> get(String namespace, String name) {
+
+        Map<String, Object> metadata = new HashMap<String, Object>();
+        metadata.put("resourceVersion", "123");
+
+        Map<String, Object> res = new HashMap<String, Object>();
+        res.put("metadata", metadata);
+
+        return res;
+      }
+    };
+    String jsonString = "{ \"metadata\": " + Serialization.jsonMapper().writeValueAsString(new ObjectMetaBuilder().withName("myresource").withNamespace("mynamespace").build()) + "}";
+
+    // When
+    Map<String, Object> res = rawCustomResourceOperations.edit(jsonString);
+
+    // Then
+    assertNotEquals(res, null);
   }
 
   private void assertRequestCaptured(ArgumentCaptor<Request> captor, String url, String method) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -659,18 +659,7 @@ public class RawCustomResourceOperationsImplTest {
   @Test
   void testEditCR() throws IOException {
     // Given
-    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext) {
-      public Map<String, Object> get(String namespace, String name) {
-
-        Map<String, Object> metadata = new HashMap<String, Object>();
-        metadata.put("resourceVersion", "123");
-
-        Map<String, Object> res = new HashMap<String, Object>();
-        res.put("metadata", metadata);
-
-        return res;
-      }
-    };
+    RawCustomResourceOperationsImpl rawCustomResourceOperations = new RawCustomResourceOperationsImpl(mockClient, config, clusterCustomResourceDefinitionContext);
     String jsonString = "{ \"metadata\": " + Serialization.jsonMapper().writeValueAsString(new ObjectMetaBuilder().withName("myresource").withNamespace("mynamespace").build()) + "}";
 
     // When

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -188,9 +188,12 @@ class CustomResourceTest {
 
   @Test
   void testEdit() throws IOException {
+    String jsonObject = "{\"apiVersion\": \"test.fabric8.io/v1alpha1\",\"kind\": \"Hello\"," +
+      "\"metadata\": {\"resourceVersion\": \"1\", \"name\": \"example-hello\"},\"spec\": {\"size\": 3}}";
     String jsonObjectNew = "{\"apiVersion\": \"test.fabric8.io/v1alpha1\",\"kind\": \"Hello\"," +
       "\"metadata\": {\"resourceVersion\": \"1\", \"name\": \"example-hello\"},\"spec\": {\"size\": 4}}";
-    server.expect().put().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello").andReturn(HttpURLConnection.HTTP_OK, jsonObjectNew).once();
+    server.expect().patch().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello").andReturn(HttpURLConnection.HTTP_OK, jsonObjectNew).once();
+    server.expect().get().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello").andReturn(HttpURLConnection.HTTP_OK, jsonObject).once();
     server.expect().get().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello").andReturn(HttpURLConnection.HTTP_OK, jsonObjectNew).once();
 
     KubernetesClient client = server.getClient();


### PR DESCRIPTION
## Description
Trying to use the `edit` of a CR I found a couple of issues:
 - it throws `ClassCastException` if there are external json modules registered e.g.: https://github.com/andreaTP/fabric8-edit-as-patch/blob/master/src/main/scala/Main.scala#L59
 - edit perform a `PUT` while it's supposed to be a `PATCH` as per: https://github.com/fabric8io/kubernetes-client/blob/8d0957cac72cc27083a53faa84a7e80a7470b8e1/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java#L37-L39

this PR address both issues.

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

I tested the final result with this demo project:
https://github.com/andreaTP/fabric8-edit-as-patch
run with: `sbt run`

I don't know how/where to add more exhaustive tests, I'm looking forward to guidance here 🙏 