### PR TITLE
chore: make RawCustomResourceOperationsImpl watch methods to return Watch

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -717,10 +717,11 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
    *
    * @param namespace namespace to watch
    * @param watcher watcher object which reports updates with object
+   * @return watch object for watching resource
    * @throws IOException in case of network error
    */
-  public void watch(String namespace, Watcher<String> watcher) throws IOException {
-    watch(namespace, null, null, new ListOptionsBuilder().build(), watcher);
+  public Watch watch(String namespace, Watcher<String> watcher) throws IOException {
+    return watch(namespace, null, null, new ListOptionsBuilder().build(), watcher);
   }
 
   /**
@@ -730,10 +731,11 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
    * @param namespace namespace to watch
    * @param resourceVersion resource version since when to watch
    * @param watcher watcher object which reports updates
+   * @return watch object for watching resource
    * @throws IOException in case of network error
    */
-  public void watch(String namespace, String resourceVersion, Watcher<String> watcher) throws IOException {
-    watch(namespace, null, null, new ListOptionsBuilder().withResourceVersion(resourceVersion).build(), watcher);
+  public Watch watch(String namespace, String resourceVersion, Watcher<String> watcher) throws IOException {
+    return watch(namespace, null, null, new ListOptionsBuilder().withResourceVersion(resourceVersion).build(), watcher);
   }
 
   /**
@@ -743,10 +745,11 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
    * @param namespace namespace to watch
    * @param options {@link ListOptions} list options for watching
    * @param watcher watcher object which reports updates
+   * @return watch object for watching resource
    * @throws IOException in case of network error
    */
-  public void watch(String namespace, ListOptions options, Watcher<String> watcher) throws IOException {
-    watch(namespace, null, null, options, watcher);
+  public Watch watch(String namespace, ListOptions options, Watcher<String> watcher) throws IOException {
+    return watch(namespace, null, null, options, watcher);
   }
 
   /**
@@ -754,10 +757,11 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
    * for string type only. User has to deserialize object itself.
    *
    * @param watcher watcher object which reports events
+   * @return watch object for watching resource
    * @throws IOException in case of network error
    */
-  public void watch(Watcher<String> watcher) throws IOException {
-    watch(null, null, null, new ListOptionsBuilder().build(), watcher);
+  public Watch watch(Watcher<String> watcher) throws IOException {
+    return watch(null, null, null, new ListOptionsBuilder().build(), watcher);
   }
 
   /**


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
