### PR TITLE
fix #3304: preventing npe race condition on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.6-SNAPSHOT
 
 #### Bugs
+* Fix #3304: Prevent NPE in after informer stop
 * Fix #3083: CertificateException due to PEM being decoded in CertUtils
 
 #### Improvements

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/SharedProcessor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/SharedProcessor.java
@@ -35,10 +35,10 @@ import java.util.function.Supplier;
  * <br>Modified to simplify threading
  */
 public class SharedProcessor<T> {
-  private ReadWriteLock lock = new ReentrantReadWriteLock();
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-  private List<ProcessorListener<T>> listeners;
-  private List<ProcessorListener<T>> syncingListeners;
+  private final List<ProcessorListener<T>> listeners = new ArrayList<>();
+  private final List<ProcessorListener<T>> syncingListeners = new ArrayList<>();
   private final Executor executor;
   
   public SharedProcessor() {
@@ -46,8 +46,6 @@ public class SharedProcessor<T> {
   }
 
   public SharedProcessor(Executor executor) {
-    this.listeners = new ArrayList<>();
-    this.syncingListeners = new ArrayList<>();
     this.executor = executor;
   }
 
@@ -96,7 +94,7 @@ public class SharedProcessor<T> {
     lock.writeLock().lock();
     boolean resyncNeeded = false;
     try {
-      this.syncingListeners = new ArrayList<>();
+      this.syncingListeners.clear();
 
       ZonedDateTime now = ZonedDateTime.now();
       for (ProcessorListener<T> listener : this.listeners) {
@@ -115,8 +113,8 @@ public class SharedProcessor<T> {
   public void stop() {
     lock.writeLock().lock();
     try {
-      syncingListeners = null;
-      listeners = null;
+      syncingListeners.clear();
+      listeners.clear();
     } finally {
       lock.writeLock().unlock();
     }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/SharedProcessorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/SharedProcessorTest.java
@@ -48,6 +48,19 @@ class SharedProcessorTest {
     assertTrue(expectUpdateHandler.isSatisfied());
     assertTrue(expectDeleteHandler.isSatisfied());
   }
+  
+  @Test
+  void testDistributeAfterStop() throws InterruptedException {
+    SharedProcessor<Pod> sharedProcessor = new SharedProcessor<>();
+    
+    sharedProcessor.stop();
+
+    Pod foo1 = new PodBuilder().withNewMetadata().withName("foo1").withNamespace("default").endMetadata().build();
+    ProcessorListener.Notification<Pod> addNotification = new ProcessorListener.AddNotification<>(foo1);
+
+    // nothing should happen
+    sharedProcessor.distribute(addNotification, false);
+  }
 
   private static class ExpectingNotificationHandler<T> extends ProcessorListener<T> {
     ExpectingNotificationHandler(Notification<T> notification) {


### PR DESCRIPTION
## Description
Prevents npes after the processor has been stopped.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift