### PR TITLE
Fix #2712: Add Support for watching logs in multi-container Controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### New Features
 * Fix #3291: Retrying the HTTP operation in case of IOException too
+* Fix #2712: Add support for watching logs in multi-container Controller resources (Deployments, StatefulSets, ReplicaSet etc)
 
 ### 5.5.0 (2021-06-30)
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ScalableResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ScalableResource.java
@@ -16,5 +16,6 @@
 package io.fabric8.kubernetes.client.dsl;
 
 public interface ScalableResource<T> extends Resource<T>,
-  Scaleable<T> , Loggable<LogWatch> {
+  Scaleable<T> , Loggable<LogWatch>,
+  Containerable<String, Loggable<LogWatch>> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodControllerOperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodControllerOperationContext.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import okhttp3.OkHttpClient;
+
+import java.util.Map;
+
+public class PodControllerOperationContext extends OperationContext {
+  protected String containerId;
+
+  public PodControllerOperationContext() { }
+
+  public PodControllerOperationContext(OkHttpClient client, Config config, String plural, String namespace, String name, String containerId, String apiGroupName, String apiGroupVersion, boolean cascading, Object item, Map<String, String> labels, Map<String, String[]> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Map<String, String[]> fieldsNot, String resourceVersion, boolean reloadingFromServer, long gracePeriodSeconds, DeletionPropagation propagationPolicy, long watchRetryInitialBackoffMillis, double watchRetryBackoffMultiplier, boolean isNamespaceFromGlobalConfig, boolean dryRun) {
+    super(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading, item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, isNamespaceFromGlobalConfig, dryRun);
+    this.containerId = containerId;
+  }
+
+  public String getContainerId() {
+    return containerId;
+  }
+
+  @Override
+  public PodControllerOperationContext withOkhttpClient(OkHttpClient client) {
+    return new PodControllerOperationContext(client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withConfig(Config config) {
+    return new PodControllerOperationContext(this.client, config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withPlural(String plural) {
+    return new PodControllerOperationContext(this.client, this.config, plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withNamespace(String namespace) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withName(String name) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withApiGroupName(String apiGroupName) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withApiGroupVersion(String apiGroupVersion) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withItem(Object item) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withCascading(boolean cascading) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withLabels(Map<String, String> labels) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withLabelsIn(Map<String, String[]> labelsIn) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withLabelsNot(Map<String, String[]> labelsNot) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withLabelsNotIn(Map<String, String[]> labelsNotIn) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withFields(Map<String, String> fields) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withFieldsNot(Map<String, String[]> fieldsNot) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withResourceVersion(String resourceVersion) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withReloadingFromServer(boolean reloadingFromServer) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withGracePeriodSeconds(long gracePeriodSeconds) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withPropagationPolicy(DeletionPropagation propagationPolicy) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+
+  @Override
+  public PodControllerOperationContext withDryRun(boolean dryRun) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, this.containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, dryRun);
+  }
+
+  public PodControllerOperationContext withContainerId(String containerId) {
+    return new PodControllerOperationContext(this.client, this.config, this.plural, this.namespace, this.name, containerId, this.apiGroupName,
+      apiGroupVersion, this.cascading, this.item, this.labels, this.labelsNot, this.labelsIn, this.labelsNotIn,
+      this.fields, this.fieldsNot, this.resourceVersion, this.reloadingFromServer, this.gracePeriodSeconds,
+      this.propagationPolicy, this.watchRetryInitialBackoffMillis, this.watchRetryBackoffMultiplier,
+      this.namespaceFromGlobalConfig, this.dryRun);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollingOperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/RollingOperationContext.java
@@ -17,13 +17,12 @@ package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import okhttp3.OkHttpClient;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-public class RollingOperationContext extends OperationContext {
+public class RollingOperationContext extends PodControllerOperationContext {
 
  private boolean rolling;
  private long rollingTimeout;
@@ -32,8 +31,8 @@ public class RollingOperationContext extends OperationContext {
   public RollingOperationContext() {
   }
 
-  public RollingOperationContext(OkHttpClient client, Config config, String plural, String namespace, String name, String apiGroupName, String apiGroupVersion, boolean cascading, Object item, Map<String, String> labels, Map<String, String[]> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Map<String, String[]> fieldsNot, String resourceVersion, boolean reloadingFromServer, long gracePeriodSeconds, DeletionPropagation propagationPolicy, long watchRetryInitialBackoffMillis, double watchRetryBackoffMultiplier, boolean rolling, long rollingTimeout, TimeUnit rollingTimeUnit, boolean isNamespaceFromGlobalConfig, boolean dryRun) {
-    super(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading, item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, isNamespaceFromGlobalConfig, dryRun);
+  public RollingOperationContext(OkHttpClient client, Config config, String plural, String namespace, String name, String containerId, String apiGroupName, String apiGroupVersion, boolean cascading, Object item, Map<String, String> labels, Map<String, String[]> labelsNot, Map<String, String[]> labelsIn, Map<String, String[]> labelsNotIn, Map<String, String> fields, Map<String, String[]> fieldsNot, String resourceVersion, boolean reloadingFromServer, long gracePeriodSeconds, DeletionPropagation propagationPolicy, long watchRetryInitialBackoffMillis, double watchRetryBackoffMultiplier, boolean rolling, long rollingTimeout, TimeUnit rollingTimeUnit, boolean isNamespaceFromGlobalConfig, boolean dryRun) {
+    super(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading, item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, isNamespaceFromGlobalConfig, dryRun);
     this.rolling = rolling;
     this.rollingTimeout = rollingTimeout;
     this.rollingTimeUnit = rollingTimeUnit != null ? rollingTimeUnit : TimeUnit.MILLISECONDS;
@@ -52,96 +51,100 @@ public class RollingOperationContext extends OperationContext {
   }
 
   public RollingOperationContext withOkhttpClient(OkHttpClient client) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withConfig(Config config) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withPlural(String plural) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withNamespace(String namespace) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withName(String name) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withApiGroupName(String apiGroupName) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withApiGroupVersion(String apiGroupVersion) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   @Override
   public RollingOperationContext withItem(Object item) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withCascading(boolean cascading) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withLabels(Map<String, String> labels) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withLabelsIn(Map<String, String[]> labelsIn) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withLabelsNot(Map<String, String[]> labelsNot) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withLabelsNotIn(Map<String, String[]> labelsNotIn) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withFields(Map<String, String> fields) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withFieldsNot(Map<String, String[]> fieldsNot) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withResourceVersion(String resourceVersion) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withReloadingFromServer(boolean reloadingFromServer) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withGracePeriodSeconds(long gracePeriodSeconds) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withPropagationPolicy(DeletionPropagation propagationPolicy) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withRolling(boolean rolling) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withRollingTimeout(long rollingTimeout) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   public RollingOperationContext withRollingTimeUnit(TimeUnit rollingTimeUnit) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 
   @Override
   public RollingOperationContext withDryRun(boolean dryRun) {
-    return new RollingOperationContext(client, config, plural, namespace, name, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
+  }
+
+  public RollingOperationContext withContainerId(String containerId) {
+    return new RollingOperationContext(client, config, plural, namespace, name, containerId, apiGroupName, apiGroupVersion, cascading,item, labels, labelsNot, labelsIn, labelsNotIn, fields, fieldsNot, resourceVersion, reloadingFromServer, gracePeriodSeconds, propagationPolicy, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier, rolling, rollingTimeout, rollingTimeUnit, namespaceFromGlobalConfig, dryRun);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/PodOperationUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/PodOperationUtil.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.utils;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
@@ -25,6 +26,8 @@ import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.OutputStream;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,19 +56,47 @@ public class PodOperationUtil {
     return pods;
   }
 
-  public static PodOperationsImpl getGenericPodOperations(OperationContext context, boolean isPretty, Integer podLogWaitTimeout) {
+  public static PodOperationsImpl getGenericPodOperations(OperationContext context, boolean isPretty, Integer podLogWaitTimeout, String containerId) {
     return new PodOperationsImpl(new PodOperationContext(context.getClient(),
       context.getConfig(), context.getPlural(), context.getNamespace(), null, null,
       "v1", context.getCascading(), context.getItem(), context.getLabels(), context.getLabelsNot(),
       context.getLabelsIn(), context.getLabelsNotIn(), context.getFields(), context.getFieldsNot(), context.getResourceVersion(),
       context.isReloadingFromServer(), context.getGracePeriodSeconds(), context.getPropagationPolicy(),
-      context.getWatchRetryInitialBackoffMillis(), context.getWatchRetryBackoffMultiplier(), context.isNamespaceFromGlobalConfig(), context.getDryRun(), null, null, null, null, null,
+      context.getWatchRetryInitialBackoffMillis(), context.getWatchRetryBackoffMultiplier(), context.isNamespaceFromGlobalConfig(), context.getDryRun(), containerId, null, null, null, null,
       null, null, null, null, false, false, false, null, null,
       null, isPretty, null, null, null, null, null, podLogWaitTimeout));
   }
 
-  public static List<PodResource<Pod>> getPodOperationsForController(OperationContext context, String controllerUid, Map<String, String> selectorLabels, boolean isPretty, Integer podLogWaitTimeout) {
-    return getPodOperationsForController(PodOperationUtil.getGenericPodOperations(context, isPretty, podLogWaitTimeout), controllerUid, selectorLabels);
+  public static List<PodResource<Pod>> getPodOperationsForController(OperationContext context, String controllerUid, Map<String, String> selectorLabels, boolean isPretty, Integer podLogWaitTimeout, String containerId) {
+    return getPodOperationsForController(PodOperationUtil.getGenericPodOperations(context, isPretty, podLogWaitTimeout, containerId), controllerUid, selectorLabels);
+  }
+
+  public static LogWatch watchLog(List<PodResource<Pod>> podResources, OutputStream out) {
+    if (!podResources.isEmpty()) {
+      if (podResources.size() > 1) {
+        LOG.debug("Found {} pods, Using first one to watch logs", podResources.size());
+      }
+      return podResources.get(0).watchLog(out);
+    }
+    return null;
+  }
+
+  public static Reader getLogReader(List<PodResource<Pod>> podResources) {
+    if (!podResources.isEmpty()) {
+      if (podResources.size() > 1) {
+        LOG.debug("Found {} pods, Using first one to get log reader", podResources.size());
+      }
+      return podResources.get(0).getLogReader();
+    }
+    return null;
+  }
+
+  public static String getLog(List<PodResource<Pod>> podOperationList, Boolean isPretty) {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (PodResource<Pod> podOperation : podOperationList) {
+      stringBuilder.append(podOperation.getLog(isPretty));
+    }
+    return stringBuilder.toString();
   }
 
   static List<PodResource<Pod>> getPodOperationsForController(PodOperationsImpl podOperations, String controllerUid, Map<String, String> selectorLabels) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/PodOperationUtilTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
@@ -30,15 +31,19 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.ByteArrayOutputStream;
+import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,11 +76,12 @@ class PodOperationUtilTest {
   @Test
   void testGetGenericPodOperations() {
     // When
-    PodOperationsImpl podOperations = PodOperationUtil.getGenericPodOperations(operationContext, false, 5);
+    PodOperationsImpl podOperations = PodOperationUtil.getGenericPodOperations(operationContext, false, 5, "container1");
 
     // Then
-    assertNotNull(podOperations);
-    assertNull(podOperations.getName());
+    assertThat(podOperations).isNotNull();
+    assertThat(podOperations.getName()).isNull();
+    assertThat(podOperations.getContext().getContainerId()).isEqualTo("container1");
   }
 
   @Test
@@ -112,6 +118,78 @@ class PodOperationUtilTest {
     assertEquals(1, podResources.size());
   }
 
+  @Test
+  void testWatchLogSinglePod() {
+    // Given
+    PodResource<Pod> podResource = Mockito.mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+    ByteArrayOutputStream byteArrayOutputStream = Mockito.mock(ByteArrayOutputStream.class, Mockito.RETURNS_DEEP_STUBS);
+
+    // When
+    LogWatch logWatch = PodOperationUtil.watchLog(createMockPodResourceList(podResource), byteArrayOutputStream);
+
+    // Then
+    assertThat(logWatch).isNotNull();
+    verify(podResource, times(1)).watchLog(byteArrayOutputStream);
+  }
+
+  @Test
+  void testWatchLogMultiplePodReplicasPicksFirstPod() {
+    // Given
+    PodResource<Pod> p1 = Mockito.mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+    PodResource<Pod> p2 = Mockito.mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+    ByteArrayOutputStream byteArrayOutputStream = Mockito.mock(ByteArrayOutputStream.class, Mockito.RETURNS_DEEP_STUBS);
+
+    // When
+    LogWatch logWatch = PodOperationUtil.watchLog(createMockPodResourceList(p1, p2), byteArrayOutputStream);
+
+    // Then
+    assertThat(logWatch).isNotNull();
+    verify(p1, times(1)).watchLog(byteArrayOutputStream);
+    verify(p2, times(0)).watchLog(byteArrayOutputStream);
+  }
+
+  @Test
+  void testWatchLogEmptyPodResourceList() {
+    assertThat(PodOperationUtil.watchLog(Collections.emptyList(), null)).isNull();
+  }
+
+  @Test
+  void testGetLogReaderEmptyPodResourceList() {
+    assertThat(PodOperationUtil.getLogReader(Collections.emptyList())).isNull();
+  }
+
+  @Test
+  void testGetLogReaderMultiplePodReplicasPicksFirstPod() {
+    // Given
+    PodResource<Pod> p1 = Mockito.mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+    PodResource<Pod> p2 = Mockito.mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+
+    // When
+    Reader reader = PodOperationUtil.getLogReader(createMockPodResourceList(p1, p2));
+
+    // Then
+    assertThat(reader).isNotNull();
+    verify(p1, times(1)).getLogReader();
+    verify(p2, times(0)).getLogReader();
+  }
+
+  @Test
+  void testGetLog() {
+    // Given
+    PodResource<Pod> p1 = Mockito.mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+    PodResource<Pod> p2 = Mockito.mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+    when(p1.getLog(anyBoolean())).thenReturn("p1-log");
+    when(p2.getLog(anyBoolean())).thenReturn("p2-log");
+
+    // When
+    String result = PodOperationUtil.getLog(createMockPodResourceList(p1, p2), false);
+
+    // Then
+    assertThat(result).isNotNull().isEqualTo("p1-logp2-log");
+    verify(p1, times(1)).getLog(false);
+    verify(p2, times(1)).getLog(false);
+  }
+
   private PodList getMockPodList(String controllerUid) {
     return new PodListBuilder()
       .addToItems(
@@ -137,5 +215,12 @@ class PodOperationUtilTest {
       }
     });
     return result;
+  }
+
+  @SafeVarargs
+  private final List<PodResource<Pod>> createMockPodResourceList(PodResource<Pod>... podResources) {
+    List<PodResource<Pod>> podResourceList = new ArrayList<>();
+    Collections.addAll(podResourceList, podResources);
+    return podResourceList;
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -466,9 +466,9 @@ class DeploymentTest {
     // Given
     String imageToUpdate = "nginx:latest";
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).times(3);
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
     server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder()
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder()
         .editSpec().editTemplate().editSpec().editContainer(0)
           .withImage(imageToUpdate)
         .endContainer().endSpec().endTemplate().endSpec()
@@ -492,9 +492,9 @@ class DeploymentTest {
     // Given
     Map<String, String> containerToImageMap = Collections.singletonMap("nginx", "nginx:latest");
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).times(3);
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
     server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder()
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder()
         .editSpec().editTemplate().editSpec().editContainer(0)
         .withImage(containerToImageMap.get("nginx"))
         .endContainer().endSpec().endTemplate().endSpec()
@@ -517,9 +517,9 @@ class DeploymentTest {
   void testRolloutPause() throws InterruptedException {
     // Given
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).times(3);
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
     server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).once();
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
 
     // When
     Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
@@ -536,9 +536,9 @@ class DeploymentTest {
   void testRolloutResume() throws InterruptedException {
     // Given
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).times(3);
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
     server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).once();
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
 
     // When
     Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
@@ -556,9 +556,9 @@ class DeploymentTest {
   void testRolloutRestart() throws InterruptedException {
     // Given
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).times(3);
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
     server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).once();
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
 
     // When
     Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
@@ -627,9 +627,9 @@ class DeploymentTest {
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=" + Utils.toUrlEncoded("app=nginx"))
       .andReturn(HttpURLConnection.HTTP_OK, new ReplicaSetListBuilder().withItems(replicaSetRevision1, replicaSetRevision2).build()).once();
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).times(3);
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
     server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build()).once();
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
 
     // When
     Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
@@ -646,44 +646,10 @@ class DeploymentTest {
   @DisplayName("Should get logs for a Deployment")
   void testDeploymentGetLog() {
     // Given
-    ReplicaSet replicaSet = new ReplicaSetBuilder()
-      .withNewMetadata()
-      .withOwnerReferences(
-        new OwnerReferenceBuilder()
-        .withApiVersion("apps/v1")
-        .withBlockOwnerDeletion(true)
-        .withController(true)
-        .withKind("Deployment")
-        .withName("deploy1")
-        .withUid("136581bf-82c2-4675-af05-63c55500b378")
-        .build()
-      )
-      .withName("deploy1-hk9nf")
-      .addToLabels("app", "nginx")
-      .withUid("3Dc4c8746c-94fd-47a7-ac01-11047c0323b4")
-      .endMetadata()
-      .withNewSpec()
-      .withNewSelector()
-      .addToMatchLabels("app", "nginx")
-      .endSelector()
-      .endSpec()
-      .build();
-
-    Pod deployPod = new PodBuilder()
-      .withNewMetadata()
-      .withOwnerReferences(new OwnerReferenceBuilder().withApiVersion("apps/v1")
-        .withBlockOwnerDeletion(true)
-        .withController(true)
-        .withKind("ReplicaSet")
-        .withName("1")
-        .withUid("3Dc4c8746c-94fd-47a7-ac01-11047c0323b4")
-        .build())
-      .withName("deploy1-hk9nf").addToLabels("controller-uid", "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4")
-      .endMetadata()
-      .build();
-
+    ReplicaSet replicaSet = createMockReplicaSet("deploy1", "136581bf-82c2-4675-af05-63c55500b378", "deploy1-hk9nf", Collections.singletonMap("app", "nginx"), "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4");
+    Pod deployPod = createMockPod("1", "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4", "deploy1-hk9nf", Collections.singletonMap("controller-uid", "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4"));
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-      .andReturn(HttpURLConnection.HTTP_OK, getDeploymentBuilder().build())
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
       .always();
 
     server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
@@ -707,7 +673,56 @@ class DeploymentTest {
     assertEquals("hello", log);
   }
 
-  private DeploymentBuilder getDeploymentBuilder() {
+  @Test
+  void testDeploymentGetLogMultiContainer() {
+    // Given
+    ReplicaSet replicaSet = createMockReplicaSet("deploy-multi1", "93b8b619-731a-435a-bcb0-4b0c19f07f2f", "multi-container-deploy-5dfdf5ddfc", Collections.singletonMap("app", "nginx"), "f9ed6d37-9256-44aa-93b0-4af70e046348");
+    Pod deployPod = createMockPod("multi-container-deploy-5dfdf5ddfc", "f9ed6d37-9256-44aa-93b0-4af70e046348", "multi-container-deploy-5dfdf5ddfc-r6q4j", Collections.singletonMap("controller-uid", "f9ed6d37-9256-44aa-93b0-4af70e046348"));
+
+    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy-multi1")
+      .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().editMetadata()
+        .withName("deploy-multi1")
+        .withUid("93b8b619-731a-435a-bcb0-4b0c19f07f2f")
+        .endMetadata().build())
+      .always();
+
+    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
+      .andReturn(HttpURLConnection.HTTP_OK, new ReplicaSetListBuilder().withItems(replicaSet).build())
+      .once();
+    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets/multi-container-deploy-5dfdf5ddfc")
+      .andReturn(HttpURLConnection.HTTP_OK, replicaSet)
+      .once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=app%3Dnginx")
+      .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder().withItems(deployPod).build())
+      .once();
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/multi-container-deploy-5dfdf5ddfc-r6q4j/log?pretty=false&container=container1")
+      .andReturn(HttpURLConnection.HTTP_OK, "hello")
+      .once();
+
+    // When
+    String log = client.apps().deployments().inNamespace("ns1").withName("deploy-multi1").inContainer("container1").getLog();
+
+    // Then
+    assertNotNull(log);
+    assertEquals("hello", log);
+  }
+
+  @Test
+  void testDeploymentLoadWithoutApiVersion() {
+    // Given
+
+    // When
+    List<HasMetadata> list = client.load(getClass().getResourceAsStream("/valid-deployment-without-apiversion.json")).get();
+    Deployment deployment = (Deployment) list.get(0);
+
+    // Then
+    assertNotNull(deployment);
+    assertEquals("test", deployment.getMetadata().getName());
+    assertEquals(1, deployment.getSpec().getReplicas());
+    assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
+  }
+
+  private DeploymentBuilder createDeploymentBuilder() {
     return new DeploymentBuilder()
       .withNewMetadata()
       .withName("deploy1")
@@ -733,19 +748,44 @@ class DeploymentTest {
       .endSpec();
   }
 
-  @Test
-  void testDeploymentLoadWithoutApiVersion() {
-    // Given
+  private ReplicaSet createMockReplicaSet(String ownerDeploymentName, String deploymentUid, String name, Map<String, String> labels, String uid) {
+    return new ReplicaSetBuilder()
+      .withNewMetadata()
+      .withOwnerReferences(
+        new OwnerReferenceBuilder()
+          .withApiVersion("apps/v1")
+          .withBlockOwnerDeletion(true)
+          .withController(true)
+          .withKind("Deployment")
+          .withName(ownerDeploymentName)
+          .withUid(deploymentUid)
+          .build()
+      )
+      .withName(name)
+      .addToLabels(labels)
+      .withUid(uid)
+      .endMetadata()
+      .withNewSpec()
+      .withNewSelector()
+      .withMatchLabels(labels)
+      .endSelector()
+      .endSpec()
+      .build();
+  }
 
-    // When
-    List<HasMetadata> list = client.load(getClass().getResourceAsStream("/valid-deployment-without-apiversion.json")).get();
-    Deployment deployment = (Deployment) list.get(0);
-
-    // Then
-    assertNotNull(deployment);
-    assertEquals("test", deployment.getMetadata().getName());
-    assertEquals(1, deployment.getSpec().getReplicas());
-    assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
+  private Pod createMockPod(String replicaSetName, String replicaSetUid, String name, Map<String, String> labels) {
+    return new PodBuilder()
+      .withNewMetadata()
+      .withOwnerReferences(new OwnerReferenceBuilder().withApiVersion("apps/v1")
+        .withBlockOwnerDeletion(true)
+        .withController(true)
+        .withKind("ReplicaSet")
+        .withName(replicaSetName)
+        .withUid(replicaSetUid)
+        .build())
+      .withName(name).addToLabels(labels)
+      .endMetadata()
+      .build();
   }
 
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -227,7 +227,7 @@ public class DeploymentConfigOperationsImpl extends OpenShiftOperation<Deploymen
 
   @Override
   public String getLog(Boolean isPretty) {
-    try(ResponseBody body = doGetLog(isPretty)) {
+    try {
       return doGetLog(isPretty).string();
     } catch (IOException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("getLog"), e);
@@ -301,7 +301,7 @@ public class DeploymentConfigOperationsImpl extends OpenShiftOperation<Deploymen
 
   private void waitUntilDeploymentConfigPodBecomesReady(DeploymentConfig deploymentConfig) {
     List<PodResource<Pod>> podOps = PodOperationUtil.getPodOperationsForController(context, deploymentConfig.getMetadata().getUid(),
-      getDeploymentConfigPodLabels(deploymentConfig), false, podLogWaitTimeout);
+      getDeploymentConfigPodLabels(deploymentConfig), false, podLogWaitTimeout, ((RollingOperationContext)context).getContainerId());
 
     waitForBuildPodToBecomeReady(podOps, podLogWaitTimeout != null ? podLogWaitTimeout : DEFAULT_POD_LOG_WAIT_TIMEOUT);
   }
@@ -318,5 +318,10 @@ public class DeploymentConfigOperationsImpl extends OpenShiftOperation<Deploymen
       labels.put(OPENSHIFT_IO_DEPLOYMENT_CONFIG_NAME, deploymentConfig.getMetadata().getName());
     }
     return labels;
+  }
+
+  @Override
+  public Loggable<LogWatch> inContainer(String id) {
+    return newInstance(((RollingOperationContext) context).withContainerId(id));
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
@@ -256,7 +256,7 @@ public class BuildOperationsImpl extends OpenShiftOperation<Build, BuildList,
 
   private void waitUntilBuildPodBecomesReady(Build build) {
     List<PodResource<Pod>> podOps = PodOperationUtil.getPodOperationsForController(context, build.getMetadata().getUid(),
-      getBuildPodLabels(build), withPrettyOutput, podLogWaitTimeout);
+      getBuildPodLabels(build), withPrettyOutput, podLogWaitTimeout, null);
 
     waitForBuildPodToBecomeReady(podOps, podLogWaitTimeout != null ? podLogWaitTimeout : DEFAULT_POD_LOG_WAIT_TIMEOUT);
   }


### PR DESCRIPTION
Fix #2712 

Add support for providing `inContainer(String containerName)` method in controller operation classes to be able to specify containers while fetching logs from multi-container resources

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
