### PR TITLE
Fix #2921 adding generated metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Improvements
 
+* Fix #2921: chore: Kubernetes server mock will generate missing metadata fields
+
 #### Dependency Upgrade
 
 #### New Features

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudAttributesExtractorTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudAttributesExtractorTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class KubernetesCrudAttributesExtractorTest {
 
@@ -232,6 +233,25 @@ public class KubernetesCrudAttributesExtractorTest {
     AttributeSet expected = new AttributeSet();
     expected = expected.add(new Attribute("labels:example.com/name", "myname"));
     assertTrue(attributes.matches(expected));
+  }
+
+  @Test
+  public void shouldGenerateMetadata() {
+    KubernetesServer kubernetesServer = new KubernetesServer(false, true);
+    kubernetesServer.before();
+    KubernetesClient kubernetesClient = kubernetesServer.getClient();
+    Deployment deployment1 = new DeploymentBuilder().withNewMetadata().withGenerateName("prefix")
+      .endMetadata().build();
+    kubernetesClient.apps().deployments().create(deployment1);
+
+    Deployment result = kubernetesClient.apps().deployments().list()
+      .getItems().get(0);
+
+    assertTrue(result.getMetadata().getName().startsWith("prefix"));
+    assertNotNull(result.getMetadata().getUid());
+    assertNotNull(result.getMetadata().getResourceVersion());
+    assertNotNull(result.getMetadata().getCreationTimestamp());
+    assertNotNull(result.getMetadata().getGeneration());
   }
 
   // https://github.com/fabric8io/kubernetes-client/issues/1688


### PR DESCRIPTION
## Description
Fix for issue https://github.com/fabric8io/kubernetes-client/issues/2921

## Type of change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 