### PR TITLE
fix #3328: moving the watch type conversion logic up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #3083: CertificateException due to PEM being decoded in CertUtils
 * Fix #3295: Fix wrong kind getting registered in KubernetesDeserializer in SharedInformerFactory
 * Fix #3318: Informer relist add/update should not always be sync events
+* Fix #3328: Allow for generic watches of known types
 
 #### Improvements
 * Fix #3284: refined how builders are obtained / used by HasMetadataOperation

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationRequestBuilder.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationRequestBuilder.java
@@ -30,7 +30,7 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 
-class BaseOperationRequestBuilder<T extends HasMetadata, L extends KubernetesResourceList<T>> implements AbstractWatchManager.RequestBuilder {
+class BaseOperationRequestBuilder<T extends HasMetadata, L extends KubernetesResourceList<T>> {
   private final URL requestUrl;
   private final BaseOperation<T, L, ?> baseOperation;
   private final ListOptions listOptions;
@@ -40,8 +40,11 @@ class BaseOperationRequestBuilder<T extends HasMetadata, L extends KubernetesRes
     this.requestUrl = baseOperation.getNamespacedUrl();
     this.listOptions = listOptions;
   }
-
-  @Override
+  
+  public BaseOperation<T, L, ?> getBaseOperation() {
+    return baseOperation;
+  }
+  
   public Request build(final String resourceVersion) {
     HttpUrl.Builder httpUrlBuilder = HttpUrl.get(requestUrl).newBuilder();
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -60,9 +60,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   }
 
   public WatchConnectionManager(final OkHttpClient client, final BaseOperation<T, L, ?> baseOperation, final ListOptions listOptions, final Watcher<T> watcher, final int reconnectInterval, final int reconnectLimit, long websocketTimeout, int maxIntervalExponent) throws MalformedURLException {
-    super(
-        watcher, listOptions, reconnectLimit, reconnectInterval, maxIntervalExponent,
-        new BaseOperationRequestBuilder<>(baseOperation, listOptions), () -> client.newBuilder()
+    super(watcher, baseOperation, listOptions, reconnectLimit, reconnectInterval, maxIntervalExponent, () -> client.newBuilder()
             .readTimeout(websocketTimeout, TimeUnit.MILLISECONDS)
             .build());
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -56,8 +56,7 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
     throws MalformedURLException {
     
     super(
-        watcher, listOptions, reconnectLimit, reconnectInterval, maxIntervalExponent,
-        new BaseOperationRequestBuilder<>(baseOperation, listOptions), () -> {
+        watcher, baseOperation, listOptions, reconnectLimit, reconnectInterval, maxIntervalExponent, () -> {
           final OkHttpClient clonedClient = client.newBuilder()
               .connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
               .readTimeout(0, TimeUnit.MILLISECONDS)

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -128,11 +128,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
       if (resource == null) {
         throw new KubernetesClientException("Unrecognized resource");  
       }
-      // the WatchEvent deserialization is not specifically typed
-      // modify the type here if needed
-      if (!apiTypeClass.isAssignableFrom(resource.getClass())) {
-        resource = Serialization.jsonMapper().convertValue(resource, apiTypeClass);
-      }
       if (log.isDebugEnabled()) {
         log.debug("Event received {} {}# resourceVersion {}", action.name(), resource.getKind(), resource.getMetadata().getResourceVersion());
       }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -19,13 +19,16 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
+import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.Request;
 import okhttp3.WebSocket;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.net.MalformedURLException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -43,7 +46,7 @@ class AbstractWatchManagerTest {
 
   @Test
   @DisplayName("closeEvent, is idempotent, multiple calls only close watcher once")
-  void closeEventIsIdempotent() {
+  void closeEventIsIdempotent() throws MalformedURLException {
     // Given
     final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
     final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
@@ -57,7 +60,7 @@ class AbstractWatchManagerTest {
 
   @Test
   @DisplayName("closeEvent, with Exception, is idempotent, multiple calls only close watcher once")
-  void closeEventWithExceptionIsIdempotent() {
+  void closeEventWithExceptionIsIdempotent() throws MalformedURLException {
     // Given
     final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
     final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
@@ -82,7 +85,7 @@ class AbstractWatchManagerTest {
 
   @Test
   @DisplayName("nextReconnectInterval, returns exponential interval values up to the provided limit")
-  void nextReconnectInterval() {
+  void nextReconnectInterval() throws MalformedURLException {
     // Given
     final WatchManager<HasMetadata> awm = new WatchManager<>(
       null, mock(ListOptions.class), 0, 10, 5);
@@ -98,7 +101,7 @@ class AbstractWatchManagerTest {
 
   @Test
   @DisplayName("cancelReconnect, with null attempt, should do nothing")
-  void cancelReconnectNullAttempt() {
+  void cancelReconnectNullAttempt() throws MalformedURLException {
     // Given
     final ScheduledFuture<?> sf = spy(ScheduledFuture.class);
     final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
@@ -111,7 +114,7 @@ class AbstractWatchManagerTest {
 
   @Test
   @DisplayName("cancelReconnect, with non-null attempt, should cancel")
-  void cancelReconnectNonNullAttempt() {
+  void cancelReconnectNonNullAttempt() throws MalformedURLException {
     // Given
     final ScheduledFuture<?> sf = mock(ScheduledFuture.class);
     final MockedStatic<Utils> utils = mockStatic(Utils.class);
@@ -127,7 +130,7 @@ class AbstractWatchManagerTest {
 
   @Test
   @DisplayName("isClosed, after close invocation, should return true")
-  void isForceClosedWhenClosed() {
+  void isForceClosedWhenClosed() throws MalformedURLException {
     // Given
     final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
     final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
@@ -139,7 +142,7 @@ class AbstractWatchManagerTest {
 
   @Test
   @DisplayName("close, after close invocation, should return true")
-  void closeWithNonNullRunnerShouldCancelRunner() {
+  void closeWithNonNullRunnerShouldCancelRunner() throws MalformedURLException {
     // Given
     final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
     final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
@@ -149,7 +152,7 @@ class AbstractWatchManagerTest {
     assertThat(awm.closeCount.get()).isEqualTo(1);
   }
 
-  private static <T extends HasMetadata> WatchManager<T> withDefaultWatchManager(Watcher<T> watcher) {
+  private static <T extends HasMetadata> WatchManager<T> withDefaultWatchManager(Watcher<T> watcher) throws MalformedURLException {
     return new WatchManager<>(
       watcher, mock(ListOptions.class, RETURNS_DEEP_STUBS), 1, 0, 0);
   }
@@ -175,8 +178,8 @@ class AbstractWatchManagerTest {
     
     private final AtomicInteger closeCount = new AtomicInteger(0);
 
-    public WatchManager(Watcher<T> watcher, ListOptions listOptions, int reconnectLimit, int reconnectInterval, int maxIntervalExponent) {
-      super(watcher, listOptions, reconnectLimit, reconnectInterval, maxIntervalExponent, resourceVersion -> null, ()->null);
+    public WatchManager(Watcher<T> watcher, ListOptions listOptions, int reconnectLimit, int reconnectInterval, int maxIntervalExponent) throws MalformedURLException {
+      super(watcher, Mockito.mock(BaseOperation.class), listOptions, reconnectLimit, reconnectInterval, maxIntervalExponent, () -> null);
     }
 
     @Override


### PR DESCRIPTION
## Description
fix for #3328 moves the informer type conversion logic up to the abstractwatchmanager to apply to watches as well.

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift