### PR TITLE
fix: Potential NullPointerException on custom resource delete

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java
@@ -1038,7 +1038,7 @@ public class RawCustomResourceOperationsImpl extends OperationSupport implements
 
     // In most cases Status object is sent on deletion, but when deprecated DeleteOptions.orphanDependents
     // is used; object which is being deleted is sent
-    if (response.get("kind").toString().equals("Status")) {
+    if (!response.isEmpty() && response.get("kind").toString().equals("Status")) {
       return response.get("status").toString().equals("Success");
     }
     return true;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -282,6 +282,23 @@ class CustomResourceTest {
   }
 
   @Test
+  void testDeleteWithEmptyResponse() throws InterruptedException, IOException {
+    // Given
+    server.expect().delete().withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos/example-hello").andReturn(HttpURLConnection.HTTP_OK, "").once();
+
+    // When
+    boolean result = client.customResource(customResourceDefinitionContext)
+      .delete("ns1", "example-hello", "Orphan");
+
+    // Then
+    assertTrue(result);
+    RecordedRequest request = server.getLastRequest();
+    assertEquals("DELETE", request.getMethod());
+    assertEquals("{\"apiVersion\":\"v1\",\"kind\":\"DeleteOptions\",\"propagationPolicy\":\"Orphan\"}",
+      request.getBody().readUtf8());;
+  }
+
+  @Test
   void testDeleteWithNamespaceMismatch() {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       client.customResource(customResourceDefinitionContext).delete("ns2", "example-hello");


### PR DESCRIPTION
## Description
Fixes potential NPE when delete CR response is empty.

Delete operation response can be empty in https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java#L1030

This lead to NPE when trying to read status object from response in https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RawCustomResourceOperationsImpl.java#L1034


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
