### PR TITLE
cleaning up the reflectorwatcher logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #2989: serialization will generate valid yaml when using subtypes
 * Fix #2996: Generating CRDs from the API should now properly work
 * Fix #3000: Set no_proxy in the okhttp builder in case the proxy_url is null
+* Fix #2991: reduced the level of ReflectWatcher event recieved log
 
 #### Improvements
 * Fix #2910: Move crd-generator tests from kubernetes-itests to kubernetes-tests

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -47,7 +47,9 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
       final String errorMessage = String.format("Unrecognized event %s", resource.getMetadata().getName());
       throw new KubernetesClientException(errorMessage);
     }
-    log.trace("Event received {}", action.name());
+    if (log.isDebugEnabled()) {
+      log.debug("Event received {} {}# resourceVersion {}", action.name(), resource.getKind(), resource.getMetadata().getResourceVersion());
+    }
     switch (action) {
       case ERROR:
         final String errorMessage = String.format("ERROR event for %s", resource.getMetadata().getName());
@@ -63,7 +65,6 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
         break;
     }
     lastSyncResourceVersion.set(resource.getMetadata().getResourceVersion());
-    log.trace("{}#Receiving resourceVersion {}", resource.getKind(), lastSyncResourceVersion.get());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -48,7 +48,7 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
       log.error(errorMessage);
       throw new KubernetesClientException(errorMessage);
     }
-    log.info("Event received {}", action.name());
+    log.debug("Event received {}", action.name());
     switch (action) {
       case ERROR:
         final String errorMessage = String.format("ERROR event for %s", resource.getMetadata().getName());

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -44,16 +44,17 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
   @Override
   public void eventReceived(Action action, T resource) {
     if (action == null) {
-      final String errorMessage = String.format("Unrecognized event %s", resource.getMetadata().getName());
-      throw new KubernetesClientException(errorMessage);
+      throw new KubernetesClientException("Unrecognized event");
+    }
+    if (resource == null) {
+      throw new KubernetesClientException("Unrecognized resource");  
     }
     if (log.isDebugEnabled()) {
       log.debug("Event received {} {}# resourceVersion {}", action.name(), resource.getKind(), resource.getMetadata().getResourceVersion());
     }
     switch (action) {
       case ERROR:
-        final String errorMessage = String.format("ERROR event for %s", resource.getMetadata().getName());
-        throw new KubernetesClientException(errorMessage);
+        throw new KubernetesClientException("ERROR event");
       case ADDED:
         store.add(resource);
         break;


### PR DESCRIPTION
## Description
Fix for #2991 - event received logged at too high of a level.

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
