### PR TITLE
refactoring informer logic for type safety and to refine the role of stores

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ResyncRunnable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ResyncRunnable.java
@@ -15,7 +15,8 @@
  */
 package io.fabric8.kubernetes.client.informers;
 
-import io.fabric8.kubernetes.client.informers.cache.Store;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.informers.cache.DeltaFIFO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,18 +26,19 @@ import java.util.function.Supplier;
  * Calls the resync function of store interface which is always implemented
  * by DeltaFIFO.
  */
-public class ResyncRunnable<T> implements Runnable {
+public class ResyncRunnable<T extends HasMetadata> implements Runnable {
 
   private static final Logger log = LoggerFactory.getLogger(ResyncRunnable.class);
 
-  private Store<T> store;
+  private DeltaFIFO<T> store;
   private Supplier<Boolean> shouldResyncFunc;
 
-  public ResyncRunnable(Store<T> store, Supplier<Boolean> shouldResyncFunc) {
+  public ResyncRunnable(DeltaFIFO<T> store, Supplier<Boolean> shouldResyncFunc) {
     this.store = store;
     this.shouldResyncFunc = shouldResyncFunc;
   }
 
+  @Override
   public void run() {
     if (log.isDebugEnabled()) {
       log.debug("ResyncRunnable#resync .. ..");

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.kubernetes.client.informers;
 
+import io.fabric8.kubernetes.client.informers.cache.Store;
+
 /**
  * SharedInformer defines basic methods of an informer.
  *
@@ -59,4 +61,9 @@ public interface SharedInformer<T> {
    * @return string value
    */
   String lastSyncResourceVersion();
+
+  /**
+   * @return the informer's local cache as a Store
+   */
+  Store<T, T> getStore();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
@@ -129,36 +129,6 @@ public class Cache<T> implements Indexer<T> {
   }
 
   /**
-   * Replace the content in the cache completely.
-   *
-   * @param list list of objects
-   * @param resourceVersion resource version
-   */
-  @Override
-  public synchronized void replace(List<T> list, String resourceVersion) {
-    Map<String, T> newItems = new HashMap<>();
-    for (T item : list) {
-      String key = keyFunc.apply(item);
-      newItems.put(key, item);
-    }
-    this.items = newItems;
-
-    // rebuild any index
-    this.indices = new HashMap<>();
-    for (Map.Entry<String, T> itemEntry : items.entrySet()) {
-      this.updateIndices(null, itemEntry.getValue(), itemEntry.getKey());
-    }
-  }
-
-  /**
-   * Resync
-   */
-  @Override
-  public void resync() {
-    // Do nothing
-  }
-
-  /**
    * List keys
    *
    * @return the list of keys
@@ -217,12 +187,12 @@ public class Cache<T> implements Indexer<T> {
    * @return the list
    */
   @Override
-  public synchronized List<T> index(String indexName, Object obj) {
+  public synchronized List<T> index(String indexName, T obj) {
     if (!this.indexers.containsKey(indexName)) {
       throw new IllegalArgumentException(String.format("index %s doesn't exist!", indexName));
     }
     Function<T, List<String>> indexFunc = this.indexers.get(indexName);
-    List<String> indexKeys = indexFunc.apply((T) obj);
+    List<String> indexKeys = indexFunc.apply(obj);
     Map<String, Set<String>> index = this.indices.get(indexName);
     if (index.isEmpty()) {
       return new ArrayList<>();
@@ -287,11 +257,6 @@ public class Cache<T> implements Indexer<T> {
       items.add(this.items.get(key));
     }
     return items;
-  }
-
-  @Override
-  public void isPopulated(boolean isPopulated) {
-    // Do nothing
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.informers.ListerWatcher;
-import io.fabric8.kubernetes.client.informers.ResyncRunnable;
 import io.fabric8.kubernetes.client.informers.SharedInformerEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
@@ -168,6 +168,10 @@ public class Controller<T extends HasMetadata, L extends KubernetesResourceList<
   }
 
   private void initReflector() {
-      reflector = new Reflector<>(apiTypeClass, listerWatcher, queue, operationContext, fullResyncPeriod);
+    reflector = new Reflector<>(apiTypeClass, listerWatcher, queue, operationContext);
+  }
+
+  public long getFullResyncPeriod() {
+    return fullResyncPeriod;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFO.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFO.java
@@ -42,7 +42,7 @@ import java.util.function.Function;
  *
  * This is taken from official client: https://github.com/kubernetes-client/java/blob/master/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
  * which is ported from official go client: https://github.com/kubernetes/client-go/blob/master/tools/cache/delta_fifo.go
- * 
+ *
  * Updated to be more type safe, and to take ownership of the lastResourceVersion
  */
 public class DeltaFIFO<T extends HasMetadata> implements Store<T, Deque<AbstractMap.SimpleEntry<DeltaFIFO.DeltaType, Object>>> {
@@ -285,7 +285,7 @@ public class DeltaFIFO<T extends HasMetadata> implements Store<T, Deque<Abstract
   /**
    * @return the last known resource version
    */
-  public String getLastResourceVersion() {
+  public String getLastSyncResourceVersion() {
     return lastSyncResourceVersion;
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Indexer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Indexer.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
  *
  * @param <T> resource
  */
-public interface Indexer<T> extends Store<T> {
+public interface Indexer<T> extends Store<T, T> {
   /**
    * Retrieve list of obejcts that match on the named indexing function.
    *

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -110,7 +110,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
 
   private void startWatcher() {
-    log.debug("Starting watcher for resource {} v{}", apiTypeClass, store.getLastResourceVersion());
+    log.debug("Starting watcher for resource {} v{}", apiTypeClass, store.getLastSyncResourceVersion());
     if (watch.get() != null) {
       log.debug("Stopping previous watcher");
       watch.get().close();
@@ -129,13 +129,13 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       isWatcherStarted.set(true);
       watch.set(
         listerWatcher.watch(new ListOptionsBuilder()
-          .withWatch(Boolean.TRUE).withResourceVersion(store.getLastResourceVersion()).withTimeoutSeconds(null).build(),
+          .withWatch(Boolean.TRUE).withResourceVersion(store.getLastSyncResourceVersion()).withTimeoutSeconds(null).build(),
         operationContext.getNamespace(), operationContext, watcher)
       );
     }
   }
 
   public String getLastSyncResourceVersion() {
-    return store.getLastResourceVersion();
+    return store.getLastSyncResourceVersion();
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -37,7 +37,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private final ListerWatcher<T, L> listerWatcher;
   private final DeltaFIFO<T> store;
   private final OperationContext operationContext;
-  private final ReflectorWatcher<T> watcher;
+  private final ReflectorWatcher<T, ?> watcher;
   private final AtomicBoolean isActive;
   private final AtomicBoolean isWatcherStarted;
   private final AtomicReference<Watch> watch;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -24,15 +24,15 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
-public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
+public class ReflectorWatcher<T extends HasMetadata, V> implements Watcher<T> {
 
   private static final Logger log = LoggerFactory.getLogger(ReflectorWatcher.class);
 
-  private final DeltaFIFO<T> store;
+  private final Store<T, V> store;
   private final Runnable onClose;
   private final Runnable onHttpGone;
 
-  public ReflectorWatcher(DeltaFIFO<T> store, Runnable onClose, Runnable onHttpGone) {
+  public ReflectorWatcher(Store<T, V> store, Runnable onClose, Runnable onHttpGone) {
     this.store = store;
     this.onClose = onClose;
     this.onHttpGone = onHttpGone;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -23,20 +23,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
 
   private static final Logger log = LoggerFactory.getLogger(ReflectorWatcher.class);
 
-  private final Store<T> store;
-  private final AtomicReference<String> lastSyncResourceVersion;
+  private final DeltaFIFO<T> store;
   private final Runnable onClose;
   private final Runnable onHttpGone;
 
-  public ReflectorWatcher(Store<T> store, AtomicReference<String> lastSyncResourceVersion, Runnable onClose, Runnable onHttpGone) {
+  public ReflectorWatcher(DeltaFIFO<T> store, Runnable onClose, Runnable onHttpGone) {
     this.store = store;
-    this.lastSyncResourceVersion = lastSyncResourceVersion;
     this.onClose = onClose;
     this.onHttpGone = onHttpGone;
   }
@@ -64,8 +61,7 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
         store.delete(resource);
         break;
     }
-    lastSyncResourceVersion.set(resource.getMetadata().getResourceVersion());
-    log.debug("{}#Receiving resourceVersion {}", resource.getKind(), lastSyncResourceVersion.get());
+    log.debug("{}#Receiving resourceVersion {}", resource.getKind(), resource.getMetadata().getResourceVersion());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ResyncRunnable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ResyncRunnable.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client.informers;
+package io.fabric8.kubernetes.client.informers.cache;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.informers.cache.DeltaFIFO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Store.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Store.java
@@ -29,9 +29,12 @@ import java.util.List;
  *
  * This is ported from official go client: https://github.com/kubernetes/client-go/blob/master/tools/cache/store.go
  *
+ * Updated to be more type safe and to not assume the responsibilities of a DeltaFIFO
+ *
  * @param <T> resource
+ * @param <V> value
  */
-public interface Store<T> {
+public interface Store<T, V> {
   /**
    * Inserts an item into the store
    *
@@ -58,7 +61,7 @@ public interface Store<T> {
    *
    * @return list of all items
    */
-  List<T> list();
+  List<V> list();
 
   /**
    * returns a list of all keys of the object currently in the store.
@@ -73,7 +76,7 @@ public interface Store<T> {
    * @param object object
    * @return requested item if exists.
    */
-  Object get(T object);
+  V get(T object);
 
   /**
    * Returns the request item with specific key.
@@ -81,28 +84,6 @@ public interface Store<T> {
    * @param key specific key
    * @return the requested item
    */
-  T getByKey(String key);
-
-  /**
-   * Deletes the contents of the store, using instead the given list.
-   * Store takes ownership of the list, you should not reference it
-   * after calling this function
-   *
-   * @param list list of objects
-   * @param resourceVersion resource version
-   */
-  void replace(List<T> list, String resourceVersion);
-
-  /**
-   * Sends a resync event for each item.
-   */
-  void resync();
-
-  /**
-   * Updates the status of cache in case of any API error from Kubernetes server
-   *
-   * @param isPopulated boolean value indicating whether cache is populated or not
-   */
-  void isPopulated(boolean isPopulated);
+  V getByKey(String key);
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -52,7 +52,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
   // value).
   private long defaultEventHandlerResyncPeriod;
 
-  private Indexer<T> indexer;
+  private Cache<T> indexer;
 
   private SharedProcessor<T> processor;
 
@@ -68,7 +68,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     this.defaultEventHandlerResyncPeriod = resyncPeriod;
 
     this.processor = new SharedProcessor<>();
-    this.indexer = new Cache();
+    this.indexer = new Cache<T>();
 
     DeltaFIFO<T> fifo = new DeltaFIFO<>(Cache::metaNamespaceKeyFunc, this.indexer);
 
@@ -211,7 +211,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
 
 
   @Override
-  public Indexer getIndexer() {
+  public Indexer<T> getIndexer() {
     return this.indexer;
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.informers.cache.DeltaFIFO;
 import io.fabric8.kubernetes.client.informers.cache.Indexer;
 import io.fabric8.kubernetes.client.informers.cache.ProcessorListener;
 import io.fabric8.kubernetes.client.informers.cache.SharedProcessor;
+import io.fabric8.kubernetes.client.informers.cache.Store;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +69,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     this.defaultEventHandlerResyncPeriod = resyncPeriod;
 
     this.processor = new SharedProcessor<>();
-    this.indexer = new Cache<T>();
+    this.indexer = new Cache<>();
 
     DeltaFIFO<T> fifo = new DeltaFIFO<>(Cache::metaNamespaceKeyFunc, this.indexer);
 
@@ -209,6 +210,10 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     indexer.addIndexers(indexers);
   }
 
+  @Override
+  public Store<T, T> getStore() {
+    return this.indexer;
+  }
 
   @Override
   public Indexer<T> getIndexer() {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.informers.cache;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -28,14 +29,18 @@ import java.util.function.Function;
 import static org.junit.Assert.assertEquals;
 
 class CacheTest {
-  private static Cache cache = new Cache("mock", CacheTest::mockIndexFunction, CacheTest::mockKeyFunction);
+  private Cache cache;
+
+  @BeforeEach
+  public void initCache() {
+    cache = new Cache("mock", CacheTest::mockIndexFunction, CacheTest::mockKeyFunction);
+  }
 
   @Test
   void testCacheIndex() {
     Pod testPodObj = new PodBuilder().withNewMetadata().withName("test-pod").endMetadata().build();
 
     cache.add(testPodObj);
-    cache.replace(Arrays.asList(testPodObj), "0");
 
     String index = mockIndexFunction(testPodObj).get(0);
     String key = mockKeyFunction(testPodObj);
@@ -56,7 +61,7 @@ class CacheTest {
     Pod testPodObj = new PodBuilder().withNewMetadata().withName("test-pod2").endMetadata().build();
     String index = mockIndexFunction(testPodObj).get(0);
 
-    cache.replace(Arrays.asList(testPodObj), "0");
+    cache.add(testPodObj);
     cache.delete(testPodObj);
 
     List indexedObjectList = cache.byIndex("mock", index);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
@@ -45,7 +45,7 @@ class ControllerTest {
       1000L, operationContext, eventListeners);
 
     // Then
-    assertEquals(1000L, controller.getReflector().getResyncPeriodMillis());
+    assertEquals(1000L, controller.getFullResyncPeriod());
   }
 
   @Test
@@ -67,6 +67,6 @@ class ControllerTest {
       0L, operationContext, eventListeners);
 
     // Then
-    assertEquals(0L, controller.getReflector().getResyncPeriodMillis());
+    assertEquals(0L, controller.getFullResyncPeriod());
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFOTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFOTest.java
@@ -121,7 +121,7 @@ class DeltaFIFOTest {
   @Test
   void testResync() {
     Pod foo1 = new PodBuilder().withNewMetadata().withName("foo1").withNamespace("default").endMetadata().build();
-    Cache cache = new Cache();
+    Cache<Pod> cache = new Cache<>();
     DeltaFIFO<Pod> deltaFIFO = new DeltaFIFO<>(Cache::deletionHandlingMetaNamespaceKeyFunc, cache);
 
     // sync after addition

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFOTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/DeltaFIFOTest.java
@@ -76,7 +76,7 @@ class DeltaFIFOTest {
 
     // Sync operation
     deltaFIFO.replace(Arrays.asList(foo1), "0");
-    cache.replace(Arrays.asList(foo1), "0");
+    cache.add(foo1);
     deltaFIFO.pop(
       (deltas) -> {
         AbstractMap.SimpleEntry<DeltaFIFO.DeltaType, Object> delta = deltas.peekFirst();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ListerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ListerTest.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -33,12 +32,12 @@ class ListerTest {
     List<Pod> emptyPodList = namespacedPodLister.list();
     assertEquals(0, emptyPodList.size());
 
-    podCache.replace(
-      Arrays.asList(
-        new PodBuilder().withNewMetadata().withName("foo1").withNamespace("default").endMetadata().build(),
-        new PodBuilder().withNewMetadata().withName("foo2").withNamespace("default").endMetadata().build(),
-        new PodBuilder().withNewMetadata().withName("foo3").withNamespace("default").endMetadata().build()
-      ), "0");
+    podCache.add(
+        new PodBuilder().withNewMetadata().withName("foo1").withNamespace("default").endMetadata().build());
+    podCache.add(
+        new PodBuilder().withNewMetadata().withName("foo2").withNamespace("default").endMetadata().build());
+    podCache.add(
+        new PodBuilder().withNewMetadata().withName("foo3").withNamespace("default").endMetadata().build());
 
     List<Pod> namespacedPodList = namespacedPodLister.list();
     assertEquals(3, namespacedPodList.size());


### PR DESCRIPTION
## Description
While looking at changes for #2993, #2995, and another bug that has not been logged here.  It appears there are some clarifications that could be made to improve the readability and the safety of the informer code.  The central change is that Store should be more type specific and have a narrower interface - I realize this differs from the go implementation and this does change the public interface of SharedIndexInformer.getIndexer because the Store will no longer have replace, resync, or isPopulated.  If it's a problem to make such a change it can of course be refined (previous code, all no-ops, or throw not implemented exceptions).  In general it seems problematic that SharedIndexInformer.getIndexer returns as broad of an interface as it does - for example in DefaultSharedIndexInformer.addIndexers you can't add an indexer once running, but if you call SharedIndexInformer.getIndexer.addIndexers you can.

If you'd prefer another interface such as ResyncableStore vs direct usage of the DeltaFIFO in ResyncRunnable, Reflector, and ReflectorWatcher - that can be done as well, it just didn't seem needed given the single implementation of DeltaFIFO.  I do see several implementations of Store types in go.

This also moves the responsibility for the lastResourceVersion to the DeltaFIFO - having it updatable outside the DeltaFIFO lock is dangerous.  With the code pre #2812 it appears to allow for timing issues in threads updating the DeltaFIFO/lastResourceVersion:

1. resyncExecutor thread performs scheduled relist - sees state s1, sets the last resourceVersion to s1
2. watch thread via ReflectorWatcher - sees an update to state s2, calls DeltaFIFO.update and sets last resourceVersion to s2
3. resyncExecutor thread continues - calls DeltaFIFO.replace with state s1, adds a syncronization event to state s1 after the update event

The event generated from 2 will be an update showing s1 as the old state and s2 as the new
The event generated from 3 will be an update showing s2 as the old state and s1 as the new 

A reconnect won't fix that as the last resourceVersion is s2.

In theory though on the next relist there will be a synchronization and event to s2 (or whatever the latest state is). However with the pre #2812 code any uncaught exception from relist will inhibit the job from running again.

Granted this should no longer happen after #2812 because the scheduled relist has been removed, but it is still something that should be guarded against.  

@rohanKanojia or others let me know if you are open to these types of changes, I can refine this PR as needed.

## Type of change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift