### PR TITLE
Fix #3228: Add support for Dynamic informers for custom resources in KubernetesClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Add DSL support for `user.openshift.io/v1` Identity in OpenShiftClient DSL
 * Add DSL support for OpenShift Whereabouts CNI Model `whereabouts.cni.cncf.io` to OpenShiftClient DSL
 * Add DSL support for OpenShift Kube Storage Version Migrator resources in OpenShiftClient DSL
+* Fix #3228: Add support for Dynamic informers for custom resources in KubernetesClient
 
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/SharedInformerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/SharedInformerOperationsImpl.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+
+public class SharedInformerOperationsImpl<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>> extends HasMetadataOperation<T, L, R> {
+  private final boolean resourceNamespaced;
+
+  public SharedInformerOperationsImpl(OperationContext context, boolean resourceNamespaced) {
+    super(context);
+    this.resourceNamespaced = resourceNamespaced;
+  }
+
+  @Override
+  public boolean isResourceNamespaced() {
+    return resourceNamespaced;
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
@@ -22,6 +22,8 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefin
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.KubernetesVersionPriority;
+import io.fabric8.kubernetes.model.Scope;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Optional;
@@ -60,6 +62,13 @@ public class CustomResourceDefinitionContext {
   
   public boolean isStatusSubresource() {
     return statusSubresource;
+  }
+
+  public boolean isNamespaceScoped() {
+    if (scope != null) {
+      return Scope.NAMESPACED.value().equals(scope);
+    }
+    return false;
   }
 
   @SuppressWarnings("rawtypes")

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
@@ -17,20 +17,28 @@ package io.fabric8.kubernetes.client.informers;
 
 import static io.fabric8.kubernetes.client.utils.KubernetesResourceUtil.inferListType;
 
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.ResourceHandler;
+import io.fabric8.kubernetes.client.SharedInformerOperationsImpl;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.informers.impl.DefaultSharedIndexInformer;
+import io.fabric8.kubernetes.client.utils.ApiVersionUtil;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,8 +65,6 @@ public class SharedInformerFactory extends BaseOperation {
 
   private final ExecutorService informerExecutor;
 
-  private final BaseOperation baseOperation;
-
   private final ConcurrentLinkedQueue<SharedInformerEventListener> eventListeners = new ConcurrentLinkedQueue<>();
 
   private boolean allowShutdown = true;
@@ -82,7 +88,6 @@ public class SharedInformerFactory extends BaseOperation {
     super(new OperationContext().withOkhttpClient(okHttpClient).withConfig(configuration));
     initOperationContext(configuration);
     this.informerExecutor = threadPool;
-    this.baseOperation = this.newInstance(context);
     this.namespace = null;
   }
 
@@ -122,7 +127,7 @@ public class SharedInformerFactory extends BaseOperation {
    * @return the shared index informer
    */
   public synchronized <T extends HasMetadata> SharedIndexInformer<T> sharedIndexInformerFor(Class<T> apiTypeClass, long resyncPeriodInMillis) {
-    return sharedIndexInformerFor(apiTypeClass, inferListType(apiTypeClass), null, resyncPeriodInMillis);
+    return sharedIndexInformerFor(apiTypeClass, inferListType(apiTypeClass), null, resyncPeriodInMillis, Utils.isResourceNamespaced(apiTypeClass));
   }
 
   /**
@@ -137,7 +142,7 @@ public class SharedInformerFactory extends BaseOperation {
    * @return the shared index informer
    */
   public synchronized <T extends HasMetadata> SharedIndexInformer<T> sharedIndexInformerFor(Class<T> apiTypeClass, OperationContext operationContext, long resyncPeriodInMillis) {
-    return sharedIndexInformerFor(apiTypeClass, inferListType(apiTypeClass), operationContext, resyncPeriodInMillis);
+    return sharedIndexInformerFor(apiTypeClass, inferListType(apiTypeClass), operationContext, resyncPeriodInMillis, Utils.isResourceNamespaced(apiTypeClass));
   }
 
   /**
@@ -165,7 +170,28 @@ public class SharedInformerFactory extends BaseOperation {
       .withApiGroupName(customResourceContext.getGroup())
       .withApiGroupVersion(customResourceContext.getVersion())
       .withPlural(customResourceContext.getPlural())
-      .withIsNamespaceConfiguredFromGlobalConfig(context.isNamespaceFromGlobalConfig()), resyncPeriodInMillis);
+      .withIsNamespaceConfiguredFromGlobalConfig(context.isNamespaceFromGlobalConfig()), resyncPeriodInMillis, Utils.isResourceNamespaced(apiTypeClass));
+  }
+
+  /**
+   * Constructs and returns a shared index informer with resync period specified for a Custom Resource. You
+   * can use it for scenarios where you don't have a POJO for your custom type by specifying group, version and plural in
+   * {@link CustomResourceDefinitionContext}
+   *
+   * <b>Note:</b>It watches for events in <b>ALL NAMESPACES</b>.
+   *
+   * @param genericResourceContext object containing details about resource like apiGroup, version and plural, etc.
+   * @param resyncPeriodInMillis resync period in milliseconds.
+   * @return {@link SharedIndexInformer} for GenericKubernetesResource
+   */
+  public synchronized SharedIndexInformer<GenericKubernetesResource> sharedIndexInformerForCustomResource(CustomResourceDefinitionContext genericResourceContext, long resyncPeriodInMillis) {
+    validateCustomResourceProvided(genericResourceContext);
+    return sharedIndexInformerFor(GenericKubernetesResource.class, GenericKubernetesResourceList.class, new OperationContext()
+      .withApiGroupName(genericResourceContext.getGroup())
+      .withApiGroupVersion(genericResourceContext.getVersion())
+      .withPlural(genericResourceContext.getPlural())
+      .withNamespace(this.namespace)
+      .withIsNamespaceConfiguredFromGlobalConfig(context.isNamespaceFromGlobalConfig()), resyncPeriodInMillis, genericResourceContext.isNamespaceScoped());
   }
 
   /**
@@ -178,7 +204,7 @@ public class SharedInformerFactory extends BaseOperation {
    */
   public synchronized <T extends CustomResource<?,?>> SharedIndexInformer<T> sharedIndexInformerForCustomResource(
     Class<T> apiTypeClass, OperationContext operationContext, long resyncPeriodInMillis) {
-    return sharedIndexInformerFor(apiTypeClass, inferListType(apiTypeClass), operationContext, resyncPeriodInMillis);
+    return sharedIndexInformerFor(apiTypeClass, inferListType(apiTypeClass), operationContext, resyncPeriodInMillis, Utils.isResourceNamespaced(apiTypeClass));
   }
 
   /**
@@ -208,7 +234,7 @@ public class SharedInformerFactory extends BaseOperation {
    * @return the shared index informer
    */
   public synchronized <T extends CustomResource<?,?>, L extends KubernetesResourceList<T>> SharedIndexInformer<T> sharedIndexInformerForCustomResource(Class<T> apiTypeClass, Class<L> apiListTypeClass, long resyncPeriodInMillis) {
-    return sharedIndexInformerFor(apiTypeClass, apiListTypeClass, null, resyncPeriodInMillis);
+    return sharedIndexInformerFor(apiTypeClass, apiListTypeClass, null, resyncPeriodInMillis, Utils.isResourceNamespaced(apiTypeClass));
   }
 
   /**
@@ -224,8 +250,8 @@ public class SharedInformerFactory extends BaseOperation {
    * @param <L> the type's list parameter (should extend {@link io.fabric8.kubernetes.api.model.KubernetesResourceList}
    * @return the shared index informer
    */
-  private synchronized <T extends HasMetadata, L extends KubernetesResourceList<T>> SharedIndexInformer<T> sharedIndexInformerFor(Class<T> apiTypeClass, Class<L> apiListTypeClass, OperationContext operationContext, long resyncPeriodInMillis) {
-    ListerWatcher<T, L> listerWatcher = listerWatcherFor(apiTypeClass, apiListTypeClass);
+  private synchronized <T extends HasMetadata, L extends KubernetesResourceList<T>> SharedIndexInformer<T> sharedIndexInformerFor(Class<T> apiTypeClass, Class<L> apiListTypeClass, OperationContext operationContext, long resyncPeriodInMillis, boolean isResourceNamespaced) {
+    ListerWatcher<T, L> listerWatcher = listerWatcherFor(apiTypeClass, apiListTypeClass, isResourceNamespaced);
     OperationContext context = this.context.withApiGroupName(HasMetadata.getGroup(apiTypeClass))
       .withApiGroupVersion(HasMetadata.getVersion(apiTypeClass))
       .withPlural(HasMetadata.getPlural(apiTypeClass))
@@ -248,19 +274,19 @@ public class SharedInformerFactory extends BaseOperation {
     return informer;
   }
 
-  private <T extends HasMetadata, L extends KubernetesResourceList<T>> ListerWatcher<T, L> listerWatcherFor(Class<T> apiTypeClass, Class<L> apiListTypeClass) {
+  private <T extends HasMetadata, L extends KubernetesResourceList<T>> ListerWatcher<T, L> listerWatcherFor(Class<T> apiTypeClass, Class<L> apiListTypeClass, boolean isResourceNamespaced) {
 
     return new ListerWatcher<T, L>() {
       @Override
       public L list(ListOptions params, String namespace, OperationContext context) {
-        BaseOperation<T, L, ?> listBaseOperation = getConfiguredBaseOperation(namespace, context, apiTypeClass, apiListTypeClass);
+        BaseOperation<T, L, ?> listBaseOperation = getConfiguredBaseOperation(namespace, context, apiTypeClass, apiListTypeClass, isResourceNamespaced);
         registerKindToKubernetesDeserializer(apiTypeClass);
         return listBaseOperation.list();
       }
 
       @Override
       public Watch watch(ListOptions params, String namespace, OperationContext context, Watcher<T> resourceWatcher) {
-        BaseOperation<T, L, ?> watchBaseOperation = getConfiguredBaseOperation(namespace, context, apiTypeClass, apiListTypeClass);
+        BaseOperation<T, L, ?> watchBaseOperation = getConfiguredBaseOperation(namespace, context, apiTypeClass, apiListTypeClass, isResourceNamespaced);
         registerKindToKubernetesDeserializer(apiTypeClass);
         return watchBaseOperation.watch(params.getResourceVersion(), resourceWatcher);
       }
@@ -372,23 +398,23 @@ public class SharedInformerFactory extends BaseOperation {
     return key.contains(plural);
   }
 
-    private <T extends HasMetadata, L extends KubernetesResourceList<T>> BaseOperation<T, L, ?> getConfiguredBaseOperation(String namespace, OperationContext context, Class<T> apiTypeClass, Class<L> apiListTypeClass) {
-    BaseOperation<T, L, ?> baseOperationWithContext;
+  private <T extends HasMetadata, L extends KubernetesResourceList<T>> BaseOperation<T, L, ?> getConfiguredBaseOperation(String namespace, OperationContext context, Class<T> apiTypeClass, Class<L> apiListTypeClass, boolean isNamespacedScoped) {
+    SharedInformerOperationsImpl<T, L, Resource<T>> sharedInformerOperations;
     // Avoid adding Namespace if it's picked from Global Configuration
     if (context.isNamespaceFromGlobalConfig()) {
       // SharedInformer default behavior is to watch in all namespaces
       // unless we specify namespace explicitly in OperationContext
-      baseOperationWithContext = baseOperation.newInstance(context
+      sharedInformerOperations = new SharedInformerOperationsImpl<>(context
         .withConfig(new ConfigBuilder(config)
           .withNamespace(null)
           .build())
-        .withNamespace(null));
+        .withNamespace(null), isNamespacedScoped);
     } else {
-      baseOperationWithContext = baseOperation.newInstance(context.withNamespace(namespace));
+      sharedInformerOperations = new SharedInformerOperationsImpl<>(context.withNamespace(namespace), isNamespacedScoped);
     }
-    baseOperationWithContext.setType(apiTypeClass);
-    baseOperationWithContext.setListType(apiListTypeClass);
-    return baseOperationWithContext;
+    sharedInformerOperations.setType(apiTypeClass);
+    sharedInformerOperations.setListType(apiListTypeClass);
+    return sharedInformerOperations;
   }
 
   private void initOperationContext(Config configuration) {
@@ -400,6 +426,17 @@ public class SharedInformerFactory extends BaseOperation {
   private <T extends HasMetadata> void registerKindToKubernetesDeserializer(Class<T> apiTypeClass) {
     if (CustomResource.class.isAssignableFrom(apiTypeClass)) {
       KubernetesDeserializer.registerCustomKind(HasMetadata.getApiVersion(apiTypeClass), apiTypeClass.getSimpleName(), apiTypeClass);
+    }
+  }
+
+  private void validateCustomResourceProvided(CustomResourceDefinitionContext genericResourceContext) {
+    if (Utils.isNullOrEmpty(genericResourceContext.getKind())) {
+      throw new IllegalArgumentException("CustomResourceDefinitionContext.kind: required value.");
+    }
+    ResourceHandler<HasMetadata, ?> resourceHandler = Handlers.get(genericResourceContext.getKind(), ApiVersionUtil.joinApiGroupAndVersion(genericResourceContext.getGroup(), genericResourceContext.getVersion()));
+
+    if (resourceHandler != null) {
+      throw new IllegalArgumentException("Using sharedIndexInformerDynamicResource for core type. Please use sharedIndexInformerFor(Class<T>, long) instead.");
     }
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ApiVersionUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ApiVersionUtil.java
@@ -94,4 +94,18 @@ public class ApiVersionUtil {
     }
     return null;
   }
+
+  /**
+   * Join group and version strings to form apiVersion key in Kubernetes objects
+   *
+   * @param group ApiGroup for resource
+   * @param version ApiVersion for resource
+   * @return version if group is null or empty, joined string otherwise.
+   */
+  public static String joinApiGroupAndVersion(String group, String version) {
+    if (Utils.isNullOrEmpty(group)) {
+      return version;
+    }
+    return group + "/" + version;
+  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
@@ -138,4 +138,15 @@ class CustomResourceDefinitionContextTest {
       .hasFieldOrPropertyWithValue("plural", "foobars")
       .hasFieldOrPropertyWithValue("kind", "Foobar");
   }
+
+  @Test
+  void isNamespaceScoped() {
+    // Given
+    CustomResourceDefinitionContext crdc1 = new CustomResourceDefinitionContext.Builder().withScope("Namespaced").build();
+    CustomResourceDefinitionContext crdc2 = new CustomResourceDefinitionContext.Builder().withScope("Cluster").build();
+
+    // When + Then
+    assertThat(crdc1.isNamespaceScoped()).isTrue();
+    assertThat(crdc2.isNamespaceScoped()).isFalse();
+  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ApiVersionUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/ApiVersionUtilTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ApiVersionUtilTest {
+  @Test
+  void apiGroup() {
+    assertThat(ApiVersionUtil.apiGroup(new Deployment(), "apps/v1"))
+      .isEqualTo("apps");
+    assertThat(ApiVersionUtil.apiGroup(new DeploymentSpec(), "apps/v1"))
+      .isEqualTo("apps");
+    assertThat(ApiVersionUtil.apiGroup(new Pod(), "v1"))
+      .isNull();
+    assertThat(ApiVersionUtil.apiGroup(new DeploymentSpec(), ""))
+      .isNull();
+  }
+
+  @Test
+  void apiVersion() {
+    assertThat(ApiVersionUtil.apiVersion(new Deployment(), "apps/v1"))
+      .isEqualTo("v1");
+    assertThat(ApiVersionUtil.apiVersion(new DeploymentSpec(), "apps/v1"))
+      .isEqualTo("v1");
+    assertThat(ApiVersionUtil.apiVersion(new Pod(), "v1"))
+      .isEqualTo("v1");
+    assertThat(ApiVersionUtil.apiVersion(new DeploymentSpec(), ""))
+      .isNull();
+  }
+
+  @Test
+  void joinApiGroupAndVersion() {
+    assertThat(ApiVersionUtil.joinApiGroupAndVersion("", "v1"))
+      .isEqualTo("v1");
+    assertThat(ApiVersionUtil.joinApiGroupAndVersion("apps", "v1"))
+      .isEqualTo("apps/v1");
+  }
+
+  @Test
+  void trimVersion() {
+    assertThat(ApiVersionUtil.trimVersion("rbac.authorization.k8s.io/v1"))
+      .isEqualTo("v1");
+    assertThat(ApiVersionUtil.trimVersion("v1"))
+      .isEqualTo("v1");
+  }
+
+  @Test
+  void trimGroup() {
+    assertThat(ApiVersionUtil.trimGroup("rbac.authorization.k8s.io/v1"))
+      .isEqualTo("rbac.authorization.k8s.io");
+    assertThat(ApiVersionUtil.trimGroup("v1"))
+      .isEqualTo("v1");
+  }
+}

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceInformerExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceInformerExample.java
@@ -17,7 +17,6 @@ package io.fabric8.kubernetes.examples;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/DynamicSharedIndexInformerExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/DynamicSharedIndexInformerExample.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.examples;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * You would need to have Dummy CRD installed. See <code>test-crd.yaml</code> in resources/ folder.
+ *
+ * Run this sample using this command:
+ * <code>
+ *   mvn exec:java -Dexec.mainClass="io.fabric8.kubernetes.examples.DynamicSharedIndexInformerExample"
+ * </code>
+ *
+ */
+public class DynamicSharedIndexInformerExample {
+  private static final Logger logger = LoggerFactory.getLogger(DynamicSharedIndexInformerExample.class.getSimpleName());
+
+  public static void main(String[] args) {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      SharedInformerFactory informerFactory = client.informers();
+      CustomResourceDefinitionContext context = new CustomResourceDefinitionContext.Builder()
+        .withGroup("demo.fabric8.io")
+        .withVersion("v1")
+        .withPlural("dummies")
+        .withKind("Dummy")
+        .withScope("Namespaced")
+        .build();
+
+      SharedIndexInformer<GenericKubernetesResource> informer = informerFactory.sharedIndexInformerForCustomResource(context, 60 * 1000L);
+      informer.addEventHandler(new ResourceEventHandler<GenericKubernetesResource>() {
+        @Override
+        public void onAdd(GenericKubernetesResource genericKubernetesResource) {
+          logger.info("ADD {}/{}", genericKubernetesResource.getMetadata().getNamespace(), genericKubernetesResource.getMetadata().getName());
+        }
+
+        @Override
+        public void onUpdate(GenericKubernetesResource genericKubernetesResource, GenericKubernetesResource t1) {
+          logger.info("UPDATE {}/{}", genericKubernetesResource.getMetadata().getNamespace(), genericKubernetesResource.getMetadata().getName());
+        }
+
+        @Override
+        public void onDelete(GenericKubernetesResource genericKubernetesResource, boolean b) {
+          logger.info("DELETE {}/{}", genericKubernetesResource.getMetadata().getNamespace(), genericKubernetesResource.getMetadata().getName());
+        }
+      });
+
+      informerFactory.addSharedInformerEventListener(e -> logger.error(e.getMessage()));
+      informerFactory.startAllRegisteredInformers();
+
+      TimeUnit.MINUTES.sleep(10);
+    } catch (InterruptedException interruptedException) {
+      Thread.currentThread().interrupt();
+      logger.error("interrupted: {}", interruptedException.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Description
Fix #3228 
Introduce a new method in SharedInformerFactory which will only accept
CustomResourceDefinitionContext, types would automatically be assumed
to be GenericKubernetesResource and GenericKubernetesResourceList.

Till now we were deciding whether a resource is namespaced or not
depending upon whether it implements Namespaced interface or not. But
having dynamic informers required change to consider `scope` field in
CustomResourceDefinitionContext as well, hence I introduced a new class
SharedInformerOperationsImpl which overrides `isResourceNamespaced()` so
that it can be configured from calling methods.

<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
