### PR TITLE
fix #3122 normalizing the service create exception to be a conflict

### DIFF
--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CreateOrReplaceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CreateOrReplaceIT.java
@@ -105,6 +105,8 @@ public class CreateOrReplaceIT {
 
     // 1st createOrReplace(); should create the resource
     service = client.services().inNamespace(session.getNamespace()).createOrReplace(service);
+    // second call should be a no-op
+    service = client.services().inNamespace(session.getNamespace()).createOrReplace(service);
     assertNotNull(service);
     assertEquals(getTestResourcePrefix() + "-svc", service.getMetadata().getName());
     assertEquals(1, service.getSpec().getPorts().size());


### PR DESCRIPTION
## Description
fixing #3122 - normalizing the 422 create exception to a 409 conflict

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
