### PR TITLE
fix #3101 making isWatching better reflect health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Fix #3186: WebSockets and HTTP connections are closed as soon as possible for Watches.
 * Fix #2937: Add `SharedInformerFactory#getExistingSharedIndexInformers` method to return list of registered informers
 * Fix #3239: Add the `Informable` interface for context specific dsl methods to create `SharedIndexInformer`s.
+* Fix #3101: making isWatching a health check for the informer
 
 #### Dependency Upgrade
 * Fix #2741: Update Knative Model to v0.23.0

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -81,7 +81,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
    */
   public void listSyncAndWatch() {
     running = true;
-    watching = false;
     final L list = getList();
     final String latestResourceVersion = list.getMetadata().getResourceVersion();
     lastSyncResourceVersion = latestResourceVersion;
@@ -155,12 +154,21 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
 
     @Override
     public void onClose(WatcherException exception) {
-      watchStopped();
       // this close was triggered by an exception,
       // not the user, it is expected that the watch retry will handle this
       log.warn("Watch closing with exception", exception);
-      if (exception.isHttpGone()) {
+      boolean restarted = false;
+      try {
+        if (exception.isHttpGone()) {
           listSyncAndWatch();
+          restarted = true;
+        } else {
+          running = false; // shouldn't happen, but it means the watch won't restart
+        }
+      } finally {
+        if (!restarted) {
+          watchStopped(); // report the watch as stopped after a problem
+        }
       }
     }
 
@@ -175,6 +183,10 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       return true;
     }
     
+  }
+  
+  public ReflectorWatcher getWatcher() {
+    return watcher;
   }
 
 }


### PR DESCRIPTION
## Description
Based upon trying to close out #3101 it seems better to refine the flag behavior so that it will be better as health checks.  So now if a non-http gone exception is provided we'll also report running = false.  And in the http gone case we won't report anything as wrong until something fails with the re-list/watch.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
