### PR TITLE
Retry HTTP operation in case IOException too (exponential backoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Fix #3291: Retrying the HTTP operation in case of IOException too
 
 ### 5.5.0 (2021-06-30)
 


### PR DESCRIPTION
## Description

Fixing #3291: Retrying the HTTP operation in case of IOException too.

Tested with unit tests.

With the following logger config:
```
$ cat kubernetes-client/src/test/resources/simplelogger.properties
org.slf4j.simpleLogger.defaultLogLevel=info
org.slf4j.simpleLogger.log.io.fabric8.kubernetes.client.dsl.base = debug
```

the unit tests produced the following example output (partial output):
```
[main] DEBUG io.fabric8.kubernetes.client.dsl.base.OperationSupport - HTTP operation on url: https://172.17.0.2:8443/api/v1/pods/test-pod should be retried as the response code was 500, retrying after 2000 millis
[main] DEBUG io.fabric8.kubernetes.client.dsl.base.OperationSupport - HTTP operation on url: https://172.17.0.2:8443/api/v1/pods/test-pod should be retried after 4000 millis because of IOException
java.io.IOException: For example java.net.ConnectException
        at io.fabric8.kubernetes.client.dsl.base.BaseOperationTest.lambda$newHttpClientWithSomeFailures$0(BaseOperationTest.java:245)
        at org.mockito.internal.stubbing.StubbedInvocationMatcher.answer(StubbedInvocationMatcher.java:42)
        at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:103)
        at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
```

## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

