### PR TITLE
RawCustomResourceOperationsImpl should also work with standard resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix: CRD generator no longer treat enum values as properties (performance)
 
 #### Improvements
+- RawCustomResourceOperationsImpl should also work with standard resources
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -950,10 +950,15 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
     StringBuilder urlBuilder = new StringBuilder(config.getMasterUrl());
 
     urlBuilder.append(config.getMasterUrl().endsWith("/") ? "" : "/");
-    urlBuilder.append("apis/")
-      .append(customResourceDefinition.getGroup())
-      .append("/")
-      .append(customResourceDefinition.getVersion())
+
+    if (Utils.isNotNullOrEmpty(customResourceDefinition.getGroup())) {
+      urlBuilder.append("apis/");
+      urlBuilder.append(customResourceDefinition.getGroup())
+        .append("/");
+    } else {
+      urlBuilder.append("api/");
+    }
+    urlBuilder.append(customResourceDefinition.getVersion())
       .append("/");
 
     if(customResourceDefinition.getScope().equals("Namespaced") && namespace != null) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImplTest.java
@@ -636,6 +636,27 @@ public class RawCustomResourceOperationsImplTest {
     assertRequestCaptured(captor, "/apis/test.fabric8.io/v1alpha1/hellos/myresource", "DELETE");
   }
 
+  @Test
+  void testGetConfigmap() {
+    // Given
+    CustomResourceDefinitionContext configMapContext = new CustomResourceDefinitionContext.Builder()
+      .withGroup(null)
+      .withVersion("v1")
+      .withPlural("configmaps")
+      .withScope("Namespaced")
+      .withKind("ConfigMap")
+      .build();
+    RawCustomResourceOperationsImpl rawOp = new RawCustomResourceOperationsImpl(mockClient, config, configMapContext);
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    Map<String, Object> unstructuredConfigMap = rawOp.inNamespace("default").withName("game-config").get();
+
+    // Then
+    assertThat(unstructuredConfigMap).isNotNull();
+    assertRequestCaptured(captor, "/api/v1/namespaces/default/configmaps/game-config", "GET");
+  }
+
   private void assertRequestCaptured(ArgumentCaptor<Request> captor, String url, String method) {
     verify(mockClient).newCall(captor.capture());
     assertEquals(url, captor.getValue().url().encodedPath());


### PR DESCRIPTION
RawCustomResourceOperationsImpl should also consider the case of Core
APIGroup when apiGroup is null/empty. It should use /api instead of
standard /apis

This is related to https://github.com/fabric8io/kubernetes-client/issues/2929 . With this we should be able to use Raw API for now until we provide a new unstructured() DSL

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
