### PR TITLE
Allow delete with optimistic lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #3316: allow locking deletion to resource version
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchDeletable.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.GracePeriodConfigurable;
 
-public interface EditReplacePatchDeletable<T> extends EditReplacePatchable<T>, Deletable,
+public interface EditReplacePatchDeletable<T> extends EditReplacePatchable<T>, Deletable, ReplaceDeletable<T>,
                                                           GracePeriodConfigurable<Deletable>
 
 {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchDeletable.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.dsl;
 
 import io.fabric8.kubernetes.client.GracePeriodConfigurable;
 
-public interface EditReplacePatchDeletable<T> extends EditReplacePatchable<T>, Deletable, ReplaceDeletable<T>,
+public interface EditReplacePatchDeletable<T> extends EditReplacePatchable<T>, ReplaceDeletable<T>,
                                                           GracePeriodConfigurable<Deletable>
 
 {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ReplaceDeletable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ReplaceDeletable.java
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
-
-public interface CascadingEditReplacePatchDeletable<T> extends
-  EditReplacePatchDeletable<T>,
-  Cascading<EditReplacePatchDeletable<T>>,
-  PropagationPolicyConfigurable<EditReplacePatchDeletable<T>>,
-  Lockable<ReplaceDeletable<T>> {
+public interface ReplaceDeletable<T> extends Replaceable<T>, Deletable {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -46,6 +46,7 @@ import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.Informable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ReplaceDeletable;
 import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.internal.DefaultOperationInfo;
@@ -265,7 +266,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
-  public Replaceable<T> lockResourceVersion(String resourceVersion) {
+  public ReplaceDeletable<T> lockResourceVersion(String resourceVersion) {
     return newInstance(context.withResourceVersion(resourceVersion));
   }
 
@@ -653,9 +654,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     try {
       if (item != null) {
         updateApiVersion(item);
-        handleDelete(item, gracePeriodSeconds, propagationPolicy, cascading);
+        handleDelete(item, gracePeriodSeconds, propagationPolicy, resourceVersion, cascading);
       } else {
-        handleDelete(getResourceURLForWriteOperation(getResourceUrl()), gracePeriodSeconds, propagationPolicy, cascading);
+        handleDelete(getResourceURLForWriteOperation(getResourceUrl()), gracePeriodSeconds, propagationPolicy, resourceVersion, cascading);
       }
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(forOperationType("delete"), e);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.DeleteOptions;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Preconditions;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
@@ -261,15 +262,18 @@ public class OperationSupport {
       return handleResponse(requestBuilder, type);
   }
 
-  protected <T> void handleDelete(T resource, long gracePeriodSeconds, DeletionPropagation propagationPolicy, boolean cascading) throws ExecutionException, InterruptedException, IOException {
-    handleDelete(getResourceURLForWriteOperation(getResourceUrl(checkNamespace(resource), checkName(resource))), gracePeriodSeconds, propagationPolicy, cascading);
+  protected <T> void handleDelete(T resource, long gracePeriodSeconds, DeletionPropagation propagationPolicy, String resourceVersion, boolean cascading) throws ExecutionException, InterruptedException, IOException {
+    handleDelete(getResourceURLForWriteOperation(getResourceUrl(checkNamespace(resource), checkName(resource))), gracePeriodSeconds, propagationPolicy, resourceVersion, cascading);
   }
 
-  protected void handleDelete(URL requestUrl, long gracePeriodSeconds, DeletionPropagation propagationPolicy, boolean cascading) throws ExecutionException, InterruptedException, IOException {
+  protected void handleDelete(URL requestUrl, long gracePeriodSeconds, DeletionPropagation propagationPolicy, String resourceVersion, boolean cascading) throws ExecutionException, InterruptedException, IOException {
     RequestBody requestBody = null;
     DeleteOptions deleteOptions = new DeleteOptions();
     if (gracePeriodSeconds >= 0) {
       deleteOptions.setGracePeriodSeconds(gracePeriodSeconds);
+    }
+    if (resourceVersion != null) {
+      deleteOptions.setPreconditions(new Preconditions(resourceVersion, null));
     }
     /*
      * Either the propagation policy or the orphan dependent (deprecated) property must be set, but not both.

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/ConfigMapLockTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/ConfigMapLockTest.java
@@ -21,7 +21,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Replaceable;
+import io.fabric8.kubernetes.client.dsl.ReplaceDeletable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -133,7 +133,7 @@ class ConfigMapLockTest {
   void updateWithValidLeaderElectionRecordShouldSendPutRequest() throws Exception {
     // Given
     final Resource<ConfigMap> configMapResource = configMaps.withName("name");
-    final Replaceable<ConfigMap> replaceable = mock(Replaceable.class, Answers.RETURNS_DEEP_STUBS);
+    final ReplaceDeletable<ConfigMap> replaceable = mock(ReplaceDeletable.class, Answers.RETURNS_DEEP_STUBS);
     when(configMapResource.lockResourceVersion(any())).thenReturn(replaceable);
     final ConfigMap configMapInTheCluster = new ConfigMap();
     configMapInTheCluster.setMetadata(new ObjectMetaBuilder().withAnnotations(new HashMap<>()).build());

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaseLockTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaseLockTest.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.coordination.v1.LeaseList;
 import io.fabric8.kubernetes.api.model.coordination.v1.LeaseSpec;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Replaceable;
+import io.fabric8.kubernetes.client.dsl.ReplaceDeletable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -126,7 +126,7 @@ class LeaseLockTest {
   void updateWithValidLeaderElectionRecordShouldSendPutRequest() throws Exception {
     // Given
     final Resource<Lease> leaseResource = leases.withName("name");
-    final Replaceable<Lease> replaceable = mock(Replaceable.class, Answers.RETURNS_DEEP_STUBS);
+    final ReplaceDeletable<Lease> replaceable = mock(ReplaceDeletable.class, Answers.RETURNS_DEEP_STUBS);
     when(leaseResource.lockResourceVersion(any())).thenReturn(replaceable);
     final Lease leaseInTheCluster = new Lease();
     leaseInTheCluster.setSpec(new LeaseSpec());

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/image/ImageSignatureOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/image/ImageSignatureOperationsImpl.java
@@ -39,7 +39,7 @@ public class ImageSignatureOperationsImpl extends CreateOnlyResourceOperationsIm
   @Override
   public Boolean delete() {
     try {
-      handleDelete(getResourceUrl(), context.getGracePeriodSeconds(), context.getPropagationPolicy(), null, context.getCascading());
+      handleDelete(getResourceUrl(), context.getGracePeriodSeconds(), context.getPropagationPolicy(), context.getResourceVersion(), context.getCascading());
       return true;
     } catch (IOException | ExecutionException exception) {
       return false;

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/image/ImageSignatureOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/image/ImageSignatureOperationsImpl.java
@@ -39,7 +39,7 @@ public class ImageSignatureOperationsImpl extends CreateOnlyResourceOperationsIm
   @Override
   public Boolean delete() {
     try {
-      handleDelete(getResourceUrl(), context.getGracePeriodSeconds(), context.getPropagationPolicy(), context.getCascading());
+      handleDelete(getResourceUrl(), context.getGracePeriodSeconds(), context.getPropagationPolicy(), null, context.getCascading());
       return true;
     } catch (IOException | ExecutionException exception) {
       return false;


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

This PR allows using optimistic locking with deletion operations, like so:

```java
k8sClientResource.lockResourceVersion(resourceVersion).delete();
```

Fixes #3316

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] ~~I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly~~ (not applicable)
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] ~~I tested my code in OpenShift~~ (not sure if applicable)

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
