### PR TITLE
refactoring informer code for type safety and to refine the role of stores

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ResyncRunnable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ResyncRunnable.java
@@ -15,7 +15,8 @@
  */
 package io.fabric8.kubernetes.client.informers;
 
-import io.fabric8.kubernetes.client.informers.cache.Store;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.informers.cache.DeltaFIFO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,18 +26,19 @@ import java.util.function.Supplier;
  * Calls the resync function of store interface which is always implemented
  * by DeltaFIFO.
  */
-public class ResyncRunnable<T> implements Runnable {
+public class ResyncRunnable<T extends HasMetadata> implements Runnable {
 
   private static final Logger log = LoggerFactory.getLogger(ResyncRunnable.class);
 
-  private Store<T> store;
+  private DeltaFIFO<T> store;
   private Supplier<Boolean> shouldResyncFunc;
 
-  public ResyncRunnable(Store<T> store, Supplier<Boolean> shouldResyncFunc) {
+  public ResyncRunnable(DeltaFIFO<T> store, Supplier<Boolean> shouldResyncFunc) {
     this.store = store;
     this.shouldResyncFunc = shouldResyncFunc;
   }
 
+  @Override
   public void run() {
     if (log.isDebugEnabled()) {
       log.debug("ResyncRunnable#resync .. ..");

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
@@ -129,36 +129,6 @@ public class Cache<T> implements Indexer<T> {
   }
 
   /**
-   * Replace the content in the cache completely.
-   *
-   * @param list list of objects
-   * @param resourceVersion resource version
-   */
-  @Override
-  public synchronized void replace(List<T> list, String resourceVersion) {
-    Map<String, T> newItems = new HashMap<>();
-    for (T item : list) {
-      String key = keyFunc.apply(item);
-      newItems.put(key, item);
-    }
-    this.items = newItems;
-
-    // rebuild any index
-    this.indices = new HashMap<>();
-    for (Map.Entry<String, T> itemEntry : items.entrySet()) {
-      this.updateIndices(null, itemEntry.getValue(), itemEntry.getKey());
-    }
-  }
-
-  /**
-   * Resync
-   */
-  @Override
-  public void resync() {
-    // Do nothing
-  }
-
-  /**
    * List keys
    *
    * @return the list of keys
@@ -217,12 +187,12 @@ public class Cache<T> implements Indexer<T> {
    * @return the list
    */
   @Override
-  public synchronized List<T> index(String indexName, Object obj) {
+  public synchronized List<T> index(String indexName, T obj) {
     if (!this.indexers.containsKey(indexName)) {
       throw new IllegalArgumentException(String.format("index %s doesn't exist!", indexName));
     }
     Function<T, List<String>> indexFunc = this.indexers.get(indexName);
-    List<String> indexKeys = indexFunc.apply((T) obj);
+    List<String> indexKeys = indexFunc.apply(obj);
     Map<String, Set<String>> index = this.indices.get(indexName);
     if (index.isEmpty()) {
       return new ArrayList<>();
@@ -287,11 +257,6 @@ public class Cache<T> implements Indexer<T> {
       items.add(this.items.get(key));
     }
     return items;
-  }
-
-  @Override
-  public void isPopulated(boolean isPopulated) {
-    // Do nothing
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Indexer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Indexer.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
  *
  * @param <T> resource
  */
-public interface Indexer<T> extends Store<T> {
+public interface Indexer<T> extends Store<T, T> {
   /**
    * Retrieve list of obejcts that match on the named indexing function.
    *

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -23,20 +23,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
 
   private static final Logger log = LoggerFactory.getLogger(ReflectorWatcher.class);
 
-  private final Store<T> store;
-  private final AtomicReference<String> lastSyncResourceVersion;
+  private final DeltaFIFO<T> store;
   private final Runnable onClose;
   private final Runnable onHttpGone;
 
-  public ReflectorWatcher(Store<T> store, AtomicReference<String> lastSyncResourceVersion, Runnable onClose, Runnable onHttpGone) {
+  public ReflectorWatcher(DeltaFIFO<T> store, Runnable onClose, Runnable onHttpGone) {
     this.store = store;
-    this.lastSyncResourceVersion = lastSyncResourceVersion;
     this.onClose = onClose;
     this.onHttpGone = onHttpGone;
   }
@@ -64,8 +61,7 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
         store.delete(resource);
         break;
     }
-    lastSyncResourceVersion.set(resource.getMetadata().getResourceVersion());
-    log.debug("{}#Receiving resourceVersion {}", resource.getKind(), lastSyncResourceVersion.get());
+    log.debug("{}#Receiving resourceVersion {}", resource.getKind(), resource.getMetadata().getResourceVersion());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Store.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Store.java
@@ -29,9 +29,12 @@ import java.util.List;
  *
  * This is ported from official go client: https://github.com/kubernetes/client-go/blob/master/tools/cache/store.go
  *
+ * Updated to be more type safe and to not assume the responsibilities of a DeltaFIFO
+ *
  * @param <T> resource
+ * @param <V> value
  */
-public interface Store<T> {
+public interface Store<T, V> {
   /**
    * Inserts an item into the store
    *
@@ -58,7 +61,7 @@ public interface Store<T> {
    *
    * @return list of all items
    */
-  List<T> list();
+  List<V> list();
 
   /**
    * returns a list of all keys of the object currently in the store.
@@ -73,7 +76,7 @@ public interface Store<T> {
    * @param object object
    * @return requested item if exists.
    */
-  Object get(T object);
+  V get(T object);
 
   /**
    * Returns the request item with specific key.
@@ -81,28 +84,6 @@ public interface Store<T> {
    * @param key specific key
    * @return the requested item
    */
-  T getByKey(String key);
-
-  /**
-   * Deletes the contents of the store, using instead the given list.
-   * Store takes ownership of the list, you should not reference it
-   * after calling this function
-   *
-   * @param list list of objects
-   * @param resourceVersion resource version
-   */
-  void replace(List<T> list, String resourceVersion);
-
-  /**
-   * Sends a resync event for each item.
-   */
-  void resync();
-
-  /**
-   * Updates the status of cache in case of any API error from Kubernetes server
-   *
-   * @param isPopulated boolean value indicating whether cache is populated or not
-   */
-  void isPopulated(boolean isPopulated);
+  V getByKey(String key);
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -52,7 +52,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
   // value).
   private long defaultEventHandlerResyncPeriod;
 
-  private Indexer<T> indexer;
+  private Cache<T> indexer;
 
   private SharedProcessor<T> processor;
 
@@ -68,7 +68,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     this.defaultEventHandlerResyncPeriod = resyncPeriod;
 
     this.processor = new SharedProcessor<>();
-    this.indexer = new Cache();
+    this.indexer = new Cache<T>();
 
     DeltaFIFO<T> fifo = new DeltaFIFO<>(Cache::metaNamespaceKeyFunc, this.indexer);
 
@@ -211,7 +211,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
 
 
   @Override
-  public Indexer getIndexer() {
+  public Indexer<T> getIndexer() {
     return this.indexer;
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.informers.cache;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -28,14 +29,18 @@ import java.util.function.Function;
 import static org.junit.Assert.assertEquals;
 
 class CacheTest {
-  private static Cache cache = new Cache("mock", CacheTest::mockIndexFunction, CacheTest::mockKeyFunction);
+  private Cache cache;
+
+  @BeforeEach
+  public void initCache() {
+    cache = new Cache("mock", CacheTest::mockIndexFunction, CacheTest::mockKeyFunction);
+  }
 
   @Test
   void testCacheIndex() {
     Pod testPodObj = new PodBuilder().withNewMetadata().withName("test-pod").endMetadata().build();
 
     cache.add(testPodObj);
-    cache.replace(Arrays.asList(testPodObj), "0");
 
     String index = mockIndexFunction(testPodObj).get(0);
     String key = mockKeyFunction(testPodObj);
@@ -56,7 +61,7 @@ class CacheTest {
     Pod testPodObj = new PodBuilder().withNewMetadata().withName("test-pod2").endMetadata().build();
     String index = mockIndexFunction(testPodObj).get(0);
 
-    cache.replace(Arrays.asList(testPodObj), "0");
+    cache.add(testPodObj);
     cache.delete(testPodObj);
 
     List indexedObjectList = cache.byIndex("mock", index);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFOTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFOTest.java
@@ -76,7 +76,7 @@ class DeltaFIFOTest {
 
     // Sync operation
     deltaFIFO.replace(Arrays.asList(foo1), "0");
-    cache.replace(Arrays.asList(foo1), "0");
+    cache.add(foo1);
     deltaFIFO.pop(
       (deltas) -> {
         AbstractMap.SimpleEntry<DeltaFIFO.DeltaType, Object> delta = deltas.peekFirst();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ListerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ListerTest.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -33,12 +32,12 @@ class ListerTest {
     List<Pod> emptyPodList = namespacedPodLister.list();
     assertEquals(0, emptyPodList.size());
 
-    podCache.replace(
-      Arrays.asList(
-        new PodBuilder().withNewMetadata().withName("foo1").withNamespace("default").endMetadata().build(),
-        new PodBuilder().withNewMetadata().withName("foo2").withNamespace("default").endMetadata().build(),
-        new PodBuilder().withNewMetadata().withName("foo3").withNamespace("default").endMetadata().build()
-      ), "0");
+    podCache.add(
+        new PodBuilder().withNewMetadata().withName("foo1").withNamespace("default").endMetadata().build());
+    podCache.add(
+        new PodBuilder().withNewMetadata().withName("foo2").withNamespace("default").endMetadata().build());
+    podCache.add(
+        new PodBuilder().withNewMetadata().withName("foo3").withNamespace("default").endMetadata().build());
 
     List<Pod> namespacedPodList = namespacedPodLister.list();
     assertEquals(3, namespacedPodList.size());


### PR DESCRIPTION
## Description
While looking at changes for #2993, #2995, and another bug that has not been logged here.  It appears there are some clarifications that could be made to improve the readability and the safety of the informer code.  The central change is that Store should be more type specific and have a narrower interface - I realize this differs from the go implementation and this does change the public interface of SharedIndexInformer.getIndexer because the Store will no longer have replace, resync, or isPopulated.  If it's a problem to make such a change it can of course be refined (previous code, all no-ops, or throw not implemented exceptions).  In general it seems problematic that SharedIndexInformer.getIndexer returns as broad of an interface as it does - for example in DefaultSharedIndexInformer.addIndexers you can't add an indexer once running, but if you call SharedIndexInformer.getIndexer.addIndexers you can.

If you'd prefer another interface such as ResyncableStore vs direct usage of the DeltaFIFO in ResyncRunnable, Reflector, and ReflectorWatcher - that can be done as well, it just didn't seem needed given the single implementation of DeltaFIFO.  I do see several implementations of Store types in go.

This also moves the responsibility for the lastResourceVersion to the DeltaFIFO - having it updatable outside the DeltaFIFO lock is dangerous.  With the code pre #2812 it appears to allow for timing issues in threads updating the DeltaFIFO/lastResourceVersion:

1. resyncExecutor thread performs scheduled relist - sees state s1, sets the last resourceVersion to s1
2. watch thread via ReflectorWatcher - sees an update to state s2, calls DeltaFIFO.update and sets last resourceVersion to s2
3. resyncExecutor thread continues - calls DeltaFIFO.replace with state s1, adds a syncronization event to state s1 after the update event

The event generated from 2 will be an update showing s1 as the old state and s2 as the new
The event generated from 3 will be an update showing s2 as the old state and s1 as the new 

A reconnect won't fix that as the last resourceVersion is s2.

In theory though on the next relist there will be a synchronization and event to s2 (or whatever the latest state is). However with the pre #2812 code any uncaught exception from relist will inhibit the job from running again.

Granted this should no longer happen after #2812 because the scheduled relist has been removed, but it is still something that should be guarded against.  

@rohanKanojia or others let me know if you are open to these types of changes, I can refine this PR as needed.

## Type of change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift