### PR TITLE
Retry HTTP for status >= 500 (exponential backoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix #3166: Add DSL Support for `machineconfiguration.openshift.io/v1` resources in OpenShiftClient
 * Fix #3142: Add DSL support for missing resources in `operator.openshift.io` and `monitoring.coreos.com` apiGroups
 * Add DSL support for missing resources in `template.openshift.io`, `helm.openshift.io`, `network.openshift.io`, `user.openshift.io` apigroups
+* Fix #3087: Support HTTP operation retry with exponential backoff (for status code >= 500)
 
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ System properties are preferred over environment variables. The following system
 | `kubernetes.watch.reconnectLimit` / `KUBERNETES_WATCH_RECONNECTLIMIT` | Number of reconnect attempts (-1 for infinite) | `-1` |
 | `kubernetes.connection.timeout` / `KUBERNETES_CONNECTION_TIMEOUT` | Connection timeout in ms (0 for no timeout) | `10000` |
 | `kubernetes.request.timeout` / `KUBERNETES_REQUEST_TIMEOUT` | Read timeout in ms | `10000` |
-| `kubernetes.request.retry.backoffLimit` / `KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY` | Number of retry attempts | `0` |
-| `kubernetes.request.retry.backoffInterval` / `KUBERNETES_REQUEST_RETRY_BACKOFFINTERVAL_SYSTEM_PROPERTY` | Retry initial backoff interval in ms | `1000` |
+| `kubernetes.request.retry.backoffLimit` / `KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT` | Number of retry attempts | `0` |
+| `kubernetes.request.retry.backoffInterval` / `KUBERNETES_REQUEST_RETRY_BACKOFFINTERVAL` | Retry initial backoff interval in ms | `1000` |
 | `kubernetes.rolling.timeout` / `KUBERNETES_ROLLING_TIMEOUT` | Rolling timeout in ms | `900000` |
 | `kubernetes.logging.interval` / `KUBERNETES_LOGGING_INTERVAL` | Logging interval in ms | `20000` |
 | `kubernetes.scale.timeout` / `KUBERNETES_SCALE_TIMEOUT` | Scale timeout in ms | `600000` |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ System properties are preferred over environment variables. The following system
 | `kubernetes.watch.reconnectLimit` / `KUBERNETES_WATCH_RECONNECTLIMIT` | Number of reconnect attempts (-1 for infinite) | `-1` |
 | `kubernetes.connection.timeout` / `KUBERNETES_CONNECTION_TIMEOUT` | Connection timeout in ms (0 for no timeout) | `10000` |
 | `kubernetes.request.timeout` / `KUBERNETES_REQUEST_TIMEOUT` | Read timeout in ms | `10000` |
+| `kubernetes.request.retry.backoff.count` / `KUBERNETES_REQUEST_RETRY_BACKOFF_COUNT_SYSTEM_PROPERTY` | Retry count | `0` |
+| `kubernetes.request.retry.backoff.initial` / `KUBERNETES_REQUEST_RETRY_BACKOFF_INITIAL_SYSTEM_PROPERTY` | Retry initial backoff in ms | `1000` |
+| `kubernetes.request.retry.backoff.multipier` / `KUBERNETES_REQUEST_RETRY_BACKOFF_MULTIPIER_SYSTEM_PROPERTY` | Retry multipliler | `2` |
 | `kubernetes.rolling.timeout` / `KUBERNETES_ROLLING_TIMEOUT` | Rolling timeout in ms | `900000` |
 | `kubernetes.logging.interval` / `KUBERNETES_LOGGING_INTERVAL` | Logging interval in ms | `20000` |
 | `kubernetes.scale.timeout` / `KUBERNETES_SCALE_TIMEOUT` | Scale timeout in ms | `600000` |

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ System properties are preferred over environment variables. The following system
 | `kubernetes.watch.reconnectLimit` / `KUBERNETES_WATCH_RECONNECTLIMIT` | Number of reconnect attempts (-1 for infinite) | `-1` |
 | `kubernetes.connection.timeout` / `KUBERNETES_CONNECTION_TIMEOUT` | Connection timeout in ms (0 for no timeout) | `10000` |
 | `kubernetes.request.timeout` / `KUBERNETES_REQUEST_TIMEOUT` | Read timeout in ms | `10000` |
-| `kubernetes.request.retry.backoff.count` / `KUBERNETES_REQUEST_RETRY_BACKOFF_COUNT_SYSTEM_PROPERTY` | Retry count | `0` |
-| `kubernetes.request.retry.backoff.initial` / `KUBERNETES_REQUEST_RETRY_BACKOFF_INITIAL_SYSTEM_PROPERTY` | Retry initial backoff in ms | `1000` |
-| `kubernetes.request.retry.backoff.multipier` / `KUBERNETES_REQUEST_RETRY_BACKOFF_MULTIPIER_SYSTEM_PROPERTY` | Retry multipliler | `2` |
+| `kubernetes.request.retry.backoffLimit` / `KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY` | Number of retry attempts | `0` |
+| `kubernetes.request.retry.backoffInterval` / `KUBERNETES_REQUEST_RETRY_BACKOFFINTERVAL_SYSTEM_PROPERTY` | Retry initial backoff interval in ms | `1000` |
 | `kubernetes.rolling.timeout` / `KUBERNETES_ROLLING_TIMEOUT` | Rolling timeout in ms | `900000` |
 | `kubernetes.logging.interval` / `KUBERNETES_LOGGING_INTERVAL` | Logging interval in ms | `20000` |
 | `kubernetes.scale.timeout` / `KUBERNETES_SCALE_TIMEOUT` | Scale timeout in ms | `600000` |

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -87,6 +87,9 @@ public class Config {
   public static final String KUBERNETES_WATCH_RECONNECT_LIMIT_SYSTEM_PROPERTY = "kubernetes.watch.reconnectLimit";
   public static final String KUBERNETES_CONNECTION_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.connection.timeout";
   public static final String KUBERNETES_REQUEST_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.request.timeout";
+  public static final String KUBERNETES_REQUEST_RETRY_BACKOFF_COUNT_SYSTEM_PROPERTY = "kubernetes.request.retry.count";
+  public static final String KUBERNETES_REQUEST_RETRY_BACKOFF_INITIAL_SYSTEM_PROPERTY = "kubernetes.request.retry.backoff.initial";
+  public static final String KUBERNETES_REQUEST_RETRY_BACKOFF_MULTIPLIER_SYSTEM_PROPERTY = "kubernetes.request.retry.backoff.multiplier";
   public static final String KUBERNETES_ROLLING_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.rolling.timeout";
   public static final String KUBERNETES_LOGGING_INTERVAL_SYSTEM_PROPERTY = "kubernetes.logging.interval";
   public static final String KUBERNETES_SCALE_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.scale.timeout";
@@ -135,6 +138,10 @@ public class Config {
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS = 64;
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST = 5;
 
+  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFF_COUNT = 0;
+  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL = 1000;
+  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER = 2;
+
   public static final String HTTP_PROTOCOL_PREFIX = "http://";
   public static final String HTTPS_PROTOCOL_PREFIX = "https://";
 
@@ -173,6 +180,9 @@ public class Config {
   private int watchReconnectInterval = 1000;
   private int watchReconnectLimit = -1;
   private int connectionTimeout = 10 * 1000;
+  private int requestRetryBackoffCount;
+  private int requestRetryBackoffInitial;
+  private int requestRetryBackoffMultiplier;
   private int requestTimeout = 10 * 1000;
   private long rollingTimeout = DEFAULT_ROLLING_TIMEOUT;
   private long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
@@ -289,11 +299,11 @@ public class Config {
 
   @Deprecated
   public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequests, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras) {
-    this(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, false, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions,  websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras, null,null);
+    this(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, false, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions,  websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras, null,null, DEFAULT_REQUEST_RETRY_BACKOFF_COUNT, DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL, DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
-  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequests, int maxConcurrentRequestsPerHost, boolean http2Disable, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,Map<String,String> customHeaders) {
+  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequests, int maxConcurrentRequestsPerHost, boolean http2Disable, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,Map<String,String> customHeaders, int requestRetryBackoffCount, int requestRetryBackoffInitial, int requestRetryBackoffMultiplier) {
     this.masterUrl = masterUrl;
     this.apiVersion = apiVersion;
     this.namespace = namespace;
@@ -308,7 +318,7 @@ public class Config {
     this.clientKeyAlgo = clientKeyAlgo;
     this.clientKeyPassphrase = clientKeyPassphrase;
 
-    this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, oauthTokenProvider);
+    this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, oauthTokenProvider, requestRetryBackoffCount, requestRetryBackoffInitial, requestRetryBackoffMultiplier);
     this.requestConfig.setImpersonateUsername(impersonateUsername);
     this.requestConfig.setImpersonateGroups(impersonateGroups);
     this.requestConfig.setImpersonateExtras(impersonateExtras);
@@ -399,6 +409,9 @@ public class Config {
 
     config.setConnectionTimeout(Utils.getSystemPropertyOrEnvVar(KUBERNETES_CONNECTION_TIMEOUT_SYSTEM_PROPERTY, config.getConnectionTimeout()));
     config.setRequestTimeout(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_TIMEOUT_SYSTEM_PROPERTY, config.getRequestTimeout()));
+    config.setRequestRetryBackoffCount(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFF_COUNT_SYSTEM_PROPERTY, config.getRequestRetryBackoffCount()));
+    config.setRequestRetryBackoffInitial(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFF_INITIAL_SYSTEM_PROPERTY, config.getRequestRetryBackoffInitial()));
+    config.setRequestRetryBackoffMultiplier(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFF_MULTIPLIER_SYSTEM_PROPERTY, config.getRequestRetryBackoffMultiplier()));
 
     String configuredWebsocketTimeout = Utils.getSystemPropertyOrEnvVar(KUBERNETES_WEBSOCKET_TIMEOUT_SYSTEM_PROPERTY, String.valueOf(config.getWebsocketTimeout()));
     if (configuredWebsocketTimeout != null) {
@@ -1034,6 +1047,33 @@ public class Config {
 
   public void setRequestTimeout(int requestTimeout) {
     this.requestConfig.setRequestTimeout(requestTimeout);
+  }
+
+  @JsonProperty("requestRetryBackoffCount")
+  public int getRequestRetryBackoffCount() {
+    return getRequestConfig().getRequestRetryBackoffCount();
+  }
+
+  public void setRequestRetryBackoffCount(int requestRetryBackoffCount) {
+    requestConfig.setRequestRetryBackoffCount(requestRetryBackoffCount);
+  }
+
+  @JsonProperty("requestRetryBackoffInitial")
+  public int getRequestRetryBackoffInitial() {
+    return getRequestConfig().getRequestRetryBackoffInitial();
+  }
+
+  public void setRequestRetryBackoffInitial(int requestRetryBackoffInitial) {
+    requestConfig.setRequestRetryBackoffInitial(requestRetryBackoffInitial);
+  }
+
+  @JsonProperty("requestRetryBackoffMultiplier")
+  public int getRequestRetryBackoffMultiplier() {
+    return getRequestConfig().getRequestRetryBackoffMultiplier();
+  }
+
+  public void setRequestRetryBackoffMultiplier(int requestRetryBackoffMultiplier) {
+    requestConfig.setRequestRetryBackoffMultiplier(requestRetryBackoffMultiplier);
   }
 
   @JsonProperty("rollingTimeout")

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -87,9 +87,8 @@ public class Config {
   public static final String KUBERNETES_WATCH_RECONNECT_LIMIT_SYSTEM_PROPERTY = "kubernetes.watch.reconnectLimit";
   public static final String KUBERNETES_CONNECTION_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.connection.timeout";
   public static final String KUBERNETES_REQUEST_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.request.timeout";
-  public static final String KUBERNETES_REQUEST_RETRY_BACKOFF_COUNT_SYSTEM_PROPERTY = "kubernetes.request.retry.count";
-  public static final String KUBERNETES_REQUEST_RETRY_BACKOFF_INITIAL_SYSTEM_PROPERTY = "kubernetes.request.retry.backoff.initial";
-  public static final String KUBERNETES_REQUEST_RETRY_BACKOFF_MULTIPLIER_SYSTEM_PROPERTY = "kubernetes.request.retry.backoff.multiplier";
+  public static final String KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY = "kubernetes.request.retry.backoffLimit";
+  public static final String KUBERNETES_REQUEST_RETRY_BACKOFFINTERVAL_SYSTEM_PROPERTY = "kubernetes.request.retry.backoffInterval";
   public static final String KUBERNETES_ROLLING_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.rolling.timeout";
   public static final String KUBERNETES_LOGGING_INTERVAL_SYSTEM_PROPERTY = "kubernetes.logging.interval";
   public static final String KUBERNETES_SCALE_TIMEOUT_SYSTEM_PROPERTY = "kubernetes.scale.timeout";
@@ -138,9 +137,8 @@ public class Config {
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS = 64;
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST = 5;
 
-  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFF_COUNT = 0;
-  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL = 1000;
-  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER = 2;
+  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFLIMIT = 0;
+  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL = 1000;
 
   public static final String HTTP_PROTOCOL_PREFIX = "http://";
   public static final String HTTPS_PROTOCOL_PREFIX = "https://";
@@ -180,9 +178,8 @@ public class Config {
   private int watchReconnectInterval = 1000;
   private int watchReconnectLimit = -1;
   private int connectionTimeout = 10 * 1000;
-  private int requestRetryBackoffCount;
-  private int requestRetryBackoffInitial;
-  private int requestRetryBackoffMultiplier;
+  private int requestRetryBackoffLimit;
+  private int requestRetryBackoffInterval;
   private int requestTimeout = 10 * 1000;
   private long rollingTimeout = DEFAULT_ROLLING_TIMEOUT;
   private long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
@@ -299,11 +296,11 @@ public class Config {
 
   @Deprecated
   public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequests, int maxConcurrentRequestsPerHost, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras) {
-    this(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, false, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions,  websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras, null,null, DEFAULT_REQUEST_RETRY_BACKOFF_COUNT, DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL, DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER);
+    this(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData, clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password, oauthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, rollingTimeout, scaleTimeout, loggingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, false, httpProxy, httpsProxy, noProxy, errorMessages, userAgent, tlsVersions,  websocketTimeout, websocketPingInterval, proxyUsername, proxyPassword, trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups, impersonateExtras, null,null, DEFAULT_REQUEST_RETRY_BACKOFFLIMIT, DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
-  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequests, int maxConcurrentRequestsPerHost, boolean http2Disable, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,Map<String,String> customHeaders, int requestRetryBackoffCount, int requestRetryBackoffInitial, int requestRetryBackoffMultiplier) {
+  public Config(String masterUrl, String apiVersion, String namespace, boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password, String oauthToken, int watchReconnectInterval, int watchReconnectLimit, int connectionTimeout, int requestTimeout, long rollingTimeout, long scaleTimeout, int loggingInterval, int maxConcurrentRequests, int maxConcurrentRequestsPerHost, boolean http2Disable, String httpProxy, String httpsProxy, String[] noProxy, Map<Integer, String> errorMessages, String userAgent, TlsVersion[] tlsVersions, long websocketTimeout, long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,Map<String,String> customHeaders, int requestRetryBackoffLimit, int requestRetryBackoffInterval) {
     this.masterUrl = masterUrl;
     this.apiVersion = apiVersion;
     this.namespace = namespace;
@@ -318,7 +315,7 @@ public class Config {
     this.clientKeyAlgo = clientKeyAlgo;
     this.clientKeyPassphrase = clientKeyPassphrase;
 
-    this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, oauthTokenProvider, requestRetryBackoffCount, requestRetryBackoffInitial, requestRetryBackoffMultiplier);
+    this.requestConfig = new RequestConfig(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval, websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, oauthTokenProvider, requestRetryBackoffLimit, requestRetryBackoffInterval);
     this.requestConfig.setImpersonateUsername(impersonateUsername);
     this.requestConfig.setImpersonateGroups(impersonateGroups);
     this.requestConfig.setImpersonateExtras(impersonateExtras);
@@ -409,9 +406,8 @@ public class Config {
 
     config.setConnectionTimeout(Utils.getSystemPropertyOrEnvVar(KUBERNETES_CONNECTION_TIMEOUT_SYSTEM_PROPERTY, config.getConnectionTimeout()));
     config.setRequestTimeout(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_TIMEOUT_SYSTEM_PROPERTY, config.getRequestTimeout()));
-    config.setRequestRetryBackoffCount(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFF_COUNT_SYSTEM_PROPERTY, config.getRequestRetryBackoffCount()));
-    config.setRequestRetryBackoffInitial(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFF_INITIAL_SYSTEM_PROPERTY, config.getRequestRetryBackoffInitial()));
-    config.setRequestRetryBackoffMultiplier(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFF_MULTIPLIER_SYSTEM_PROPERTY, config.getRequestRetryBackoffMultiplier()));
+    config.setRequestRetryBackoffLimit(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY, config.getRequestRetryBackoffLimit()));
+    config.setRequestRetryBackoffInterval(Utils.getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFFINTERVAL_SYSTEM_PROPERTY, config.getRequestRetryBackoffInterval()));
 
     String configuredWebsocketTimeout = Utils.getSystemPropertyOrEnvVar(KUBERNETES_WEBSOCKET_TIMEOUT_SYSTEM_PROPERTY, String.valueOf(config.getWebsocketTimeout()));
     if (configuredWebsocketTimeout != null) {
@@ -1049,31 +1045,22 @@ public class Config {
     this.requestConfig.setRequestTimeout(requestTimeout);
   }
 
-  @JsonProperty("requestRetryBackoffCount")
-  public int getRequestRetryBackoffCount() {
-    return getRequestConfig().getRequestRetryBackoffCount();
+  @JsonProperty("requestRetryBackoffLimit")
+  public int getRequestRetryBackoffLimit() {
+    return getRequestConfig().getRequestRetryBackoffLimit();
   }
 
-  public void setRequestRetryBackoffCount(int requestRetryBackoffCount) {
-    requestConfig.setRequestRetryBackoffCount(requestRetryBackoffCount);
+  public void setRequestRetryBackoffLimit(int requestRetryBackoffLimit) {
+    requestConfig.setRequestRetryBackoffLimit(requestRetryBackoffLimit);
   }
 
-  @JsonProperty("requestRetryBackoffInitial")
-  public int getRequestRetryBackoffInitial() {
-    return getRequestConfig().getRequestRetryBackoffInitial();
+  @JsonProperty("requestRetryBackoffInterval")
+  public int getRequestRetryBackoffInterval() {
+    return getRequestConfig().getRequestRetryBackoffInterval();
   }
 
-  public void setRequestRetryBackoffInitial(int requestRetryBackoffInitial) {
-    requestConfig.setRequestRetryBackoffInitial(requestRetryBackoffInitial);
-  }
-
-  @JsonProperty("requestRetryBackoffMultiplier")
-  public int getRequestRetryBackoffMultiplier() {
-    return getRequestConfig().getRequestRetryBackoffMultiplier();
-  }
-
-  public void setRequestRetryBackoffMultiplier(int requestRetryBackoffMultiplier) {
-    requestConfig.setRequestRetryBackoffMultiplier(requestRetryBackoffMultiplier);
+  public void setRequestRetryBackoffInterval(int requestRetryBackoffInterval) {
+    requestConfig.setRequestRetryBackoffInterval(requestRetryBackoffInterval);
   }
 
   @JsonProperty("rollingTimeout")

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_LOGGING_INTERVAL;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_MAX_CONCURRENT_REQUESTS;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFF_COUNT;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_ROLLING_TIMEOUT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_SCALE_TIMEOUT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_WEBSOCKET_PING_INTERVAL;
@@ -45,6 +48,9 @@ public class RequestConfig {
   private int watchReconnectInterval = 1000;
   private int watchReconnectLimit = -1;
   private int connectionTimeout = 10 * 1000;
+  private int requestRetryBackoffCount = DEFAULT_REQUEST_RETRY_BACKOFF_COUNT;
+  private int requestRetryBackoffInitial = DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL;
+  private int requestRetryBackoffMultiplier = DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER;
   private int requestTimeout = 10 * 1000;
   private long rollingTimeout = DEFAULT_ROLLING_TIMEOUT;
   private long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
@@ -83,7 +89,8 @@ public class RequestConfig {
                        long websocketTimeout, long websocketPingInterval,
                        int maxConcurrentRequests, int maxConcurrentRequestsPerHost) {
     this(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval,
-         websocketTimeout,  websocketPingInterval,maxConcurrentRequests, maxConcurrentRequestsPerHost, null);
+         websocketTimeout,  websocketPingInterval,maxConcurrentRequests, maxConcurrentRequestsPerHost, null, DEFAULT_REQUEST_RETRY_BACKOFF_COUNT, DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL,
+         DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
@@ -91,7 +98,8 @@ public class RequestConfig {
                        int watchReconnectLimit, int watchReconnectInterval,
                        int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
                        long websocketTimeout, long websocketPingInterval,
-                       int maxConcurrentRequests, int maxConcurrentRequestsPerHost, OAuthTokenProvider oauthTokenProvider) {
+                       int maxConcurrentRequests, int maxConcurrentRequestsPerHost, OAuthTokenProvider oauthTokenProvider,
+                       int requestRetryBackoffCount, int requestRetryBackoffInitial, int requestRetryBackoffMultiplier) {
     this.username = username;
     this.oauthToken = oauthToken;
     this.password = password;
@@ -107,6 +115,9 @@ public class RequestConfig {
     this.maxConcurrentRequests = maxConcurrentRequests;
     this.maxConcurrentRequestsPerHost = maxConcurrentRequestsPerHost;
     this.oauthTokenProvider = oauthTokenProvider;
+    this.requestRetryBackoffCount = requestRetryBackoffCount;
+    this.requestRetryBackoffInitial = requestRetryBackoffInitial;
+    this.requestRetryBackoffMultiplier = requestRetryBackoffMultiplier;
   }
 
   public String getUsername() {
@@ -166,6 +177,30 @@ public class RequestConfig {
 
   public void setRequestTimeout(int requestTimeout) {
     this.requestTimeout = requestTimeout;
+  }
+
+  public int getRequestRetryBackoffCount() {
+    return requestRetryBackoffCount;
+  }
+
+  public void setRequestRetryBackoffCount(int requestRetryBackoffCount) {
+    this.requestRetryBackoffCount = requestRetryBackoffCount;
+  }
+
+  public int getRequestRetryBackoffInitial() {
+    return requestRetryBackoffInitial;
+  }
+
+  public void setRequestRetryBackoffInitial(int requestRetryBackoffInitial) {
+    this.requestRetryBackoffInitial = requestRetryBackoffInitial;
+  }
+
+  public int getRequestRetryBackoffMultiplier() {
+    return requestRetryBackoffMultiplier;
+  }
+
+  public void setRequestRetryBackoffMultiplier(int requestRetryBackoffMultiplier) {
+    this.requestRetryBackoffMultiplier = requestRetryBackoffMultiplier;
   }
 
   public int getConnectionTimeout() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -26,9 +26,8 @@ import java.util.Map;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_LOGGING_INTERVAL;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_MAX_CONCURRENT_REQUESTS;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST;
-import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFF_COUNT;
-import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL;
-import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_ROLLING_TIMEOUT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_SCALE_TIMEOUT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_WEBSOCKET_PING_INTERVAL;
@@ -48,9 +47,8 @@ public class RequestConfig {
   private int watchReconnectInterval = 1000;
   private int watchReconnectLimit = -1;
   private int connectionTimeout = 10 * 1000;
-  private int requestRetryBackoffCount = DEFAULT_REQUEST_RETRY_BACKOFF_COUNT;
-  private int requestRetryBackoffInitial = DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL;
-  private int requestRetryBackoffMultiplier = DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER;
+  private int requestRetryBackoffLimit = DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
+  private int requestRetryBackoffInterval = DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL;
   private int requestTimeout = 10 * 1000;
   private long rollingTimeout = DEFAULT_ROLLING_TIMEOUT;
   private long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
@@ -78,8 +76,6 @@ public class RequestConfig {
    * @param scaleTimeout scale timeout
    * @param loggingInterval logging interval
    * @param websocketTimeout web socket timeout
-   * @param websocketPingInterval web socket ping interval
-   * @param maxConcurrentRequests max concurrent requests
    * @param maxConcurrentRequestsPerHost max concurrent requests per host
    */
   @Deprecated
@@ -89,8 +85,7 @@ public class RequestConfig {
                        long websocketTimeout, long websocketPingInterval,
                        int maxConcurrentRequests, int maxConcurrentRequestsPerHost) {
     this(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval,
-         websocketTimeout,  websocketPingInterval,maxConcurrentRequests, maxConcurrentRequestsPerHost, null, DEFAULT_REQUEST_RETRY_BACKOFF_COUNT, DEFAULT_REQUEST_RETRY_BACKOFF_INITIAL,
-         DEFAULT_REQUEST_RETRY_BACKOFF_MULTIPIER);
+         websocketTimeout,  websocketPingInterval,maxConcurrentRequests, maxConcurrentRequestsPerHost, null, DEFAULT_REQUEST_RETRY_BACKOFFLIMIT, DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
@@ -99,7 +94,7 @@ public class RequestConfig {
                        int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
                        long websocketTimeout, long websocketPingInterval,
                        int maxConcurrentRequests, int maxConcurrentRequestsPerHost, OAuthTokenProvider oauthTokenProvider,
-                       int requestRetryBackoffCount, int requestRetryBackoffInitial, int requestRetryBackoffMultiplier) {
+                       int requestRetryBackoffLimit, int requestRetryBackoffInterval) {
     this.username = username;
     this.oauthToken = oauthToken;
     this.password = password;
@@ -115,9 +110,8 @@ public class RequestConfig {
     this.maxConcurrentRequests = maxConcurrentRequests;
     this.maxConcurrentRequestsPerHost = maxConcurrentRequestsPerHost;
     this.oauthTokenProvider = oauthTokenProvider;
-    this.requestRetryBackoffCount = requestRetryBackoffCount;
-    this.requestRetryBackoffInitial = requestRetryBackoffInitial;
-    this.requestRetryBackoffMultiplier = requestRetryBackoffMultiplier;
+    this.requestRetryBackoffLimit = requestRetryBackoffLimit;
+    this.requestRetryBackoffInterval = requestRetryBackoffInterval;
   }
 
   public String getUsername() {
@@ -179,28 +173,20 @@ public class RequestConfig {
     this.requestTimeout = requestTimeout;
   }
 
-  public int getRequestRetryBackoffCount() {
-    return requestRetryBackoffCount;
+  public int getRequestRetryBackoffLimit() {
+    return requestRetryBackoffLimit;
   }
 
-  public void setRequestRetryBackoffCount(int requestRetryBackoffCount) {
-    this.requestRetryBackoffCount = requestRetryBackoffCount;
+  public void setRequestRetryBackoffLimit(int requestRetryBackoffLimit) {
+    this.requestRetryBackoffLimit = requestRetryBackoffLimit;
   }
 
-  public int getRequestRetryBackoffInitial() {
-    return requestRetryBackoffInitial;
+  public int getRequestRetryBackoffInterval() {
+    return requestRetryBackoffInterval;
   }
 
-  public void setRequestRetryBackoffInitial(int requestRetryBackoffInitial) {
-    this.requestRetryBackoffInitial = requestRetryBackoffInitial;
-  }
-
-  public int getRequestRetryBackoffMultiplier() {
-    return requestRetryBackoffMultiplier;
-  }
-
-  public void setRequestRetryBackoffMultiplier(int requestRetryBackoffMultiplier) {
-    this.requestRetryBackoffMultiplier = requestRetryBackoffMultiplier;
+  public void setRequestRetryBackoffInterval(int requestRetryBackoffInterval) {
+    this.requestRetryBackoffInterval = requestRetryBackoffInterval;
   }
 
   public int getConnectionTimeout() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ExponentialBackoffIntervalCalculator.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ExponentialBackoffIntervalCalculator.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+public class ExponentialBackoffIntervalCalculator {
+
+  private final int initialInterval;
+  private final int maxRetryIntervalExponent;
+
+  public ExponentialBackoffIntervalCalculator(int initialInterval, int maxRetryIntervalExponent) {
+    this.initialInterval = initialInterval;
+    this.maxRetryIntervalExponent = maxRetryIntervalExponent;
+  }
+
+  public long getInterval(int retryIndex) {
+    int exponentOfTwo = retryIndex;
+    if (exponentOfTwo > maxRetryIntervalExponent) {
+      exponentOfTwo = maxRetryIntervalExponent;
+    }
+    return (long)initialInterval * (1 << exponentOfTwo);
+  }
+
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
@@ -271,7 +271,7 @@ class BaseOperationTest {
     final AtomicInteger httpExecutionCounter = new AtomicInteger(0);
     OkHttpClient mockClient = newHttpClientWithSomeFailures(httpExecutionCounter, 1000);
     BaseOperation<Pod, PodList, Resource<Pod>> baseOp = new BaseOperation(new OperationContext()
-      .withConfig(new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").withRequestRetryBackoffCount(3).build())
+      .withConfig(new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").withRequestRetryBackoffLimit(3).build())
       .withPlural("pods")
       .withName("test-pod")
       .withOkhttpClient(mockClient));
@@ -292,7 +292,7 @@ class BaseOperationTest {
     final AtomicInteger httpExecutionCounter = new AtomicInteger(0);
     OkHttpClient mockClient = newHttpClientWithSomeFailures(httpExecutionCounter, 2);
     BaseOperation<Pod, PodList, Resource<Pod>> baseOp = new BaseOperation(new OperationContext()
-      .withConfig(new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").withRequestRetryBackoffCount(3).build())
+      .withConfig(new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").withRequestRetryBackoffLimit(3).build())
       .withPlural("pods")
       .withName("test-pod")
       .withOkhttpClient(mockClient));

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
@@ -15,17 +15,25 @@
  */
 package io.fabric8.kubernetes.client.dsl.base;
 
+import static okhttp3.Protocol.HTTP_1_1;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,14 +47,19 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchDeletable;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.URLUtils;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import org.junit.jupiter.api.Assertions;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
-import org.mockito.ArgumentCaptor;
 
 class BaseOperationTest {
 
@@ -208,5 +221,88 @@ class BaseOperationTest {
     // Then
     assertNotNull(result);
     assertEquals("https://172.17.0.2:8443/api/v1/namespaces/ns1/pods/foo", result.toString());
+  }
+
+  private OkHttpClient newHttpClientWithSomeFailures(final AtomicInteger httpExecutionCounter, final int numFailures) {
+    OkHttpClient mockClient = mock(OkHttpClient.class);
+    when(mockClient.newCall(any())).thenAnswer(
+      invocation -> {
+        Call mockCall = mock(Call.class);
+        Request req = invocation.getArgument(0);
+        when(mockCall.execute()).thenAnswer(i -> {
+          int count = httpExecutionCounter.getAndIncrement();
+          if (count < numFailures) {
+            return new Response.Builder().request(req).message("Internal Server Error").protocol(HTTP_1_1).code(500).build();
+          } else {
+            Pod podNoLabels = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+            ResponseBody body = ResponseBody.create(MediaType.get("application/json"), Serialization.asJson(podNoLabels));
+            return new Response.Builder().request(req).protocol(HTTP_1_1).body(body).message("OK").code(HttpURLConnection.HTTP_OK).build();
+          }
+        });
+        return mockCall;
+      }
+    );
+    return mockClient;
+  }
+
+  @Test
+  void testNoHttpRetryWithDefaultConfig() throws MalformedURLException, IOException {
+    final AtomicInteger httpExecutionCounter = new AtomicInteger(0);
+    OkHttpClient mockClient = newHttpClientWithSomeFailures(httpExecutionCounter, 1000);
+    BaseOperation<Pod, PodList, Resource<Pod>> baseOp = new BaseOperation(new OperationContext()
+      .withConfig(new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").build())
+      .withPlural("pods")
+      .withName("test-pod")
+      .withOkhttpClient(mockClient));
+    baseOp.setType(Pod.class);
+
+    // When
+    Exception exception = assertThrows(KubernetesClientException.class, () -> {
+      Pod result = baseOp.get();
+    });
+
+    // Then
+    assertTrue(exception.getMessage().contains("Internal Server Error"));
+    assertEquals(1, httpExecutionCounter.get());
+  }
+
+  @Test
+  void testHttpRetryWithMoreFailuresThanRetries() throws MalformedURLException, IOException {
+    final AtomicInteger httpExecutionCounter = new AtomicInteger(0);
+    OkHttpClient mockClient = newHttpClientWithSomeFailures(httpExecutionCounter, 1000);
+    BaseOperation<Pod, PodList, Resource<Pod>> baseOp = new BaseOperation(new OperationContext()
+      .withConfig(new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").withRequestRetryBackoffCount(3).build())
+      .withPlural("pods")
+      .withName("test-pod")
+      .withOkhttpClient(mockClient));
+    baseOp.setType(Pod.class);
+
+    // When
+    Exception exception = assertThrows(KubernetesClientException.class, () -> {
+      Pod result = baseOp.get();
+    });
+
+    // Then
+    assertTrue(exception.getMessage().contains("Internal Server Error"));
+    assertEquals("Expected 4 calls: one normal try and 3 backoff retries!", 4, httpExecutionCounter.get());
+  }
+
+  @Test
+  void testHttpRetryWithLessFailuresThanRetries() throws MalformedURLException, IOException {
+    final AtomicInteger httpExecutionCounter = new AtomicInteger(0);
+    OkHttpClient mockClient = newHttpClientWithSomeFailures(httpExecutionCounter, 2);
+    BaseOperation<Pod, PodList, Resource<Pod>> baseOp = new BaseOperation(new OperationContext()
+      .withConfig(new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").withRequestRetryBackoffCount(3).build())
+      .withPlural("pods")
+      .withName("test-pod")
+      .withOkhttpClient(mockClient));
+    baseOp.setType(Pod.class);
+
+    // When
+    Pod result = baseOp.get();
+
+    // Then
+    assertNotNull(result);
+    assertEquals("Expected 3 calls: 2 failures and 1 success!", 3, httpExecutionCounter.get());
   }
 }


### PR DESCRIPTION
## Description

Fix #3087 
This PR introduces configurable retry with exponential backoff for HTTP operations.
As according to the [API conventions](https://github.com/fabric8io/kubernetes-client/issues/3087) when the HTTP status code is one of the followings:

- 500 StatusInternalServerError
- 503 StatusServiceUnavailable
- 504 StatusServerTimeout

Then the suggested client recovery behavior is "retry with exponential backoff".

Although in case of 504 it is "Increase the value of the timeout param and retry with exponential backoff" but in this PR I would only focus on the retries. That can be implemented in a follow up PR.

For the intention behind please check: https://github.com/fabric8io/kubernetes-client/issues/3087.

## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

