### PR TITLE
fix #3159: simplifying the resync logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 #### New Features
 * Fix #3133: Add DSL Support for `authorization.openshift.io/v1` resources in OpenShiftClient
 
+#### _**Note**_: Breaking changes in the API
+##### DSL Changes:
+- #3159 The resync period that an informer is created with is the only relevant period for that informer.  Handlers that are added will use the informer resync period unless resync is disabled when the handler is added.
+
 ### 5.4.0 (2021-05-19)
 
 #### Bugs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
@@ -31,12 +31,17 @@ public interface SharedInformer<T> {
 
   /**
    * Adds an event handler to the shared informer using the specified resync period.
+   * The period may be equal to 0 to disable resync events for this listener.  Any other value
+   * will become the same as the SharedInformer default. 
+   * 
    * Events to a single handler are delivered sequentially, but there is no
    * coordination between different handlers.
    *
    * @param handle the event handler
    * @param resyncPeriod the specific resync period
+   * @deprecated
    */
+  @Deprecated
   void addEventHandlerWithResyncPeriod(ResourceEventHandler<T> handle, long resyncPeriod);
 
   /**
@@ -71,4 +76,15 @@ public interface SharedInformer<T> {
    * Return the class this informer is watching
    */
   Class<T> getApiTypeClass();
+
+  /**
+   * Adds an event handler to the shared informer without resync.
+   * 
+   * Events to a single handler are delivered sequentially, but there is no
+   * coordination between different handlers.
+   *
+   * @param handle the event handler
+   * @param resyncPeriod the specific resync period
+   */
+  void addEventHandlerWithoutResync(ResourceEventHandler<T> handler);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
@@ -117,7 +117,7 @@ public class SharedInformerFactory extends BaseOperation {
    * <b>Note:</b>It watches for events in <b>ALL NAMESPACES</b>.
    *
    * @param apiTypeClass apiType class
-   * @param resyncPeriodInMillis resync period in milliseconds
+   * @param resyncPeriodInMillis resync period in milliseconds. Use 0 to disable resyncs. 1000 is the minimum value.
    * @param <T> the type parameter (should extend {@link io.fabric8.kubernetes.api.model.HasMetadata} and implement {@link io.fabric8.kubernetes.api.model.Namespaced}) if Namespace scoped resource
    * @return the shared index informer
    */
@@ -132,7 +132,7 @@ public class SharedInformerFactory extends BaseOperation {
    *
    * @param apiTypeClass apiType class
    * @param operationContext {@link OperationContext} Operation Context
-   * @param resyncPeriodInMillis resync period in milliseconds
+   * @param resyncPeriodInMillis resync period in milliseconds. Use 0 to disable resyncs. 1000 is the minimum value.
    * @param <T> the type parameter (should extend {@link io.fabric8.kubernetes.api.model.HasMetadata} and implement {@link io.fabric8.kubernetes.api.model.Namespaced}) if Namespace scoped resource
    * @return the shared index informer
    */
@@ -148,7 +148,7 @@ public class SharedInformerFactory extends BaseOperation {
    * @param customResourceContext basic information about the Custom Resource Definition corresponding to that custom resource
    * @param apiTypeClass apiType class
    * @param apiListTypeClass api list type class
-   * @param resyncPeriodInMillis resync period in milliseconds
+   * @param resyncPeriodInMillis resync period in milliseconds. Use 0 to disable resyncs. 1000 is the minimum value.
    * @param <T> the type parameter (should extend {@link io.fabric8.kubernetes.api.model.HasMetadata} and implement {@link io.fabric8.kubernetes.api.model.Namespaced})
    * @param <L> the type's list parameter (should extend {@link io.fabric8.kubernetes.api.model.KubernetesResourceList}
    * @return the shared index informer
@@ -172,7 +172,7 @@ public class SharedInformerFactory extends BaseOperation {
    * Constructs and returns a shared index informer with resync period specified for custom resources.
    *
    * @param apiTypeClass apiType class
-   * @param resyncPeriodInMillis resync period in milliseconds
+   * @param resyncPeriodInMillis resync period in milliseconds. Use 0 to disable resyncs. 1000 is the minimum value.
    * @param <T> the type parameter (should extend {@link CustomResource} and implement {@link io.fabric8.kubernetes.api.model.Namespaced})
    * @return the shared index informer
    */
@@ -186,7 +186,7 @@ public class SharedInformerFactory extends BaseOperation {
    * POJO
    *
    * @param apiTypeClass apiType class
-   * @param resyncPeriodInMillis  resync period in milliseconds
+   * @param resyncPeriodInMillis  resync period in milliseconds. Use 0 to disable resyncs.
    * @param <T> the type parameter (should extend {@link io.fabric8.kubernetes.api.model.HasMetadata} and implement {@link io.fabric8.kubernetes.api.model.Namespaced})
    * @return the shared index informer
    */
@@ -202,7 +202,7 @@ public class SharedInformerFactory extends BaseOperation {
    *
    * @param apiTypeClass apiType class
    * @param apiListTypeClass api list type class
-   * @param resyncPeriodInMillis resync period in milliseconds
+   * @param resyncPeriodInMillis resync period in milliseconds. Use 0 to disable resyncs. 1000 is the minimum value.
    * @param <T> the type parameter (should extend {@link io.fabric8.kubernetes.api.model.HasMetadata} and implement {@link io.fabric8.kubernetes.api.model.Namespaced})
    * @param <L> the type's list parameter (should extend {@link io.fabric8.kubernetes.api.model.KubernetesResourceList}
    * @return the shared index informer

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorListener.java
@@ -19,9 +19,6 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-
 /**
  * ProcessorListener implements Runnable interface. It's supposed to run in background
  * and actually executes its event handler on notification. 
@@ -35,15 +32,10 @@ import java.time.temporal.ChronoUnit;
  */
 public class ProcessorListener<T> {
   private static final Logger log = LoggerFactory.getLogger(ProcessorListener.class);
-  private long resyncPeriodInMillis;
-  private ZonedDateTime nextResync;
   private ResourceEventHandler<T> handler;
   
-  public ProcessorListener(ResourceEventHandler<T> handler, long resyncPeriodInMillis) {
-    this.resyncPeriodInMillis = resyncPeriodInMillis;
+  public ProcessorListener(ResourceEventHandler<T> handler) {
     this.handler = handler;
-
-    determineNextResync(ZonedDateTime.now());
   }
 
   public void add(Notification<T> notification) {
@@ -52,14 +44,6 @@ public class ProcessorListener<T> {
     } catch (Exception ex) {
       log.error("Failed invoking {} event handler: {}", handler, ex.getMessage(), ex);
     }
-  }
-
-  public void determineNextResync(ZonedDateTime now) {
-    this.nextResync = now.plus(this.resyncPeriodInMillis, ChronoUnit.MILLIS);
-  }
-
-  public boolean shouldResync(ZonedDateTime now) {
-    return this.resyncPeriodInMillis != 0 && (now.isAfter(this.nextResync) || now.equals(this.nextResync));
   }
 
   public abstract static class Notification<T> {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStore.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.kubernetes.client.informers.cache;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +28,8 @@ import java.util.Map;
  * @param <T>
  */
 public class ProcessorStore<T> implements Store<T> {
+  
+  private static final Logger log = LoggerFactory.getLogger(ProcessorStore.class);
 
   private Store<T> actualStore;
   private SharedProcessor<T> processor;
@@ -106,6 +111,7 @@ public class ProcessorStore<T> implements Store<T> {
 
   @Override
   public void resync() {
+    log.debug("resync");
     this.actualStore.list()
         .forEach(i -> this.processor.distribute(new ProcessorListener.UpdateNotification<T>(i, i), true));
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ProcessorListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ProcessorListenerTest.java
@@ -48,7 +48,7 @@ class ProcessorListenerTest {
           assertEquals(pod, obj);
           deleteNotificationReceived = true;
         }
-      }, 0);
+      });
 
     listener.add(new ProcessorListener.AddNotification<>(pod));
     listener.add(new ProcessorListener.UpdateNotification<>(null, pod));

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/SharedProcessorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/SharedProcessorTest.java
@@ -36,9 +36,9 @@ class SharedProcessorTest {
     ExpectingNotificationHandler<Pod> expectUpdateHandler = new ExpectingNotificationHandler<>(updateNotification);
     ExpectingNotificationHandler<Pod> expectDeleteHandler = new ExpectingNotificationHandler<>(deleteNotification);
 
-    sharedProcessor.addListener(expectAddHandler);
-    sharedProcessor.addListener(expectUpdateHandler);
-    sharedProcessor.addListener(expectDeleteHandler);
+    sharedProcessor.addListener(expectAddHandler, false);
+    sharedProcessor.addListener(expectUpdateHandler, false);
+    sharedProcessor.addListener(expectDeleteHandler, false);
 
     sharedProcessor.distribute(addNotification, false);
     sharedProcessor.distribute(updateNotification, false);
@@ -60,12 +60,12 @@ class SharedProcessorTest {
 
         @Override
         public void onDelete(T obj, boolean deletedFinalStateUnknown) { }
-      }, 0);
+      });
       this.expectingNotification = notification;
     }
 
-    ExpectingNotificationHandler(ResourceEventHandler<T> handler, long resyncPeriod) {
-      super(handler, resyncPeriod);
+    ExpectingNotificationHandler(ResourceEventHandler<T> handler) {
+      super(handler);
     }
 
     private ProcessorListener.Notification<T> expectingNotification;


### PR DESCRIPTION
## Description
This treats the informer resync period as the only meaningful resync interval.  It is however a breaking change and does diverge from the go client.
 
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift