### PR TITLE
Add missing entry for Trigger CRD to TektonTriggersResourceMappingProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix #3011: properly handle enum types for additional printer columns
 * Fix #3020: annotations should now properly have their associated values when processing CRDs from the API
 * Fix #3027: fix NPE when sorting events in KubernetesResourceUtil
+* Fix missing entry for Trigger in TektonTriggersResourceMappingProvider
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider

--- a/extensions/tekton/model-triggers/src/main/java/io/fabric8/tekton/TektonTriggersResourceMappingProvider.java
+++ b/extensions/tekton/model-triggers/src/main/java/io/fabric8/tekton/TektonTriggersResourceMappingProvider.java
@@ -30,6 +30,7 @@ public class TektonTriggersResourceMappingProvider implements KubernetesResource
       mappings.put("triggers.tekton.dev/v1alpha1#TriggerBinding", io.fabric8.tekton.triggers.v1alpha1.TriggerBinding.class);
       mappings.put("triggers.tekton.dev/v1alpha1#EventListener", io.fabric8.tekton.triggers.v1alpha1.EventListener.class);
       mappings.put("triggers.tekton.dev/v1alpha1#ClusterTriggerBinding", io.fabric8.tekton.triggers.v1alpha1.ClusterTriggerBinding.class);
+      mappings.put("triggers.tekton.dev/v1alpha1#Trigger", io.fabric8.tekton.triggers.v1alpha1.Trigger.class);
     }
 
     public Map<String, Class<? extends KubernetesResource>> getMappings() {


### PR DESCRIPTION
## Description
We missed enhancing the TektonTriggersResourceMappingProvider during https://github.com/fabric8io/kubernetes-client/pull/2948 😇

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
