### PR TITLE
KubernetesMockServer should not read local `.kube/config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.5-SNAPSHOT
 
 #### Bugs
+* KubernetesMockServer should not read local `.kube/config` while initializing client
 
 #### Improvements
 * Fix #3135 added mock crud support for patch status, and will return exceptions for unsupported patch types

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -31,6 +31,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -88,12 +89,17 @@ public class KubernetesMockServer extends DefaultMockServer {
     }
 
     public NamespacedKubernetesClient createClient() {
-        Config config = new ConfigBuilder()
+        Config config = getMockConfiguration();
+        return new DefaultKubernetesClient(createHttpClientForMockServer(config), config);
+    }
+
+    protected Config getMockConfiguration() {
+        Config config = new ConfigBuilder(Config.empty())
                 .withMasterUrl(url("/"))
                 .withTrustCerts(true)
                 .withTlsVersions(TLS_1_2)
                 .withNamespace("test")
                 .build();
-        return new DefaultKubernetesClient(createHttpClientForMockServer(config), config);
+        return config;
     }
 }

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTests.java
@@ -28,5 +28,8 @@ public class KubernetesMockServerExtensionTests {
 	@Test
 	void testExample() {
 		Assertions.assertNotNull(client);
+    Assertions.assertNull(client.getConfiguration().getOauthToken());
+    Assertions.assertNull(client.getConfiguration().getCurrentContext());
+    Assertions.assertTrue(client.getConfiguration().getContexts().isEmpty());
 	}
 }

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/MockServerKubeconfigTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/MockServerKubeconfigTest.java
@@ -13,23 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.junit.jupiter.api.Assertions;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@EnableKubernetesMockClient(crud = true)
-public class KubernetesMockServerExtensionStaticTests {
+import org.junit.jupiter.api.Assertions;
 
-	static KubernetesClient client;
+import java.util.Objects;
 
-	@Test
-	void testExample() {
-		Assertions.assertNotNull(client);
+class MockServerKubeconfigTest {
+
+  @BeforeEach
+  void setKubeConfigProperty() {
+    System.setProperty("kubeconfig", Objects.requireNonNull(getClass().getResource("/testkubeconfig")).getFile());
+  }
+
+  @Test
+  void mockServerShouldNotPickTokenAndNameContextIfKubeConfigFound() {
+    // Given
+    KubernetesMockServer server = new KubernetesMockServer();
+
+    // When
+    KubernetesClient client = server.createClient();
+
+    // Then
+    Assertions.assertNotNull(client);
     Assertions.assertNull(client.getConfiguration().getOauthToken());
     Assertions.assertNull(client.getConfiguration().getCurrentContext());
     Assertions.assertTrue(client.getConfiguration().getContexts().isEmpty());
-	}
+  }
+
+  @AfterEach
+  public void cleanup() {
+    System.clearProperty("kubeconfig");
+  }
 }

--- a/kubernetes-server-mock/src/test/resources/testkubeconfig
+++ b/kubernetes-server-mock/src/test/resources/testkubeconfig
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://api.crc.testing:6443
+  name: api-crc-testing:6443
+contexts:
+- context:
+    cluster: api-crc-testing:6443
+    namespace: default
+    user: kubeadmin/api-crc-testing:6443
+  name: default/api-crc-testing:6443/kubeadmin
+current-context: default/api-crc-testing:6443/kubeadmin
+kind: Config
+preferences: {}
+users:
+- name: kubeadmin/api-crc-testing:6443
+  user:
+    token: sha256~iYtvbJNJEE0_QSxYE0Wl1MJJxpSvDUsNyYfzkCIoDkw

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
@@ -23,7 +23,6 @@ import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfig;
-import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockWebServer;
 
@@ -31,7 +30,6 @@ import java.util.Map;
 import java.util.Queue;
 
 import static io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer;
-import static okhttp3.TlsVersion.TLS_1_2;
 
 public class OpenShiftMockServer extends KubernetesMockServer {
   private boolean disableApiGroupCheck = true;
@@ -54,13 +52,8 @@ public class OpenShiftMockServer extends KubernetesMockServer {
   }
 
   public NamespacedOpenShiftClient createOpenShiftClient() {
-    OpenShiftConfig config = new OpenShiftConfigBuilder()
-      .withMasterUrl(url("/"))
-      .withNamespace("test")
-      .withTrustCerts(true)
-      .withTlsVersions(TLS_1_2)
-      .withDisableApiGroupCheck(disableApiGroupCheck)
-      .build();
+    OpenShiftConfig config = OpenShiftConfig.wrap(getMockConfiguration());
+    config.setDisableApiGroupCheck(disableApiGroupCheck);
     return new DefaultOpenShiftClient(createHttpClientForMockServer(config), config);
   }
 

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
@@ -19,6 +19,8 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableOpenShiftMockClient(crud = true)
 class OpenShiftMockServerExtensionStaticTests {
@@ -27,5 +29,8 @@ class OpenShiftMockServerExtensionStaticTests {
   @Test
   void testStaticOpenShiftClientGetsInitialized() {
     assertNotNull(openShiftClient);
+    assertNull(openShiftClient.getConfiguration().getOauthToken());
+    assertNull(openShiftClient.getConfiguration().getCurrentContext());
+    assertTrue(openShiftClient.getConfiguration().getContexts().isEmpty());
   }
 }

--- a/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
+++ b/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
@@ -19,6 +19,8 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableOpenShiftMockClient(crud = true)
 class OpenShiftMockServerExtensionTests {
@@ -27,5 +29,8 @@ class OpenShiftMockServerExtensionTests {
   @Test
   void testOpenShiftClientGetsInitialized() {
     assertNotNull(client);
+    assertNull(client.getConfiguration().getOauthToken());
+    assertNull(client.getConfiguration().getCurrentContext());
+    assertTrue(client.getConfiguration().getContexts().isEmpty());
   }
 }


### PR DESCRIPTION
## Description
Fix #3152 
Fix #3064

KubernetesMockServer is using [ConfigBuilder](https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/test/java/io/fabric8/kubernetes/server/mock/KubernetesMockServer.java#L77) which tries to autoconfigure
Config by reading it automatically from local kubeconfig. this results
in issues where some code might accidentally read token/context set in
KubernetesClient's config which is set by Config autoconfigure.

This PR explicitly sets token, contexts to null/empty so that mockServer
tests run independently of local Kubernetes config


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
