### PR TITLE
Possibly address decorator-related instability

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/Resources.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/Resources.java
@@ -20,13 +20,14 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 public class Resources {
   private final KubernetesListBuilder global = new KubernetesListBuilder();
-  private final Set<Decorator> globalDecorators = new HashSet<>();
+  private final SortedSet<Decorator> globalDecorators = new TreeSet<>();
 
   /**
    * Get the global builder

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/Resources.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/Resources.java
@@ -44,7 +44,10 @@ public class Resources {
    * @param decorator The decorator.
    */
   public void decorate(Decorator decorator) {
-    globalDecorators.add(decorator);
+    final boolean added = globalDecorators.add(decorator);
+    if (!added) {
+      throw new RuntimeException("Conflict adding decorator " + decorator.getClass().getName());
+    }
   }
 
 


### PR DESCRIPTION
## Description
Seems like tests instability might be linked to how decorators are added and processed so change how they are added (sorted now, vs hashCode-based before) and also fail the build when there's a conflict when adding the decorator so that it's obvious when the decorators are not set up as expected.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
