### PR TITLE
fix #3149 #3127 - deprecate updateStatus(item) operation and use resourceVersion if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #3121: ServiceOperationImpl replace will throw a KubernetesClientException rather than a NPE if the item doesn't exist
 
 #### Improvements
+* Fix #3149: replace(item) will consult the item's resourceVersion for the first PUT attempt when not specifically locked on a resourceVersion
 * Fix #3135: added mock crud support for patch status, and will return exceptions for unsupported patch types
 * Fix #3072: various changes to refine how threads are handled by informers.  Note that the SharedInformer.run call is now blocking when starting the informer.
 * Fix #3143: a new SharedInformerEventListener.onException(SharedIndexInformer, Exception) method is available to determine which informer could not start.
@@ -19,6 +20,10 @@
 * Fix #3133: Add DSL Support for `authorization.openshift.io/v1` resources in OpenShiftClient
 * Fix #3142: Add DSL support for missing resources in `operator.openshift.io` and `monitoring.coreos.com` apiGroups
 * Add DSL support for missing resources in `template.openshift.io`, `helm.openshift.io`, `network.openshift.io`, `user.openshift.io` apigroups
+
+#### _**Note**_: Breaking changes in the API
+##### DSL Changes:
+- #3127 `StatusUpdatable.updateStatus` deprecated, please use patchStatus, editStatus, or replaceStatus
 
 ### 5.4.0 (2021-05-19)
 

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1702,9 +1702,19 @@ CronTabList cronTabList = cronTabClient.inNamespace("default").list();
 ```java
 Boolean isDeleted = cronTabClient.inNamespace("default").withName("my-third-cron-object").delete();
 ```
-- Update Status of `CustomResource`:
+- Replace Status of `CustomResource`:
 ```java
-cronTabClient.inNamespace("default").updateStatus(updatedCronTab);
+cronTabClient.inNamespace("default").replaceStatus(updatedCronTab);
+```
+- Patch Status of `CustomResource`:
+```java
+// does not require a full instance of the updatedCronTab, will produce a json merge patch based upon what is set in updatedCronTab
+cronTabClient.inNamespace("default").pachStatus(updatedCronTab);
+```
+- Edit Status of `CustomResource`:
+```java
+// generates a json patch between the passed in cronTab and the updated result.  Typically you will use a builder to construct a copy from the current and make modifications
+cronTabClient.inNamespace("default").editStatus(cronTab->updatedCronTab);
 ``` 
 - Watch `CustomResource`, (*note:* You need to register your `CustomResource` to `KubernetesDeserializer` otherwise you won't be able to use watch):
 ```java

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusUpdatable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusUpdatable.java
@@ -23,6 +23,8 @@ public interface StatusUpdatable<T> {
    *
    * @param item kubernetes object
    * @return updated object
+   * @deprecated please use one of patchStatus, editStatus, or replaceStatus
    */
+  @Deprecated
   T updateStatus(T item);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -161,7 +161,7 @@ public class OperationSupport {
   public URL getResourceUrl(String namespace, String name, boolean status) throws MalformedURLException {
     if (name == null) {
       if (status) {
-        throw new KubernetesClientException("Name not specified. But operation requires name.");
+        throw new KubernetesClientException("name not specified for an operation requiring one.");
       }
       return getNamespacedUrl(namespace);
     }
@@ -209,7 +209,7 @@ public class OperationSupport {
       if (!isResourceNamespaced()) {
         return null;
       } else {
-        throw new KubernetesClientException("Namespace not specified. But operation requires namespace.");
+        throw new KubernetesClientException("namespace not specified for an operation requiring one.");
       }
     } else if (Utils.isNullOrEmpty(itemNs)) {
       return operationNs;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedCustomResourceApiTest.java
@@ -134,7 +134,6 @@ class TypedCustomResourceApiTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertEquals("PUT", recordedRequest.getMethod());
     assertEquals("{\"apiVersion\":\"demo.k8s.io/v1alpha1\",\"kind\":\"PodSet\",\"metadata\":{\"name\":\"example-podset\"},\"spec\":{\"replicas\":5},\"status\":{\"availableReplicas\":4}}", recordedRequest.getBody().readUtf8());
-    System.out.println(recordedRequest.getBody().readUtf8());
   }
 
   private PodSet getPodSet() {


### PR DESCRIPTION
## Description
This fix deprecates updateStatus now that there are other operations.  It also consolidates more util calls, makes some of the messages more consistent, and uses the passed in resourceVersion first in a replace operation.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
