### PR TITLE
fix #3318: add and actual updates on relist should not be sync events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #3304: Prevent NPE in after informer stop
 * Fix #3083: CertificateException due to PEM being decoded in CertUtils
 * Fix #3295: Fix wrong kind getting registered in KubernetesDeserializer in SharedInformerFactory
+* Fix #3318: Informer relist add/update should not always be sync events
 
 #### Improvements
 * Fix #3284: refined how builders are obtained / used by HasMetadataOperation

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStore.java
@@ -16,13 +16,17 @@
 
 package io.fabric8.kubernetes.client.informers.cache;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Wraps a {@link Cache} and a {@link SharedProcessor} to distribute events related to changes and syncs
  */
-public class ProcessorStore<T> implements SyncableStore<T> {
+public class ProcessorStore<T extends HasMetadata> implements SyncableStore<T> {
 
   private Cache<T> cache;
   private SharedProcessor<T> processor;
@@ -83,9 +87,10 @@ public class ProcessorStore<T> implements SyncableStore<T> {
     for (T newValue : list) {
       T old = oldState.remove(cache.getKey(newValue));
       if (old == null) {
-        this.processor.distribute(new ProcessorListener.AddNotification<>(newValue), true);
+        this.processor.distribute(new ProcessorListener.AddNotification<>(newValue), false);
       } else {
-        this.processor.distribute(new ProcessorListener.UpdateNotification<>(old, newValue), true);
+        boolean same = Objects.equals(KubernetesResourceUtil.getResourceVersion(old), KubernetesResourceUtil.getResourceVersion(newValue));
+        this.processor.distribute(new ProcessorListener.UpdateNotification<>(old, newValue), same);
       }
     }
     // deletes are not marked as sync=true in keeping with the old code

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStoreTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ProcessorStoreTest.java
@@ -85,7 +85,7 @@ public class ProcessorStoreTest {
     Pod pod = new PodBuilder().withNewMetadata().endMetadata().build();
     Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").endMetadata().build();
     
-    // replace two values with an empty store
+    // replace empty store with two values
     processorStore.replace(Arrays.asList(pod, pod2));
 
     // resync two values
@@ -102,7 +102,8 @@ public class ProcessorStoreTest {
     assertThat(notifications.get(1)).isInstanceOf(AddNotification.class);
     assertThat(notifications.get(2)).isInstanceOf(UpdateNotification.class);
     assertThat(notifications.get(3)).isInstanceOf(UpdateNotification.class);
-    assertTrue(syncCaptor.getAllValues().subList(0, 4).stream().allMatch(s->s.booleanValue()));
+    assertTrue(syncCaptor.getAllValues().subList(0, 2).stream().allMatch(s->!s.booleanValue()));
+    assertTrue(syncCaptor.getAllValues().subList(2, 4).stream().allMatch(s->s.booleanValue()));
     
     assertThat(notifications.get(4)).isInstanceOf(DeleteNotification.class);
     assertThat(notifications.get(5)).isInstanceOf(DeleteNotification.class);


### PR DESCRIPTION
## Description
Changes actual additions and updates into regular, not sync events.
Fix #3318 
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
