### PR TITLE
Fixes #3097 : refresh token with autoconfigure even if authprovider is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix #3047: NPE when getting version when there is no build date
 * Fix #3024: stopAllRegisteredInformers will not call startWatcher
 * Fix #3067: Added a patch(PatchContext, item) operation to be more explicit about patching and diffing behavior
+* Fix #3097: refresh token with autoconfigure even if authprovider is null
 
 #### Improvements
 * Fix #2788: Support FIPS mode in kubernetes-client with BouncyCastleFipsProvider

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
@@ -31,7 +31,7 @@ import java.net.HttpURLConnection;
  * Interceptor for handling expired OIDC tokens.
  */
 public class TokenRefreshInterceptor implements Interceptor {
-  private Config config;
+  private final Config config;
   public TokenRefreshInterceptor(Config config) {
     this.config = config;
   }
@@ -50,10 +50,11 @@ public class TokenRefreshInterceptor implements Interceptor {
       }
       AuthInfo currentAuthInfo = KubeConfigUtils.getUserAuthInfo(kubeConfig, currentContext);
       // Check if AuthProvider is set or not
-      if (currentAuthInfo != null && currentAuthInfo.getAuthProvider() != null) {
+      if (currentAuthInfo != null) {
         response.close();
         String newAccessToken;
-        if (currentAuthInfo.getAuthProvider().getName().toLowerCase().equals("oidc")) {
+        // Check if AuthProvider is set to oicd
+        if (currentAuthInfo.getAuthProvider() != null && currentAuthInfo.getAuthProvider().getName().equalsIgnoreCase("oidc")) {
           newAccessToken = OpenIDConnectionUtils.resolveOIDCTokenFromAuthConfig(currentAuthInfo.getAuthProvider().getConfig());
         } else {
           Config newestConfig = Config.autoConfigure(currentContextName);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.client.Config;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+
+import static io.fabric8.kubernetes.client.Config.KUBERNETES_KUBECONFIG_FILE;
+
+public class TokenRefreshInterceptorTest {
+
+  @Test
+  public void shouldAutoconfigureAfter401() throws IOException {
+    try {
+      // Prepare kubeconfig for autoconfiguration
+      File tempFile = Files.createTempFile("test", "kubeconfig").toFile();
+      Files.copy(Objects.requireNonNull(getClass().getResourceAsStream("/test-kubeconfig-tokeninterceptor")), Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
+      System.setProperty(KUBERNETES_KUBECONFIG_FILE, tempFile.getAbsolutePath());
+
+      // Prepare http call
+      Interceptor.Chain chain = Mockito.mock(Interceptor.Chain.class, Mockito.RETURNS_DEEP_STUBS);
+      Request req = new Request.Builder().url("http://mock").build();
+      Mockito.when(chain.request()).thenReturn(req);
+      final Response.Builder responseBuilder = new Response.Builder()
+        .request(req)
+        .protocol(Protocol.HTTP_1_1)
+        .message("")
+        .body(ResponseBody.create(MediaType.parse("text"), "foo"));
+      Mockito.when(chain.proceed(Mockito.any())).thenReturn(responseBuilder.code(HttpURLConnection.HTTP_UNAUTHORIZED).build(), responseBuilder.code(HttpURLConnection.HTTP_OK).build());
+
+      // Call
+      new TokenRefreshInterceptor(Config.autoConfigure(null)).intercept(chain);
+      Mockito.verify(chain).proceed(Mockito.argThat(argument -> "Bearer token".equals(argument.header("Authorization"))));
+    } finally {
+      // Remove any side effect
+      System.clearProperty(KUBERNETES_KUBECONFIG_FILE);
+    }
+  }
+}

--- a/kubernetes-client/src/test/resources/test-kubeconfig-tokeninterceptor
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-tokeninterceptor
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: testns/ca.pem
+    insecure-skip-tls-verify: true
+    server: https://172.28.128.4:8443
+  name: 172-28-128-4:8443
+contexts:
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: testns
+    user: user/172-28-128-4:8443
+  name: testns/172-28-128-4:8443/user
+current-context: testns/172-28-128-4:8443/user
+kind: Config
+preferences: {}
+users:
+- name: user/172-28-128-4:8443
+  user:
+    token: token


### PR DESCRIPTION
## Description
Token refreshes happen after a 401 and retries to call to the k8s API. On a local machine using AWS EKS, token generation is done via an Exec task and not an authprovider. The token refresher was only refreshing in case authprovider was not null thus was throwing a kubernetesclientexception after a small timeout (10-15 min to my memory) imposed by AWS.
This PR makes sure to refresh token via autoconfigure in any case..

Fixes #3097 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
