### PR TITLE
Fix #3225: Pod metric does not have corresponding label selector variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix #3194: the mock server will now infer the namespace from the path
 * Fix #3076: the MetadataObject for CustomResource is now seen as Buildable
 * Fix #3216: made the mock server aware of apiVersions
+* Fix #3225: Pod metric does not have corresponding label selector variant
 
 #### Improvements
 * Fix #3078: adding javadocs to further clarify patch, edit, replace, etc. and note the possibility of items being modified.

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1526,23 +1526,23 @@ try (KubernetesClient client = new DefaultKubernetesClient()) {
 ### Fetching Metrics
 Kubernetes Client also supports fetching metrics from API server if metrics are enabled on it. You can access metrics via `client.top()`. Here are some examples of its usage:
 - Get `NodeMetrics` for all nodes:
-```
+```java
 NodeMetricsList nodeMetricList = client.top().nodes().metrics();
 ```
 - Get `NodeMetrics` for some specific nodes:
-```
-NodeMetrics nodeMetric = client.top().nodes().metrics("minikube");
+```java
+NodeMetrics nodeMetric = client.top().nodes().withName("minikube").metric();
 ```
 - Get `PodMetrics` for all pods in all namespaces:
-```
+```java
 PodMetricsList podMetricsList = client.top().pods().metrics();
 ```
 - Get `PodMetrics` for all pods in some specific namespace:
-```
-PodMetricsList podMetricsList = client.top().pods().metrics("default");
+```java
+PodMetricsList podMetricsList = client.top().pods().inNamespace("default").metrics();
 ```
 - Get `PodMetrics` for a particular pod:
-```
+```java
 PodMetrics podMetrics = client.top().pods().metrics("default", "nginx-pod");
 ```
 
@@ -1606,18 +1606,17 @@ Boolean deleted = client.resourceList(new PodListBuilder().withItems(pod1, pod2,
 ```
 
 ### CustomResourceDefinition
-`CustomResourceDefinition` which are like templates for `CustomResource` objects in Kubernetes API are available in Kubernetes Client API via `client.customResourceDefinitions()`. Here are some examples of it's common usage:
+`CustomResourceDefinition` which are like templates for `CustomResource` objects in Kubernetes API are available in Kubernetes Client API via `client.apiextensions().v1beta1().customResourceDefinitions()` or `client.apiextensions().v1().customResourceDefinitions()`. Here are some examples of it's common usage:
 - Load a `CustomResourceDefinition` from yaml:
-```
-CustomResourceDefinition customResourceDefinition = client.customResourceDefinitions().load(new FileInputStream("/sparkapplication-crd.yml")).get();
+```java
+CustomResourceDefinition customResourceDefinition = client.apiextensions().v1beta1().customResourceDefinitions().load(new FileInputStream("/sparkapplication-crd.yml")).get();
 ```
 - Get a `CustomResourceDefinition` from Kubernetes APIServer
-```
-CustomResourceDefinition crd = client.customResourceDefinitions().withName("sparkclusters.radanalytics.io").get();
+```java
+CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().withName("sparkclusters.radanalytics.io").get();
 ```
 - Create `CustomResourceDefinition`:
-```
-
+```java
 CustomResourceDefinition customResourceDefinition = new CustomResourceDefinitionBuilder()
       .withApiVersion("apiextensions.k8s.io/v1beta1")
       .withNewMetadata().withName("sparkclusters.radanalytics.io")
@@ -1637,19 +1636,19 @@ CustomResourceDefinition customResourceDefinition = new CustomResourceDefinition
       .endSpec()
       .build();
 
-CustomResourceDefinition crd = client.customResourceDefinitions().createOrReplace(customResourceDefinition);
+CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().createOrReplace(customResourceDefinition);
 ```
 - Create or Replace some `CustomResourceDefinition`:
-```
-CustomResourceDefinition crd = client.customResourceDefinitions().createOrReplace(customResourceDefinition);
+```java
+CustomResourceDefinition crd = client.apiextensions().v1beta1().customResourceDefinitions().createOrReplace(customResourceDefinition);
 ```
 - List `CustomResourceDefinition`:
-```
-CustomResourceDefinitionList crdList = client.customResourceDefinitions().list();
+```java
+CustomResourceDefinitionList crdList = client.apiextensions().v1beta1().customResourceDefinitions().list();
 ```
 - Delete `CustomResourceDefinition`:
-```
-Boolean deleted = client.customResourceDefinitions().withName("sparkclusters.radanalytics.io").delete();
+```java
+Boolean deleted = client.apiextensions().v1beta1().customResourceDefinitions().withName("sparkclusters.radanalytics.io").delete();
 ```
 
 ### CustomResource Typed API

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/MetricOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/MetricOperationsImpl.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.Nameable;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.utils.URLUtils;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+public class MetricOperationsImpl<T, L> extends OperationSupport implements Nameable<MetricOperationsImpl<T, L>> {
+  public static final String METRIC_ENDPOINT_URL = "apis/metrics.k8s.io/v1beta1/";
+  private final Class<L> apiTypeListClass;
+  private final Class<T> apiTypeClass;
+  private final String plural;
+  private final String configuredNamespace;
+  private final String configuredName;
+  private final Map<String, String> configuredLabels;
+
+  public MetricOperationsImpl(OkHttpClient client, Config config, String configuredName, String configuredNamespace, String plural, Map<String, String> configuredLabels, Class<T> apiTypeClass, Class<L> apiTypeListClass) {
+    super(new OperationContext().withOkhttpClient(client).withConfig(config));
+    this.plural = plural;
+    this.apiTypeClass = apiTypeClass;
+    this.apiTypeListClass = apiTypeListClass;
+    this.configuredNamespace = configuredNamespace;
+    this.configuredName = configuredName;
+    this.configuredLabels = configuredLabels;
+  }
+
+  @Override
+  public MetricOperationsImpl<T, L> withName(String name) {
+    return new MetricOperationsImpl<>(client, config, name, configuredNamespace, plural, configuredLabels, apiTypeClass, apiTypeListClass);
+  }
+
+  /**
+   * Filter metrics via labels.
+   *
+   * @param labels labels as HashMap
+   * @return {@link MetricOperationsImpl} with which you can call metrics() for getting filtered Metrics
+   */
+  public MetricOperationsImpl<T, L> withLabels(Map<String, String> labels) {
+    return new MetricOperationsImpl<>(client, config, name, configuredNamespace, plural, labels, apiTypeClass, apiTypeListClass);
+  }
+
+  /**
+   * Get a list of metrics
+   *
+   * @return a list object for metrics
+   */
+  public L metrics() {
+    try {
+      return handleMetric(getMetricEndpointUrl(), apiTypeListClass);
+    } catch (IOException | ExecutionException exception) {
+      throw KubernetesClientException.launderThrowable(exception);
+    } catch (InterruptedException interruptedException) {
+      Thread.currentThread().interrupt();
+      throw KubernetesClientException.launderThrowable(interruptedException);
+    }
+  }
+
+  /**
+   * Get a single metric. name needs to be provided.
+   *
+   * @return a single metric
+   */
+  public T metric() {
+    try {
+      return handleMetric(getMetricEndpointUrl(), apiTypeClass);
+    } catch (IOException | ExecutionException exception) {
+      throw KubernetesClientException.launderThrowable(exception);
+    } catch (InterruptedException interruptedException) {
+      Thread.currentThread().interrupt();
+      throw KubernetesClientException.launderThrowable(interruptedException);
+    }
+  }
+
+  /**
+   * Returns a list of metrics matching specified labels
+   *
+   * @param labelsMap labels as HashMap
+   * @return list of metrics found matching provided label
+   */
+  public L metrics(Map<String, Object> labelsMap) {
+    Map<String, String> labels = new HashMap<>();
+    labelsMap.forEach((k, v) -> labels.put(k, v.toString()));
+
+    return withLabels(labels).metrics();
+  }
+
+  protected String getMetricEndpointUrlWithPlural(String plural) {
+    String result = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL);
+    if (configuredNamespace != null) {
+      result += "namespaces/" + configuredNamespace + "/";
+    }
+    result += plural;
+    if (configuredName != null) {
+      result += "/" + configuredName;
+    }
+    if (configuredLabels != null) {
+      result = getUrlWithLabels(result, configuredLabels);
+    }
+    return result;
+  }
+
+  private String getMetricEndpointUrl() {
+    return getMetricEndpointUrlWithPlural(plural);
+  }
+
+  private String getUrlWithLabels(String baseUrl, Map<String, String> labels) {
+    HttpUrl.Builder httpUrlBuilder = HttpUrl.get(baseUrl).newBuilder();
+
+    StringBuilder sb = new StringBuilder();
+    for(Map.Entry<String, String> entry : labels.entrySet()) {
+      sb.append(entry.getKey()).append("=").append(entry.getValue()).append(",");
+    }
+    httpUrlBuilder.addQueryParameter("labelSelector", sb.substring(0, sb.toString().length() - 1));
+    return httpUrlBuilder.toString();
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NodeMetricOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NodeMetricOperationsImpl.java
@@ -15,56 +15,23 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import java.util.Map;
-
 import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
 import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.base.OperationContext;
-import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
-import io.fabric8.kubernetes.client.utils.URLUtils;
-import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
-public class NodeMetricOperationsImpl extends OperationSupport {
-	private static String METRIC_ENDPOINT_URL = "apis/metrics.k8s.io/v1beta1/nodes";
-
+public class NodeMetricOperationsImpl extends MetricOperationsImpl<NodeMetrics, NodeMetricsList> {
 	public NodeMetricOperationsImpl(OkHttpClient client, Config config) {
-		super(new OperationContext().withOkhttpClient(client).withConfig(config));
+		super(client, config, null, null, "nodes", null, NodeMetrics.class, NodeMetricsList.class);
 	}
 
-	public NodeMetricsList metrics() {
-		try {
-			String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL);
-			return handleMetric(resourceUrl, NodeMetricsList.class);
-		} catch(Exception e) {
-			throw KubernetesClientException.launderThrowable(e);
-		}
-	}
-
-	public NodeMetrics metrics(String nodeName) {
-		try {
-			String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL, nodeName);
-			return handleMetric(resourceUrl, NodeMetrics.class);
-		} catch(Exception e) {
-			throw KubernetesClientException.launderThrowable(e);
-		}
-	}
-
-	public NodeMetricsList metrics(Map<String, Object> labelsMap) {
-		try {
-      HttpUrl.Builder httpUrlBuilder = HttpUrl.get(URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL)).newBuilder();
-
-      StringBuilder sb = new StringBuilder();
-			for(Map.Entry<String, Object> entry : labelsMap.entrySet()) {
-				sb.append(entry.getKey()).append("=").append(entry.getValue().toString()).append(",");
-			}
-      httpUrlBuilder.addQueryParameter("labelSelector", sb.toString().substring(0, sb.toString().length() - 1));
-			return handleMetric(httpUrlBuilder.build().toString(), NodeMetricsList.class);
-		} catch(Exception e) {
-			throw KubernetesClientException.launderThrowable(e);
-		}
-	}
-
+  /**
+   * Get NodeMetric with specified name
+   *
+   * @param nodeName name of the node
+   * @return NodeMetric fetched from ApiServer
+   */
+  public NodeMetrics metrics(String nodeName) {
+	  return withName(nodeName).metric();
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodMetricOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodMetricOperationsImpl.java
@@ -18,49 +18,41 @@ package io.fabric8.kubernetes.client.dsl.internal;
 import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
 import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.base.OperationContext;
-import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
-import io.fabric8.kubernetes.client.utils.URLUtils;
-import io.fabric8.kubernetes.client.utils.Utils;
+import io.fabric8.kubernetes.client.dsl.Namespaceable;
 import okhttp3.OkHttpClient;
 
-public class PodMetricOperationsImpl extends OperationSupport {
-  private static String METRIC_ENDPOINT_URL = "apis/metrics.k8s.io/v1beta1";
-
+public class PodMetricOperationsImpl extends MetricOperationsImpl<PodMetrics, PodMetricsList> implements Namespaceable<PodMetricOperationsImpl> {
   public PodMetricOperationsImpl(OkHttpClient client, Config config) {
-    super(new OperationContext().withOkhttpClient(client).withConfig(config));
+    super(client, config, null, null, "pods", null, PodMetrics.class, PodMetricsList.class);
   }
 
+  private PodMetricOperationsImpl(OkHttpClient client, Config config, String name, String namespace) {
+    super(client, config, name, namespace, "pods", null, PodMetrics.class, PodMetricsList.class);
+  }
+
+  /**
+   * Get PodMetrics in a namespace with a name.
+   *
+   * @param namespace namespace of pod
+   * @param podName name of pod
+   * @return PodMetric corresponding to specified Pod
+   */
   public PodMetrics metrics(String namespace, String podName) {
-    try {
-      Utils.checkNotNull(namespace, "Namespace not provided");
-      Utils.checkNotNull(podName, "Name not provided");
-
-      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL,
-        "namespaces", namespace, "pods", podName);
-      return handleMetric(resourceUrl, PodMetrics.class);
-    } catch(Exception e) {
-      throw KubernetesClientException.launderThrowable(e);
-    }
+    return inNamespace(namespace).withName(podName).metric();
   }
 
-  public PodMetricsList metrics() {
-    try {
-      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL, "pods");
-      return handleMetric(resourceUrl, PodMetricsList.class);
-    } catch(Exception e) {
-      throw KubernetesClientException.launderThrowable(e);
-    }
-  }
-
+  /**
+   * Get PodMetricsList for a namespace.
+   *
+   * @param namespace namespace for which PodMetrics are queries
+   * @return PodMetricsList for all pods in specified namespace
+   */
   public PodMetricsList metrics(String namespace) {
-    try {
-      String resourceUrl = URLUtils.join(config.getMasterUrl(), METRIC_ENDPOINT_URL,
-        "namespaces", namespace, "pods");
-      return handleMetric(resourceUrl, PodMetricsList.class);
-    } catch(Exception e) {
-      throw KubernetesClientException.launderThrowable(e);
-    }
+    return inNamespace(namespace).metrics();
+  }
+
+  @Override
+  public PodMetricOperationsImpl inNamespace(String namespace) {
+    return new PodMetricOperationsImpl(client, config, null, namespace);
   }
 }


### PR DESCRIPTION
## Description
Fix #3225 

Refactor NodeMetricOperationsImpl and PodMetricOperationsImpl to move
common logic to MetricOperationsImpl

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
