### PR TITLE
removed curly braces from single lambda statements

### DIFF
--- a/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServiceClasses.java
+++ b/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServiceClasses.java
@@ -24,9 +24,7 @@ public class ListServiceClasses {
       System.out.println("Listing Cluster Service Classes:");
       ClusterServiceClassList list = client.clusterServiceClasses().list();
       list.getItems().stream()
-          .forEach(b -> {
-                          System.out.println(b.getSpec().getClusterServiceBrokerName() + "\t\t" + b.getSpec().getExternalName() + "\t\t\t\t" + b.getMetadata().getName());
-              });
+          .forEach(b -> System.out.println(b.getSpec().getClusterServiceBrokerName() + "\t\t" + b.getSpec().getExternalName() + "\t\t\t\t" + b.getMetadata().getName()));
       System.out.println("Done");
   }
 }

--- a/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServiceClassesByBroker.java
+++ b/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServiceClassesByBroker.java
@@ -29,9 +29,7 @@ public class ListServiceClassesByBroker {
         System.out.println("Listing Cluster Service Classes" + broker + ":");
         ClusterServiceClassList list = client.clusterServiceBrokers().withName(broker).listClasses();
         list.getItems().stream()
-                .forEach(b -> {
-                    System.out.println(b.getSpec().getExternalName() + "\t\t\t\t" + b.getMetadata().getName());
-                });
+                .forEach(b -> System.out.println(b.getSpec().getExternalName() + "\t\t\t\t" + b.getMetadata().getName()));
         System.out.println("Done");
     }
 }

--- a/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServiceInstances.java
+++ b/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServiceInstances.java
@@ -26,9 +26,7 @@ public class ListServiceInstances {
 
       System.out.println("Listing Service Instances:");
       list.getItems().stream()
-          .forEach(b -> {
-                  System.out.println(b);
-              });
+          .forEach(b -> System.out.println(b));
 
       System.out.println("Done");
   }

--- a/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServicePlans.java
+++ b/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServicePlans.java
@@ -27,9 +27,7 @@ public class ListServicePlans {
       ClusterServicePlan c;
       System.out.println("Listing Cluster Service Plans:");
       list.getItems().stream()
-          .forEach(b -> {
-                  System.out.println(b.getSpec().getClusterServiceBrokerName() + "\t\t\t" + b.getSpec().getClusterServiceClassRef() + "\t\t\t" + b.getSpec().getExternalName());
-              });
+          .forEach(b -> System.out.println(b.getSpec().getClusterServiceBrokerName() + "\t\t\t" + b.getSpec().getClusterServiceClassRef() + "\t\t\t" + b.getSpec().getExternalName()));
       System.out.println("Done");
   }
 }

--- a/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServicePlansByBroker.java
+++ b/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ListServicePlansByBroker.java
@@ -30,9 +30,7 @@ public class ListServicePlansByBroker {
         System.out.println("Listing Cluster Service Plans" + broker + ":");
         ClusterServicePlanList list = client.clusterServiceBrokers().withName(broker).listPlans();
         list.getItems().stream()
-                .forEach(b -> {
-                    System.out.println(b.getSpec().getClusterServiceClassRef()+ "\t\t\t" + b.getSpec().getExternalName() + "\t\t\t\t" + b.getMetadata().getName());
-                });
+                .forEach(b -> System.out.println(b.getSpec().getClusterServiceClassRef()+ "\t\t\t" + b.getSpec().getExternalName() + "\t\t\t\t" + b.getMetadata().getName()));
         System.out.println("Done");
     }
 }

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
@@ -269,11 +269,10 @@ public class KubernetesCrudDispatcher extends CrudDispatcher {
       query = query.add(new Attribute("name", resourceName));
     }
     WatchEventsListener watchEventListener = new WatchEventsListener(context, query, watchEventListeners, LOGGER,
-      watch -> {
+      watch -> 
         map.entrySet().stream()
           .filter(entry -> watch.attributeMatches(entry.getKey()))
-          .forEach(entry -> watch.sendWebSocketResponse(entry.getValue(), Action.ADDED));
-      });
+          .forEach(entry -> watch.sendWebSocketResponse(entry.getValue(), Action.ADDED)));
     watchEventListeners.add(watchEventListener);
     mockResponse.setSocketPolicy(SocketPolicy.KEEP_OPEN);
     return mockResponse.withWebSocketUpgrade(watchEventListener);


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
fixes #3342
This change removes Curly braces from single lambda statements in mentioned examples files and KubernetesCrudDispatcher.java file.