### PR TITLE
fix #3047: NPE when getting version when there is no build date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #3020: annotations should now properly have their associated values when processing CRDs from the API
 * Fix #3027: fix NPE when sorting events in KubernetesResourceUtil
 * Fix missing entry for Trigger in TektonTriggersResourceMappingProvider
+* Fix #3047: NPE when getting version when there is no build date
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/VersionInfo.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/VersionInfo.java
@@ -102,7 +102,9 @@ public class VersionInfo {
     }
 
     public Builder withBuildDate(String buildDate) throws ParseException {
-      this.versionInfo.buildDate = new SimpleDateFormat(VersionKeys.BUILD_DATE_FORMAT).parse(buildDate);
+      if (buildDate != null) {
+        this.versionInfo.buildDate = new SimpleDateFormat(VersionKeys.BUILD_DATE_FORMAT).parse(buildDate);
+      }
       return this;
     }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
@@ -25,6 +25,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @EnableKubernetesMockClient
 public class VersionInfoTest {
@@ -47,6 +48,23 @@ public class VersionInfoTest {
     assertEquals("3", client.getVersion().getMajor());
     assertEquals("6", client.getVersion().getMinor());
     assertEquals(118, client.getVersion().getBuildDate().getYear());
-    assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse("2018-03-01T14:27:17Z").getTime(), client.getVersion().getBuildDate().getTime());
+    assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse("2018-03-01T14:27:17Z").getTime(),
+      client.getVersion().getBuildDate().getTime());
+  }
+
+  @Test
+  public void testClusterVersioningWithMissingBuildDate() {
+    server.expect().withPath("/version").andReturn(200, "{" +
+      "    \"gitCommit\": \"e6301f88a8\"," +
+      "    \"gitVersion\": \"v1.6.1+5115d708d7\"," +
+      "    \"major\": \"3\"," +
+      "    \"minor\": \"6\"" +
+      "}").always();
+
+    assertEquals("v1.6.1+5115d708d7", client.getVersion().getGitVersion());
+    assertEquals("e6301f88a8", client.getVersion().getGitCommit());
+    assertEquals("3", client.getVersion().getMajor());
+    assertEquals("6", client.getVersion().getMinor());
+    assertNull(client.getVersion().getBuildDate());
   }
 }


### PR DESCRIPTION
## Description
Fix #3047
NPE when getting version when there is no build date.
* Add null check for build date before trying to parse it.

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift