### PR TITLE
Adding a dsl inform method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix #3001: WatchConnectionManager logs that provide little information are now logged at a lower level
 * Fix #3186: WebSockets and HTTP connections are closed as soon as possible for Watches.
 * Fix #2937: Add `SharedInformerFactory#getExistingSharedIndexInformers` method to return list of registered informers
+* Fix #3239: Add the `Informable` interface for context specific dsl methods to create `SharedIndexInformer`s.
 
 #### Dependency Upgrade
 * Fix #2741: Update Knative Model to v0.23.0
@@ -52,6 +53,7 @@
 #### _**Note**_: Breaking changes in the API
 ##### DSL Changes:
 - #3127 `StatusUpdatable.updateStatus` deprecated, please use patchStatus, editStatus, or replaceStatus
+- #3239 deprecated methods on SharedInformerFactory directly dealing with the OperationContext, withName, and withNamespace - the Informable interface should be used instead.
 
 ##### Util Changes:
 - #3197 `Utils.waitUntilReady` now accepts a Future, rather than a BlockingQueue

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
@@ -400,11 +400,7 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
    */
   @Override
   public <T extends CustomResource, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(Class<T> resourceType, Class<L> listClass) {
-    return new CustomResourceOperationsImpl<>(new CustomResourceOperationContext().withOkhttpClient(httpClient).withConfig(getConfiguration())
-      .withCrdContext(CustomResourceDefinitionContext.fromCustomResourceType(resourceType))
-      .withType(resourceType)
-      .withListType(listClass)
-      .withPropagationPolicy(DEFAULT_PROPAGATION_POLICY));
+    return customResources(CustomResourceDefinitionContext.fromCustomResourceType(resourceType), resourceType, listClass);
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -161,12 +161,12 @@ public interface KubernetesClient extends Client {
   <T extends HasMetadata, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass);
   
   /**
-   * Semi-Typed API for managing CustomResources.
+   * Semi-Typed API for managing {@link GenericKubernetesResource}s which can represent any resource.
    *
-   * @param crdContext CustomResourceDefinitionContext describes the core fields used to search for CustomResources
-   * @return returns a MixedOperation object with which you can do basic CustomResource operations
+   * @param crdContext CustomResourceDefinitionContext describes the core fields
+   * @return returns a MixedOperation object with which you can do basic operations
    */
-  default MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericCustomResources(
+  default MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericKubernetesResources(
       CustomResourceDefinitionContext crdContext) {
     return customResources(crdContext, GenericKubernetesResource.class, GenericKubernetesResourceList.class);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -27,6 +27,8 @@ import io.fabric8.kubernetes.api.model.ComponentStatus;
 import io.fabric8.kubernetes.api.model.ComponentStatusList;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsList;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LimitRange;
 import io.fabric8.kubernetes.api.model.LimitRangeList;
 import io.fabric8.kubernetes.api.model.Namespace;
@@ -157,6 +159,17 @@ public interface KubernetesClient extends Client {
    */
   @Deprecated
   <T extends HasMetadata, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(CustomResourceDefinitionContext crdContext, Class<T> resourceType, Class<L> listClass);
+  
+  /**
+   * Semi-Typed API for managing CustomResources.
+   *
+   * @param crdContext CustomResourceDefinitionContext describes the core fields used to search for CustomResources
+   * @return returns a MixedOperation object with which you can do basic CustomResource operations
+   */
+  default MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericCustomResources(
+      CustomResourceDefinitionContext crdContext) {
+    return customResources(crdContext, GenericKubernetesResource.class, GenericKubernetesResourceList.class);
+  }
 
   /**
    * Discovery API entrypoint for APIGroup discovery.k8s.io

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
@@ -1,20 +1,67 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 public interface Informable<T> {
   
   /**
+   * The indexers to add to {@link SharedInformer}s created by subsequent inform calls;
+   * @param indexers to customize the indexing
+   * @return the current {@link Informable}
+   */
+  public Informable<T> withIndexers(Map<String, Function<T, List<String>>> indexers);
+  
+  /**
    * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
-   * <br>This call will be blocking for the initial list and watch.
-   * <br>You are expected to call stop to terminate the underlying Watch.
+   * and provides a store of all the current resources.
+   * <p>This returned informer will not support resync.
+   * <p>This call will be blocking for the initial list and watch.
+   * <p>You are expected to call stop to terminate the underlying Watch.
+   * <p>Additional handlers can be added, but processing of the events will be in the websocket thread, 
+   * so consider non-blocking handler operations for more than one handler.
+   * 
+   * @param handler to notify
+   * @return a running {@link SharedIndexInformer}
+   */
+  default SharedIndexInformer<T> inform(ResourceEventHandler<T> handler) {
+    return inform(handler, 0);
+  }
+  
+  /**
+   * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
+   * and provides a store of all the current resources.
+   * <p>This call will be blocking for the initial list and watch.
+   * <p>You are expected to call stop to terminate the underlying Watch.
+   * <p>Additional handlers can be added, but processing of the events will be in the websocket thread, 
+   * so consider non-blocking handleroperations for more than one handler.
    * 
    * @param handler to notify
    * @param resync the resync period or 0 for no resync
-   * @return a running {@link SharedInformer}
+   * @return a running {@link SharedIndexInformer}
    */
-  public SharedInformer<T> inform(ResourceEventHandler<T> handler, long resync);
+  public SharedIndexInformer<T> inform(ResourceEventHandler<T> handler, long resync);
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
@@ -32,7 +32,7 @@ public interface Informable<T> {
    * @param indexers to customize the indexing
    * @return the current {@link Informable}
    */
-  public Informable<T> withIndexers(Map<String, Function<T, List<String>>> indexers);
+  Informable<T> withIndexers(Map<String, Function<T, List<String>>> indexers);
   
   /**
    * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
@@ -62,6 +62,6 @@ public interface Informable<T> {
    * @param resync the resync period or 0 for no resync
    * @return a running {@link SharedIndexInformer}
    */
-  public SharedIndexInformer<T> inform(ResourceEventHandler<T> handler, long resync);
+  SharedIndexInformer<T> inform(ResourceEventHandler<T> handler, long resync);
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
@@ -1,0 +1,20 @@
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedInformer;
+
+public interface Informable<T> {
+  
+  /**
+   * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
+   * <br>This call will be blocking for the initial list and watch.
+   * <br>You are expected to call stop to terminate the underlying Watch.
+   * 
+   * @param handler to notify
+   * @param resync the resync period or 0 for no resync
+   * @return a running {@link SharedInformer}
+   */
+  public SharedInformer<T> inform(ResourceEventHandler<T> handler, long resync);
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
@@ -25,5 +25,5 @@ public interface Resource<T> extends CreateOrReplaceable<T>,
   CascadingEditReplacePatchDeletable<T>,
   VersionWatchAndWaitable<T>,
   DryRunable<WritableOperation<T>>,
-  Requirable<T>, Readiable {
+  Requirable<T>, Readiable, Informable<T> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
 public interface WatchListDeletable<T, L> extends VersionWatchAndWaitable<T>, Listable<L>, Deletable,
                                                         GracePeriodConfigurable<Deletable>,
                                                         PropagationPolicyConfigurable<EditReplacePatchDeletable<T>>,
-                                                        StatusUpdatable<T>
+                                                        StatusUpdatable<T>,
+                                                        Informable<T>
 {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.kubernetes.client.informers;
 
+import io.fabric8.kubernetes.client.informers.cache.Store;
+
 /**
  * SharedInformer defines basic methods of an informer.
  *
@@ -84,4 +86,10 @@ public interface SharedInformer<T> {
    * <br>Will return false when {@link #isRunning()} is true when the watch needs to be re-established.
    */
   boolean isWatching();
+  
+  /**
+   * Return the Store associated with this informer
+   * @return the store
+   */
+  Store<T> getStore();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStore.java
@@ -39,11 +39,11 @@ public class ProcessorStore<T> implements SyncableStore<T> {
 
   @Override
   public void update(T obj) {
-    Object oldObj = this.cache.put(obj);
+    T oldObj = this.cache.put(obj);
     if (oldObj != null) {
-      this.processor.distribute(new ProcessorListener.UpdateNotification(oldObj, obj), false);
+      this.processor.distribute(new ProcessorListener.UpdateNotification<>(oldObj, obj), false);
     } else {
-      this.processor.distribute(new ProcessorListener.AddNotification(obj), false);
+      this.processor.distribute(new ProcessorListener.AddNotification<>(obj), false);
     }
   }
 
@@ -51,7 +51,7 @@ public class ProcessorStore<T> implements SyncableStore<T> {
   public void delete(T obj) {
     Object oldObj = this.cache.remove(obj);
     if (oldObj != null) {
-      this.processor.distribute(new ProcessorListener.DeleteNotification(obj, false), false);
+      this.processor.distribute(new ProcessorListener.DeleteNotification<>(obj, false), false);
     }
   }
 
@@ -83,14 +83,14 @@ public class ProcessorStore<T> implements SyncableStore<T> {
     for (T newValue : list) {
       T old = oldState.remove(cache.getKey(newValue));
       if (old == null) {
-        this.processor.distribute(new ProcessorListener.AddNotification(newValue), true);
+        this.processor.distribute(new ProcessorListener.AddNotification<>(newValue), true);
       } else {
-        this.processor.distribute(new ProcessorListener.UpdateNotification(old, newValue), true);
+        this.processor.distribute(new ProcessorListener.UpdateNotification<>(old, newValue), true);
       }
     }
     // deletes are not marked as sync=true in keeping with the old code
     oldState.values()
-        .forEach(old -> this.processor.distribute(new ProcessorListener.DeleteNotification(old, true), false));
+        .forEach(old -> this.processor.distribute(new ProcessorListener.DeleteNotification<>(old, true), false));
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.informers.ListerWatcher;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,6 +128,11 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       }
       if (resource == null) {
         throw new KubernetesClientException("Unrecognized resource");  
+      }
+      // the WatchEvent deserialization is not specifically typed
+      // modify the type here if needed
+      if (!apiTypeClass.isAssignableFrom(resource.getClass())) {
+        resource = Serialization.jsonMapper().convertValue(resource, apiTypeClass);
       }
       if (log.isDebugEnabled()) {
         log.debug("Event received {} {}# resourceVersion {}", action.name(), resource.getKind(), resource.getMetadata().getResourceVersion());

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.client.informers.cache.ProcessorListener;
 import io.fabric8.kubernetes.client.informers.cache.ProcessorStore;
 import io.fabric8.kubernetes.client.informers.cache.Reflector;
 import io.fabric8.kubernetes.client.informers.cache.SharedProcessor;
+import io.fabric8.kubernetes.client.informers.cache.Store;
 import io.fabric8.kubernetes.client.utils.SerialExecutor;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.slf4j.Logger;
@@ -183,6 +184,11 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
 
   @Override
   public Indexer<T> getIndexer() {
+    return this.indexer;
+  }
+  
+  @Override
+  public Store<T> getStore() {
     return this.indexer;
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -123,7 +123,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     }
 
     this.processor.addProcessorListener(handler,
-        determineResyncPeriod(resyncPeriodMillis, this.resyncCheckPeriodMillis), () -> this.indexer.list());
+        determineResyncPeriod(resyncPeriodMillis, this.resyncCheckPeriodMillis), this.indexer::list);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.client.informers.ResyncRunnable;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.fabric8.kubernetes.client.informers.cache.Indexer;
-import io.fabric8.kubernetes.client.informers.cache.ProcessorListener;
 import io.fabric8.kubernetes.client.informers.cache.ProcessorStore;
 import io.fabric8.kubernetes.client.informers.cache.Reflector;
 import io.fabric8.kubernetes.client.informers.cache.SharedProcessor;
@@ -123,16 +122,8 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
       }
     }
 
-    ProcessorListener<T> listener = this.processor.addProcessorListener(handler, determineResyncPeriod(resyncPeriodMillis, this.resyncCheckPeriodMillis));
-
-    if (!started.get()) {
-      return;
-    }
-
-    List<T> objectList = this.indexer.list();
-    for (T item : objectList) {
-      listener.add(new ProcessorListener.AddNotification<>(item));
-    }
+    this.processor.addProcessorListener(handler,
+        determineResyncPeriod(resyncPeriodMillis, this.resyncCheckPeriodMillis), () -> this.indexer.list());
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/SharedInformerFactoryTest.java
@@ -39,8 +39,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SharedInformerFactoryTest {
   public static final long RESYNC_PERIOD = 10 * 1000L;
@@ -112,23 +110,6 @@ class SharedInformerFactoryTest {
     // Then
     assertThat(informer).isNotNull();
     assertThat(sharedInformerFactory.getExistingSharedIndexInformers()).hasSize(1);
-  }
-
-  @Test
-  void testSharedIndexInformerForCustomResourceThrowsIllegalArgumentExceptionOnCoreType() {
-    // Given
-    SharedInformerFactory sharedInformerFactory = new SharedInformerFactory(executorService, mockClient, config);
-    CustomResourceDefinitionContext context = new CustomResourceDefinitionContext.Builder()
-      .withKind("Service")
-      .withScope("Namespaced")
-      .withVersion("v1")
-      .withGroup("")
-      .withPlural("services")
-      .build();
-
-    // When + Then
-    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> sharedInformerFactory.sharedIndexInformerForCustomResource(context, 10 * 1000L));
-    assertEquals("Using sharedIndexInformerDynamicResource for core type. Please use sharedIndexInformerFor(Class<T>, long) instead.", exception.getMessage());
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -65,7 +65,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -30,7 +30,6 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -46,12 +45,7 @@ class InformTest {
   private static final Long EVENT_WAIT_PERIOD_MS = 10L;
 
   KubernetesMockServer server;
-  private KubernetesClient client;
-
-  @BeforeEach
-  void setUp() {
-    client = server.createClient().inNamespace("test");
-  }
+  KubernetesClient client;
 
   @Test
   void testInformPodWithLabel() throws InterruptedException {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ListMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnableKubernetesMockClient(https = false)
+class InformTest {
+
+  private static final Long EVENT_WAIT_PERIOD_MS = 10L;
+
+  KubernetesMockServer server;
+  private KubernetesClient client;
+
+  @BeforeEach
+  void setUp() {
+    client = server.createClient().inNamespace("test");
+  }
+
+  @Test
+  void testInformPodWithLabel() throws InterruptedException {
+    // Given
+    Pod pod1 = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
+        .withResourceVersion("1").endMetadata().build();
+
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label")
+        .andReturn(HttpURLConnection.HTTP_OK,
+            new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
+        .once();
+
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=1&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "DELETED"))
+        .done()
+        .once();
+    final CountDownLatch deleteLatch = new CountDownLatch(1);
+    final CountDownLatch addLatch = new CountDownLatch(1);
+    final ResourceEventHandler<Pod> handler = new ResourceEventHandler<Pod>() {
+
+      @Override
+      public void onAdd(Pod obj) {
+        addLatch.countDown();
+      }
+
+      @Override
+      public void onDelete(Pod obj, boolean deletedFinalStateUnknown) {
+        deleteLatch.countDown();
+      }
+
+      @Override
+      public void onUpdate(Pod oldObj, Pod newObj) {
+
+      }
+
+    };
+    // When
+    SharedIndexInformer<Pod> informer = client.pods().withLabel("my-label").inform(handler);
+
+    assertTrue(deleteLatch.await(10, TimeUnit.SECONDS));
+    assertTrue(addLatch.await(10, TimeUnit.SECONDS));
+
+    informer.stop();
+  }
+
+  @Test
+  void testInformGeneric() throws InterruptedException {
+    // Given
+    GenericKubernetesResource dummy = new GenericKubernetesResource();
+    dummy.setMetadata(new ObjectMetaBuilder().withName("one").withNamespace("test").build());
+    dummy.setKind("dummy");
+    dummy.setApiVersion("demos.fabric8.io/v1");
+    GenericKubernetesResourceList list = new GenericKubernetesResourceList();
+    list.setMetadata(new ListMetaBuilder().withResourceVersion("1").build());
+    list.setItems(Arrays.asList(dummy));
+
+    server.expect()
+        .withPath("/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label")
+        .andReturn(HttpURLConnection.HTTP_OK, list)
+        .once();
+
+    server.expect()
+        .withPath("/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label&resourceVersion=1&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(dummy, "DELETED"))
+        .done()
+        .once();
+    final CountDownLatch deleteLatch = new CountDownLatch(1);
+    final CountDownLatch addLatch = new CountDownLatch(1);
+    final ResourceEventHandler<GenericKubernetesResource> handler = new ResourceEventHandler<GenericKubernetesResource>() {
+
+      @Override
+      public void onAdd(GenericKubernetesResource obj) {
+        addLatch.countDown();
+      }
+
+      @Override
+      public void onDelete(GenericKubernetesResource obj, boolean deletedFinalStateUnknown) {
+        deleteLatch.countDown();
+      }
+
+      @Override
+      public void onUpdate(GenericKubernetesResource oldObj, GenericKubernetesResource newObj) {
+
+      }
+
+    };
+
+    // When
+    CustomResourceDefinitionContext context = new CustomResourceDefinitionContext.Builder()
+        .withKind("Dummy")
+        .withScope("Namespaced")
+        .withVersion("v1")
+        .withGroup("demos.fabric8.io")
+        .withPlural("dummies")
+        .build();
+
+    SharedIndexInformer<GenericKubernetesResource> informer =
+        client.genericCustomResources(context).withLabel("my-label").inform(handler);
+
+    assertTrue(deleteLatch.await(10, TimeUnit.SECONDS));
+    assertTrue(addLatch.await(10, TimeUnit.SECONDS));
+
+    informer.stop();
+  }
+
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -52,12 +52,11 @@ class WatchTest {
   private static final Long EVENT_WAIT_PERIOD_MS = 10L;
 
   KubernetesMockServer server;
-  private KubernetesClient client;
+  KubernetesClient client;
   private Pod pod1;
 
   @BeforeEach
   void setUp() {
-    client = server.createClient().inNamespace("test");
     pod1 = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
       .withResourceVersion("1").endMetadata().build();
   }


### PR DESCRIPTION
## Description
A possible implementation for the informer mentioned in https://github.com/fabric8io/kubernetes-client/pull/3230#pullrequestreview-682321798

This implementation is just a simple wrapper over a Watch - no additional threads are consumed.

It is not a SharedIndexInformer because of the simplification that it is already started, which means that Indexers cannot be added.  Since I haven't needed to use Indexers I'm probably biasing this toward simplicity.

For generic functionality I've added a second commit to expand the existing RawCustomResourceOperationsImpl - it's a little cumbersome.  Narrowing to a more specific interface than the SharedInformer (run isn't needed, etc.) would help a little. The pro is that this doesn't require yet exposing the GenericKubernetesResource for #3233 - but as mentioned above it's not quite functionally equivalent since the factory supports indexing and additional sharing.

If this seems sensible, then the SharedInformerFactory methods dealing with an OperationContext could be deprecated.  

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
