### PR TITLE
Fix #3189: VersionInfo contains null data in OpenShift 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Retry only Non-Restful Create-only resources in OpenShiftOAuthInterceptor
 * Fix #3126: a KubernetesClientException will be thrown from patch/replace rather than a null being returned when the item does not exist
 * Fix #3121: ServiceOperationImpl replace will throw a KubernetesClientException rather than a NPE if the item doesn't exist
+* Fix #3189: VersionInfo contains null data in OpenShift 4.6
 
 #### Improvements
 * Fix #3149: replace(item) will consult the item's resourceVersion for the first PUT attempt when not specifically locked on a resourceVersion

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ClusterOperationsImpl.java
@@ -43,7 +43,10 @@ public class ClusterOperationsImpl extends OperationSupport {
 
   public VersionInfo fetchVersion() {
     try {
-      Response response = handleVersionGet(versionEndpoint);
+      Request request = getRequest(versionEndpoint);
+      Response response = handleVersionGet(request);
+      assertResponseCode(request, response);
+
       Map<String, String> myMap = new HashMap<>();
 
       if (response.body() != null) {
@@ -55,11 +58,15 @@ public class ClusterOperationsImpl extends OperationSupport {
     }
   }
 
-  protected Response handleVersionGet(String versionEndpointToBeUsed) throws IOException {
-    Request.Builder requestBuilder = new Request.Builder()
+  protected Response handleVersionGet(Request request) throws IOException {
+    return client.newCall(request).execute();
+  }
+
+  protected Request getRequest(String versionEndpointToBeUsed) {
+    return new Request.Builder()
       .get()
-      .url(URLUtils.join(config.getMasterUrl(), versionEndpointToBeUsed));
-    return client.newCall(requestBuilder.build()).execute();
+      .url(URLUtils.join(config.getMasterUrl(), versionEndpointToBeUsed))
+      .build();
   }
 
   protected static VersionInfo fetchVersionInfoFromResponse(Map<String, String> responseAsMap) throws ParseException {

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/VersionIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/VersionIT.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift;
+
+import io.fabric8.kubernetes.client.VersionInfo;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class VersionIT {
+  @ArquillianResource
+  OpenShiftClient client;
+
+  @Test
+  public void getVersionShouldReturnValidVersion() {
+    // Given + When
+    VersionInfo versionInfo = client.getVersion();
+
+    // Then
+    assertThat(versionInfo).isNotNull();
+    assertThat(versionInfo.getMajor()).isNotNull();
+    assertThat(versionInfo.getMinor()).isNotNull();
+    assertThat(versionInfo.getBuildDate()).isNotNull();
+  }
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftClusterOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftClusterOperationsImpl.java
@@ -53,7 +53,7 @@ public class OpenShiftClusterOperationsImpl extends ClusterOperationsImpl {
   }
 
   private VersionInfo fetchOpenshift4Version() throws IOException, ParseException {
-    Response response = handleVersionGet(OPENSHIFT4_VERSION_ENDPOINT);
+    Response response = handleVersionGet(getRequest(OPENSHIFT4_VERSION_ENDPOINT));
     if (response.isSuccessful() && response.body() != null) {
       ClusterVersionList clusterVersionList = Serialization.jsonMapper().readValue(response.body().string(), ClusterVersionList.class);
       if (!clusterVersionList.getItems().isEmpty()) {


### PR DESCRIPTION
## Description
Fix #3189 

assert response code after getting response from apiServer rather than
depending upon fragile null check.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
