### PR TITLE
fix #3284: using handlers to get a builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #3284: refined how builders are obtained / used by HasMetadataOperation
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -924,7 +924,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
    * @param list Kubernetes resource list
    */
   protected void updateApiVersion(KubernetesResourceList<T> list) {
-    String version = getApiVersion();
+    String version = apiVersion;
     if (list != null && version != null && version.length() > 0 && list.getItems() != null) {
       list.getItems().forEach(this::updateApiVersion);
     }
@@ -937,7 +937,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
    * @param hasMetadata object whose api version needs to be updated
    */
   protected void updateApiVersion(HasMetadata hasMetadata) {
-    String version = getApiVersion();
+    String version = apiVersion;
     if (hasMetadata != null && version != null && version.length() > 0) {
       String current = hasMetadata.getApiVersion();
       // lets overwrite the api version if its currently missing, the resource uses an API Group with '/'
@@ -946,19 +946,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         hasMetadata.setApiVersion(version);
       }
     }
-  }
-
-  public String getApiVersion() {
-    return apiVersion;
-  }
-
-  /**
-   * Return true if this is an API Group where the versions include a slash in them
-   *
-   * @return boolean value indicating whether API group or not
-   */
-  public boolean isApiGroup() {
-    return apiVersion != null && apiVersion.indexOf('/') > 0;
   }
 
   public Readiness getReadiness() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -117,11 +117,11 @@ public class OperationSupport {
     this.retryIntervalCalculator = new ExponentialBackoffIntervalCalculator(requestRetryBackoffInterval, maxRetryIntervalExponent);
   }
 
-  public String getAPIGroup() {
+  public String getAPIGroupName() {
     return apiGroupName;
   }
 
-  public String getAPIVersion() {
+  public String getAPIGroupVersion() {
     return apiGroupVersion;
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CustomResourceOperationsImpl.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.utils.ApiVersionUtil;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import okhttp3.OkHttpClient;
 
@@ -48,7 +49,7 @@ public class CustomResourceOperationsImpl<T extends HasMetadata, L extends Kuber
     this.listType = context.getListType() != null ? context.getListType() : (Class) inferListType(this.type);
 
     this.resourceNamespaced = resourceNamespaced(context.getCrdContext());
-    this.apiVersion = getAPIGroup() + "/" + getAPIVersion();
+    this.apiVersion = ApiVersionUtil.joinApiGroupAndVersion(getAPIGroupName(), getAPIGroupVersion());
 
     KubernetesDeserializer.registerCustomKind(apiVersion, kind(context.getCrdContext()), type);
     if (KubernetesResource.class.isAssignableFrom(listType)) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -35,7 +35,6 @@ import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.Handlers;
@@ -52,7 +51,6 @@ import io.fabric8.kubernetes.client.dsl.Readiable;
 import io.fabric8.kubernetes.client.dsl.VisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.Waitable;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
-import io.fabric8.kubernetes.client.handlers.KubernetesListHandler;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import okhttp3.OkHttpClient;
 
@@ -304,12 +302,12 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
     throw new IllegalArgumentException("Item needs to be an instance of HasMetadata or String.");
   }
 
-  static <T> ResourceHandler<? extends KubernetesResource, ?> checkForHandlerOf(T item) {
+  static <T> void checkForHandlerOf(T item) {
     if (item instanceof HasMetadata) {
-      return handlerOf((HasMetadata)item);
-    } else if (item instanceof KubernetesList) {
-      return new KubernetesListHandler();
-    } else {
+      if (handlerOf((HasMetadata)item) == null) {
+        throw new KubernetesClientException("No handler found for object:" + item);
+      }
+    } else if (!(item instanceof KubernetesList)) {
       throw new IllegalArgumentException("Could not find a registered handler for item: [" + item + "].");
     }
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.apps.v1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Status;
@@ -30,7 +29,6 @@ import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -383,11 +381,6 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   @Override
   public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
     return new DeploymentOperationsImpl(((RollingOperationContext)context), logWaitTimeout);
-  }
-
-  @Override
-  protected VisitableBuilder<Deployment, ?> createVisitableBuilder(Deployment item) {
-    return new DeploymentBuilder(item);
   }
 
   private Deployment sendPatchedDeployment(Map<String, Object> patchedUpdate) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
@@ -15,12 +15,10 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.apps.v1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
-import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetList;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
 import io.fabric8.kubernetes.client.Config;
@@ -231,11 +229,6 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
   @Override
   public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
     return new ReplicaSetOperationsImpl(((RollingOperationContext)context), logWaitTimeout);
-  }
-
-  @Override
-  protected VisitableBuilder<ReplicaSet, ?> createVisitableBuilder(ReplicaSet item) {
-    return new ReplicaSetBuilder(item);
   }
 
   static Map<String, String> getReplicaSetSelectorLabels(ReplicaSet replicaSet) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.apps.v1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -23,7 +22,6 @@ import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.apps.ControllerRevision;
 import io.fabric8.kubernetes.api.model.apps.ControllerRevisionList;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
 import io.fabric8.kubernetes.client.Config;
@@ -259,11 +257,6 @@ public class StatefulSetOperationsImpl extends RollableScalableResourceOperation
     ControllerRevision previousControllerRevision = controllerRevisions.get(1);
 
     return sendPatchedStatefulSetData(previousControllerRevision.getData());
-  }
-
-  @Override
-  protected VisitableBuilder<StatefulSet, ?> createVisitableBuilder(StatefulSet item) {
-    return new StatefulSetBuilder(item);
   }
 
   private StatefulSet sendPatchedStatefulSet(Map<String, Object> patchedUpdate) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.batch.v1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
@@ -25,7 +24,6 @@ import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.utils.PodOperationUtil;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
-import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -236,11 +234,6 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
     }
 
     return super.replace(job);
-  }
-
-  @Override
-  protected VisitableBuilder<Job, ?> createVisitableBuilder(Job item) {
-    return new JobBuilder(item);
   }
 
   static Map<String, String> getJobPodLabels(Job job) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/BindingOperationsImpl.java
@@ -17,9 +17,7 @@ package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Binding;
-import io.fabric8.kubernetes.api.model.BindingBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -42,11 +40,6 @@ public class BindingOperationsImpl extends HasMetadataOperation<Binding, Kuberne
       .withPlural("bindings"));
     this.type = Binding.class;
     this.listType = (Class<KubernetesResourceList<Binding>>) TypeFactory.rawClass(new TypeReference<KubernetesResourceList<Binding>>(){}.getType());
-  }
-
-  @Override
-  protected VisitableBuilder<Binding, ?> createVisitableBuilder(Binding item) {
-    return new BindingBuilder(item);
   }
 
   public BindingOperationsImpl newInstance(OperationContext context) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ComponentStatusOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ComponentStatusOperationsImpl.java
@@ -15,14 +15,11 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
-import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import okhttp3.OkHttpClient;
 
 import io.fabric8.kubernetes.api.model.ComponentStatus;
-import io.fabric8.kubernetes.api.model.ComponentStatusBuilder;
 import io.fabric8.kubernetes.api.model.ComponentStatusList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
@@ -47,11 +44,6 @@ public class ComponentStatusOperationsImpl extends HasMetadataOperation<Componen
   @Override
   public ComponentStatusOperationsImpl newInstance(OperationContext context) {
     return new ComponentStatusOperationsImpl(context);
-  }
-
-  @Override
-  protected VisitableBuilder<ComponentStatus, ?> createVisitableBuilder(ComponentStatus item) {
-    return new ComponentStatusBuilder(item);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.api.model.DeleteOptions;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.policy.v1beta1.Eviction;
 import io.fabric8.kubernetes.api.model.policy.v1beta1.EvictionBuilder;
@@ -73,7 +72,6 @@ import io.fabric8.kubernetes.client.dsl.internal.PortForwarderWebsocket;
 import io.fabric8.kubernetes.client.dsl.internal.uploadable.PodUpload;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -687,9 +685,5 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     return new PodOperationsImpl(getContext().withTimestamps(true));
   }
 
-  @Override
-  protected VisitableBuilder<Pod, ?> createVisitableBuilder(Pod item) {
-    return new PodBuilder(item);
-  }
 }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
@@ -15,11 +15,9 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerList;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
@@ -239,11 +237,6 @@ public class ReplicationControllerOperationsImpl extends RollableScalableResourc
   @Override
   public ReplicationController undo() {
     throw new UnsupportedOperationException("no rollbacker has been implemented for \"" + get().getKind() +"\"");
-  }
-
-  @Override
-  protected VisitableBuilder<ReplicationController, ?> createVisitableBuilder(ReplicationController item) {
-    return new ReplicationControllerBuilder(item);
   }
 
   static Map<String, String> getReplicationControllerPodLabels(ReplicationController replicationController) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceOperationsImpl.java
@@ -18,7 +18,6 @@ package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServiceList;
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.*;
 import io.fabric8.kubernetes.client.Config;
@@ -135,11 +134,6 @@ public class ServiceOperationsImpl extends HasMetadataOperation<Service, Service
         .inNamespace(m.getMetadata().getNamespace())
         .withName(m.getMetadata().getName())
         .portForward(port);
-  }
-
-  @Override
-  protected VisitableBuilder<Service, ?> createVisitableBuilder(Service item) {
-    return new ServiceBuilder(item);
   }
 
   public class ServiceToUrlSortComparator implements Comparator<ServiceToURLProvider> {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
@@ -15,12 +15,10 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.extensions.v1beta1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentList;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
@@ -390,11 +388,6 @@ public class DeploymentOperationsImpl extends RollableScalableResourceOperation<
   @Override
   public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
     return new DeploymentOperationsImpl(((RollingOperationContext) context), logWaitTimeout);
-  }
-
-  @Override
-  protected VisitableBuilder<Deployment, ?> createVisitableBuilder(Deployment item) {
-    return new DeploymentBuilder(item);
   }
 
   private Deployment sendPatchedDeployment(Map<String, Object> patchedUpdate) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
@@ -15,13 +15,11 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.extensions.v1beta1;
 
-import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
-import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetList;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -234,11 +232,6 @@ public class ReplicaSetOperationsImpl extends RollableScalableResourceOperation<
   @Override
   public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
     return new ReplicaSetOperationsImpl(((RollingOperationContext) context), logWaitTimeout);
-  }
-
-  @Override
-  protected VisitableBuilder<ReplicaSet, ?> createVisitableBuilder(ReplicaSet item) {
-    return new ReplicaSetBuilder(item);
   }
 
   static Map<String, String> getReplicaSetSelectorLabels(ReplicaSet replicaSet) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.kubernetes.client.mock;
 
+import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -91,6 +92,17 @@ class PodCrudTest {
     Pod pod = client.pods().inNamespace("ns1").withName("pod2").get();
     assertNotNull(pod);
     assertEquals(2, pod.getMetadata().getLabels().size());
+
+    pod2 = client.pods().inNamespace("ns1").withName("pod2").edit(new Visitor<PodBuilder>() {
+
+      @Override
+      public void visit(PodBuilder buidler) {
+        buidler.editMetadata().addToLabels("another", "one").endMetadata();
+      }
+
+    });
+    assertNotNull(pod2);
+    assertEquals("one", pod2.getMetadata().getLabels().get("another"));
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -93,11 +93,13 @@ class PodCrudTest {
     assertNotNull(pod);
     assertEquals(2, pod.getMetadata().getLabels().size());
 
-    pod2 = client.pods().inNamespace("ns1").withName("pod2").edit(new Visitor<PodBuilder>() {
+    pod2 = client.pods().inNamespace("ns1").withName("pod2").edit(new Visitor<Object>() {
 
       @Override
-      public void visit(PodBuilder buidler) {
-        buidler.editMetadata().addToLabels("another", "one").endMetadata();
+      public void visit(Object builder) {
+        if (builder instanceof PodBuilder) {
+          ((PodBuilder)builder).editMetadata().addToLabels("another", "one").endMetadata();
+        }
       }
 
     });

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.fabric8.kubernetes.client.utils.ApiVersionUtil;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.client.OpenShiftConfig;
@@ -106,13 +107,10 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
   }
 
   private void updateApiVersion() {
-    if (apiGroupName != null && apiGroupVersion != null) {
-      this.apiVersion = apiGroupName + "/" + apiGroupVersion;
-    } else if (apiGroupVersion != null) {
-      this.apiVersion = apiGroupVersion;
-    }
+    this.apiVersion = ApiVersionUtil.joinApiGroupAndVersion(apiGroupName, apiGroupVersion);
   }
 
+  @Override
   protected Class<? extends Config> getConfigType() {
     return OpenShiftConfig.class;
   }


### PR DESCRIPTION
## Description
Based upon #3284 this pr:
- uses handler logic to get a builder
- just using serialization for cloning
- clarifies the apiversion methods on baseoperation and operationsupport

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

