### PR TITLE
Deprecated methods fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The kubernetes API defines a bunch of extensions like `daemonSets`, `jobs`, `ing
 e.g. to list the jobs...
 
 ```
-jobs = client.batch().jobs().list();
+jobs = client.batch().v1().jobs().list();
 ```
 
 ### Loading resources from external sources

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -701,14 +701,14 @@ Boolean isDeleted = client.secrets().inNamespace("default").withName("secret1").
 ```
 
 ### Job
-`Job` resource is available in Kubernetes Client API via `client.batch().jobs()`. Here are some of the examples of common usage:
+`Job` resource is available in Kubernetes Client API via `client.batch().v1().jobs()`. Here are some of the examples of common usage:
 - Loading a `Job` from yaml:
 ```
-Job job = client.batch().jobs().load(new FileInputStream("sample-job.yml")).get();
+Job job = client.batch().v1().jobs().load(new FileInputStream("sample-job.yml")).get();
 ```
 - Get a `Job` resource with some name from API server:
 ```
-Job job = client.batch().jobs().inNamespace("default").withName("pi").get();
+Job job = client.batch().v1().jobs().inNamespace("default").withName("pi").get();
 ```
 - Create `Job`:
 ```
@@ -733,31 +733,31 @@ final Job job = new JobBuilder()
     .endSpec()
     .build();
 
-client.batch().jobs().inNamespace("default").create(job);
+client.batch().v1().inNamespace("default").create(job);
 ```
 - Create or Replace an existing `Job`:
 ```
-Job job = client.batch().jobs().inNamespace("default").createOrReplace(job);
+Job job = client.batch().v1().jobs().inNamespace("default").createOrReplace(job);
 ```
 - List `Job` in some namespace:
 ```
-JobList jobList = client.batch().jobs().inNamespace("default").list();
+JobList jobList = client.batch().v1().jobs().inNamespace("default").list();
 ```
 - List `Job` in any namespace:
 ```
-JobList jobList = client.batch().jobs().inAnyNamespace().list();
+JobList jobList = client.batch().v1().jobs().inAnyNamespace().list();
 ```
 - List `Job` resources in some namespace with some labels:
 ```
-JobList jobList = client.batch().jobs().inNamespace("default").withLabel("foo", "bar").list();
+JobList jobList = client.batch().v1().jobs().inNamespace("default").withLabel("foo", "bar").list();
 ```
 - Delete `Job`:
 ```
-Boolean isDeleted = client.batch().jobs().inNamespace("default").withName("pi").delete();
+Boolean isDeleted = client.batch().v1().jobs().inNamespace("default").withName("pi").delete();
 ```
 - Watch `Job`:
 ```
-  client.batch().jobs().inNamespace("default").watch(new Watcher<Job>() {
+  client.batch().v1().jobs().inNamespace("default").watch(new Watcher<Job>() {
     @Override
     public void eventReceived(Action action, Job resource) {
       // Do something depending upon action 

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -733,7 +733,7 @@ final Job job = new JobBuilder()
     .endSpec()
     .build();
 
-client.batch().v1().inNamespace("default").create(job);
+client.batch().v1().jobs().inNamespace("default").create(job);
 ```
 - Create or Replace an existing `Job`:
 ```

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -771,14 +771,14 @@ Boolean isDeleted = client.batch().v1().jobs().inNamespace("default").withName("
 ```
 
 ### CronJob
-`CronJob` resource is available in Kubernetes Client api via `client.batch().cronjobs()`. Here are some of the examples of its usages:
+`CronJob` resource is available in Kubernetes Client api via `client.batch().v1().cronjobs()`. Here are some of the examples of its usages:
 - Load `CronJob` from yaml:
 ```
-CronJob cronJob = client.batch().cronjobs().load(new FileInputStream("cronjob.yml")).get();
+CronJob cronJob = client.batch().v1().cronjobs().load(new FileInputStream("cronjob.yml")).get();
 ```
 - Get a `CronJob` from Kubernetes API server:
 ```
-CronJob aCronJob = client.batch().cronjobs().inNamespace("default").withName("some-cj").get();
+CronJob aCronJob = client.batch().v1().cronjobs().inNamespace("default").withName("some-cj").get();
 ```
 - Create `CronJob`:
 ```
@@ -807,33 +807,33 @@ CronJob cronJob1 = new CronJobBuilder()
     .endSpec()
     .build();
 
-cronJob1 = client.batch().cronjobs().inNamespace("default").create(cronJob1);
+cronJob1 = client.batch().v1().cronjobs().inNamespace("default").create(cronJob1);
 ```
 - Create or Replace an existing `CronJob`:
 ```
-CronJob cronJob = client.batch().cronjobs().inNamespace("default").createOrReplace(cronJob1);
+CronJob cronJob = client.batch().v1().cronjobs().inNamespace("default").createOrReplace(cronJob1);
 ```
 - List some `CronJob` objects in some namespace:
 ```
-CronJobList cronJobList = client.batch().cronjobs().inNamespace("default").list()
+CronJobList cronJobList = client.batch().v1().cronjobs().inNamespace("default").list()
 ```
 - List some `CronJob` objects in any namespace:
 ```
-CronJobList cronJobList = client.batch().cronjobs().inAnyNamespace().list();
+CronJobList cronJobList = client.batch().v1().cronjobs().inAnyNamespace().list();
 ```
 - List some `CronJob` objects in some namespace with some label:
 ```
-CronJobList cronJobList = client.batch().cronjobs().inNamespace("default").withLabel("foo", "bar").list();
+CronJobList cronJobList = client.batch().v1().cronjobs().inNamespace("default").withLabel("foo", "bar").list();
 ```
 - Edit/Update `CronJob`:
 ```java
-CronJob cronJob1 = client.batch().cronjobs().inNamespace("default").withName(cronJob1.getMetadata().getName()).edit(
+CronJob cronJob1 = client.batch().v1().cronjobs().inNamespace("default").withName(cronJob1.getMetadata().getName()).edit(
   cj -> new CronJobBuilder(cj).editSpec().withSchedule("*/1 * * * *").endSpec().build()
 );
 ```
 - Delete `CronJob`:
 ```
-Boolean isDeleted = client.batch().cronjobs().inNamespace("default").withName("pi").delete();
+Boolean isDeleted = client.batch().v1().cronjobs().inNamespace("default").withName("pi").delete();
 ```
 
 ### Namespace
@@ -1398,14 +1398,14 @@ Boolean deleted = client.network().networkPolicies().withName("np-test").delete(
 ```
 
 ### PodDisruptionBudget
-`PodDisruptionBudget` is available in Kubernetes Client API via `client.policy().podDisruptionBudget()`. Here are some of the examples of its usage:
+`PodDisruptionBudget` is available in Kubernetes Client API via `client.policy().v1().podDisruptionBudget()`. Here are some of the examples of its usage:
 - Load `PodDisruptionBudget` from yaml:
 ```
-PodDisruptionBudget pdb = client.policy().podDisruptionBudget().load(new FileInputStream("/test-pdb.yml")).get();
+PodDisruptionBudget pdb = client.policy().v1().podDisruptionBudget().load(new FileInputStream("/test-pdb.yml")).get();
 ```
 - Get `PodDisruptionBudget` from Kubernetes API server:
 ```
-PodDisruptionBudget podDisruptionBudget = client.policy().podDisruptionBudget().inNamespace("default").withName("poddisruptionbudget1").get();
+PodDisruptionBudget podDisruptionBudget = client.policy().v1().podDisruptionBudget().inNamespace("default").withName("poddisruptionbudget1").get();
 ```
 - Create `PodDisruptionBudget`:
 ```
@@ -1419,27 +1419,27 @@ PodDisruptionBudget podDisruptionBudget = new PodDisruptionBudgetBuilder()
     .endSpec()
     .build();
 
-client.policy().podDisruptionBudget().inNamespace("default").create(podDisruptionBudget);
+client.policy().v1().podDisruptionBudget().inNamespace("default").create(podDisruptionBudget);
 ```
 - Create or Replace `PodDisruptionBudget`:
 ```
-PodDisruptionBudget pdb = client.policy().podDisruptionBudget().inNamespace("default").createOrReplace(podDisruptionBudgetObj);
+PodDisruptionBudget pdb = client.policy().v1().podDisruptionBudget().inNamespace("default").createOrReplace(podDisruptionBudgetObj);
 ```
 - List `PodDisruptionBudget` in some namespace:
 ```
-PodDisruptionBudgetList podDisruptionBudgetList = client.policy().podDisruptionBudget().inNamespace("default").list();
+PodDisruptionBudgetList podDisruptionBudgetList = client.policy().v1().podDisruptionBudget().inNamespace("default").list();
 ```
 - List `PodDisruptionBudget` in any namespace:
 ```
-PodDisruptionBudgetList pdbList = client.policy().podDisruptionBudget().inAnyNamespace().list();
+PodDisruptionBudgetList pdbList = client.policy().v1().podDisruptionBudget().inAnyNamespace().list();
 ```
 - List `PodDisruptionBudget` with labels:
 ```
-PodDisruptionBudgetList pdbList = client.policy().podDisruptionBudget().inNamespace("default").withLabel("foo", "bar").list();
+PodDisruptionBudgetList pdbList = client.policy().v1().podDisruptionBudget().inNamespace("default").withLabel("foo", "bar").list();
 ```
 - Delete `PodDisruptionBudget`:
 ```
-Boolean deleted = client.policy().podDisruptionBudget().inNamespace("default").withName("poddisruptionbudget1").delete();
+Boolean deleted = client.policy().v1().podDisruptionBudget().inNamespace("default").withName("poddisruptionbudget1").delete();
 ```
 
 ### SelfSubjectAccessReview

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CronJobIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CronJobIT.java
@@ -53,7 +53,7 @@ public class CronJobIT {
 
   @Test
   public void load() {
-    CronJob aCronJob = client.batch().cronjobs().load(getClass().getResourceAsStream("/test-cronjob.yml")).get();
+    CronJob aCronJob = client.batch().v1().cronjobs().load(getClass().getResourceAsStream("/test-cronjob.yml")).get();
     assertNotNull(aCronJob);
     assertEquals("hello", aCronJob.getMetadata().getName());
   }
@@ -61,14 +61,14 @@ public class CronJobIT {
   @Test
   public void get() {
     currentNamespace = session.getNamespace();
-    CronJob cronJob1 = client.batch().cronjobs().inNamespace(currentNamespace).withName("hello-get").get();
+    CronJob cronJob1 = client.batch().v1().cronjobs().inNamespace(currentNamespace).withName("hello-get").get();
     assertThat(cronJob1).isNotNull();
   }
 
   @Test
   public void list() {
     currentNamespace = session.getNamespace();
-    CronJobList cronJobList = client.batch().cronjobs().inNamespace(currentNamespace).list();
+    CronJobList cronJobList = client.batch().v1().cronjobs().inNamespace(currentNamespace).list();
     assertNotNull(cronJobList);
     assertTrue(cronJobList.getItems().size() >= 1);
   }
@@ -76,7 +76,7 @@ public class CronJobIT {
   @Test
   public void update() {
     currentNamespace = session.getNamespace();
-    CronJob cronJob1 = client.batch().cronjobs().inNamespace(currentNamespace).withName("hello-update")
+    CronJob cronJob1 = client.batch().v1().cronjobs().inNamespace(currentNamespace).withName("hello-update")
       .edit(c -> new CronJobBuilder(c)
       .editSpec()
       .withSchedule("*/1 * * * *")
@@ -88,7 +88,7 @@ public class CronJobIT {
   @Test
   public void delete() {
     currentNamespace = session.getNamespace();
-    assertTrue(client.batch().cronjobs().inNamespace(currentNamespace).withName("hello-delete").delete());
+    assertTrue(client.batch().v1().cronjobs().inNamespace(currentNamespace).withName("hello-delete").delete());
   }
 
   @AfterClass

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/JobIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/JobIT.java
@@ -50,9 +50,9 @@ public class JobIT {
     Job job = getJobBuilder().build();
 
     // When
-    client.batch().jobs().inNamespace(session.getNamespace()).createOrReplace(job);
+    client.batch().v1().jobs().inNamespace(session.getNamespace()).createOrReplace(job);
     ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
-    LogWatch logWatch = client.batch().jobs().inNamespace(session.getNamespace())
+    LogWatch logWatch = client.batch().v1().jobs().inNamespace(session.getNamespace())
       .withName(job.getMetadata().getName())
       .withLogWaitTimeout(30)
       .watchLog(baos);
@@ -73,7 +73,7 @@ public class JobIT {
       .endMetadata().build();
 
     // When
-    Job jobCreated = client.batch().jobs().inNamespace(session.getNamespace()).create(job);
+    Job jobCreated = client.batch().v1().jobs().inNamespace(session.getNamespace()).create(job);
 
     // Then
     assertNotNull(jobCreated);
@@ -81,7 +81,7 @@ public class JobIT {
     assertEquals("test-job-", jobCreated.getMetadata().getGenerateName());
     assertNotNull(jobCreated.getMetadata().getName());
     assertNotEquals("test-job-", jobCreated.getMetadata().getName());
-    assertTrue(client.batch().jobs().inNamespace(session.getNamespace()).withName(jobCreated.getMetadata().getName()).delete());
+    assertTrue(client.batch().v1().jobs().inNamespace(session.getNamespace()).withName(jobCreated.getMetadata().getName()).delete());
   }
 
   private JobBuilder getJobBuilder() {

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodSecurityPolicyIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodSecurityPolicyIT.java
@@ -55,7 +55,7 @@ public class PodSecurityPolicyIT {
   @Test
   public void load() {
 
-    PodSecurityPolicy loadedPodSecurityPolicy = client.policy().podSecurityPolicies()
+    PodSecurityPolicy loadedPodSecurityPolicy = client.policy().v1beta1().podSecurityPolicies()
       .load(getClass().getResourceAsStream("/test-podsecuritypolicy.yml")).get();
 
     assertNotNull(loadedPodSecurityPolicy);
@@ -69,7 +69,7 @@ public class PodSecurityPolicyIT {
 
   @Test
   public void get() {
-    PodSecurityPolicy getPodSecurityPolicy = client.policy().podSecurityPolicies()
+    PodSecurityPolicy getPodSecurityPolicy = client.policy().v1beta1().podSecurityPolicies()
       .withName("psp-get").get();
     assertNotNull(getPodSecurityPolicy);
     assertEquals("psp-get", getPodSecurityPolicy.getMetadata().getName());
@@ -78,7 +78,7 @@ public class PodSecurityPolicyIT {
   @Test
   public void list() {
 
-    PodSecurityPolicyList podSecurityPolicyList = client.policy().podSecurityPolicies()
+    PodSecurityPolicyList podSecurityPolicyList = client.policy().v1beta1().podSecurityPolicies()
       .withLabels(Collections.singletonMap("foo","bar")).list();
     assertNotNull(podSecurityPolicyList);
     assertEquals(1,podSecurityPolicyList.getItems().size());
@@ -92,7 +92,7 @@ public class PodSecurityPolicyIT {
   @Test
   public void update(){
 
-    PodSecurityPolicy podSecurityPolicy = client.policy().podSecurityPolicies().withName("psp-update").edit(p -> new PodSecurityPolicyBuilder(p)
+    PodSecurityPolicy podSecurityPolicy = client.policy().v1beta1().podSecurityPolicies().withName("psp-update").edit(p -> new PodSecurityPolicyBuilder(p)
       .editSpec().withPrivileged(true).endSpec()
       .build());
 
@@ -107,7 +107,7 @@ public class PodSecurityPolicyIT {
 
   @Test
   public void delete(){
-    boolean deleted = client.policy().podSecurityPolicies().withName("psp-delete").delete();
+    boolean deleted = client.policy().v1beta1().podSecurityPolicies().withName("psp-delete").delete();
     assertTrue(deleted);
 
     DeleteEntity<PodSecurityPolicy> deleteEntity = new DeleteEntity<>(PodSecurityPolicy.class, client, "psp-delete", null);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobCrudTest.java
@@ -101,35 +101,35 @@ class CronJobCrudTest {
       .endSpec()
       .build();
 
-    client.batch().cronjobs().inNamespace("ns1").create(cronJob1);
-    client.batch().cronjobs().inNamespace("ns2").create(cronJob2);
+    client.batch().v1().cronjobs().inNamespace("ns1").create(cronJob1);
+    client.batch().v1().cronjobs().inNamespace("ns2").create(cronJob2);
 
-    CronJobList cronJobList = client.batch().cronjobs().list();
+    CronJobList cronJobList = client.batch().v1().cronjobs().list();
     assertNotNull(cronJobList);
     assertEquals(0, cronJobList.getItems().size());
 
-    cronJobList = client.batch().cronjobs().inAnyNamespace().list();
+    cronJobList = client.batch().v1().cronjobs().inAnyNamespace().list();
     assertNotNull(cronJobList);
     assertEquals(2, cronJobList.getItems().size());
 
-    cronJobList = client.batch().cronjobs().inNamespace("ns1").list();
+    cronJobList = client.batch().v1().cronjobs().inNamespace("ns1").list();
     assertNotNull(cronJobList);
     assertEquals(1, cronJobList.getItems().size());
 
-    cronJobList = client.batch().cronjobs().inNamespace("ns2").list();
+    cronJobList = client.batch().v1().cronjobs().inNamespace("ns2").list();
     assertNotNull(cronJobList);
     assertEquals(1, cronJobList.getItems().size());
 
-    cronJobList = client.batch().cronjobs().inNamespace("ns1").withLabels(Collections.singletonMap("foo", "bar")).list();
+    cronJobList = client.batch().v1().cronjobs().inNamespace("ns1").withLabels(Collections.singletonMap("foo", "bar")).list();
     assertNotNull(cronJobList);
     assertEquals(1, cronJobList.getItems().size());
 
-    boolean bDeleted = client.batch().cronjobs().inNamespace("ns1").withName("cronJob1").delete();
-    cronJobList = client.batch().cronjobs().inNamespace("ns1").list();
+    boolean bDeleted = client.batch().v1().cronjobs().inNamespace("ns1").withName("cronJob1").delete();
+    cronJobList = client.batch().v1().cronjobs().inNamespace("ns1").list();
     assertTrue(bDeleted);
     assertEquals(0, cronJobList.getItems().size());
 
-    cronJob2 = client.batch().cronjobs().inNamespace("ns2").withName("cronJob2").edit(c -> new CronJobBuilder(c).editSpec().withSchedule("*/1 * * * *").and().build());
+    cronJob2 = client.batch().v1().cronjobs().inNamespace("ns2").withName("cronJob2").edit(c -> new CronJobBuilder(c).editSpec().withSchedule("*/1 * * * *").and().build());
     assertNotNull(cronJob2);
     assertEquals("*/1 * * * *", cronJob2.getSpec().getSchedule());
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobTest.java
@@ -56,15 +56,15 @@ class CronJobTest {
       .addNewItem()
       .and().build()).once();
 
-    CronJobList cronJobList = client.batch().cronjobs().list();
+    CronJobList cronJobList = client.batch().v1().cronjobs().list();
     assertNotNull(cronJobList);
     assertEquals(0, cronJobList.getItems().size());
 
-    cronJobList = client.batch().cronjobs().inNamespace("ns1").list();
+    cronJobList = client.batch().v1().cronjobs().inNamespace("ns1").list();
     assertNotNull(cronJobList);
     assertEquals(2, cronJobList.getItems().size());
 
-    cronJobList = client.batch().cronjobs().inAnyNamespace().list();
+    cronJobList = client.batch().v1().cronjobs().inAnyNamespace().list();
     assertNotNull(cronJobList);
     assertEquals(3, cronJobList.getItems().size());
   }
@@ -78,7 +78,7 @@ class CronJobTest {
       .addNewItem().and()
       .build()).once();
 
-    CronJobList cronJobList = client.batch().cronjobs()
+    CronJobList cronJobList = client.batch().v1().cronjobs()
       .withLabel("key1", "value1")
       .withLabel("key2","value2")
       .withLabel("key3","value3")
@@ -88,7 +88,7 @@ class CronJobTest {
     assertNotNull(cronJobList);
     assertEquals(0, cronJobList.getItems().size());
 
-    cronJobList = client.batch().cronjobs()
+    cronJobList = client.batch().v1().cronjobs()
       .withLabel("key1", "value1")
       .withLabel("key2","value2")
       .list();
@@ -102,13 +102,13 @@ class CronJobTest {
     server.expect().withPath("/apis/batch/v1beta1/namespaces/ns1/cronjobs/cronjob2").andReturn(200, new CronJobBuilder().build()).once();
 
 
-    CronJob cronjob = client.batch().cronjobs().withName("cronjob1").get();
+    CronJob cronjob = client.batch().v1().cronjobs().withName("cronjob1").get();
     assertNotNull(cronjob);
 
-    cronjob = client.batch().cronjobs().withName("cronjob2").get();
+    cronjob = client.batch().v1().cronjobs().withName("cronjob2").get();
     assertNull(cronjob);
 
-    cronjob = client.batch().cronjobs().inNamespace("ns1").withName("cronjob2").get();
+    cronjob = client.batch().v1().cronjobs().inNamespace("ns1").withName("cronjob2").get();
     assertNotNull(cronjob);
   }
 
@@ -178,11 +178,11 @@ class CronJobTest {
       .build()).once();
 
 
-    Boolean deleted = client.batch().cronjobs().withName("cronJob1").delete();
+    Boolean deleted = client.batch().v1().cronjobs().withName("cronJob1").delete();
     assertNotNull(deleted);
     assertTrue(deleted);
 
-    deleted = client.batch().cronjobs().withName("cronJob2").delete();
+    deleted = client.batch().v1().cronjobs().withName("cronJob2").delete();
     assertTrue(deleted);
   }
 
@@ -218,10 +218,10 @@ class CronJobTest {
       .editStatus().endStatus().build()).times(5);
 
 
-    Boolean deleted = client.batch().cronjobs().inAnyNamespace().delete(cronjob1, cronjob2);
+    Boolean deleted = client.batch().v1().cronjobs().inAnyNamespace().delete(cronjob1, cronjob2);
     assertTrue(deleted);
 
-    deleted = client.batch().cronjobs().inAnyNamespace().delete(cronjob3);
+    deleted = client.batch().v1().cronjobs().inAnyNamespace().delete(cronjob3);
     assertFalse(deleted);
   }
 
@@ -230,7 +230,7 @@ class CronJobTest {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       CronJob cronjob1 = new CronJobBuilder().withNewMetadata().withName("cronjob1").withNamespace("test").and().build();
 
-      Boolean deleted = client.batch().cronjobs().inNamespace("test1").delete(cronjob1);
+      Boolean deleted = client.batch().v1().cronjobs().inNamespace("test1").delete(cronjob1);
       assertFalse(deleted);
     });
   }
@@ -240,13 +240,13 @@ class CronJobTest {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       CronJob cronjob1 = new CronJobBuilder().withNewMetadata().withName("cronjob1").withNamespace("test").and().build();
 
-      client.batch().cronjobs().inNamespace("test1").withName("mycronjob1").create(cronjob1);
+      client.batch().v1().cronjobs().inNamespace("test1").withName("mycronjob1").create(cronjob1);
     });
   }
 
   @Test
   void testLoadFromFile() {
-    assertNotNull(client.batch().cronjobs().load(getClass().getResourceAsStream("/test-cronjob.yml")).get());
+    assertNotNull(client.batch().v1().cronjobs().load(getClass().getResourceAsStream("/test-cronjob.yml")).get());
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/JobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/JobTest.java
@@ -62,7 +62,7 @@ public class JobTest {
       .and().build()).once();
 
 
-    JobList jobList = client.batch().jobs().list();
+    JobList jobList = client.batch().v1().jobs().list();
     assertNotNull(jobList);
     assertEquals(0, jobList.getItems().size());
 
@@ -84,7 +84,7 @@ public class JobTest {
       .addNewItem().and()
       .build()).once();
 
-    JobList jobList = client.batch().jobs()
+    JobList jobList = client.batch().v1().jobs()
       .withLabel("key1", "value1")
       .withLabel("key2","value2")
       .withLabel("key3","value3")

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodDisruptionBudgetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodDisruptionBudgetTest.java
@@ -55,15 +55,15 @@ public class PodDisruptionBudgetTest {
       .addNewItem()
       .and().build()).once();
 
-    PodDisruptionBudgetList podDisruptionBudgetList = client.policy().podDisruptionBudget().list();
+    PodDisruptionBudgetList podDisruptionBudgetList = client.policy().v1().podDisruptionBudget().list();
     assertNotNull(podDisruptionBudgetList);
     assertEquals(0, podDisruptionBudgetList.getItems().size());
 
-    podDisruptionBudgetList = client.policy().podDisruptionBudget().inNamespace("ns1").list();
+    podDisruptionBudgetList = client.policy().v1().podDisruptionBudget().inNamespace("ns1").list();
     assertNotNull(podDisruptionBudgetList);
     assertEquals(2, podDisruptionBudgetList.getItems().size());
 
-    podDisruptionBudgetList = client.policy().podDisruptionBudget().inAnyNamespace().list();
+    podDisruptionBudgetList = client.policy().v1().podDisruptionBudget().inAnyNamespace().list();
     assertNotNull(podDisruptionBudgetList);
     assertEquals(3, podDisruptionBudgetList.getItems().size());
   }
@@ -77,7 +77,7 @@ public class PodDisruptionBudgetTest {
       .addNewItem().and()
       .build()).once();
 
-    PodDisruptionBudgetList podDisruptionBudgetList = client.policy().podDisruptionBudget()
+    PodDisruptionBudgetList podDisruptionBudgetList = client.policy().v1().podDisruptionBudget()
       .withLabel("key1", "value1")
       .withLabel("key2", "value2")
       .withLabel("key3", "value3")
@@ -87,7 +87,7 @@ public class PodDisruptionBudgetTest {
     assertNotNull(podDisruptionBudgetList);
     assertEquals(0, podDisruptionBudgetList.getItems().size());
 
-    podDisruptionBudgetList = client.policy().podDisruptionBudget()
+    podDisruptionBudgetList = client.policy().v1().podDisruptionBudget()
       .withLabel("key1", "value1")
       .withLabel("key2", "value2")
       .list();
@@ -102,13 +102,13 @@ public class PodDisruptionBudgetTest {
     server.expect().withPath("/apis/policy/v1beta1/namespaces/ns1/poddisruptionbudgets/poddisruptionbudget2").andReturn(200, new PodDisruptionBudgetBuilder().build()).once();
 
 
-    PodDisruptionBudget podDisruptionBudget = client.policy().podDisruptionBudget().withName("poddisruptionbudget1").get();
+    PodDisruptionBudget podDisruptionBudget = client.policy().v1().podDisruptionBudget().withName("poddisruptionbudget1").get();
     assertNotNull(podDisruptionBudget);
 
-    podDisruptionBudget = client.policy().podDisruptionBudget().withName("poddisruptionbudget2").get();
+    podDisruptionBudget = client.policy().v1().podDisruptionBudget().withName("poddisruptionbudget2").get();
     assertNull(podDisruptionBudget);
 
-    podDisruptionBudget = client.policy().podDisruptionBudget().inNamespace("ns1").withName("poddisruptionbudget2").get();
+    podDisruptionBudget = client.policy().v1().podDisruptionBudget().inNamespace("ns1").withName("poddisruptionbudget2").get();
     assertNotNull(podDisruptionBudget);
   }
 
@@ -125,7 +125,7 @@ public class PodDisruptionBudgetTest {
       .build()).once();
 
 
-    Boolean deleted = client.policy().podDisruptionBudget().withName("poddisruptionbudget1").delete();
+    Boolean deleted = client.policy().v1().podDisruptionBudget().withName("poddisruptionbudget1").delete();
     assertNotNull(deleted);
     assertTrue(deleted);
   }
@@ -135,7 +135,7 @@ public class PodDisruptionBudgetTest {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       PodDisruptionBudget podDisruptionBudget1 = new PodDisruptionBudgetBuilder().withNewMetadata().withName("podDisruptionBudget1").withNamespace("test").and().build();
 
-      Boolean deleted = client.policy().podDisruptionBudget().inNamespace("test1").delete(podDisruptionBudget1);
+      Boolean deleted = client.policy().v1().podDisruptionBudget().inNamespace("test1").delete(podDisruptionBudget1);
       assertFalse(deleted);
     });
 
@@ -146,12 +146,12 @@ public class PodDisruptionBudgetTest {
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       PodDisruptionBudget podDisruptionBudget1 = new PodDisruptionBudgetBuilder().withNewMetadata().withName("podDisruptionBudget1").withNamespace("test").and().build();
 
-      client.policy().podDisruptionBudget().inNamespace("test1").withName("mypodDisruptionBudget1").create(podDisruptionBudget1);
+      client.policy().v1().podDisruptionBudget().inNamespace("test1").withName("mypodDisruptionBudget1").create(podDisruptionBudget1);
     });
   }
 
   @Test
   public void testLoadFromFile() {
-    assertNotNull(client.policy().podDisruptionBudget().load(getClass().getResourceAsStream("/test-pdb.yml")).get());
+    assertNotNull(client.policy().v1().podDisruptionBudget().load(getClass().getResourceAsStream("/test-pdb.yml")).get());
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
@@ -274,7 +274,7 @@ class PropagationPolicyTest {
       .once();
 
     // When
-    Boolean isDeleted = client.batch().jobs().inNamespace("ns1").withName("myjob").delete();
+    Boolean isDeleted = client.batch().v1().jobs().inNamespace("ns1").withName("myjob").delete();
 
     // Then
     assertTrue(isDeleted);
@@ -291,7 +291,7 @@ class PropagationPolicyTest {
       .once();
 
     // When
-    Boolean isDeleted = client.batch().jobs().inNamespace("ns1").withName("myjob").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+    Boolean isDeleted = client.batch().v1().jobs().inNamespace("ns1").withName("myjob").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
 
     // Then
     assertTrue(isDeleted);


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Made the following changes to documentation and tests:
Add .v1() to .jobs()
Add .v1() to .cronjobs() and .podDisruptionBudget()
Add .v1beta1() to .podSecurityPolicies()

See #3309

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
