### PR TITLE
fix NPE when sorting events in KubernetesResourceUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #2996: Generating CRDs from the API should now properly work
 * Fix #3000: Set no_proxy in the okhttp builder in case the proxy_url is null
 * Fix #2991: reduced the level of ReflectWatcher event recieved log
+* Fix #3027: fix NPE when sorting events in KubernetesResourceUtil
 
 #### Improvements
 * Fix #2910: Move crd-generator tests from kubernetes-itests to kubernetes-tests

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -326,12 +327,8 @@ public class KubernetesResourceUtil {
 
   public static void sortEventListBasedOnTimestamp(List<Event> eventList) {
     if (eventList != null) {
-      // Sort to get latest events in begining
-      eventList.sort((o1, o2) -> {
-          Instant d1 = Instant.parse(o1.getLastTimestamp());
-          Instant d2 = Instant.parse(o2.getLastTimestamp());
-          return (int) (d2.getEpochSecond() - d1.getEpochSecond());
-      });
+      // Sort to get latest events in beginning, putting events without lastTimestamp first
+      eventList.sort(Comparator.comparing(Event::getLastTimestamp, Comparator.nullsFirst(Comparator.comparing(Instant::parse).reversed())));
     }
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/KubernetesResourceUtilTest.java
@@ -117,14 +117,18 @@ class KubernetesResourceUtilTest {
       .withNewMetadata().withName("event3").endMetadata()
       .withLastTimestamp("2020-06-13T06:45:16Z")
       .build());
+    eventList.add(new EventBuilder()
+      .withNewMetadata().withName("eventWithoutLastTimestamp").endMetadata()
+      .build());
 
     // When
     KubernetesResourceUtil.sortEventListBasedOnTimestamp(eventList);
 
     // Then
-    assertEquals("event3", eventList.get(0).getMetadata().getName());
-    assertEquals("event2", eventList.get(1).getMetadata().getName());
-    assertEquals("event1", eventList.get(2).getMetadata().getName());
+    assertEquals("eventWithoutLastTimestamp", eventList.get(0).getMetadata().getName());
+    assertEquals("event3", eventList.get(1).getMetadata().getName());
+    assertEquals("event2", eventList.get(2).getMetadata().getName());
+    assertEquals("event1", eventList.get(3).getMetadata().getName());
   }
 
   @Test


### PR DESCRIPTION
## Description
fixes https://github.com/fabric8io/kubernetes-client/issues/3027

According to kubernetes/kubernetes#90482, the firstTimestamp/lastTimestamp and eventTime fields are optional, so clients must tolerate events without those timestamps set.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
