### PR TITLE
I fixed the usage of the diamond operator in 'additionalProperties' Map.

### DIFF
--- a/extensions/certmanager/model-v1/src/main/java/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01Ingress.java
+++ b/extensions/certmanager/model-v1/src/main/java/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01Ingress.java
@@ -72,7 +72,6 @@ public class ACMEChallengeSolverHTTP01Ingress implements KubernetesResource
   private java.lang.String serviceType;
   @JsonIgnore
   private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
-
   /**
    * No args constructor for use in serialization
    *


### PR DESCRIPTION
## Description
Fixed the lack of diamond operator in the instantiation of **additionalProperties** Map

Issue number:  #3163

Link for the issue: 
https://github.com/fabric8io/kubernetes-client/issues/3163
