### PR TITLE
fix #3057 adding read only to fields that don't need set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix #2910: Move crd-generator tests from kubernetes-itests to kubernetes-tests
 * Fix #3005: Make it possible to select which CRD version is generated / improve output
 * Fix #3015: Thread interruption in a nominal case (like closing the client) are now logged in debug
+* Fix #3057: Removed debug calls for CustomResource during deserialization
 
 #### Dependency Upgrade
 * Fix #2979: Update Kubernetes Model to v1.21.0

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -80,7 +81,9 @@ public abstract class CustomResource<S, T> implements HasMetadata {
 
   private final String singular;
   private final String crdName;
+  @JsonProperty(access = Access.READ_ONLY)
   private final String kind;
+  @JsonProperty(access = Access.READ_ONLY)
   private final String apiVersion;
   private final String scope;
   private final String plural;


### PR DESCRIPTION
## Description
#3057 
The debug log is excessive when using deserialization, this will omit that.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
