### PR TITLE
Add missing resources in `security.openshift.io` apiGroup in OpenShiftClient DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add DSL support for missing resources in `template.openshift.io`, `helm.openshift.io`, `network.openshift.io`, `user.openshift.io` apigroups
 * Fix #3087: Support HTTP operation retry with exponential backoff (for status code >= 500)
 * Add DSL support for `autoscaling.openshift.io` resources in OpenShiftClient
+* Add DSL support for PodSecurityPolicySubjectReview, PodSecurityPolicyReview, PodSecurityPolicySelfSubjectReview in `security.openshift.io/v1` apiGroup to OpenShiftClient
 
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicyReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicyReviewTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.api.model.PodSecurityPolicyReview;
+import io.fabric8.openshift.api.model.PodSecurityPolicyReviewBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+import java.net.HttpURLConnection;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableOpenShiftMockClient
+class PodSecurityPolicyReviewTest {
+  private OpenShiftClient client;
+  private OpenShiftMockServer server;
+
+  @Test
+  void create() {
+    // Given
+    PodSecurityPolicyReview pspr = createPodSecurityPolicyReviewBuilder().build();
+    server.expect().post().withPath("/apis/security.openshift.io/v1/namespaces/ns1/podsecuritypolicyreviews")
+      .andReturn(HttpURLConnection.HTTP_CREATED, createPodSecurityPolicyReviewBuilder()
+        .withNewStatus()
+        .addNewAllowedServiceAccount()
+        .withName("test")
+        .endAllowedServiceAccount()
+        .endStatus().build())
+      .once();
+
+    // When
+    PodSecurityPolicyReview createdPspr = client.podSecurityPolicyReviews().inNamespace("ns1").create(pspr);
+
+    // Then
+    assertThat(createdPspr).isNotNull();
+    assertThat(createdPspr.getStatus().getAllowedServiceAccounts()).hasSize(1);
+    assertThat(createdPspr.getStatus().getAllowedServiceAccounts().get(0).getName()).isEqualTo("test");
+  }
+
+  private PodSecurityPolicyReviewBuilder createPodSecurityPolicyReviewBuilder() {
+    return new PodSecurityPolicyReviewBuilder()
+      .withNewSpec()
+      .withNewTemplate()
+      .withNewMetadata()
+      .addToAnnotations("foo", "bar")
+      .endMetadata()
+      .withNewSpec()
+      .addNewContainer()
+      .withImage("nginx:perl-stable")
+      .withName("test")
+      .endContainer()
+      .endSpec()
+      .endTemplate()
+      .endSpec();
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySelfSubjectReviewTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.api.model.PodSecurityPolicySelfSubjectReview;
+import io.fabric8.openshift.api.model.PodSecurityPolicySelfSubjectReviewBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableOpenShiftMockClient
+class PodSecurityPolicySelfSubjectReviewTest {
+  private OpenShiftClient client;
+  private OpenShiftMockServer server;
+
+  @Test
+  void create() {
+    // Given
+    PodSecurityPolicySelfSubjectReview pspr = createPodSecurityPolicySelfSubjectReviewBuilder().build();
+    server.expect().post().withPath("/apis/security.openshift.io/v1/namespaces/ns1/podsecuritypolicyselfsubjectreviews")
+      .andReturn(HttpURLConnection.HTTP_CREATED, createPodSecurityPolicySelfSubjectReviewBuilder()
+        .withNewStatus()
+        .withNewAllowedBy()
+        .withName("anyuid")
+        .withUid("xyz")
+        .withApiVersion("security.openshift.io/v1")
+        .withKind("SecurityContextConstraint")
+        .endAllowedBy()
+        .endStatus().build())
+      .once();
+
+    // When
+    PodSecurityPolicySelfSubjectReview createdPspr = client.podSecurityPolicySelfSubjectReviews().inNamespace("ns1").create(pspr);
+
+    // Then
+    assertThat(createdPspr).isNotNull();
+    assertThat(createdPspr.getStatus().getAllowedBy()).isNotNull();
+    assertThat(createdPspr.getStatus().getAllowedBy())
+      .hasFieldOrPropertyWithValue("name", "anyuid")
+      .hasFieldOrPropertyWithValue("uid", "xyz")
+      .hasFieldOrPropertyWithValue("kind", "SecurityContextConstraint")
+      .hasFieldOrPropertyWithValue("apiVersion", "security.openshift.io/v1");
+  }
+
+  private PodSecurityPolicySelfSubjectReviewBuilder createPodSecurityPolicySelfSubjectReviewBuilder() {
+    return new PodSecurityPolicySelfSubjectReviewBuilder()
+      .withNewSpec()
+      .withNewTemplate()
+      .withNewMetadata()
+      .addToAnnotations("foo", "bar")
+      .endMetadata()
+      .withNewSpec()
+      .addNewContainer()
+      .withImage("nginx:perl-stable")
+      .withName("test")
+      .endContainer()
+      .endSpec()
+      .endTemplate()
+      .endSpec();
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySubjectReviewTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.server.mock;
+
+import io.fabric8.openshift.api.model.PodSecurityPolicySubjectReview;
+import io.fabric8.openshift.api.model.PodSecurityPolicySubjectReviewBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableOpenShiftMockClient
+class PodSecurityPolicySubjectReviewTest {
+  private OpenShiftClient client;
+  private OpenShiftMockServer server;
+
+  @Test
+  void create() {
+    // Given
+    PodSecurityPolicySubjectReview pspr = createPodSecurityPolicySubjectReviewBuilder().build();
+    server.expect().post().withPath("/apis/security.openshift.io/v1/namespaces/ns1/podsecuritypolicysubjectreviews")
+      .andReturn(HttpURLConnection.HTTP_CREATED, createPodSecurityPolicySubjectReviewBuilder()
+        .withNewStatus()
+        .withNewAllowedBy()
+        .withName("anyuid")
+        .withUid("xyz")
+        .withApiVersion("security.openshift.io/v1")
+        .withKind("SecurityContextConstraint")
+        .endAllowedBy()
+        .endStatus().build())
+      .once();
+
+    // When
+    PodSecurityPolicySubjectReview createdPspr = client.podSecurityPolicySubjectReviews().inNamespace("ns1").create(pspr);
+
+    // Then
+    assertThat(createdPspr).isNotNull();
+    assertThat(createdPspr.getStatus().getAllowedBy()).isNotNull();
+    assertThat(createdPspr.getStatus().getAllowedBy())
+      .hasFieldOrPropertyWithValue("name", "anyuid")
+      .hasFieldOrPropertyWithValue("uid", "xyz")
+      .hasFieldOrPropertyWithValue("kind", "SecurityContextConstraint")
+      .hasFieldOrPropertyWithValue("apiVersion", "security.openshift.io/v1");
+  }
+
+  private PodSecurityPolicySubjectReviewBuilder createPodSecurityPolicySubjectReviewBuilder() {
+    return new PodSecurityPolicySubjectReviewBuilder()
+      .withNewSpec()
+      .withNewTemplate()
+      .withNewMetadata()
+      .addToAnnotations("foo", "bar")
+      .endMetadata()
+      .withNewSpec()
+      .addNewContainer()
+      .withImage("nginx:perl-stable")
+      .withName("test")
+      .endContainer()
+      .endSpec()
+      .endTemplate()
+      .endSpec();
+  }
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -53,7 +53,6 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.authentication.TokenReview;
-import io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReview;
 import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
 import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestList;
 import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
@@ -165,6 +164,9 @@ import io.fabric8.openshift.api.model.OAuthAuthorizeToken;
 import io.fabric8.openshift.api.model.OAuthAuthorizeTokenList;
 import io.fabric8.openshift.api.model.OAuthClient;
 import io.fabric8.openshift.api.model.OAuthClientList;
+import io.fabric8.openshift.api.model.PodSecurityPolicyReview;
+import io.fabric8.openshift.api.model.PodSecurityPolicySelfSubjectReview;
+import io.fabric8.openshift.api.model.PodSecurityPolicySubjectReview;
 import io.fabric8.openshift.api.model.RangeAllocation;
 import io.fabric8.openshift.api.model.RangeAllocationList;
 import io.fabric8.openshift.api.model.ResourceAccessReview;
@@ -227,7 +229,7 @@ import io.fabric8.openshift.client.dsl.internal.network.NetNamespaceOperationsIm
 import io.fabric8.openshift.client.dsl.internal.oauth.OAuthAccessTokenOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.oauth.OAuthAuthorizeTokenOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.oauth.OAuthClientOperationsImpl;
-import io.fabric8.openshift.client.dsl.internal.OpenShiftSubjectAccessReviewOperationsImpl;
+import io.fabric8.openshift.client.dsl.internal.OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.project.ProjectOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.ProjectRequestsOperationImpl;
 import io.fabric8.openshift.client.dsl.internal.security.RangeAllocationOperationsImpl;
@@ -263,6 +265,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   private static final Map<String, Boolean> API_GROUPS_ENABLED_PER_URL = new HashMap<>();
   public static final String AUTHORIZATION_OPENSHIFT_IO = "authorization.openshift.io";
   public static final String V1_APIVERSION = "v1";
+  private static final String SECURITY_OPENSHIFT_APIGROUP = "security.openshift.io";
 
   private final URL openShiftUrl;
   private final NamespacedKubernetesClient delegate;
@@ -610,6 +613,21 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
+  public OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicyReview, PodSecurityPolicyReview> podSecurityPolicyReviews() {
+    return new OpenShiftCreateOnlyResourceOperationsImpl<>(getHttpClient(), getConfiguration(), SECURITY_OPENSHIFT_APIGROUP, V1_APIVERSION, HasMetadata.getPlural(PodSecurityPolicyReview.class), PodSecurityPolicyReview.class);
+  }
+
+  @Override
+  public OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicySelfSubjectReview, PodSecurityPolicySelfSubjectReview> podSecurityPolicySelfSubjectReviews() {
+    return new OpenShiftCreateOnlyResourceOperationsImpl<>(getHttpClient(), getConfiguration(), SECURITY_OPENSHIFT_APIGROUP, V1_APIVERSION, HasMetadata.getPlural(PodSecurityPolicySelfSubjectReview.class), PodSecurityPolicySelfSubjectReview.class);
+  }
+
+  @Override
+  public OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicySubjectReview, PodSecurityPolicySubjectReview> podSecurityPolicySubjectReviews() {
+    return new OpenShiftCreateOnlyResourceOperationsImpl<>(getHttpClient(), getConfiguration(), SECURITY_OPENSHIFT_APIGROUP, V1_APIVERSION, HasMetadata.getPlural(PodSecurityPolicySubjectReview.class), PodSecurityPolicySubjectReview.class);
+  }
+
+  @Override
   public ProjectOperation projects() {
     return new ProjectOperationsImpl(httpClient, OpenShiftConfig.wrap(getConfiguration()));
   }
@@ -776,32 +794,32 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
 
   @Override
   public InOutCreateable<SubjectAccessReview, SubjectAccessReviewResponse> subjectAccessReviews() {
-    return new OpenShiftSubjectAccessReviewOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(SubjectAccessReview.class), SubjectAccessReviewResponse.class);
+    return new OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(SubjectAccessReview.class), SubjectAccessReviewResponse.class);
   }
 
   @Override
   public InOutCreateable<ResourceAccessReview, ResourceAccessReviewResponse> resourceAccessReviews() {
-    return new OpenShiftSubjectAccessReviewOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(ResourceAccessReview.class), ResourceAccessReviewResponse.class);
+    return new OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(ResourceAccessReview.class), ResourceAccessReviewResponse.class);
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<LocalSubjectAccessReview, SubjectAccessReviewResponse> localSubjectAccessReviews() {
-    return new OpenShiftLocalSubjectAccessReviewOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(LocalSubjectAccessReview.class), SubjectAccessReviewResponse.class);
+  public OpenShiftCreateOnlyResourceOperationsImpl<LocalSubjectAccessReview, SubjectAccessReviewResponse> localSubjectAccessReviews() {
+    return new OpenShiftCreateOnlyResourceOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(LocalSubjectAccessReview.class), SubjectAccessReviewResponse.class);
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<LocalResourceAccessReview, ResourceAccessReviewResponse> localResourceAccessReviews() {
-    return new OpenShiftLocalSubjectAccessReviewOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(LocalResourceAccessReview.class), ResourceAccessReviewResponse.class);
+  public OpenShiftCreateOnlyResourceOperationsImpl<LocalResourceAccessReview, ResourceAccessReviewResponse> localResourceAccessReviews() {
+    return new OpenShiftCreateOnlyResourceOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(LocalResourceAccessReview.class), ResourceAccessReviewResponse.class);
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<SelfSubjectRulesReview, SelfSubjectRulesReview> selfSubjectRulesReviews() {
-    return new OpenShiftLocalSubjectAccessReviewOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(SelfSubjectRulesReview.class), SelfSubjectRulesReview.class);
+  public OpenShiftCreateOnlyResourceOperationsImpl<SelfSubjectRulesReview, SelfSubjectRulesReview> selfSubjectRulesReviews() {
+    return new OpenShiftCreateOnlyResourceOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(SelfSubjectRulesReview.class), SelfSubjectRulesReview.class);
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<SubjectRulesReview, SubjectRulesReview> subjectRulesReviews() {
-    return new OpenShiftLocalSubjectAccessReviewOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(SubjectRulesReview.class), SubjectRulesReview.class);
+  public OpenShiftCreateOnlyResourceOperationsImpl<SubjectRulesReview, SubjectRulesReview> subjectRulesReviews() {
+    return new OpenShiftCreateOnlyResourceOperationsImpl<>(httpClient, getConfiguration(), AUTHORIZATION_OPENSHIFT_IO, V1_APIVERSION, HasMetadata.getPlural(SubjectRulesReview.class), SubjectRulesReview.class);
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
@@ -244,6 +244,27 @@ public interface OpenShiftClient extends KubernetesClient {
   NonNamespaceOperation<OAuthClient, OAuthClientList, Resource<OAuthClient>> oAuthClients();
 
   /**
+   * API entrypoint for accessing PodSecurityPolicyReview (security.openshift.io/v1)
+   *
+   * @return InOutCreateable object for PodSecurityPolicyReview
+   */
+  OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicyReview, PodSecurityPolicyReview> podSecurityPolicyReviews();
+
+  /**
+   * API entrypoint for accessing PodSecurityPolicySelfSubjectReview (security.openshift.io/v1)
+   *
+   * @return InOutCreateable object for PodSecurityPolicySelfSubjectReview
+   */
+  OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicySelfSubjectReview, PodSecurityPolicySelfSubjectReview> podSecurityPolicySelfSubjectReviews();
+
+  /**
+   * API entrypoint for accessing PodSecurityPolicySubjectReview (security.openshift.io/v1)
+   *
+   * @return InOutCreateable object for PodSecurityPolicySubjectReview
+   */
+  OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicySubjectReview, PodSecurityPolicySubjectReview> podSecurityPolicySubjectReviews();
+
+  /**
    * API entrypoint for accessing Project operations(project.openshift.io/v1)
    *
    * @return {@link ProjectOperation} for Project specific operations
@@ -348,33 +369,33 @@ public interface OpenShiftClient extends KubernetesClient {
    * API entrypoint for LocalSubjectAccessReview (authorization.openshift.io/v1)
    * This only supports create operation. SubjectAccessReviewResponse from server is returned as output
    *
-   * @return {@link OpenShiftLocalSubjectAccessReviewOperationsImpl} for LocalSubjectAccessReview
+   * @return {@link OpenShiftCreateOnlyResourceOperationsImpl} for LocalSubjectAccessReview
    */
-  OpenShiftLocalSubjectAccessReviewOperationsImpl<LocalSubjectAccessReview, SubjectAccessReviewResponse> localSubjectAccessReviews();
+  OpenShiftCreateOnlyResourceOperationsImpl<LocalSubjectAccessReview, SubjectAccessReviewResponse> localSubjectAccessReviews();
 
   /**
    * API entrypoint for LocalResourceAccessReview (authorization.openshift.io/v1)
    * This only supports create operation. ResourceAccessReviewResponse from server is returned as output
    *
-   * @return {@link OpenShiftLocalSubjectAccessReviewOperationsImpl} for LocalResourceAccessReview
+   * @return {@link OpenShiftCreateOnlyResourceOperationsImpl} for LocalResourceAccessReview
    */
-  OpenShiftLocalSubjectAccessReviewOperationsImpl<LocalResourceAccessReview, ResourceAccessReviewResponse> localResourceAccessReviews();
+  OpenShiftCreateOnlyResourceOperationsImpl<LocalResourceAccessReview, ResourceAccessReviewResponse> localResourceAccessReviews();
 
   /**
    * API entrypoint for SelfSubjectRulesReview (authorization.openshift.io/v1)
    * This only supports create operation. SelfSubjectRulesReview from server is returned as output
    *
-   * @return {@link OpenShiftLocalSubjectAccessReviewOperationsImpl} for SelfSubjectRulesReview
+   * @return {@link OpenShiftCreateOnlyResourceOperationsImpl} for SelfSubjectRulesReview
    */
-  OpenShiftLocalSubjectAccessReviewOperationsImpl<SelfSubjectRulesReview, SelfSubjectRulesReview> selfSubjectRulesReviews();
+  OpenShiftCreateOnlyResourceOperationsImpl<SelfSubjectRulesReview, SelfSubjectRulesReview> selfSubjectRulesReviews();
 
   /**
    * API entrypoint for SubjectRulesReview (authorization.openshift.io/v1)
    * This only supports create operation. SubjectRulesReview from server is returned as output
    *
-   * @return {@link OpenShiftLocalSubjectAccessReviewOperationsImpl} for SubjectRulesReview
+   * @return {@link OpenShiftCreateOnlyResourceOperationsImpl} for SubjectRulesReview
    */
-  OpenShiftLocalSubjectAccessReviewOperationsImpl<SubjectRulesReview, SubjectRulesReview> subjectRulesReviews();
+  OpenShiftCreateOnlyResourceOperationsImpl<SubjectRulesReview, SubjectRulesReview> subjectRulesReviews();
 
   /**
    * API entrypoint for ClusterRole (authorization.openshift.io/v1)

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl.java
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.openshift.client;
+package io.fabric8.openshift.client.dsl.internal;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.InOutCreateable;
-import io.fabric8.kubernetes.client.dsl.Namespaceable;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import okhttp3.OkHttpClient;
@@ -26,37 +25,33 @@ import okhttp3.OkHttpClient;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-public class OpenShiftLocalSubjectAccessReviewOperationsImpl<I, O> extends OperationSupport implements InOutCreateable<I, O>, Namespaceable<OpenShiftLocalSubjectAccessReviewOperationsImpl<I, O>> {
-  private final String subjectAccessApiGroupName;
-  private final String subjectAccessApiGroupVersion;
-  private final String plural;
-  private final Class<O> responseClass;
 
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl(OkHttpClient client, Config config, String apiGroupName, String apiGroupVersion, String plural, Class<O> responseClass) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config), apiGroupName, apiGroupVersion, plural, responseClass);
+public class OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl<I, O> extends OperationSupport implements InOutCreateable<I, O> {
+  private final Class<O> responseType;
+
+  public OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl(OkHttpClient client, Config config, String apiGroupName, String apiGroupVersion, String plural, Class<O> responseType) {
+    this(new OperationContext().withOkhttpClient(client).withConfig(config), apiGroupName, apiGroupVersion, plural, responseType);
   }
 
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl(OperationContext context, String apiGroupName, String apiGroupVersion, String plural, Class<O> responseClass) {
+  public OpenShiftCreateOnlyResourceNonNamespaceOperationsImpl(OperationContext context, String apiGroupName, String apiGroupVersion, String plural, Class<O> responseType) {
     super(context.withApiGroupName(apiGroupName)
       .withApiGroupVersion(apiGroupVersion)
       .withPlural(plural));
-    this.subjectAccessApiGroupName = apiGroupName;
-    this.subjectAccessApiGroupVersion = apiGroupVersion;
-    this.plural = plural;
-    this.responseClass = responseClass;
+    this.responseType = responseType;
   }
 
+  @SafeVarargs
   @Override
-  public O create(I... resources) {
+  public final O create(I... resources) {
     try {
       if (resources.length > 1) {
         throw new IllegalArgumentException("Too many items to create.");
       } else if (resources.length == 1) {
-        return handleCreate(resources[0], responseClass);
+        return handleCreate(resources[0], responseType);
       } else if (getItem() == null) {
         throw new IllegalArgumentException("Nothing to create.");
       } else {
-        return handleCreate(getItem(), responseClass);
+        return handleCreate(getItem(), responseType);
       }
     } catch (ExecutionException | IOException e) {
       throw KubernetesClientException.launderThrowable(e);
@@ -69,7 +64,7 @@ public class OpenShiftLocalSubjectAccessReviewOperationsImpl<I, O> extends Opera
   @Override
   public O create(I item) {
     try {
-      return handleCreate(item, responseClass);
+      return handleCreate(item, responseType);
     } catch (ExecutionException | IOException e) {
       throw KubernetesClientException.launderThrowable(e);
     } catch (InterruptedException ie) {
@@ -79,13 +74,11 @@ public class OpenShiftLocalSubjectAccessReviewOperationsImpl<I, O> extends Opera
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<I, O> inNamespace(String namespace) {
-    this.namespace = namespace;
-    return new OpenShiftLocalSubjectAccessReviewOperationsImpl<>(context.withNamespace(namespace), subjectAccessApiGroupName, subjectAccessApiGroupVersion, this.plural, responseClass);
+  public boolean isResourceNamespaced() {
+    return false;
   }
 
   public I getItem() {
     return (I) context.getItem();
   }
 }
-

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -141,6 +141,9 @@ import io.fabric8.openshift.api.model.OAuthAuthorizeToken;
 import io.fabric8.openshift.api.model.OAuthAuthorizeTokenList;
 import io.fabric8.openshift.api.model.OAuthClient;
 import io.fabric8.openshift.api.model.OAuthClientList;
+import io.fabric8.openshift.api.model.PodSecurityPolicyReview;
+import io.fabric8.openshift.api.model.PodSecurityPolicySelfSubjectReview;
+import io.fabric8.openshift.api.model.PodSecurityPolicySubjectReview;
 import io.fabric8.openshift.api.model.RangeAllocation;
 import io.fabric8.openshift.api.model.RangeAllocationList;
 import io.fabric8.openshift.api.model.ResourceAccessReview;
@@ -170,7 +173,7 @@ import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
-import io.fabric8.openshift.client.OpenShiftLocalSubjectAccessReviewOperationsImpl;
+import io.fabric8.openshift.client.OpenShiftCreateOnlyResourceOperationsImpl;
 import io.fabric8.openshift.client.dsl.BuildConfigResource;
 import io.fabric8.openshift.client.dsl.BuildResource;
 import io.fabric8.openshift.client.dsl.DeployableScalableResource;
@@ -413,6 +416,21 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   @Override
   public NonNamespaceOperation<OAuthClient, OAuthClientList, Resource<OAuthClient>> oAuthClients() {
     return delegate.oAuthClients();
+  }
+
+  @Override
+  public OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicyReview, PodSecurityPolicyReview> podSecurityPolicyReviews() {
+    return delegate.podSecurityPolicyReviews();
+  }
+
+  @Override
+  public OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicySelfSubjectReview, PodSecurityPolicySelfSubjectReview> podSecurityPolicySelfSubjectReviews() {
+    return delegate.podSecurityPolicySelfSubjectReviews();
+  }
+
+  @Override
+  public OpenShiftCreateOnlyResourceOperationsImpl<PodSecurityPolicySubjectReview, PodSecurityPolicySubjectReview> podSecurityPolicySubjectReviews() {
+    return delegate.podSecurityPolicySubjectReviews();
   }
 
   @Override
@@ -797,22 +815,22 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<LocalSubjectAccessReview, SubjectAccessReviewResponse> localSubjectAccessReviews() {
+  public OpenShiftCreateOnlyResourceOperationsImpl<LocalSubjectAccessReview, SubjectAccessReviewResponse> localSubjectAccessReviews() {
     return delegate.localSubjectAccessReviews();
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<LocalResourceAccessReview, ResourceAccessReviewResponse> localResourceAccessReviews() {
+  public OpenShiftCreateOnlyResourceOperationsImpl<LocalResourceAccessReview, ResourceAccessReviewResponse> localResourceAccessReviews() {
     return delegate.localResourceAccessReviews();
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<SelfSubjectRulesReview, SelfSubjectRulesReview> selfSubjectRulesReviews() {
+  public OpenShiftCreateOnlyResourceOperationsImpl<SelfSubjectRulesReview, SelfSubjectRulesReview> selfSubjectRulesReviews() {
     return delegate.selfSubjectRulesReviews();
   }
 
   @Override
-  public OpenShiftLocalSubjectAccessReviewOperationsImpl<SubjectRulesReview, SubjectRulesReview> subjectRulesReviews() {
+  public OpenShiftCreateOnlyResourceOperationsImpl<SubjectRulesReview, SubjectRulesReview> subjectRulesReviews() {
     return delegate.subjectRulesReviews();
   }
 


### PR DESCRIPTION
## Description
+ Add DSL support for the following resources in  `security.openshift.io/v1` apiGroup:
  - PodSecurityPolicyReview `openShiftClient.podSecurityPolicyReviews()`
  - PodSecurityPolicySelfSubjectReview `openShiftClient.podSecurityPolicySelfSubjectReviews()`
  - PodSecurityPolicySubjectReview `openShiftClient.podSecurityPolicySubjectReviews()`

Related to #2949

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
