### PR TITLE
adding a patch item operation with a context and other patch / patch derived operation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix missing entry for Trigger in TektonTriggersResourceMappingProvider
 * Fix #3047: NPE when getting version when there is no build date
 * Fix #3024: stopAllRegisteredInformers will not call startWatcher
+* Fix #3067: Added a patch operation with an explicit base
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 * Fix #3050: More enforcement of the informer lifecycle
 * Fix #3061: Removed the deltafifo from the informer logic
 * Use apiGroupName in generated package for OpenShiftClient Handler/OperationsImpl classes
+* Fix #3089: Allowing patch/edit to infer context from the item
+* Fix #3066: Added an applyStatus method
 
 #### Dependency Upgrade
 * Fix #2979: Update Kubernetes Model to v1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Fix missing entry for Trigger in TektonTriggersResourceMappingProvider
 * Fix #3047: NPE when getting version when there is no build date
 * Fix #3024: stopAllRegisteredInformers will not call startWatcher
-* Fix #3067: Added a patch operation with an explicit base
+* Fix #3067: Added a patch(patchcontet, item) operation to be more explicit about patching and diffing behavior
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider
@@ -35,7 +35,7 @@
 * Fix #3061: Removed the deltafifo from the informer logic
 * Use apiGroupName in generated package for OpenShiftClient Handler/OperationsImpl classes
 * Fix #3089: Allowing patch/edit to infer context from the item
-* Fix #3066: Added an applyStatus method
+* Fix #3066: Added replaceStatus (PUT), editStatus (JSON PATCH), and patchStatus (JSON MERGE PATCH) methods to support non-locking status updates
 
 #### Dependency Upgrade
 * Fix #2979: Update Kubernetes Model to v1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Fix missing entry for Trigger in TektonTriggersResourceMappingProvider
 * Fix #3047: NPE when getting version when there is no build date
 * Fix #3024: stopAllRegisteredInformers will not call startWatcher
-* Fix #3067: Added a patch(patchcontet, item) operation to be more explicit about patching and diffing behavior
+* Fix #3067: Added a patch(PatchContext, item) operation to be more explicit about patching and diffing behavior
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
@@ -15,5 +15,5 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface EditReplacePatchable<T> extends Editable<T>, Replaceable<T>, Patchable<T>, StatusUpdatable<T> {
+public interface EditReplacePatchable<T> extends Editable<T>, Replaceable<T>, Patchable<T>, StatusUpdatable<T>, StatusEditable<T>, StatusReplaceable<T>, StatusPatchable<T> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -35,7 +35,7 @@ public interface Patchable<T> {
    * as the comparison for the patch.
    *
    * @param item item to be patched with patched values
-   * @param item base to be compared with to generate the patch, use null for the current
+   * @param base item to be compared with to generate the patch, use null to create a merge patch from item 
    * @return returns deserialized version of api server response
    */
   T patch(T base, T item);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -21,11 +21,24 @@ public interface Patchable<T> {
 
   /**
    * Update field(s) of a resource using a JSON patch.
+   * 
+   * <br>WARNING: This call assumes the base object is the current one on the server.
+   * It may overwrite existing changes.
    *
    * @param item item to be patched with patched values
    * @return returns deserialized version of api server response
    */
   T patch(T item);
+  
+  /**
+   * Update field(s) of a resource using a JSON patch, using the base object
+   * as the comparison for the patch.
+   *
+   * @param item item to be patched with patched values
+   * @param item base to be compared with to generate the patch, use null for the current
+   * @return returns deserialized version of api server response
+   */
+  T patch(T base, T item);
 
   /**
    * Update field(s) of a resource using strategic merge patch.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -16,29 +16,41 @@
 package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
 
 public interface Patchable<T> {
 
   /**
    * Update field(s) of a resource using a JSON patch.
    * 
-   * <br>WARNING: This call assumes the base object is the current one on the server.
-   * It may overwrite existing changes.
-   *
+   * <br>It is the same as calling {@link #patch(PatchContext, Object)} with {@link PatchType#JSON} specified.
+   * 
+   * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected way.
+   * Consider using edit instead.
+   * 
    * @param item item to be patched with patched values
    * @return returns deserialized version of api server response
    */
-  T patch(T item);
+  default T patch(T item) {
+    return patch(new PatchContext.Builder().withPatchType(PatchType.JSON).build(), item);
+  }
   
   /**
-   * Update field(s) of a resource using a JSON patch, using the base object
-   * as the comparison for the patch.
-   *
+   * Update field(s) of a resource using type specified in {@link PatchContext}(defaults to strategic merge if not specified).
+   * 
+   * <li>{@link PatchType#JSON} - will create a JSON patch against the current item.  
+   * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected way.
+   * Consider using edit instead.
+   * <li>{@link PatchType#JSON_MERGE} - will send the serialization of the item as a JSON MERGE patch.  
+   * Set the resourceVersion to null to prevent optimistic locking.
+   * <li>{@link PatchType#STRATEGIC_MERGE} - will send the serialization of the item as a STRATEGIC MERGE patch.  
+   * Set the resourceVersion to null to prevent optimistic locking.
+   * 
    * @param item item to be patched with patched values
-   * @param base item to be compared with to generate the patch, use null to create a merge patch from item 
+   * @param patchContext {@link PatchContext} for patch request
    * @return returns deserialized version of api server response
    */
-  T patch(T base, T item);
+  T patch(PatchContext patchContext, T item);
 
   /**
    * Update field(s) of a resource using strategic merge patch.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -22,30 +22,32 @@ public interface Patchable<T> {
 
   /**
    * Update field(s) of a resource using a JSON patch.
-   * 
+   *
    * <br>It is the same as calling {@link #patch(PatchContext, Object)} with {@link PatchType#JSON} specified.
-   * 
+   *
    * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected way.
    * Consider using edit instead.
-   * 
+   *
    * @param item item to be patched with patched values
    * @return returns deserialized version of api server response
    */
   default T patch(T item) {
     return patch(new PatchContext.Builder().withPatchType(PatchType.JSON).build(), item);
   }
-  
+
   /**
    * Update field(s) of a resource using type specified in {@link PatchContext}(defaults to strategic merge if not specified).
-   * 
-   * <li>{@link PatchType#JSON} - will create a JSON patch against the current item.  
+   *
+   * <ul>
+   * <li>{@link PatchType#JSON} - will create a JSON patch against the current item.
    * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected way.
    * Consider using edit instead.
-   * <li>{@link PatchType#JSON_MERGE} - will send the serialization of the item as a JSON MERGE patch.  
+   * <li>{@link PatchType#JSON_MERGE} - will send the serialization of the item as a JSON MERGE patch.
    * Set the resourceVersion to null to prevent optimistic locking.
-   * <li>{@link PatchType#STRATEGIC_MERGE} - will send the serialization of the item as a STRATEGIC MERGE patch.  
+   * <li>{@link PatchType#STRATEGIC_MERGE} - will send the serialization of the item as a STRATEGIC MERGE patch.
    * Set the resourceVersion to null to prevent optimistic locking.
-   * 
+   * </ul>
+   *
    * @param item item to be patched with patched values
    * @param patchContext {@link PatchContext} for patch request
    * @return returns deserialized version of api server response

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusEditable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusEditable.java
@@ -15,14 +15,10 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface StatusUpdatable<T> {
-  /**
-   * When the status subresource is enabled, the /status subresource for the custom resource is exposed.
-   * It does a PUT requests to the /status subresource take a resource object and ignore changes
-   * to anything except the status stanza.
-   *
-   * @param item kubernetes object
-   * @return updated object
-   */
-  T updateStatus(T item);
+import java.util.function.UnaryOperator;
+
+public interface StatusEditable<T> {
+
+    T editStatus(UnaryOperator<T> function);
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusPatchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusPatchable.java
@@ -25,7 +25,6 @@ public interface StatusPatchable<T> {
    * <p>This method has the same patching behavior as {@link Patchable#patch(PatchContext, Object)}, with {@link PatchType#JSON_MERGE} but against the status subresource.
    * <p>Set the resourceVersion to null to prevent optimistic locking.
    *
-   * @param patchContext {@link PatchContext} for patch request
    * @param item kubernetes object
    * @return updated object
    */

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusPatchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusPatchable.java
@@ -15,14 +15,20 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface StatusUpdatable<T> {
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+
+public interface StatusPatchable<T> {
+
   /**
-   * When the status subresource is enabled, the /status subresource for the custom resource is exposed.
-   * It does a PUT requests to the /status subresource take a resource object and ignore changes
-   * to anything except the status stanza.
+   * Does a PATCH request to the /status subresource ignoring changes to anything except the status stanza.
+   * <p>This method has the same patching behavior as {@link Patchable#patch(PatchContext, Object)}, with {@link PatchType#JSON_MERGE} but against the status subresource.
+   * <p>Set the resourceVersion to null to prevent optimistic locking.
    *
+   * @param patchContext {@link PatchContext} for patch request
    * @param item kubernetes object
    * @return updated object
    */
-  T updateStatus(T item);
+  T patchStatus(T item);
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusReplaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusReplaceable.java
@@ -15,14 +15,8 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface StatusUpdatable<T> {
-  /**
-   * When the status subresource is enabled, the /status subresource for the custom resource is exposed.
-   * It does a PUT requests to the /status subresource take a resource object and ignore changes
-   * to anything except the status stanza.
-   *
-   * @param item kubernetes object
-   * @return updated object
-   */
-  T updateStatus(T item);
+public interface StatusReplaceable<T> {
+
+  T replaceStatus(T item);
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusUpdatable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusUpdatable.java
@@ -25,4 +25,14 @@ public interface StatusUpdatable<T> {
    * @return updated object
    */
   T updateStatus(T item);
+  
+  /**
+   * When the status subresource is enabled, the /status subresource for the custom resource is exposed.
+   * It does a PATCH requests to the /status subresource take a resource object and ignore changes
+   * to anything except the status stanza.
+   *
+   * @param item kubernetes object
+   * @return updated object
+   */
+  T applyStatus(T item);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -745,7 +745,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   @Override
   public T updateStatus(T item) {
     try {
-      return handleStatusUpdate(item, getType());
+      return handleReplace(item, true);
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
       throw KubernetesClientException.launderThrowable(forOperationType("statusUpdate"), ie);
@@ -753,6 +753,11 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       throw KubernetesClientException.launderThrowable(forOperationType("statusUpdate"), e);
     }
 
+  }
+  
+  @Override
+  public T applyStatus(T item) {
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
   public BaseOperation<T, L, R> withItem(T item) {
@@ -883,14 +888,14 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return handleCreate(resource, getType());
   }
 
-  protected T handleReplace(T updated) throws ExecutionException, InterruptedException, IOException {
+  protected T handleReplace(T updated, boolean status) throws ExecutionException, InterruptedException, IOException {
     updateApiVersion(updated);
-    return handleReplace(updated, getType());
+    return handleReplace(updated, getType(), status);
   }
 
-  protected T handlePatch(T current, T updated) throws ExecutionException, InterruptedException, IOException {
+  protected T handlePatch(T current, T updated, boolean status) throws ExecutionException, InterruptedException, IOException {
     updateApiVersion(updated);
-    return handlePatch(current, updated, getType());
+    return handlePatch(current, updated, getType(), status);
   }
 
   protected T handlePatch(T current, Map<String, Object> patchedUpdate) throws ExecutionException, InterruptedException, IOException {
@@ -900,7 +905,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   protected T sendPatchedObject(T oldObject, T updatedObject) {
     try {
-      return handlePatch(oldObject, updatedObject);
+      return handlePatch(oldObject, updatedObject, false);
     } catch (InterruptedException interruptedException) {
       Thread.currentThread().interrupt();
       throw KubernetesClientException.launderThrowable(interruptedException);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -858,6 +858,11 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   public T patch(T item) {
     throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
+  
+  @Override
+  public T patch(T base, T item) {
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
+  }
 
   @Override
   public T patch(PatchContext patchContext, String patch) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -249,6 +249,11 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   public T edit(UnaryOperator<T> function) {
     throw new KubernetesClientException(READ_ONLY_EDIT_EXCEPTION_MESSAGE);
   }
+  
+  @Override
+  public T editStatus(UnaryOperator<T> function) {
+    throw new KubernetesClientException(READ_ONLY_EDIT_EXCEPTION_MESSAGE);
+  }
 
   @Override
   public T edit(Visitor... visitors) {
@@ -745,7 +750,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   @Override
   public T updateStatus(T item) {
     try {
-      return handleReplace(item, true);
+      return handleUpdate(item, true);
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
       throw KubernetesClientException.launderThrowable(forOperationType("statusUpdate"), ie);
@@ -756,7 +761,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
   
   @Override
-  public T applyStatus(T item) {
+  public T patchStatus(T item) {
     throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
@@ -858,19 +863,19 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   public T replace(T item) {
     throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
-
-  @Override
-  public T patch(T item) {
-    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
-  }
   
   @Override
-  public T patch(T base, T item) {
+  public T replaceStatus(T item) {
     throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
   @Override
   public T patch(PatchContext patchContext, String patch) {
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
+  }
+  
+  @Override
+  public T patch(PatchContext patchContext, T item) {
     throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
@@ -888,14 +893,14 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return handleCreate(resource, getType());
   }
 
-  protected T handleReplace(T updated, boolean status) throws ExecutionException, InterruptedException, IOException {
+  protected T handleUpdate(T updated, boolean status) throws ExecutionException, InterruptedException, IOException {
     updateApiVersion(updated);
-    return handleReplace(updated, getType(), status);
+    return handleUpdate(updated, getType(), status);
   }
 
-  protected T handlePatch(T current, T updated, boolean status) throws ExecutionException, InterruptedException, IOException {
+  protected T handlePatch(PatchContext context, T current, T updated, boolean status) throws ExecutionException, InterruptedException, IOException {
     updateApiVersion(updated);
-    return handlePatch(current, updated, getType(), status);
+    return handlePatch(context, current, updated, getType(), status);
   }
 
   protected T handlePatch(T current, Map<String, Object> patchedUpdate) throws ExecutionException, InterruptedException, IOException {
@@ -905,7 +910,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   protected T sendPatchedObject(T oldObject, T updatedObject) {
     try {
-      return handlePatch(oldObject, updatedObject, false);
+      return handlePatch(null, oldObject, updatedObject, false);
     } catch (InterruptedException interruptedException) {
       Thread.currentThread().interrupt();
       throw KubernetesClientException.launderThrowable(interruptedException);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -16,6 +16,8 @@
 
 package io.fabric8.kubernetes.client.dsl.base;
 
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
@@ -33,6 +35,8 @@ import java.util.function.UnaryOperator;
 import static io.fabric8.kubernetes.client.utils.IOHelpers.convertToJson;
 
 public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>> extends BaseOperation< T, L, R> {
+  private static final String NO_BUILDER = "Cannot edit with visitors, no builder is associated";
+  
   public static final DeletionPropagation DEFAULT_PROPAGATION_POLICY = DeletionPropagation.BACKGROUND;
   public static final long DEFAULT_GRACE_PERIOD_IN_SECONDS = -1L;
   private static final String PATCH_OPERATION = "patch";
@@ -53,6 +57,17 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
     T clone = Serialization.clone(item);
     consumer.accept(item);
     return patch(clone, item);
+  }
+  
+  protected VisitableBuilder<T, ?> createVisitableBuilder(T item) {
+    throw new KubernetesClientException(NO_BUILDER);
+  }
+  
+  @Override
+  public T edit(Visitor... visitors) {
+    T item = getMandatory();
+    T clone = Serialization.clone(item);
+    return patch(clone, createVisitableBuilder(item).accept(visitors).build());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -44,15 +44,15 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
   @Override
   public T edit(UnaryOperator<T> function) {
     T item = getMandatory();
-    String yaml = Serialization.asYaml(item);
-    return patch((T) Serialization.unmarshal(yaml, item.getClass()), function.apply(item));
+    return patch(Serialization.clone(item), function.apply(item));
   }
 
   @Override
   public T accept(Consumer<T> consumer) {
     T item = getMandatory();
+    T clone = Serialization.clone(item);
     consumer.accept(item);
-    return patch(item);
+    return patch(clone, item);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.DeleteOptions;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
@@ -222,7 +223,8 @@ public class OperationSupport {
 
   protected <T> String checkName(T item) {
     String operationName = getName();
-    String itemName = item instanceof HasMetadata ? ((HasMetadata) item).getMetadata().getName() : null;
+    ObjectMeta metadata = item instanceof HasMetadata ? ((HasMetadata) item).getMetadata() : null;
+    String itemName = metadata != null ? metadata.getName() : null;
     if (Utils.isNullOrEmpty(operationName) && Utils.isNullOrEmpty(itemName)) {
       return null;
     } else if (Utils.isNullOrEmpty(itemName)) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.apps.v1;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Status;
@@ -132,11 +132,11 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public Deployment patch(Deployment item) {
+  public Deployment patch(Deployment base, Deployment item) {
     if (isCascading()) {
-      return cascading(false).patch(item);
+      return cascading(false).patch(base, item);
     }
-    return super.patch(item);
+    return super.patch(base, item);
   }
 
   @Override
@@ -386,8 +386,8 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public Deployment edit(Visitor... visitors) {
-    return patch(new DeploymentBuilder(getMandatory()).accept(visitors).build());
+  protected VisitableBuilder<Deployment, ?> createVisitableBuilder(Deployment item) {
+    return new DeploymentBuilder(item);
   }
 
   private Deployment sendPatchedDeployment(Map<String, Object> patchedUpdate) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.apps.ReplicaSetList;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
 import io.fabric8.kubernetes.client.dsl.*;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.internal.RollingOperationContext;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -132,11 +133,11 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public Deployment patch(Deployment base, Deployment item) {
+  public Deployment patch(PatchContext patchContext, Deployment item) {
     if (isCascading()) {
-      return cascading(false).patch(base, item);
+      return cascading(false).patch(patchContext, item);
     }
-    return super.patch(base, item);
+    return super.patch(patchContext, item);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentRollingUpdater.java
@@ -81,24 +81,20 @@ class DeploymentRollingUpdater extends RollingUpdater<Deployment, DeploymentList
 
   @Override
   protected Deployment updateDeploymentKey(String name, String hash) {
-     Deployment old = resources().inNamespace(namespace).withName(name).get();
-     Deployment updated = new DeploymentBuilder(old).editSpec()
-       .editSelector().addToMatchLabels(DEPLOYMENT_KEY, hash).endSelector()
-       .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, hash).endMetadata().endTemplate()
-       .endSpec()
-       .build();
-     return resources().inNamespace(namespace).withName(name).patch(updated);
+     return resources().inNamespace(namespace).withName(name).edit(old->new DeploymentBuilder(old).editSpec()
+         .editSelector().addToMatchLabels(DEPLOYMENT_KEY, hash).endSelector()
+         .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, hash).endMetadata().endTemplate()
+         .endSpec()
+         .build());
   }
 
   @Override
   protected Deployment removeDeploymentKey(String name) {
-     Deployment old = resources().inNamespace(namespace).withName(name).get();
-     Deployment updated = new DeploymentBuilder(old).editSpec()
-       .editSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endSelector()
-       .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
-       .endSpec()
-       .build();
-     return resources().inNamespace(namespace).withName(name).patch(updated);
+     return resources().inNamespace(namespace).withName(name).edit(old->new DeploymentBuilder(old).editSpec()
+         .editSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endSelector()
+         .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
+         .endSpec()
+         .build());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.apps.v1;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Status;
@@ -234,8 +234,8 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public ReplicaSet edit(Visitor... visitors) {
-    return patch(new ReplicaSetBuilder(getMandatory()).accept(visitors).build());
+  protected VisitableBuilder<ReplicaSet, ?> createVisitableBuilder(ReplicaSet item) {
+    return new ReplicaSetBuilder(item);
   }
 
   static Map<String, String> getReplicaSetSelectorLabels(ReplicaSet replicaSet) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
@@ -81,24 +81,20 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
 
   @Override
   protected ReplicaSet updateDeploymentKey(String name, String hash) {
-     ReplicaSet old = resources().inNamespace(namespace).withName(name).get();
-     ReplicaSet updated = new ReplicaSetBuilder(old).editSpec()
+     return resources().inNamespace(namespace).withName(name).edit(old->new ReplicaSetBuilder(old).editSpec()
        .editSelector().addToMatchLabels(DEPLOYMENT_KEY, hash).endSelector()
        .editTemplate().editMetadata().addToLabels(DEPLOYMENT_KEY, hash).endMetadata().endTemplate()
        .endSpec()
-       .build();
-     return resources().inNamespace(namespace).withName(name).patch(updated);
+       .build());
   }
 
   @Override
   protected ReplicaSet removeDeploymentKey(String name) {
-     ReplicaSet old = resources().inNamespace(namespace).withName(name).get();
-     ReplicaSet updated = new ReplicaSetBuilder(old).editSpec()
-       .editSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endSelector()
-       .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
-       .endSpec()
-       .build();
-     return resources().inNamespace(namespace).withName(name).patch(updated);
+     return resources().inNamespace(namespace).withName(name).edit(old->new ReplicaSetBuilder(old).editSpec()
+         .editSelector().removeFromMatchLabels(DEPLOYMENT_KEY).endSelector()
+         .editTemplate().editMetadata().removeFromLabels(DEPLOYMENT_KEY).endMetadata().endTemplate()
+         .endSpec()
+         .build());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.internal.RollingOperationContext;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.slf4j.Logger;
@@ -164,9 +165,9 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
   }
 
   @Override
-  public T patch(T base, T item) {
+  public T patch(PatchContext patchContext, T item) {
     if (!rolling) {
-      return super.patch(base, item);
+      return super.patch(patchContext, item);
     }
     return getRollingUpdater(rollingTimeout, rollingTimeUnit).rollUpdate(getMandatory(), item);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
@@ -164,11 +164,11 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
   }
 
   @Override
-  public T patch(T t) {
+  public T patch(T base, T item) {
     if (!rolling) {
-      return super.patch(t);
+      return super.patch(base, item);
     }
-    return getRollingUpdater(rollingTimeout, rollingTimeUnit).rollUpdate(getMandatory(), t);
+    return getRollingUpdater(rollingTimeout, rollingTimeUnit).rollUpdate(getMandatory(), item);
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.apps.v1;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -262,8 +262,8 @@ public class StatefulSetOperationsImpl extends RollableScalableResourceOperation
   }
 
   @Override
-  public StatefulSet edit(Visitor... visitors) {
-    return patch(new StatefulSetBuilder(getMandatory()).accept(visitors).build());
+  protected VisitableBuilder<StatefulSet, ?> createVisitableBuilder(StatefulSet item) {
+    return new StatefulSetBuilder(item);
   }
 
   private StatefulSet sendPatchedStatefulSet(Map<String, Object> patchedUpdate) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.batch.v1;
 
-import io.fabric8.kubernetes.api.builder.Visitor;;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
@@ -238,10 +238,9 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
     return super.replace(job);
   }
 
-
   @Override
-  public Job edit(Visitor... visitors) {
-    return patch(new JobBuilder(getMandatory()).accept(visitors).build());
+  protected VisitableBuilder<Job, ?> createVisitableBuilder(Job item) {
+    return new JobBuilder(item);
   }
 
   static Map<String, String> getJobPodLabels(Job job) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImpl.java
@@ -17,7 +17,7 @@ package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Binding;
 import io.fabric8.kubernetes.api.model.BindingBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
@@ -45,9 +45,8 @@ public class BindingOperationsImpl extends HasMetadataOperation<Binding, Kuberne
   }
 
   @Override
-  public Binding edit(Visitor... visitors) {
-    Binding item = new BindingBuilder(getMandatory()).accept(visitors).build();
-    return patch(item);
+  protected VisitableBuilder<Binding, ?> createVisitableBuilder(Binding item) {
+    return new BindingBuilder(item);
   }
 
   public BindingOperationsImpl newInstance(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ComponentStatusOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ComponentStatusOperationsImpl.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
@@ -49,9 +50,8 @@ public class ComponentStatusOperationsImpl extends HasMetadataOperation<Componen
   }
 
   @Override
-  public ComponentStatus edit(Visitor... visitors) {
-    ComponentStatus item = new ComponentStatusBuilder(getMandatory()).accept(visitors).build();
-    return patch(item);
+  protected VisitableBuilder<ComponentStatus, ?> createVisitableBuilder(ComponentStatus item) {
+    return new ComponentStatusBuilder(item);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -74,7 +74,7 @@ import io.fabric8.kubernetes.client.dsl.internal.uploadable.PodUpload;
 import io.fabric8.kubernetes.client.utils.BlockingInputStreamPumper;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -721,8 +721,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
-  public Pod edit(Visitor... visitors) {
-    return patch(new PodBuilder(getMandatory()).accept(visitors).build());
+  protected VisitableBuilder<Pod, ?> createVisitableBuilder(Pod item) {
+    return new PodBuilder(item);
   }
 }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.ReplicationController;
@@ -242,9 +242,8 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   }
 
   @Override
-  public ReplicationController edit(Visitor... visitors) {
-    ReplicationController item = new ReplicationControllerBuilder(getMandatory()).accept(visitors).build();
-    return patch(item);
+  protected VisitableBuilder<ReplicationController, ?> createVisitableBuilder(ReplicationController item) {
+    return new ReplicationControllerBuilder(item);
   }
 
   static Map<String, String> getReplicationControllerPodLabels(ReplicationController replicationController) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.extensions.v1beta1;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Status;
@@ -138,11 +138,11 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public Deployment patch(Deployment item) {
+  public Deployment patch(Deployment base, Deployment item) {
     if (isCascading()) {
-      return cascading(false).patch(item);
+      return cascading(false).patch(base, item);
     }
-    return super.patch(item);
+    return super.patch(base, item);
   }
 
   @Override
@@ -393,8 +393,8 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public Deployment edit(Visitor... visitors) {
-    return patch(new DeploymentBuilder(getMandatory()).accept(visitors).build());
+  protected VisitableBuilder<Deployment, ?> createVisitableBuilder(Deployment item) {
+    return new DeploymentBuilder(item);
   }
 
   private Deployment sendPatchedDeployment(Map<String, Object> patchedUpdate) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
@@ -33,6 +33,7 @@ import io.fabric8.kubernetes.client.dsl.Loggable;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.internal.RollingOperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollableScalableResourceOperation;
 import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
@@ -138,11 +139,11 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public Deployment patch(Deployment base, Deployment item) {
+  public Deployment patch(PatchContext patchContext, Deployment item) {
     if (isCascading()) {
-      return cascading(false).patch(base, item);
+      return cascading(false).patch(patchContext, item);
     }
-    return super.patch(base, item);
+    return super.patch(patchContext, item);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.extensions.v1beta1;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Status;
@@ -237,8 +237,8 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
   }
 
   @Override
-  public ReplicaSet edit(Visitor... visitors) {
-    return patch(new ReplicaSetBuilder(getMandatory()).accept(visitors).build());
+  protected VisitableBuilder<ReplicaSet, ?> createVisitableBuilder(ReplicaSet item) {
+    return new ReplicaSetBuilder(item);
   }
 
   static Map<String, String> getReplicaSetSelectorLabels(ReplicaSet replicaSet) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -312,4 +312,19 @@ public class Serialization {
     }
     return JSON_MAPPER.readerFor(KubernetesResource.class).readValue(jsonString);
   }
+  
+  /**
+   * Create a copy of the resource via serialization
+   * @param <T>
+   * @param resource
+   * @return
+   */
+  public static <T> T clone(T resource) {
+    try {
+      return (T) JSON_MAPPER.readValue(
+          JSON_MAPPER.writeValueAsString(resource), resource.getClass());
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -314,12 +314,13 @@ public class Serialization {
   }
   
   /**
-   * Create a copy of the resource via serialization
-   * @param <T>
-   * @param resource
-   * @return
+   * Create a copy of the resource via serialization.
+   * @return a deep clone of the resource
+   * @throws IllegalArgumentException if the cloning cannot be performed
    */
   public static <T> T clone(T resource) {
+    // if full serialization seems too expensive, there is also
+    //return (T) JSON_MAPPER.convertValue(resource, resource.getClass());
     try {
       return (T) JSON_MAPPER.readValue(
           JSON_MAPPER.writeValueAsString(resource), resource.getClass());

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DryRunTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DryRunTest.java
@@ -31,12 +31,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -54,29 +51,17 @@ class DryRunTest {
   public void setUp() throws IOException {
     this.mockClient = Mockito.mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
     Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
-    when(mockClient.newCall(any())).then(new Answer<Call>() {
-      @Override
-      public Call answer(InvocationOnMock invocation) throws Throwable {
-        Call mockCall = mock(Call.class);
-        Request request = invocation.getArgument(0);
-        List<String> segments = request.url().encodedPathSegments();
-        String name = segments.get(segments.size() - 1);
-        String body = "{}";
-        if (!name.endsWith("s")) {
-          body = "{\"metadata\":{\"name\":\""+name+"\"}}";
-        }
-        Response mockResponse = new Response.Builder()
-          .request(new Request.Builder().url("http://mock").build())
-          .protocol(Protocol.HTTP_1_1)
-          .code(HttpURLConnection.HTTP_OK)
-          .body(ResponseBody.create(MediaType.get("application/json"), body))
-          .message("mock")
-          .build();
-        when(mockCall.execute())
-          .thenReturn(mockResponse);
-        return mockCall;
-      }
-    });
+    Call mockCall = mock(Call.class);
+    Response mockResponse = new Response.Builder()
+      .request(new Request.Builder().url("http://mock").build())
+      .protocol(Protocol.HTTP_1_1)
+      .code(HttpURLConnection.HTTP_OK)
+      .body(ResponseBody.create(MediaType.get("application/json"), "{}"))
+      .message("mock")
+      .build();
+    when(mockCall.execute())
+      .thenReturn(mockResponse);
+    when(mockClient.newCall(any())).thenReturn(mockCall);
     kubernetesClient = new DefaultKubernetesClient(mockClient, config);
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
@@ -15,34 +15,25 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.ListOptions;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.Deletable;
-import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.fabric8.kubernetes.client.dsl.Waitable;
-import io.fabric8.kubernetes.client.dsl.WatchAndWaitable;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -138,90 +129,13 @@ class PodOperationUtilTest {
   }
 
   private FilterWatchListDeletable<Pod, PodList> getMockPodFilterOperation(String controllerUid) {
-    return new FilterWatchListDeletable<Pod, PodList>() {
+    FilterWatchListDeletable<Pod, PodList> result = Mockito.mock(FilterWatchListDeletable.class);
+    Mockito.when(result.list()).then(new Answer<PodList>() {
       @Override
-      public EditReplacePatchDeletable<Pod> withPropagationPolicy(DeletionPropagation propagationPolicy) { return null; }
-
-      @Override
-      public Deletable withGracePeriod(long gracePeriodSeconds) { return null; }
-
-      @Override
-      public Boolean delete() { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withLabels(Map<String, String> labels) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withoutLabels(Map<String, String> labels) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withLabelIn(String key, String... values) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withLabelNotIn(String key, String... values) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withLabel(String key, String value) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withLabel(String key) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withoutLabel(String key, String value) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withoutLabel(String key) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withFields(Map<String, String> labels) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withField(String key, String value) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withoutFields(Map<String, String> fields) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withoutField(String key, String value) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withLabelSelector(LabelSelector selector) { return null; }
-
-      @Override
-      public FilterWatchListDeletable<Pod, PodList> withInvolvedObject(ObjectReference objectReference) { return null; }
-
-      @Override
-      public PodList list() { return getMockPodList(controllerUid); }
-
-      @Override
-      public PodList list(Integer limitVal, String continueVal) { return null; }
-
-      @Override
-      public PodList list(ListOptions listOptions) { return null; }
-
-      @Override
-      public Pod updateStatus(Pod item) { return null; }
-
-      @Override
-      public WatchAndWaitable<Pod> withResourceVersion(String resourceVersion) { return null; }
-
-      @Override
-      public Pod waitUntilReady(long amount, TimeUnit timeUnit) { return null; }
-
-      @Override
-      public Pod waitUntilCondition(Predicate<Pod> condition, long amount, TimeUnit timeUnit) { return null; }
-
-      @Override
-      public Waitable<Pod, Pod> withWaitRetryBackoff(long initialBackoff, TimeUnit backoffUnit, double backoffMultiplier) { return null; }
-
-      @Override
-      public Watch watch(Watcher<Pod> watcher) { return null; }
-
-      @Override
-      public Watch watch(ListOptions options, Watcher<Pod> watcher) { return null; }
-
-      @Override
-      public Watch watch(String resourceVersion, Watcher<Pod> watcher) { return null; }
-    };
+      public PodList answer(InvocationOnMock invocation) throws Throwable {
+        return getMockPodList(controllerUid);
+      }
+    });
+    return result;
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.utils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
@@ -167,6 +169,20 @@ public class SerializationTest {
     assertEquals("python3", pod.getSpec().getContainers().get(1).getName());
     assertEquals("python:3.7", pod.getSpec().getContainers().get(1).getImage());
     assertEquals(new Quantity("100m"), pod.getSpec().getContainers().get(1).getResources().getRequests().get("cpu"));
+  }
+  
+  @Test
+  void testClone() {
+    // Given
+    Pod pod = new PodBuilder().withNewMetadata().withName("pod").endMetadata().build();
+
+    // When
+    Pod clonePod = Serialization.clone(pod);
+
+    // Then
+    assertNotNull(clonePod);
+    assertNotSame(pod, clonePod);
+    assertEquals(pod.getMetadata().getName(), clonePod.getMetadata().getName());
   }
 
   @JsonTypeInfo(

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
@@ -56,7 +56,7 @@ public class PatchIT {
 
   @Before
   public void initNamespace() {
-    this.currentNamespace = ClusterEntity.getArquillianNamespace();
+    this.currentNamespace = session.getNamespace();
   }
 
   @Test

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
@@ -128,7 +128,7 @@ public class PatchIT {
     // When
     ConfigMap configMapFromServer = client.configMaps().inNamespace(currentNamespace).withName(name).get();
     configMapFromServer.setData(Collections.singletonMap("foo", "bar"));
-    ConfigMap patchedConfigMap = client.configMaps().inNamespace(currentNamespace).withName(name).patch(configMapFromServer);
+    ConfigMap patchedConfigMap = client.configMaps().patch(configMapFromServer);
 
     // Then
     assertThat(patchedConfigMap).isNotNull();

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
@@ -199,6 +199,25 @@ public class TypedCustomResourceIT {
   }
 
   @Test
+  public void applyStatusSubresource() {
+    // Given
+    Pet pet = createNewPet("pet-applystatus", "Pigeon", null);
+    PetStatus petStatusToUpdate = new PetStatus();
+    petStatusToUpdate.setCurrentStatus("Sleeping");
+
+    // When
+    petClient.inNamespace(currentNamespace).create(pet);
+    await().atMost(5, TimeUnit.SECONDS)
+      .until(() -> petClient.inNamespace(currentNamespace).withName("pet-applystatus").get() != null);
+    // use the original pet, no need to pick up the resourceVersion
+    pet.setStatus(petStatusToUpdate);
+    Pet updatedPet = petClient.inNamespace(currentNamespace).applyStatus(pet);
+
+    // Then
+    assertPet(updatedPet, "pet-applystatus", "Pigeon", "Sleeping");
+  }
+
+  @Test
   public void watch() throws InterruptedException {
     // Given
     Pet pet = createNewPet("pet-watch", "Hamster", null);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.openshift.api.model.RoleBinding;
 import io.fabric8.openshift.api.model.RoleBindingBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
@@ -109,8 +109,8 @@ class SecurityContextConstraintsTest {
 
   @Test
   void testEdit() {
-   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().build()).times(2);
-   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().addToAllowedCapabilities("allowed").build()).once();
+   server.expect().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().build()).once();
+   server.expect().patch().withPath("/apis/security.openshift.io/v1/securitycontextconstraints/scc1").andReturn(200, new SecurityContextConstraintsBuilder().withNewMetadata().withName("scc1").and().addToAllowedCapabilities("allowed").build()).once();
 
     SecurityContextConstraints scc = client.securityContextConstraints().withName("scc1").edit(s -> new SecurityContextConstraintsBuilder(s).addToAllowedCapabilities("allowed").build());
     assertNotNull(scc);


### PR DESCRIPTION
## Description
This is to address #3067 the current patch operation with only the modified item is dangerous when there are concurrent modifications.

This requires a two argument patch call.

I looked at adding the resourceVersion to a GET call, but the kubernetes support is "no older than" - https://kubernetes.io/docs/reference/using-api/api-concepts/#the-resourceversion-parameter so you are not guaranteed to get back the object of that version.  Based upon that, this is the simpler and backwards compatible change.

I'm not sure about the the appropriate way to clone the item in the patch call - or even if that is needed.  I can't see any guidance on whether it's expected that the operation may modify the item passed into it.

I also removed the retry logic on patching - it seems you will get a 422 error if the patch can't be applied rather than a conflict.

@rohanKanojia let me know if this is on the right track.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift