### PR TITLE
adding status handling to the mock server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Fix #2912: Add DSL support for `storage.k8s.io/v1beta1` CSIStorageCapacity
 * Fix #2701: Better support for patching in KuberntesClient
 * Fix #3034: Added a SharedInformer.isRunning method
+* Fix #3088: mock server will assume /status is a subresource, and other refinements to match kube behavior
 
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:

--- a/extensions/knative/tests/src/test/java/io/fabric8/knative/test/crud/ServiceCrudTest.java
+++ b/extensions/knative/tests/src/test/java/io/fabric8/knative/test/crud/ServiceCrudTest.java
@@ -17,10 +17,10 @@ package io.fabric8.knative.test.crud;
 
 import io.fabric8.knative.client.KnativeClient;
 import io.fabric8.knative.mock.KnativeServer;
-
 import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.knative.serving.v1.ServiceBuilder;
 import io.fabric8.knative.serving.v1.ServiceList;
+import io.fabric8.knative.serving.v1.ServiceStatusBuilder;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
@@ -63,15 +63,17 @@ class ServiceCrudTest {
     KnativeClient client = server.getKnativeClient();
     Service service = new ServiceBuilder()
       .withNewMetadata().withName("service").endMetadata()
-      .withNewStatus().withNewAddress("http://my-service").endStatus()
       .build();
 
-    client.services().inNamespace("ns2").create(service);
+    Service created = client.services().inNamespace("ns2").create(service);
 
     ServiceList serviceList = client.services().inNamespace("ns2").list();
     assertNotNull(serviceList);
     assertEquals(1, serviceList.getItems().size());
-    assertNotNull(serviceList.getItems().get(0).getStatus());
+
+    created.setStatus(new ServiceStatusBuilder().withNewAddress("http://my-service").build());
+
+    assertNotNull(client.services().inNamespace("ns2").withName("service").updateStatus(created).getStatus());
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -37,12 +37,13 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient(crud = true)
 class CustomResourceCrudTest {
 
   KubernetesClient client;
-  
+
   private CustomResourceDefinition cronTabCrd;
 
   @BeforeEach
@@ -102,7 +103,8 @@ class CustomResourceCrudTest {
 
     Map<String, Object> created = raw.createOrReplace(object);
 
-    assertEquals(object, created);
+    assertEquals("initial", created.get("spec"));
+    assertTrue(((Map)created.get("metadata")).entrySet().containsAll(metadata.entrySet()));
 
     object.put("spec", "updated");
 
@@ -116,7 +118,7 @@ class CustomResourceCrudTest {
     CronTab cronTab1 = createCronTab("my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
     CronTab cronTab2 = createCronTab("my-second-cron-object", "* * * * */4", 2, "my-second-cron-image");
     CronTab cronTab3 = createCronTab("my-third-cron-object", "* * * * */3", 1, "my-third-cron-image");
-    
+
     MixedOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
       .customResources(CronTab.class);
 


### PR DESCRIPTION
## Description
Addresses #3088 so that the mock server is aware of the status subresource (except for patch /status).

This also addresses several issues with replace:
- it's implemented as an update, rather than delete/add
- the uid is retained

I believe these changes will help resolve https://github.com/java-operator-sdk/java-operator-sdk/issues/396

This does not address create conflicts - I've left that commented out in this pr as there seem to be quite a few tests to correct.

Fix #3088

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift