### PR TITLE
Fix #3295: Fix wrong kind getting registered in KubernetesDeserializer in SharedInformerFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #3083: CertificateException due to PEM being decoded in CertUtils
+* Fix #3295: Fix wrong kind getting registered in KubernetesDeserializer in SharedInformerFactory
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
@@ -425,9 +425,9 @@ public class SharedInformerFactory {
     }
   }
 
-  private <T extends HasMetadata> void registerKindToKubernetesDeserializer(Class<T> apiTypeClass) {
+  <T extends HasMetadata> void registerKindToKubernetesDeserializer(Class<T> apiTypeClass) {
     if (CustomResource.class.isAssignableFrom(apiTypeClass)) {
-      KubernetesDeserializer.registerCustomKind(HasMetadata.getApiVersion(apiTypeClass), apiTypeClass.getSimpleName(), apiTypeClass);
+      KubernetesDeserializer.registerCustomKind(HasMetadata.getApiVersion(apiTypeClass), HasMetadata.getKind(apiTypeClass), apiTypeClass);
     }
   }
 


### PR DESCRIPTION
## Description

Fix #3295 
We were assuming kind to be equal to class name while registering
CustomResource POJO to KubernetesDeserializer. This can be a wrong
assumption in case user decides to override kind via the `@Kind`
annotation.

Use `HasMetadata.getKind(apiTypeClass)` to resolve Kind rather than
assuming it to be class name.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
