### PR TITLE
Fix #2937: Add `SharedInformerFactory#getExistingSharedIndexInformers()` to return list of registered informers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix #3185: Introduce GenericKubernetesResource, used as delegate in RawCustomResourceOperationsImpl
 * Fix #3001: WatchConnectionManager logs that provide little information are now logged at a lower level
 * Fix #3186: WebSockets and HTTP connections are closed as soon as possible for Watches.
+* Fix #2937: Add `SharedInformerFactory#getExistingSharedIndexInformers` method to return list of registered informers
 
 #### Dependency Upgrade
 * Fix #2741: Update Knative Model to v0.23.0

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
@@ -39,8 +39,11 @@ import io.fabric8.kubernetes.client.utils.ApiVersionUtil;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -60,6 +63,7 @@ import org.slf4j.LoggerFactory;
 public class SharedInformerFactory extends BaseOperation {
   private static final Logger log = LoggerFactory.getLogger(SharedInformerFactory.class);
   private final Map<String, SharedIndexInformer> informers = new HashMap<>();
+  private final List<Map.Entry<OperationContext, SharedIndexInformer>> existingSharedIndexInformers = new ArrayList<>();
 
   private final Map<String, Future> startedInformers = new HashMap<>();
 
@@ -270,6 +274,7 @@ public class SharedInformerFactory extends BaseOperation {
       }
     }
     SharedIndexInformer<T> informer = new DefaultSharedIndexInformer<>(apiTypeClass, listerWatcher, resyncPeriodInMillis, context, informerExecutor);
+    this.existingSharedIndexInformers.add(new AbstractMap.SimpleEntry<>(context, informer));
     this.informers.put(getInformerKey(context), informer);
     return informer;
   }
@@ -310,6 +315,16 @@ public class SharedInformerFactory extends BaseOperation {
       }
     }
     return foundSharedIndexInformer;
+  }
+
+  /**
+   * Gets a list of entries of ({@link OperationContext}, {@link SharedIndexInformer}) registered
+   * by the user.
+   *
+   * @return a list of entries of {@link OperationContext} and {@link SharedIndexInformer}
+   */
+  public List<Map.Entry<OperationContext, SharedIndexInformer>> getExistingSharedIndexInformers() {
+    return this.existingSharedIndexInformers;
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.informers;
 
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
@@ -106,12 +107,11 @@ class SharedInformerFactoryTest {
       .build();
 
     // When
-    sharedInformerFactory.inNamespace("ns1").sharedIndexInformerForCustomResource(context, 10 * 1000L);
+    SharedIndexInformer<GenericKubernetesResource> informer = sharedInformerFactory.inNamespace("ns1").sharedIndexInformerForCustomResource(context, 10 * 1000L);
 
     // Then
-    assertThat(sharedInformerFactory.getInformers())
-      .hasSize(1)
-      .containsKey("demos.fabric8.io/v1/dummies/ns1");
+    assertThat(informer).isNotNull();
+    assertThat(sharedInformerFactory.getExistingSharedIndexInformers()).hasSize(1);
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import static io.fabric8.kubernetes.client.informers.SharedInformerFactory.getInformerKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,29 +71,6 @@ class SharedInformerFactoryTest {
   }
 
   @Test
-  void testGetInformerKey() {
-    assertThat(getInformerKey(new OperationContext()
-      .withApiGroupVersion("v1")
-      .withPlural("pods"))).isEqualTo("v1/pods");
-    assertThat(getInformerKey(new OperationContext()
-      .withApiGroupVersion("v1")
-      .withNamespace("ns1")
-      .withPlural("pods"))).isEqualTo("v1/pods/ns1");
-    assertThat(getInformerKey(new OperationContext()
-      .withApiGroupVersion("v1")
-      .withApiGroupName("io.fabric8")
-      .withPlural("testcustomresources"))).isEqualTo("io.fabric8/v1/testcustomresources");
-    assertThat(getInformerKey(new OperationContext()
-      .withApiGroupVersion("v1beta1")
-      .withApiGroupName("io.fabric8")
-      .withPlural("testcustomresources"))).isEqualTo("io.fabric8/v1beta1/testcustomresources");
-    assertThat(getInformerKey(new OperationContext()
-      .withApiGroupVersion("v1beta1")
-      .withApiGroupName("extensions")
-      .withPlural("deployments"))).isEqualTo("extensions/v1beta1/deployments");
-  }
-
-  @Test
   void testInformersCreatedWithSameNameButDifferentCRDContext() {
     // Given
     SharedInformerFactory sharedInformerFactory = new SharedInformerFactory(executorService, mockClient, config);
@@ -108,7 +84,7 @@ class SharedInformerFactoryTest {
       .withPlural("testcustomresources"), RESYNC_PERIOD);
 
     // Then
-    assertThat(sharedInformerFactory.getInformers())
+    assertThat(sharedInformerFactory.getExistingSharedIndexInformers())
       .hasSize(2);
   }
 
@@ -189,8 +165,6 @@ class SharedInformerFactoryTest {
 
     // When
     List<Map.Entry<OperationContext, SharedIndexInformer>> existingInformers = sharedInformerFactory.getExistingSharedIndexInformers();
-
-    SharedIndexInformer<MyAppCustomResource> in1 = existingInformers.get(0).getValue();
 
     // Then
     assertThat(existingInformers)


### PR DESCRIPTION
## Description
Fix #2937
Fix #3235

+ Add a new method `getExistingSharedIndexInformers()` to
  SharedInformerFactory which would return a list of entries containing
  registered SharedIndexInformer and their respective OperationContext.

  This is added to overcome limitation of old `getExistingSharedIndexInformer(Class<T> apiTypeClass)`
  in case there are two informers registered with same type. Based on @hibnico 's suggestion https://github.com/fabric8io/kubernetes-client/issues/2937#issuecomment-815836081
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
