### PR TITLE
fix for #2989 disable the native type id feature for yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Bugs
 
+* Fix #2989: serialization will generate valid yaml when using subtypes
+
 #### Improvements
 
 #### Dependency Upgrade

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -46,7 +47,7 @@ public class Serialization {
   static {
     JSON_MAPPER.registerModule(new JavaTimeModule());
   }
-  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID));
   private static final String DOCUMENT_DELIMITER = "---";
 
   public static ObjectMapper jsonMapper() {


### PR DESCRIPTION
## Description
See #2989 this addresses the creation of invalid yaml, when using subtypes.  This is happening in the Strimzi project due to https://github.com/strimzi/strimzi-kafka-operator/blob/ab9df1d231c08ddfd5c947f7beddf963b77e7fec/api/src/main/java/io/strimzi/api/kafka/model/storage/Storage.java#L21 

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report