### PR TITLE
Fix NPE on initial requests while syncing

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Cache.java
@@ -390,6 +390,9 @@ public class Cache<T> implements Indexer<T> {
    */
   public static String metaNamespaceKeyFunc(Object obj) {
     try {
+      if( obj == null ) {
+        return "";
+      }
       ObjectMeta metadata;
       if(obj instanceof String) {
         return (String) obj;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ReflectUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ReflectUtils.java
@@ -27,6 +27,9 @@ import java.util.List;
 public class ReflectUtils {
 
   public static ObjectMeta objectMetadata(Object obj) throws ReflectiveOperationException {
+    if( obj == null ) {
+      return null;
+    }
     if (obj instanceof HasMetadata) {
       return ((HasMetadata) obj).getMetadata();
     }
@@ -39,6 +42,9 @@ public class ReflectUtils {
   }
 
   public static String namespace(Object obj) throws ReflectiveOperationException {
+    if( obj == null ) {
+      return "";
+    }
     return objectMetadata(obj).getNamespace();
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/CacheTest.java
@@ -87,6 +87,7 @@ class CacheTest {
     Pod testPodObj = new PodBuilder().withNewMetadata().withName("test-pod4").withNamespace("default").endMetadata().build();
 
     cache.add(testPodObj);
+    assertEquals("", Cache.metaNamespaceKeyFunc(null));
     assertEquals("default/test-pod4", Cache.metaNamespaceKeyFunc(testPodObj));
     assertEquals("default/test-pod4", Cache.namespaceKeyFunc("default", "test-pod4"));
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ReflectUtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ReflectUtilsTest.java
@@ -15,8 +15,10 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -91,6 +93,42 @@ public class ReflectUtilsTest {
     Baz baz = new Baz();
     baz.setMetadata(meta);
     assertSame(meta, ReflectUtils.objectMetadata(baz));
+  }
+
+  @Test
+  void testObjectMetadataReturnsNullOnNull() throws ReflectiveOperationException {
+    // Given
+    Object input = null;
+
+    // When
+    ObjectMeta result = ReflectUtils.objectMetadata(input);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void testNamespaceReturnsValidNamespace() throws ReflectiveOperationException {
+    // Given
+    Object input = new ConfigMapBuilder().withNewMetadata().withNamespace("ns1").endMetadata().build();
+
+    // When
+    String result = ReflectUtils.namespace(input);
+
+    // Then
+    assertThat(result).isNotNull().isEqualTo("ns1");
+  }
+
+  @Test
+  void testNamespaceReturnsBlankNamespace() throws ReflectiveOperationException {
+    // Given
+    Object input = null;
+
+    // When
+    String result = ReflectUtils.namespace(input);
+
+    // Then
+    assertThat(result).isNotNull().isBlank();
   }
 
 }


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #2978 
Adds null check on cache object metadata.
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
