### PR TITLE
fix #3278: should not allow wait at a list context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix #3272: prevent index npe after informer sees an empty list
 * Fix #3275: filter related dsl methods withLabel, withField, etc. should not modify the current context.  If you need similar behavior to the previous use `Filterable.withNewFilter`.
 * Fix #3271: waitUntilReady and waitUntilCondition should handle resource too old
+* Fix #3278: `Waitable` methods should not be available at a list context
 
 #### Improvements
 * Fix #3078: adding javadocs to further clarify patch, edit, replace, etc. and note the possibility of items being modified.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
@@ -17,8 +17,9 @@ package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.GracePeriodConfigurable;
 import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
+import io.fabric8.kubernetes.client.Watcher;
 
-public interface WatchListDeletable<T, L> extends VersionWatchAndWaitable<T>, Listable<L>, Deletable,
+public interface WatchListDeletable<T, L> extends Watchable<Watcher<T>>, Versionable<WatchAndWaitable<T>>, Listable<L>, Deletable,
                                                         GracePeriodConfigurable<Deletable>,
                                                         PropagationPolicyConfigurable<EditReplacePatchDeletable<T>>,
                                                         StatusUpdatable<T>,

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -156,13 +156,14 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
     public void onClose(WatcherException exception) {
       // this close was triggered by an exception,
       // not the user, it is expected that the watch retry will handle this
-      log.warn("Watch closing with exception", exception);
       boolean restarted = false;
       try {
         if (exception.isHttpGone()) {
+          log.debug("Watch restarting due to http gone");
           listSyncAndWatch();
           restarted = true;
         } else {
+          log.warn("Watch closing with exception", exception);
           running = false; // shouldn't happen, but it means the watch won't restart
         }
       } finally {


### PR DESCRIPTION
## Description
Prevents the waitable methods from being called on a list context.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
