### PR TITLE
Fix #3015: Log InterruptedException in debug when it is a nominal terminating behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider
 * Fix #2910: Move crd-generator tests from kubernetes-itests to kubernetes-tests
 * Fix #3005: Make it possible to select which CRD version is generated / improve output
+* Fix #3015: Thread interruption in a nominal case (like closing the client) are now logged in debug
 
 #### Dependency Upgrade
 * Fix #2979: Update Kubernetes Model to v1.21.0

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -2066,10 +2066,6 @@ client.pods().inNamespace(namespace).watch(resourceVersion, new Watcher<Pod>() {
 
 // Wait till watch gets closed
 isWatchClosed.await();
-} catch (InterruptedException interruptedException) {
-logger.log(Level.INFO, "Thread Interrupted!");
-Thread.currentThread().interrupt();
-}
 ```
 - Watching with `ListOptions` object:
 ```

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -403,7 +403,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         try {
           return waitUntilCondition(Objects::nonNull, 1, TimeUnit.SECONDS);
         } catch (InterruptedException interruptedException) {
-          interruptedException.printStackTrace();
+          LOG.warn("Interrupted while waiting for the resource to be created or replaced. Gracefully assuming the resource has not been created and doesn't exist. ({})", interruptedException.getMessage());
+          Thread.currentThread().interrupt();
         }
         return null;
       },

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElector.java
@@ -200,7 +200,7 @@ public class LeaderElector<C extends Namespaceable<C> & KubernetesClient> {
       countDownLatch.await();
       return true;
     } catch (InterruptedException e) {
-      LOGGER.debug("Loop thread interrupted", e);
+      LOGGER.debug("Loop thread interrupted: {}", e.getMessage());
       Thread.currentThread().interrupt();
       return false;
     } finally {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
@@ -159,7 +159,7 @@ public class Controller<T extends HasMetadata, L extends KubernetesResourceList<
       try {
         this.queue.pop(this.processFunc);
       } catch (InterruptedException t) {
-        log.warn("DefaultController#processLoop got interrupted {}", t.getMessage(), t);
+        log.debug("DefaultController#processLoop got interrupted: {}", t.getMessage());
         Thread.currentThread().interrupt();
         return;
       } catch (Exception e) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -112,7 +112,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       try {
         Thread.sleep(WATCH_RESTART_DELAY_MILLIS);
       } catch (InterruptedException e) {
-        log.error("Reflector thread was interrupted");
+        log.debug("Reflector thread was interrupted: {}", e.getMessage());
         Thread.currentThread().interrupt();
         return;
       }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/CreateOrReplaceHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/CreateOrReplaceHelper.java
@@ -21,6 +21,8 @@ import io.fabric8.kubernetes.client.HasMetadataVisitiableBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.ResourceHandler;
 import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.HttpURLConnection;
 import java.util.Objects;
@@ -29,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 
 public class CreateOrReplaceHelper<T extends HasMetadata> {
+  private static final Logger LOG = LoggerFactory.getLogger(CreateOrReplaceHelper.class);
   public static final int CREATE_OR_REPLACE_RETRIES = 3;
   private final UnaryOperator<T> createTask;
   private final UnaryOperator<T> replaceTask;
@@ -77,7 +80,8 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
         try {
           return h.waitUntilCondition(client, config, namespaceToUse, m, Objects::nonNull, 1, TimeUnit.SECONDS);
         } catch (InterruptedException interruptedException) {
-          interruptedException.printStackTrace();
+          Thread.currentThread().interrupt();
+          LOG.warn("Interrupted waiting for item to be created or replaced. Gracefully assuming the resource hasn't been created and doesn't exist. ({})", interruptedException.getMessage());
         }
         return null;
       },

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceInformerExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceInformerExample.java
@@ -73,7 +73,7 @@ public class CustomResourceInformerExample {
           }
         } catch (InterruptedException inEx) {
           Thread.currentThread().interrupt();
-          logger.info("HAS_SYNCED_THREAD INTERRUPTED!");
+          logger.warn("HAS_SYNCED_THREAD interrupted: {}", inEx.getMessage());
         }
       });
 
@@ -93,7 +93,7 @@ public class CustomResourceInformerExample {
       TimeUnit.MINUTES.sleep(5);
     } catch (InterruptedException interruptedException) {
       Thread.currentThread().interrupt();
-      logger.info("interrupted: {}", interruptedException.getMessage());
+      logger.warn("interrupted: {}", interruptedException.getMessage());
     }
   }
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/JobExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/JobExample.java
@@ -75,7 +75,7 @@ public class JobExample {
         } catch (KubernetesClientException e) {
             logger.error("Unable to create job", e);
         } catch (InterruptedException interruptedException) {
-          logger.warn("Thread interrupted!");
+          logger.warn("Interrupted while waiting for the job to be ready: {}", interruptedException.getMessage());
           Thread.currentThread().interrupt();
         }
     }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodExecEquivalent.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodExecEquivalent.java
@@ -54,7 +54,7 @@ public class PodExecEquivalent {
       execWatch.close();
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
-      ie.printStackTrace();
+      logger.warn("Interrupted while waiting for the exec: {}", ie.getMessage());
     }
   }
 

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodWatchEquivalent.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodWatchEquivalent.java
@@ -67,7 +67,7 @@ public class PodWatchEquivalent {
             // Wait till watch gets closed
             isWatchClosed.await();
         } catch (InterruptedException interruptedException) {
-            logger.info( "Thread Interrupted!");
+            logger.warn("Interrupted while waiting for the watch to close: {}", interruptedException.getMessage());
             Thread.currentThread().interrupt();
         }
     }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PortForwardEquivalent.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PortForwardEquivalent.java
@@ -43,7 +43,7 @@ public class PortForwardEquivalent {
       logger.info("Closing port forward");
     } catch (InterruptedException interruptedException) {
       Thread.currentThread().interrupt();
-      interruptedException.printStackTrace();
+      logger.warn("Interrupted while waiting for the port forward to be ready: {}", interruptedException.getMessage());
     }
   }
 }

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/WatchEventsListener.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/WatchEventsListener.java
@@ -74,7 +74,7 @@ class WatchEventsListener extends WebSocketListener {
     try {
       executor.awaitTermination(1, TimeUnit.MINUTES);
     } catch (InterruptedException e) {
-      logger.debug(e.getLocalizedMessage());
+      logger.debug("Interrupted waiting for the executor service to shutdown: {}", e.getMessage());
       Thread.currentThread().interrupt();
     }
     watchEventListenerList.remove(this);
@@ -87,7 +87,7 @@ class WatchEventsListener extends WebSocketListener {
     try {
       executor.awaitTermination(1, TimeUnit.MINUTES);
     } catch (InterruptedException e) {
-      logger.debug(e.getLocalizedMessage());
+      logger.debug("Interrupted waiting for the executor service to shutdown: {}", e.getMessage());
       Thread.currentThread().interrupt();
     }
     watchEventListenerList.remove(this);


### PR DESCRIPTION
## Description

Here is a review of the catch of the InterruptedException and their logs. I have done more than looking to the core code of the client. These suggestions are up for debate, and thus can be reverted in this PR.

So, every log about an nominal InterruptedException is now in debug, with the message of the exception but not the stack trace.

Special cases on some catch that I found:
* `BaseOperation#createOrReplace`: there used to be a `printStackTrace`. I tried to improve it by a log and propagate the status of the interrupted thread. But considering the case here, maybe there is more to do.
* `CreateOrReplaceHelper#createOrReplaceItem`: same considerations
* `CHEATSHEET.md`: I have found these weird piece of catch without the `try` keyword. I took the liberty to juste remove it. Javac will raise an error about the InterruptedException to handle, I see no need to do it explicitely here in the cheat sheet.
* the code exemples: to make things uniform, I made the logs at the warn level

A side note on `PortForwardEquivalent` example. I don't see how the `countDownLatch` is usefull there, `countDown` is never called on it.

Fix #3015 
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
