### PR TITLE
Add option in KubernetesServerMockExtension to ignore initialization of member KubernetesClient fields in test class

### DIFF
--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/EnableKubernetesMockClient.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/EnableKubernetesMockClient.java
@@ -37,4 +37,9 @@ public @interface EnableKubernetesMockClient {
 	boolean https() default true;
 
 	boolean crud() default false;
+
+  /**
+   * mock or skip mocking instance level client in tests, if such is present
+   */
+	boolean instanceMock() default true;
 }

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -120,6 +120,9 @@ public class KubernetesMockServerExtension implements AfterEachCallback, AfterAl
     Optional<Class<?>> optClass = context.getTestClass();
     if (optClass.isPresent()) {
       Class<?> testClass = optClass.get();
+      if(!isStatic && !testClass.getAnnotation(EnableKubernetesMockClient.class).instanceMock()) {
+        return;
+      }
       initializeKubernetesClientAndMockServer(testClass);
       processTestClassDeclaredFields(context, isStatic, testClass);
     }

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelStaticTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelStaticTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.client.KubernetesClient;

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelStaticTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelStaticTests.java
@@ -1,0 +1,18 @@
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@EnableKubernetesMockClient(instanceMock = false)
+public class KubernetesMockServerExtensionMockInstanceLevelStaticTests {
+
+  private static KubernetesMockServer server;
+  private static KubernetesClient client;
+
+  @Test
+  public void test() {
+    Assertions.assertNotNull(server);
+    Assertions.assertNotNull(client);
+  }
+}

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.client.KubernetesClient;

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionMockInstanceLevelTests.java
@@ -1,0 +1,39 @@
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+
+public class KubernetesMockServerExtensionMockInstanceLevelTests {
+
+  // when "instanceMock = false", server and client are not mocked
+  @Nested
+  @EnableKubernetesMockClient(instanceMock = false)
+  class InstanceLevelFalse {
+    private KubernetesMockServer server;
+    private KubernetesClient client;
+
+    @Test
+    public void test() {
+      Assertions.assertNull(server);
+      Assertions.assertNull(client);
+    }
+  }
+
+  // when "instanceMock = true", server and client are mocked
+  @Nested
+  @EnableKubernetesMockClient(instanceMock = true)
+  class InstanceLevelTrue {
+    private KubernetesMockServer server;
+    private KubernetesClient client;
+
+    @Test
+    public void test() {
+      Assertions.assertNotNull(server);
+      Assertions.assertNotNull(client);
+    }
+  }
+
+}

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/EnableOpenShiftMockClient.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/EnableOpenShiftMockClient.java
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Annotation that is used for enabling OpenShiftMockServerExtension JUnit5 extension.
- * You may set here two parameters of `OpenShiftServer`: crudMode and https
+ * You may set here two parameters of `OpenShiftServer`: crudMode, https and instanceMock
  */
 @Target({ TYPE, METHOD, ANNOTATION_TYPE })
 @Retention(RUNTIME)
@@ -37,4 +37,9 @@ public @interface EnableOpenShiftMockClient {
   boolean https() default true;
 
   boolean crud() default false;
+
+  /**
+   * mock or skip mocking instance level client in tests, if such is present
+   */
+  boolean instanceMock() default true;
 }

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
@@ -22,6 +23,7 @@ import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -53,13 +55,17 @@ public class OpenShiftMockServerExtension extends KubernetesMockServerExtension 
   }
 
   @Override
-  protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
+  protected boolean initializeKubernetesClientAndMockServer(Class<?> testClass, boolean isStatic) {
     EnableOpenShiftMockClient a = testClass.getAnnotation(EnableOpenShiftMockClient.class);
+    if(!isStatic && !testClass.getAnnotation(EnableOpenShiftMockClient.class).instanceMock()) {
+      return false;
+    }
     openShiftMockServer = a.crud()
       ? new OpenShiftMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
       : new OpenShiftMockServer(a.https());
     openShiftMockServer.init();
     openShiftClient = openShiftMockServer.createOpenShiftClient();
+    return true;
   }
 
   @Override

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelStaticTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelStaticTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.openshift.client.OpenShiftClient;

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelStaticTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelStaticTests.java
@@ -1,0 +1,17 @@
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@EnableOpenShiftMockClient(instanceMock = false)
+public class OpenShiftMockServerExtensionMockInstanceLevelStaticTests {
+  private static OpenShiftMockServer server;
+  private static OpenShiftClient client;
+
+  @Test
+  public void test() {
+    Assertions.assertNotNull(server);
+    Assertions.assertNotNull(client);
+  }
+}

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.openshift.client.OpenShiftClient;

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionMockInstanceLevelTests.java
@@ -1,0 +1,36 @@
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class OpenShiftMockServerExtensionMockInstanceLevelTests {
+  // when "instanceMock = false", server and client are not mocked
+  @Nested
+  @EnableOpenShiftMockClient(instanceMock = false)
+  class InstanceLevelFalse {
+    private OpenShiftMockServer server;
+    private OpenShiftClient client;
+
+    @Test
+    public void test() {
+      Assertions.assertNull(server);
+      Assertions.assertNull(client);
+    }
+  }
+
+  // when "instanceMock = true", server and client are mocked
+  @Nested
+  @EnableOpenShiftMockClient(instanceMock = true)
+  class InstanceLevelTrue {
+    private OpenShiftMockServer server;
+    private OpenShiftClient client;
+
+    @Test
+    public void test() {
+      Assertions.assertNotNull(server);
+      Assertions.assertNotNull(client);
+    }
+  }
+}


### PR DESCRIPTION
Fix #3145