### PR TITLE
wrap input stream used to load certs in a try so they're automatically closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #3040: Consistently order printer columns by JSON path to prevent undue changes in generated CRDs
 * Fix #3041: Properly output `additionalProperties` field for Maps, output warning for unsupported complex maps
+* Fix #3036: Fix file descriptor leak when loading cacerts file
 * Fix #3038: Upgrade TLS versions in mock servers to 1.2.
 * Fix #3037: Account for JsonProperty annotations when computing properties' name
 * Fix #3014: Resync Future is canceled and resync executor is shutdown on informer stop

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
@@ -93,7 +93,9 @@ public class CertUtils {
     KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
 
     if (Utils.isNotNullOrEmpty(trustStoreFile)) {
-      trustStore.load(new FileInputStream(trustStoreFile), trustStorePassphrase);
+      try (FileInputStream fis = new FileInputStream(trustStoreFile)) {
+        trustStore.load(fis, trustStorePassphrase);
+      }
     } else {
       loadDefaultTrustStoreFile(trustStore, trustStorePassphrase);
     }
@@ -114,7 +116,9 @@ public class CertUtils {
 
       KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
       if (Utils.isNotNullOrEmpty(keyStoreFile)){
-        keyStore.load(new FileInputStream(keyStoreFile), keyStorePassphrase);
+        try (FileInputStream fis = new FileInputStream(keyStoreFile)) {
+          keyStore.load(fis, keyStorePassphrase);
+        }
       } else {
         loadDefaultKeyStoreFile(keyStore, keyStorePassphrase);
       }
@@ -227,7 +231,9 @@ public class CertUtils {
 
     if (fileToLoad.exists() && fileToLoad.isFile() && fileToLoad.length() > 0) {
       try {
-        keyStore.load(new FileInputStream(fileToLoad), passphrase);
+        try (FileInputStream fis = new FileInputStream(fileToLoad)) {
+          keyStore.load(fis, passphrase);
+        }
         return true;
       } catch (Exception e) {
         String passphraseToPrint = passphrase != null ? String.valueOf(passphrase) : null;


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

There are a few file descriptor leaks in cert utils: Fix #3062

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
