### PR TITLE
Fix #2529: SelfSubjectAccessReview broken with OpenShiftClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #3038: Upgrade TLS versions in mock servers to 1.2.
 * Fix #3037: Account for JsonProperty annotations when computing properties' name
 * Fix #3014: Resync Future is canceled and resync executor is shutdown on informer stop
+* Fix #2529: SelfSubjectAccessReview not working with OpenShiftClient
 * Fix #2978: Fix SharedInformer NPE on initial requests while syncing
 * Fix #2989: serialization will generate valid yaml when using subtypes
 * Fix #2991: reduced the level of ReflectWatcher event received log

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/SelfSubjectAccessReviewIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/SelfSubjectAccessReviewIT.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift;
+
+import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReview;
+import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReviewBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class SelfSubjectAccessReviewIT {
+  @ArquillianResource
+  OpenShiftClient client;
+
+  @ArquillianResource
+  Session session;
+
+  @Test
+  public void create() {
+    // Given
+    SelfSubjectAccessReview ssar = new SelfSubjectAccessReviewBuilder()
+      .withNewSpec()
+      .withNewResourceAttributes()
+      .withGroup("apps")
+      .withResource("deployments")
+      .withVerb("create")
+      .withNamespace(session.getNamespace())
+      .endResourceAttributes()
+      .endSpec()
+      .build();
+
+    // When
+    ssar = client.authorization().v1().selfSubjectAccessReview().create(ssar);
+
+    // Then
+    assertTrue(ssar.getStatus().getAllowed());
+  }
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/SubjectAccessReviewIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/SubjectAccessReviewIT.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift;
+
+import io.fabric8.openshift.api.model.SubjectAccessReview;
+import io.fabric8.openshift.api.model.SubjectAccessReviewBuilder;
+import io.fabric8.openshift.api.model.SubjectAccessReviewResponse;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class SubjectAccessReviewIT {
+  @ArquillianResource
+  OpenShiftClient client;
+
+  @ArquillianResource
+  Session session;
+
+  @Test
+  public void testCreate() {
+    // Given
+    SubjectAccessReview sar = new SubjectAccessReviewBuilder()
+      .withResource("Pod")
+      .withVerb("get")
+      .withNamespace(session.getNamespace())
+      .build();
+
+    // When
+    SubjectAccessReviewResponse response = client.subjectAccessReviews().create(sar);
+
+    // Then
+    assertNotNull(response);
+    assertTrue(response.getAllowed());
+  }
+}


### PR DESCRIPTION
## Description
Fix #2529 
Right now all create only resources in `authorization.k8s.io` apiGroup
seem to be returning HTTP_OK/HTTP_CREATED even if there are no bearer
token headers set in request. Due to this, we were always skipping token
update since we only check for HTTP_UNAUTHORIZED/HTTP_FORBIDDEN response
codes.

Added an exception in OpenShiftOAuthInterceptor to always force token
update in case url contains Kubernetes/OpenShift authorization apiGroup


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
