### PR TITLE
Fix #2701: Add Support for partial Patch for Kubernetes resources with Json Merge, Strategic Merge and Json patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix #2980: Add DSL Support for `apps/v1#ControllerRevision` resource
 * Fix #2981: Add DSL support for `storage.k8s.io/v1beta1` CSIDriver, CSINode and VolumeAttachment
 * Fix #2912: Add DSL support for `storage.k8s.io/v1beta1` CSIStorageCapacity
+* Fix #2701: Better support for patching in KuberntesClient
 
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -15,8 +15,35 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+
 public interface Patchable<T> {
 
+  /**
+   * Update field(s) of a resource using a JSON patch.
+   *
+   * @param item item to be patched with patched values
+   * @return returns deserialized version of api server response
+   */
   T patch(T item);
+
+  /**
+   * Update field(s) of a resource using strategic merge patch.
+   *
+   * @param patch The patch to be applied to the resource JSON file.
+   * @return returns deserialized version of api server response
+   */
+  default T patch(String patch) {
+    return patch(null, patch);
+  }
+
+  /**
+   * Update field(s) of a resource using type specified in {@link PatchContext}(defaults to strategic merge if not specified).
+   *
+   * @param patchContext {@link PatchContext} for patch request
+   * @param patch The patch to be applied to the resource JSON file.
+   * @return The patch to be applied to the resource JSON file.
+   */
+  T patch(PatchContext patchContext, String patch);
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -98,6 +98,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   private static final String INVOLVED_OBJECT_RESOURCE_VERSION = "involvedObject.resourceVersion";
   private static final String INVOLVED_OBJECT_API_VERSION = "involvedObject.apiVersion";
   private static final String INVOLVED_OBJECT_FIELD_PATH = "involvedObject.fieldPath";
+  private static final String READ_ONLY_UPDATE_EXCEPTION_MESSAGE = "Cannot update read-only resources";
+  private static final String READ_ONLY_EDIT_EXCEPTION_MESSAGE = "Cannot edit read-only resources";
 
   private final boolean cascading;
   private final T item;
@@ -245,12 +247,12 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public T edit(UnaryOperator<T> function) {
-    throw new KubernetesClientException("Cannot edit read-only resources");
+    throw new KubernetesClientException(READ_ONLY_EDIT_EXCEPTION_MESSAGE);
   }
 
   @Override
   public T edit(Visitor... visitors) {
-    throw new KubernetesClientException("Cannot edit read-only resources");
+    throw new KubernetesClientException(READ_ONLY_EDIT_EXCEPTION_MESSAGE);
   }
 
   @Override
@@ -270,7 +272,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public T accept(Consumer<T> consumer) {
-    throw new KubernetesClientException("Cannot edit read-only resources");
+    throw new KubernetesClientException(READ_ONLY_EDIT_EXCEPTION_MESSAGE);
   }
 
   @Override
@@ -848,12 +850,17 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public T replace(T item) {
-    throw new KubernetesClientException("Cannot update read-only resources");
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
   @Override
   public T patch(T item) {
-    throw new KubernetesClientException("Cannot update read-only resources");
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
+  }
+
+  @Override
+  public T patch(PatchContext patchContext, String patch) {
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/PatchContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/PatchContext.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.base;
+
+import java.util.List;
+
+public class PatchContext {
+  private List<String> dryRun;
+  private String fieldManager;
+  private Boolean force;
+  private PatchType patchType;
+
+  public List<String> getDryRun() {
+    return dryRun;
+  }
+
+  public void setDryRun(List<String> dryRun) {
+    this.dryRun = dryRun;
+  }
+
+  public String getFieldManager() {
+    return fieldManager;
+  }
+
+  public void setFieldManager(String fieldManager) {
+    this.fieldManager = fieldManager;
+  }
+
+  public Boolean getForce() {
+    return force;
+  }
+
+  public void setForce(Boolean force) {
+    this.force = force;
+  }
+
+  public PatchType getPatchType() {
+    return patchType;
+  }
+
+  public void setPatchType(PatchType patchType) {
+    this.patchType = patchType;
+  }
+
+  public static class Builder {
+    private final PatchContext patchContext;
+
+    public Builder() {
+      this.patchContext = new PatchContext();
+    }
+
+    public Builder withDryRun(List<String> dryRun) {
+      this.patchContext.setDryRun(dryRun);
+      return this;
+    }
+
+    public Builder withFieldManager(String fieldManager) {
+      this.patchContext.setFieldManager(fieldManager);
+      return this;
+    }
+
+    public Builder withForce(Boolean force) {
+      this.patchContext.setForce(force);
+      return this;
+    }
+
+    public Builder withPatchType(PatchType patchType) {
+      this.patchContext.setPatchType(patchType);
+      return this;
+    }
+
+    public PatchContext build() {
+      return this.patchContext;
+    }
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/PatchType.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/PatchType.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.base;
+
+import okhttp3.MediaType;
+
+import static io.fabric8.kubernetes.client.dsl.base.OperationSupport.JSON_PATCH;
+import static io.fabric8.kubernetes.client.dsl.base.OperationSupport.JSON_MERGE_PATCH;
+import static io.fabric8.kubernetes.client.dsl.base.OperationSupport.STRATEGIC_MERGE_JSON_PATCH;
+
+/**
+ * Enum for different Patch types supported by Patch
+ */
+public enum PatchType {
+  JSON(JSON_PATCH),
+  JSON_MERGE(JSON_MERGE_PATCH),
+  STRATEGIC_MERGE(STRATEGIC_MERGE_JSON_PATCH);
+
+  private final MediaType mediaType;
+
+  PatchType(MediaType mediaType) {
+    this.mediaType = mediaType;
+  }
+
+  public MediaType getMediaType() {
+    return this.mediaType;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
@@ -75,4 +75,11 @@ public class IOHelpers {
     return jsonWriter.writeValueAsString(obj);
   }
 
+  public static String convertToJson(String jsonOrYaml) throws IOException {
+      if (isJSONValid(jsonOrYaml)) {
+        return jsonOrYaml;
+      }
+      return convertYamlToJson(jsonOrYaml);
+  }
+
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/PatchTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/PatchTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PatchTest {
+  private Call mockCall;
+  private OkHttpClient mockClient;
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    this.mockClient = Mockito.mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    mockCall = mock(Call.class);
+    Response mockResponse = new Response.Builder()
+      .request(new Request.Builder().url("http://mock").build())
+      .protocol(Protocol.HTTP_1_1)
+      .code(HttpURLConnection.HTTP_OK)
+      .body(ResponseBody.create(MediaType.get("application/json"), "{\"metadata\":{\"name\":\"foo\"}}"))
+      .message("mock")
+      .build();
+    when(mockCall.execute())
+      .thenReturn(mockResponse, mockResponse);
+    when(mockClient.newCall(any())).thenReturn(mockCall);
+    kubernetesClient = new DefaultKubernetesClient(mockClient, config);
+  }
+
+  @Test
+  void testJsonPatch() {
+    // Given
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    kubernetesClient.pods().inNamespace("ns1").withName("foo")
+      .patch("{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
+
+    // Then
+    verify(mockClient, times(2)).newCall(captor.capture());
+    assertRequest(captor.getAllValues().get(0), "GET", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertRequest(captor.getAllValues().get(1), "PATCH", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertBodyContentType("strategic-merge-patch+json", captor.getAllValues().get(1));
+  }
+
+  @Test
+  void testJsonMergePatch() {
+    // Given
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+    PatchContext patchContext = new PatchContext.Builder()
+      .withPatchType(PatchType.JSON_MERGE)
+      .build();
+
+    // When
+    kubernetesClient.pods().inNamespace("ns1").withName("foo")
+      .patch(patchContext, "{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
+
+    // Then
+    verify(mockClient, times(2)).newCall(captor.capture());
+    assertRequest(captor.getAllValues().get(0), "GET", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertRequest(captor.getAllValues().get(1), "PATCH", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertBodyContentType("merge-patch+json", captor.getAllValues().get(1));
+  }
+
+  @Test
+  void testYamlPatchConvertedToJson() {
+    // Given
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    kubernetesClient.pods().inNamespace("ns1").withName("foo").patch("metadata:\n  annotations:\n    bob: martin");
+
+    // Then
+    verify(mockClient, times(2)).newCall(captor.capture());
+    assertRequest(captor.getAllValues().get(0), "GET", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertRequest(captor.getAllValues().get(1), "PATCH", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertBodyContentType("strategic-merge-patch+json", captor.getAllValues().get(1));
+  }
+
+  @Test
+  void testPatchReturnsNullWhenResourceNotFound() throws IOException {
+    // Given
+    when(mockCall.execute()).thenReturn(new Response.Builder()
+      .request(new Request.Builder().url("http://mock").build())
+      .protocol(Protocol.HTTP_1_1)
+      .code(HttpURLConnection.HTTP_NOT_FOUND)
+      .body(ResponseBody.create(MediaType.get("application/json"), "{}"))
+      .message("mock")
+      .build());
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    Pod pod = kubernetesClient.pods().inNamespace("ns1").withName("foo").patch("{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
+
+    // Then
+    verify(mockClient, times(1)).newCall(captor.capture());
+    assertRequest(captor.getValue(), "GET", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertThat(pod).isNull();
+  }
+
+  @Test
+  void testJsonPatchWithPositionalArrays() {
+    // Given
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+    PatchContext patchContext = new PatchContext.Builder().withPatchType(PatchType.JSON).build();
+
+    // When
+    kubernetesClient.pods().inNamespace("ns1").withName("foo")
+      .patch(patchContext, "[{\"op\": \"replace\", \"path\":\"/spec/containers/0/image\", \"value\":\"foo/gb-frontend:v4\"}]");
+
+    // Then
+    verify(mockClient, times(2)).newCall(captor.capture());
+    assertRequest(captor.getAllValues().get(0), "GET", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertRequest(captor.getAllValues().get(1), "PATCH", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertBodyContentType("json-patch+json", captor.getAllValues().get(1));
+  }
+
+  @Test
+  void testPatchWithPatchOptions() {
+    // Given
+    ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    // When
+    kubernetesClient.pods().inNamespace("ns1").withName("foo")
+      .patch(new PatchContext.Builder()
+        .withFieldManager("fabric8")
+        .withDryRun(Collections.singletonList("All"))
+        .build(), "{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
+
+    // Then
+    verify(mockClient, times(2)).newCall(captor.capture());
+    assertRequest(captor.getAllValues().get(0), "GET", "/api/v1/namespaces/ns1/pods/foo", null);
+    assertRequest(captor.getAllValues().get(1), "PATCH", "/api/v1/namespaces/ns1/pods/foo", "fieldManager=fabric8&dryRun=All");
+    assertBodyContentType("strategic-merge-patch+json", captor.getAllValues().get(1));
+  }
+
+  private void assertRequest(Request request, String method, String url, String queryParam) {
+    assertThat(request.url().encodedPath()).isEqualTo(url);
+    assertThat(request.method()).isEqualTo(method);
+    assertThat(request.url().encodedQuery()).isEqualTo(queryParam);
+  }
+
+  private void assertBodyContentType(String expectedContentSubtype, Request request) {
+    AssertionsForClassTypes.assertThat(request.body().contentType()).isNotNull();
+    AssertionsForClassTypes.assertThat(request.body().contentType().type()).isEqualTo("application");
+    AssertionsForClassTypes.assertThat(request.body().contentType().subtype()).isEqualTo(expectedContentSubtype);
+  }
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import io.fabric8.commons.ClusterEntity;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class PatchIT {
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  private String currentNamespace;
+
+  @BeforeClass
+  public static void init() {
+    ClusterEntity.apply(CronJobIT.class.getResourceAsStream("/patch-it.yml"));
+  }
+
+  @Before
+  public void initNamespace() {
+    this.currentNamespace = session.getNamespace();
+  }
+
+  @Test
+  public void testJsonPatch() {
+    // Given
+    String name = "patchit-testjsonpatch";
+
+    // When
+    ConfigMap patchedConfigMap = client.configMaps().inNamespace(currentNamespace).withName(name).patch("{\"metadata\":{\"labels\":{\"version\":\"v1\"}}}");
+
+    // Then
+    assertThat(patchedConfigMap).isNotNull();
+    assertThat(patchedConfigMap.getMetadata().getLabels()).isNotNull()
+      .hasFieldOrPropertyWithValue("version", "v1");
+  }
+
+  @Test
+  public void testJsonMergePatch() {
+    // Given
+    String name = "patchit-testjsonmergepatch";
+    PatchContext patchContext = new PatchContext.Builder().withPatchType(PatchType.JSON_MERGE).build();
+
+    // When
+    ConfigMap patchedConfigMap = client.configMaps().inNamespace(currentNamespace).withName(name)
+      .patch(patchContext, "{\"metadata\":{\"annotations\":{\"foo\":null}}}");
+
+    // Then
+    assertThat(patchedConfigMap).isNotNull();
+    assertThat(patchedConfigMap.getMetadata().getAnnotations()).isNull();
+  }
+
+  @Test
+  public void testJsonPatchWithPositionalArrays() {
+    // Given
+    String name = "patchit-testjsonpatchpositionalarray";
+    PatchContext patchContext = new PatchContext.Builder().withPatchType(PatchType.JSON).build();
+
+    // When
+    ReplicaSet patchedReplicaSet = client.apps().replicaSets().inNamespace(currentNamespace).withName(name)
+      .patch(patchContext
+        , "[{\"op\": \"replace\", \"path\":\"/spec/template/spec/containers/0/image\", \"value\":\"foo/gb-frontend:v4\"}]");
+
+    // Then
+    assertThat(patchedReplicaSet).isNotNull();
+    assertThat(patchedReplicaSet.getSpec().getTemplate().getSpec().getContainers().get(0).getImage()).isEqualTo("foo/gb-frontend:v4");
+  }
+
+  @Test
+  public void testYamlPatch() {
+    // Given
+    String name = "patchit-testyamlpatch";
+
+    // When
+    ConfigMap patchedConfigMap = client.configMaps().inNamespace(currentNamespace).withName(name)
+      .patch("data:\n  version: v1\n  status: patched");
+
+    // Then
+    assertThat(patchedConfigMap).isNotNull();
+    assertThat(patchedConfigMap.getData())
+      .hasFieldOrPropertyWithValue("version", "v1")
+      .hasFieldOrPropertyWithValue("status", "patched");
+  }
+
+  @Test
+  public void testFullObjectPatch() {
+    // Given
+    String name = "patchit-fullobjectpatch";
+
+    // When
+    ConfigMap configMapFromServer = client.configMaps().inNamespace(currentNamespace).withName(name).get();
+    configMapFromServer.setData(Collections.singletonMap("foo", "bar"));
+    ConfigMap patchedConfigMap = client.configMaps().inNamespace(currentNamespace).withName(name).patch(configMapFromServer);
+
+    // Then
+    assertThat(patchedConfigMap).isNotNull();
+    assertThat(patchedConfigMap.getData()).hasFieldOrPropertyWithValue("foo", "bar");
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    ClusterEntity.remove(CronJobIT.class.getResourceAsStream("/patch-it.yml"));
+  }
+}

--- a/kubernetes-itests/src/test/resources/patch-it.yml
+++ b/kubernetes-itests/src/test/resources/patch-it.yml
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patchit-testjsonpatch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patchit-testjsonmergepatch
+  annotations:
+    foo: bar
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: patchit-testjsonpatchpositionalarray
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+        - name: php-redis
+          image: foo/gb-frontend:v3
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patchit-testyamlpatch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: patchit-fullobjectpatch


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #2701 #2645

Add support for patching Kubenetes resources like we do in kubectl :
```
kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}
kubectl patch node k8s-node-1 -p $'spec:\n unschedulable: true'
kubectl patch -f node.json -p '{"spec":{"unschedulable":true}}'
kubectl patch pod valid-pod -p
'{"spec":{"containers":[{"name":"kubernetes-serve-hostname","image":"new image"}]}}'
kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path":
"/spec/containers/0/image", "value":"new image"}]'
```
User should now be able to patch like above mentioned scenarios using KubernetesClient like this:
```java
// Strategic Merge Patch
kubernetesClient.pods().inNamespace("ns1").withName("foo")
      .patch("{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}")
// Specify PatchOptions
kubernetesClient.pods().inNamespace("ns1").withName("foo")
      .patch(new PatchOptionsBuilder()
        .withFieldManager("fabric8")
        .build(), "{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}")
```
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
