### PR TITLE
using the custom resource class if possible

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import lombok.ToString;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +44,19 @@ public class CustomResourceList<T extends HasMetadata> implements KubernetesReso
 
   @JsonProperty("metadata")
   private ListMeta metadata;
+
+  public CustomResourceList() {
+    try {
+      Class<T> customResourceClass = getCustomResourceClass();
+      if (customResourceClass != null) {
+        HasMetadata instance = customResourceClass.getDeclaredConstructor().newInstance();
+        this.apiVersion = instance.getApiVersion();
+        this.kind = instance.getKind() + "List";
+      }
+    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+            | NoSuchMethodException | SecurityException e) {
+    }
+  }
 
   public String getApiVersion() {
     return apiVersion;
@@ -76,5 +90,9 @@ public class CustomResourceList<T extends HasMetadata> implements KubernetesReso
 
   public void setMetadata(ListMeta metadata) {
     this.metadata = metadata;
+  }
+
+  protected Class<T> getCustomResourceClass() {
+      return null;
   }
 }


### PR DESCRIPTION
## Description
The CustomResource constructor has side effects such as setting the version and kind from annotations.  There should be similar CustomResourceList logic.  The closest non-breaking change is to have an overridable method to provide the custom resource class.  If you are open to something like this, I can round out this pr with tests, javadocs, etc.

## Type of change
 - [x] Feature (non-breaking change which adds functionality)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
