### PR TITLE
using a strategic merge to prevent a 422

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/PatchContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/PatchContext.java
@@ -22,6 +22,10 @@ public class PatchContext {
   private String fieldManager;
   private Boolean force;
   private PatchType patchType;
+  
+  public static PatchContext of(PatchType type) {
+    return new PatchContext.Builder().withPatchType(type).build();
+  }
 
   public List<String> getDryRun() {
     return dryRun;

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
@@ -18,7 +18,12 @@ package io.fabric8.kubernetes;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.client.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
@@ -82,10 +87,14 @@ public class WatchIT {
       }
     });
 
-    client.pods().inNamespace(currentNamespace).withName("sample-watch-pod").edit(p -> new PodBuilder(p)
-      .editMetadata().addToLabels("foo", "bar")
-      .endMetadata()
-      .build());
+    client.pods()
+        .inNamespace(currentNamespace)
+        .withName("sample-watch-pod")
+        .patch(new PatchContext.Builder().withPatchType(PatchType.STRATEGIC_MERGE).build(), new PodBuilder()
+            .withNewMetadata()
+            .addToLabels("foo", "bar")
+            .endMetadata()
+            .build());
 
     assertTrue(eventLatch.await(10, TimeUnit.SECONDS));
     watch.close();

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/WatchIT.java
@@ -90,7 +90,7 @@ public class WatchIT {
     client.pods()
         .inNamespace(currentNamespace)
         .withName("sample-watch-pod")
-        .patch(new PatchContext.Builder().withPatchType(PatchType.STRATEGIC_MERGE).build(), new PodBuilder()
+        .patch(PatchContext.of(PatchType.STRATEGIC_MERGE), new PodBuilder()
             .withNewMetadata()
             .addToLabels("foo", "bar")
             .endMetadata()


### PR DESCRIPTION
## Description
Addressing the integration test timing issue seen in https://github.com/fabric8io/kubernetes-client/pull/3136#issuecomment-843243513 with a strategic merge patch.

@rohanKanojia it feels a little verbose to create a patch context of a given patch type - should there be utility methods for that?

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift