### PR TITLE
fix: Use File.toURI() to create the generated crd uri.

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
@@ -255,7 +255,7 @@ public class CRDGenerator {
 
     @Override
     public URI crdURI(String crdName) {
-      return URI.create("file://" + getCRDFile(crdName));
+      return getCRDFile(crdName).toURI();
     }
   }
 }


### PR DESCRIPTION
This is meant to fix the issue with the malformed URI on windows.

The fix has not been verified manually, but usually this short of issues are handled better when you delegate to java itself.
