### PR TITLE
Fix wrong variable name in CertManager Operations class template + wrongly generated CertificateRequestSpec class

### DIFF
--- a/extensions/certmanager/client/src/main/resources/resource-operation.vm
+++ b/extensions/certmanager/client/src/main/resources/resource-operation.vm
@@ -61,8 +61,8 @@ public class ${model.name}OperationsImpl extends HasMetadataOperation<${model.na
   }
 
   public ${model.name}OperationsImpl(OperationContext context) {
-    super(context.withApiGroupName("$apiGroupName")
-    .withApiGroupVersion("$apiGroupVersion")
+    super(context.withApiGroupName("$apiGroup")
+    .withApiGroupVersion("$apiVersion")
     .withPlural("#pluralize ($model.name.toLowerCase())"));
     this.type = ${model.name}.class;
     this.listType = ${model.name}List.class;

--- a/extensions/certmanager/model-v1/pom.xml
+++ b/extensions/certmanager/model-v1/pom.xml
@@ -83,22 +83,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.mysema.maven</groupId>
-        <artifactId>apt-maven-plugin</artifactId>
-        <version>1.1.3</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-              <processor>io.sundr.builder.internal.processor.BuildableProcessor</processor>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.jsonschema2pojo</groupId>
         <artifactId>jsonschema2pojo-maven-plugin</artifactId>
         <version>${jsonschema2pojo.version}</version>
@@ -141,37 +125,7 @@
                   file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01Ingress.java"
                   verbose="true" />
                 <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableVolume.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableObjectMeta.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableContainer.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableContainerPort.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableVolumeMount.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableLabelSelector.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableEnvVar.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01IngressFluentImpl.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01IngressFluent.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01IngressBuilder.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1/EditableACMEChallengeSolverHTTP01Ingress.java"
+                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/v1/CertificateRequestSpec.java"
                   verbose="true" />
               </target>
             </configuration>

--- a/extensions/certmanager/model-v1/src/main/java/io/fabric8/certmanager/api/model/v1/CertificateRequestSpec.java
+++ b/extensions/certmanager/model-v1/src/main/java/io/fabric8/certmanager/api/model/v1/CertificateRequestSpec.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.certmanager.api.model.v1;
+
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.Duration;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+  "duration",
+  "isCA",
+  "issuerRef",
+  "request",
+  "usages"
+})
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = true, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+  @BuildableReference(ObjectMeta.class),
+  @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+  @BuildableReference(LabelSelector.class),
+  @BuildableReference(Container.class),
+  @BuildableReference(EnvVar.class),
+  @BuildableReference(ContainerPort.class),
+  @BuildableReference(Volume.class),
+  @BuildableReference(VolumeMount.class)
+})
+public class CertificateRequestSpec implements KubernetesResource
+{
+
+  @JsonProperty("duration")
+  private Duration duration;
+  @JsonProperty("isCA")
+  private Boolean isCA;
+  @JsonProperty("issuerRef")
+  private io.fabric8.certmanager.api.model.meta.v1.ObjectReference issuerRef;
+  @JsonProperty("request")
+  private String request;
+  @JsonProperty("usages")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private List<String> usages = new ArrayList<String>();
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+  /**
+   * No args constructor for use in serialization
+   *
+   */
+  public CertificateRequestSpec() {
+  }
+
+  /**
+   *
+   * @param duration
+   * @param request
+   * @param isCA
+   * @param issuerRef
+   * @param usages
+   */
+  public CertificateRequestSpec(Duration duration, Boolean isCA, io.fabric8.certmanager.api.model.meta.v1.ObjectReference issuerRef, String request, List<String> usages) {
+    super();
+    this.duration = duration;
+    this.isCA = isCA;
+    this.issuerRef = issuerRef;
+    this.request = request;
+    this.usages = usages;
+  }
+
+  @JsonProperty("duration")
+  public Duration getDuration() {
+    return duration;
+  }
+
+  @JsonProperty("duration")
+  public void setDuration(Duration duration) {
+    this.duration = duration;
+  }
+
+  @JsonProperty("isCA")
+  public Boolean getIsCA() {
+    return isCA;
+  }
+
+  @JsonProperty("isCA")
+  public void setIsCA(Boolean isCA) {
+    this.isCA = isCA;
+  }
+
+  @JsonProperty("issuerRef")
+  public io.fabric8.certmanager.api.model.meta.v1.ObjectReference getIssuerRef() {
+    return issuerRef;
+  }
+
+  @JsonProperty("issuerRef")
+  public void setIssuerRef(io.fabric8.certmanager.api.model.meta.v1.ObjectReference issuerRef) {
+    this.issuerRef = issuerRef;
+  }
+
+  @JsonProperty("request")
+  public String getRequest() {
+    return request;
+  }
+
+  @JsonProperty("request")
+  public void setRequest(String request) {
+    this.request = request;
+  }
+
+  @JsonProperty("usages")
+  public List<String> getUsages() {
+    return usages;
+  }
+
+  @JsonProperty("usages")
+  public void setUsages(List<String> usages) {
+    this.usages = usages;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
+
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
+
+}
+

--- a/extensions/certmanager/model-v1beta1/pom.xml
+++ b/extensions/certmanager/model-v1beta1/pom.xml
@@ -83,22 +83,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.mysema.maven</groupId>
-        <artifactId>apt-maven-plugin</artifactId>
-        <version>1.1.3</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-              <processor>io.sundr.builder.internal.processor.BuildableProcessor</processor>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.jsonschema2pojo</groupId>
         <artifactId>jsonschema2pojo-maven-plugin</artifactId>
         <version>${jsonschema2pojo.version}</version>
@@ -141,37 +125,7 @@
                   file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1beta1/ACMEChallengeSolverHTTP01Ingress.java"
                   verbose="true" />
                 <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableVolume.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableObjectMeta.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableContainer.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableContainerPort.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableVolumeMount.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableLabelSelector.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/kubernetes/api/model/EditableEnvVar.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1beta1/ACMEChallengeSolverHTTP01IngressFluentImpl.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1beta1/ACMEChallengeSolverHTTP01IngressFluent.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1beta1/ACMEChallengeSolverHTTP01IngressBuilder.java"
-                  verbose="true" />
-                <delete
-                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/acme/v1beta1/EditableACMEChallengeSolverHTTP01Ingress.java"
+                  file="${project.build.directory}/generated-sources/io/fabric8/certmanager/api/model/v1beta1/CertificateRequestSpec.java"
                   verbose="true" />
               </target>
             </configuration>

--- a/extensions/certmanager/model-v1beta1/src/main/java/io/fabric8/certmanager/api/model/v1beta1/CertificateRequestSpec.java
+++ b/extensions/certmanager/model-v1beta1/src/main/java/io/fabric8/certmanager/api/model/v1beta1/CertificateRequestSpec.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.certmanager.api.model.v1beta1;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.Duration;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "duration",
+    "isCA",
+    "issuerRef",
+    "request",
+    "usages"
+})
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = true, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+public class CertificateRequestSpec implements KubernetesResource
+{
+
+    @JsonProperty("duration")
+    private Duration duration;
+    @JsonProperty("isCA")
+    private Boolean isCA;
+    @JsonProperty("issuerRef")
+    private io.fabric8.certmanager.api.model.meta.v1.ObjectReference issuerRef;
+    @JsonProperty("request")
+    private String request;
+    @JsonProperty("usages")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> usages = new ArrayList<String>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public CertificateRequestSpec() {
+    }
+
+    /**
+     * 
+     * @param duration
+     * @param request
+     * @param isCA
+     * @param issuerRef
+     * @param usages
+     */
+    public CertificateRequestSpec(Duration duration, Boolean isCA, io.fabric8.certmanager.api.model.meta.v1.ObjectReference issuerRef, String request, List<String> usages) {
+        super();
+        this.duration = duration;
+        this.isCA = isCA;
+        this.issuerRef = issuerRef;
+        this.request = request;
+        this.usages = usages;
+    }
+
+    @JsonProperty("duration")
+    public Duration getDuration() {
+        return duration;
+    }
+
+    @JsonProperty("duration")
+    public void setDuration(Duration duration) {
+        this.duration = duration;
+    }
+
+    @JsonProperty("isCA")
+    public Boolean getIsCA() {
+        return isCA;
+    }
+
+    @JsonProperty("isCA")
+    public void setIsCA(Boolean isCA) {
+        this.isCA = isCA;
+    }
+
+    @JsonProperty("issuerRef")
+    public io.fabric8.certmanager.api.model.meta.v1.ObjectReference getIssuerRef() {
+        return issuerRef;
+    }
+
+    @JsonProperty("issuerRef")
+    public void setIssuerRef(io.fabric8.certmanager.api.model.meta.v1.ObjectReference issuerRef) {
+        this.issuerRef = issuerRef;
+    }
+
+    @JsonProperty("request")
+    public String getRequest() {
+        return request;
+    }
+
+    @JsonProperty("request")
+    public void setRequest(String request) {
+        this.request = request;
+    }
+
+    @JsonProperty("usages")
+    public List<String> getUsages() {
+        return usages;
+    }
+
+    @JsonProperty("usages")
+    public void setUsages(List<String> usages) {
+        this.usages = usages;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/extensions/certmanager/tests/src/test/java/io/fabric8/certmanager/test/crud/V1CertificateRequestTest.java
+++ b/extensions/certmanager/tests/src/test/java/io/fabric8/certmanager/test/crud/V1CertificateRequestTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.certmanager.test.crud;
+
+import io.fabric8.certmanager.api.model.meta.v1.ObjectReferenceBuilder;
+import io.fabric8.certmanager.api.model.v1.CertificateRequest;
+import io.fabric8.certmanager.api.model.v1.CertificateRequestBuilder;
+import io.fabric8.certmanager.client.CertManagerClient;
+import io.fabric8.certmanager.server.mock.CertManagerServer;
+import io.fabric8.kubernetes.api.model.Duration;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+import java.net.HttpURLConnection;
+import java.text.ParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableRuleMigrationSupport
+class V1CertificateRequestTest {
+  @Rule
+  public CertManagerServer server = new CertManagerServer();
+
+  @Test
+  void testCreate() throws Exception {
+    // Given
+    CertificateRequest certificateRequest = createCertificateRequest();
+    server.expect().post().withPath("/apis/cert-manager.io/v1/namespaces/ns1/certificaterequests")
+      .andReturn(HttpURLConnection.HTTP_CREATED, certificateRequest)
+      .once();
+    CertManagerClient certManagerClient = server.getCertManagerClient();
+
+    // When
+    CertificateRequest createdRequest = certManagerClient.v1().certificateRequests().inNamespace("ns1").create(certificateRequest);
+
+    // Then
+    assertNotNull(createdRequest);
+    assertEquals("my-ca-cr", createdRequest.getMetadata().getName());
+  }
+
+  private CertificateRequest createCertificateRequest() throws ParseException {
+    return new CertificateRequestBuilder()
+      .withNewMetadata().withName("my-ca-cr").endMetadata()
+      .withNewSpec()
+      .withRequest("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQzNqQ0N")
+      .withIsCA(false)
+      .addToUsages("signing", "digital signature", "server auth")
+      .withDuration(Duration.parse("90d"))
+      .withIssuerRef(new ObjectReferenceBuilder()
+        .withName("ca-issuer")
+        .withKind("Issuer")
+        .withGroup("cert-manager.io")
+        .build())
+      .endSpec()
+      .build();
+  }
+}


### PR DESCRIPTION
## Description

+ I was trying out CertManager Extension for a blogpost. I realized none
  of the resource's apiGroup/apiVersion were getting resolved due to a
  possible typo in Operations class template
+ Added a custom class CertificateRequestSpec in order to override
  generated class's request field. In go struct it's [`byte[]`](https://github.com/jetstack/cert-manager/blob/master/pkg/apis/certmanager/v1/types_certificaterequest.go#L97) but there
  is no explicit byte type in reflect package. I'm not really sure how
  to handle this in generator

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
