### PR TITLE
Fix #3024 removing any onClose action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix #3027: fix NPE when sorting events in KubernetesResourceUtil
 * Fix missing entry for Trigger in TektonTriggersResourceMappingProvider
 * Fix #3047: NPE when getting version when there is no build date
+* Fix #3024: stopAllRegisteredInformers will not call startWatcher
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
@@ -29,7 +29,6 @@ import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Controller.java
@@ -63,8 +63,6 @@ public class Controller<T extends HasMetadata, L extends KubernetesResourceList<
 
   private final ScheduledExecutorService resyncExecutor;
 
-  private volatile ScheduledFuture resyncFuture;
-
   private final OperationContext operationContext;
 
   private final ConcurrentLinkedQueue<SharedInformerEventListener> eventListeners;
@@ -97,7 +95,7 @@ public class Controller<T extends HasMetadata, L extends KubernetesResourceList<
     if (fullResyncPeriod > 0) {
       ResyncRunnable resyncRunnable = new ResyncRunnable(queue, resyncFunc);
       if(!resyncExecutor.isShutdown()) {
-        resyncFuture = resyncExecutor.scheduleAtFixedRate(resyncRunnable, fullResyncPeriod, fullResyncPeriod, TimeUnit.MILLISECONDS);
+        resyncExecutor.scheduleAtFixedRate(resyncRunnable, fullResyncPeriod, fullResyncPeriod, TimeUnit.MILLISECONDS);
       }
     } else {
       log.info("informer#Controller: resync skipped due to 0 full resync period");
@@ -123,10 +121,7 @@ public class Controller<T extends HasMetadata, L extends KubernetesResourceList<
    */
   public void stop() {
     reflector.stop();
-    if (resyncFuture != null) {
-      resyncFuture.cancel(true);
-    }
-    resyncExecutor.shutdown();
+    resyncExecutor.shutdownNow();
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -97,7 +97,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
 
   public String getLastSyncResourceVersion() {
-      return lastSyncResourceVersion.get();
+    return lastSyncResourceVersion.get();
   }
   
   public boolean isRunning() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -36,7 +36,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private final Store<T> store;
   private final OperationContext operationContext;
   private final ReflectorWatcher<T> watcher;
-  private volatile boolean stopped;
+  private volatile boolean running = true;
   private final AtomicReference<Watch> watch;
 
   public Reflector(Class<T> apiTypeClass, ListerWatcher<T, L> listerWatcher, Store store, OperationContext operationContext) {
@@ -57,7 +57,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
 
   public void stop() {
-    stopped = true;
+    running = false;
     stopWatcher();
   }
 
@@ -85,7 +85,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
 
   private synchronized void startWatcher(final String latestResourceVersion) {
-    if (stopped) {
+    if (!running) {
         return;
     }
     log.debug("Starting watcher for resource {} v{}", apiTypeClass, latestResourceVersion);
@@ -101,6 +101,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
   
   public boolean isRunning() {
-    return !stopped;
+    return running;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ReflectorWatcher.java
@@ -30,13 +30,11 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
 
   private final Store<T> store;
   private final AtomicReference<String> lastSyncResourceVersion;
-  private final Runnable onClose;
   private final Runnable onHttpGone;
 
-  public ReflectorWatcher(Store<T> store, AtomicReference<String> lastSyncResourceVersion, Runnable onClose, Runnable onHttpGone) {
+  public ReflectorWatcher(Store<T> store, AtomicReference<String> lastSyncResourceVersion, Runnable onHttpGone) {
     this.store = store;
     this.lastSyncResourceVersion = lastSyncResourceVersion;
-    this.onClose = onClose;
     this.onHttpGone = onHttpGone;
   }
 
@@ -75,13 +73,11 @@ public class ReflectorWatcher<T extends HasMetadata> implements Watcher<T> {
     if (exception.isHttpGone()) {
         onHttpGone.run();
     }
-    onClose.run();
   }
 
   @Override
   public void onClose() {
     log.debug("Watch gracefully closed");
-    onClose.run();
   }
 
   @Override


### PR DESCRIPTION
## Description
further cleanups to the Informer onClose behavior

We don't need to call anything for the non-exceptional onClose.  It will only be triggered by the Reflector calling Watch.close.  Every other closing event will go through the exceptional onClose.  Of those calls we only want special handling for http_gone. - everything else we want to simply let watch framework keep retrying.

This supersedes the reflector changes from #3029

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift