### PR TITLE
Fix for #3243, #3244 Prevent data loss when client provides pipes to exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix #3076: the MetadataObject for CustomResource is now seen as Buildable
 * Fix #3216: made the mock server aware of apiVersions
 * Fix #3225: Pod metric does not have corresponding label selector variant
+* Fix #3243: pipes provided to exec command are no longer closed on connection close, so that client can fully read the buffer after the command finishes.
 
 #### Improvements
 * Fix #3078: adding javadocs to further clarify patch, edit, replace, etc. and note the possibility of items being modified.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -321,7 +321,6 @@ public class ExecWebSocketListener extends WebSocketListener implements ExecWatc
             return stream;
         } else if (out != null) {
             PipedInputStream pis = bufferSize == null ? new PipedInputStream() : new PipedInputStream(bufferSize.intValue());
-            toClose.add(out);
             toClose.add(pis);
             return pis;
         } else {
@@ -334,7 +333,6 @@ public class ExecWebSocketListener extends WebSocketListener implements ExecWatc
             return stream;
         } else if (in != null) {
             PipedOutputStream pos = new PipedOutputStream();
-            toClose.add(in);
             toClose.add(pos);
             return pos;
         } else {

--- a/kubernetes-client/src/test/resources/test-kubeconfig-exec-win
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-exec-win
@@ -17,7 +17,7 @@ users:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - world
-      command: ./token-generator-win.bat
+      command: ".\\token-generator-win.bat"
       env:
       - name: PART1
         value: hello

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -455,7 +455,17 @@ class PodTest {
       ByteBuffer buffer = ByteBuffer.allocate(1024);
       int read;
       do {
-        read = channel.read(buffer);
+        try {
+          read = channel.read(buffer);
+        } catch (IOException io) {
+          // On windows an exception is thrown when connection is reset during read
+          // It can only be distinguished via message, and that message is localized
+          // So let's at least handle English
+          if (!io.getMessage().startsWith("An existing connection was forcibly closed")) {
+            throw io;
+          }
+          read = -1;
+        }
       } while(read >= 0);
       buffer.flip();
       channel.socket().close();


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #3244 #3243 

This fixes data loss when using `PipedInputStream` to pump output from exec command. Since this user-provided resource was auto-closed on websocket connection close, client was unable to read contents of the buffer after last chunk was received. (#3243)

Handling of `PipedOutputStream` provided for `stdin` was changed in same fashion, although the impact there is not that big due to how the pair is implemented.

I've run the unit tests in my Windows environment and fixed any issues with tests I encountered there (none of them were related to pipes, rather OS quirks). (#3244)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
