### PR TITLE
Upgrade Jackson to 2.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
-    <jackson.version>2.11.2</jackson.version>
+    <jackson.version>2.12.3</jackson.version>
     <mockwebserver.version>0.1.8</mockwebserver.version>
 
     <!-- API versions -->


### PR DESCRIPTION
This PR upgrade Jackson to 2.12.3 to fix compatibility issue. For example:
https://github.com/apache/spark/pull/32688#issuecomment-854269717