### PR TITLE
Informer watch status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix #2980: Add DSL Support for `apps/v1#ControllerRevision` resource
 * Fix #2981: Add DSL support for `storage.k8s.io/v1beta1` CSIDriver, CSINode and VolumeAttachment
 * Fix #2912: Add DSL support for `storage.k8s.io/v1beta1` CSIStorageCapacity
+* Fix #3034: Added a SharedInformer.isRunning method
 
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
@@ -59,4 +59,9 @@ public interface SharedInformer<T> {
    * @return string value
    */
   String lastSyncResourceVersion();
+  
+  /**
+   * Return true if the informer is running
+   */
+  boolean isRunning();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -24,8 +24,6 @@ import io.fabric8.kubernetes.client.informers.ListerWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -110,6 +110,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
   
   public boolean isRunning() {
-    return isActive.get() && !watcher.isClosed();
+    return isActive.get();
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -32,7 +32,6 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
   private final AtomicReference<String> lastSyncResourceVersion;
   private final Runnable onClose;
   private final Runnable onHttpGone;
-  private volatile boolean closed;
 
   public ReflectorWatcher(Store<T> store, AtomicReference<String> lastSyncResourceVersion, Runnable onClose, Runnable onHttpGone) {
     this.store = store;
@@ -81,9 +80,6 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
 
   @Override
   public void onClose() {
-    // this should be an explicit close by the user,
-    // mark as closed
-    closed = true;
     log.debug("Watch gracefully closed");
     onClose.run();
   }
@@ -93,7 +89,4 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
     return true;
   }
   
-  public boolean isClosed() {
-    return closed;
-  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -230,4 +230,9 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     }
     return desired < check ? check : desired;
   }
+
+  @Override
+  public boolean isRunning() {
+    return !stopped && started && controller.isRunning(); 
+  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ControllerTest.java
@@ -55,7 +55,7 @@ class ControllerTest {
       1000L, operationContext, eventListeners);
 
     // Then
-    assertEquals(1000L, controller.getReflector().getResyncPeriodMillis());
+    assertEquals(1000L, controller.getFullResyncPeriod());
   }
 
   @Test
@@ -77,7 +77,7 @@ class ControllerTest {
       0L, operationContext, eventListeners);
 
     // Then
-    assertEquals(0L, controller.getReflector().getResyncPeriodMillis());
+    assertEquals(0L, controller.getFullResyncPeriod());
   }
 
   @Test
@@ -92,7 +92,6 @@ class ControllerTest {
     // When
     controller.stop();
     // Then
-    assertThat(controller.getReflectExecutor().isShutdown()).isTrue();
     assertThat(controller.getResyncExecutor().isShutdown()).isTrue();
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -67,6 +67,7 @@ import java.util.function.Function;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient
 class DefaultSharedIndexInformerTest {
@@ -835,8 +836,14 @@ class DefaultSharedIndexInformerTest {
     factory.startAllRegisteredInformers();
     updates.await(LATCH_AWAIT_PERIOD_IN_SECONDS, TimeUnit.SECONDS);
 
+    // should still be running after all that
+    assertTrue(podInformer.isRunning());
     // Then
     assertEquals(0, updates.getCount());
+
+    podInformer.stop();
+
+    assertFalse(podInformer.isRunning());
   }
 
   private KubernetesResource getAnimal(String name, String order, String resourceVersion) {


### PR DESCRIPTION
## Description
Adding a SharedInformer isRunning method, with some additional minor cleanups.  As best as I can determine if this returns true, the informer should still expect to receive events.  This does not address using the SharedInformerEventListener or some other mechanism to forward any possible abnormal termination exception to.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly