### PR TITLE
fix #3078: adding more javadocs around operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #3190: Ignore fields with name "-" when using the Go to JSON schema generator
 
 #### Improvements
+* Fix #3078: adding javadocs to further clarify patch, edit, replace, etc. and note the possibility of items being modified.
 * Fix #3149: replace(item) will consult the item's resourceVersion for the first PUT attempt when not specifically locked on a resourceVersion
 * Fix #3135: added mock crud support for patch status, and will return exceptions for unsupported patch types
 * Fix #3072: various changes to refine how threads are handled by informers.  Note that the SharedInformer.run call is now blocking when starting the informer.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -20,8 +20,9 @@ public interface CreateOrReplaceable<T> {
   /**
    * Creates a provided resource in a Kubernetes Cluster. If creation
    * fails with a HTTP_CONFLICT, it tries to replace resource.
+   * <br>The resourceVersion and other fields of the item may be modified by this call.
    *
-   * @param item item to create or replace
+   * @param item to create or replace
    * @return created item returned in kubernetes api response
    */
   T createOrReplace(T... item);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Editable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Editable.java
@@ -18,15 +18,43 @@ package io.fabric8.kubernetes.client.dsl;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.builder.Visitor;
 
 public interface Editable<T> {
 
+    /**
+     * Issues a JSON patch against the item based upon the changes made to the object returned by the function.
+     * 
+     * <p>It is generally convenient to use a Builder constructed off of the item.
+     * 
+     * @param function to modify the item
+     * @return returns deserialized version of api server response
+     */
     T edit(UnaryOperator<T> function);
 
+    /**
+     * Issues a JSON patch against the item based upon the changes made to the object by the visitors.
+     * 
+     * @param visitors to modify the Builder
+     * @return returns deserialized version of api server response
+     */
     T edit(Visitor... visitors);
 
+    /**
+     * Issues a JSON patch against the item based upon the changes made to the object by the visitor.
+     * 
+     * @param visitorType to create a {@link TypedVisitor}
+     * @param visitor to modify the Builder
+     * @return returns deserialized version of api server response
+     */
     <V> T edit(Class<V> visitorType, Visitor<V> visitor);
 
+    /**
+     * Issues a JSON patch against the item based upon the changes made by the function provided as argument  
+     * 
+     * @param function to modify the item
+     * @return returns deserialized version of api server response
+     */
     T accept(Consumer<T> function);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -28,7 +28,7 @@ public interface Patchable<T> {
    * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected way.
    * Consider using edit instead.
    *
-   * @param item item to be patched with patched values
+   * @param item to be patched with patched values
    * @return returns deserialized version of api server response
    */
   default T patch(T item) {
@@ -41,14 +41,14 @@ public interface Patchable<T> {
    * <ul>
    * <li>{@link PatchType#JSON} - will create a JSON patch against the current item.
    * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected way.
-   * Consider using edit instead.
+   * Consider using edit instead.  The resourceVersion and other fields of the item may be modified by this call.
    * <li>{@link PatchType#JSON_MERGE} - will send the serialization of the item as a JSON MERGE patch.
    * Set the resourceVersion to null to prevent optimistic locking.
    * <li>{@link PatchType#STRATEGIC_MERGE} - will send the serialization of the item as a STRATEGIC MERGE patch.
    * Set the resourceVersion to null to prevent optimistic locking.
    * </ul>
    *
-   * @param item item to be patched with patched values
+   * @param item to be patched with patched values
    * @param patchContext {@link PatchContext} for patch request
    * @return returns deserialized version of api server response
    */

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
@@ -17,6 +17,19 @@ package io.fabric8.kubernetes.client.dsl;
 
 public interface Replaceable<T> {
 
+  /**
+   * Replace the server's state with the given item. The resourceVersion and other fields of the item may be modified by this call.
+   * 
+   * <p>If {@link Lockable#lockResourceVersion(String)} has been used to lock the resourceVersion, 
+   * this operation is effectively a single update attempt against that version.
+   * <p>If {@link Lockable#lockResourceVersion(String)} has not been called, this operation  
+   * will be retried a number of times in the event of a conflict.  If a resourceVersion has been set 
+   * on the item, the first update attempt will be made against that version.  Subsequent attempts will fetch
+   * the latest resourceVersion from the server.
+   *
+   * @param item with the replacement state
+   * @return returns deserialized version of api server response
+   */
   T replace(T item);
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusReplaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/StatusReplaceable.java
@@ -17,6 +17,11 @@ package io.fabric8.kubernetes.client.dsl;
 
 public interface StatusReplaceable<T> {
 
+  /**
+   * Similar to {@link Replaceable#replace(Object)}, but only affects the status subresource
+   * @param item with the status subresource
+   * @return returns deserialized version of api server response
+   */
   T replaceStatus(T item);
 
 }


### PR DESCRIPTION
## Description
Based upon the discussion on #3078 more javadocs seemed in order to help clarify usage and the possibility of items being modified.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
