### PR TITLE
modified Cluster Scoped Kubernetes resources to NonNamespacedOperation

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoAdaptableKubernetesClient.java
@@ -146,7 +146,7 @@ public class AutoAdaptableKubernetesClient extends DefaultKubernetesClient {
   public RbacAPIGroupDSL rbac() { return delegate.rbac(); }
 
   @Override
-  public MixedOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses() {
+  public NonNamespaceOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses() {
     return delegate.componentstatuses();
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.kubernetes.client;
 
-import static io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.DEFAULT_PROPAGATION_POLICY;
-
 import io.fabric8.kubernetes.api.model.APIService;
 import io.fabric8.kubernetes.api.model.APIServiceList;
 import io.fabric8.kubernetes.api.model.Binding;
@@ -120,13 +118,14 @@ import io.fabric8.kubernetes.client.extended.run.RunConfigBuilder;
 import io.fabric8.kubernetes.client.extended.run.RunOperations;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import okhttp3.OkHttpClient;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 
-import okhttp3.OkHttpClient;
+import static io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation.DEFAULT_PROPAGATION_POLICY;
 
 /**
  * Base class for all Kubernetes Clients implementing KubernetesClient interface.
@@ -154,7 +153,7 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
    * {@inheritDoc}
    */
   @Override
-  public MixedOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses() {
+  public NonNamespaceOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses() {
     return new ComponentStatusOperationsImpl(httpClient, getConfiguration());
   }
 
@@ -322,7 +321,7 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
    * {@inheritDoc}
    */
   @Override
-  public MixedOperation<APIService, APIServiceList, Resource<APIService>> apiServices() {
+  public NonNamespaceOperation<APIService, APIServiceList, Resource<APIService>> apiServices() {
     return new APIServiceOperationsImpl(httpClient, getConfiguration());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -293,7 +293,7 @@ public interface KubernetesClient extends Client {
    *
    * @return MixedOperation object with which you can do basic operations for ComponentStatus
    */
-  MixedOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses();
+  NonNamespaceOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses();
 
   /**
    * Load a Kubernetes resource object from file InputStream
@@ -443,7 +443,7 @@ public interface KubernetesClient extends Client {
    *
    * @return MixedOperation object for APIService related operations
    */
-  MixedOperation<APIService, APIServiceList, Resource<APIService>> apiServices();
+  NonNamespaceOperation<APIService, APIServiceList, Resource<APIService>> apiServices();
 
   /**
    * List related operations.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1AdmissionRegistrationAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1AdmissionRegistrationAPIGroupClient.java
@@ -20,9 +20,10 @@ import io.fabric8.kubernetes.api.model.admissionregistration.v1.MutatingWebhookC
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfigurationList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.internal.admissionregistration.v1.ValidatingWebhookConfigurationOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.admissionregistration.v1.MutatingWebhookConfigurationOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.admissionregistration.v1.ValidatingWebhookConfigurationOperationsImpl;
 import okhttp3.OkHttpClient;
 
 public class V1AdmissionRegistrationAPIGroupClient extends BaseClient implements V1AdmissionRegistrationAPIGroupDSL {
@@ -35,7 +36,7 @@ public class V1AdmissionRegistrationAPIGroupClient extends BaseClient implements
   }
 
   @Override
-  public MixedOperation<ValidatingWebhookConfiguration, ValidatingWebhookConfigurationList, Resource<ValidatingWebhookConfiguration>> validatingWebhookConfigurations() {
+  public NonNamespaceOperation<ValidatingWebhookConfiguration, ValidatingWebhookConfigurationList, Resource<ValidatingWebhookConfiguration>> validatingWebhookConfigurations() {
     return new ValidatingWebhookConfigurationOperationsImpl(httpClient, getConfiguration());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1AdmissionRegistrationAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1AdmissionRegistrationAPIGroupDSL.java
@@ -19,10 +19,10 @@ import io.fabric8.kubernetes.api.model.admissionregistration.v1.MutatingWebhookC
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.MutatingWebhookConfigurationList;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfigurationList;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 
 public interface V1AdmissionRegistrationAPIGroupDSL extends Client  {
-  MixedOperation<ValidatingWebhookConfiguration, ValidatingWebhookConfigurationList, Resource<ValidatingWebhookConfiguration>> validatingWebhookConfigurations();
-  MixedOperation<MutatingWebhookConfiguration, MutatingWebhookConfigurationList, Resource<MutatingWebhookConfiguration>> mutatingWebhookConfigurations();
+  NonNamespaceOperation<ValidatingWebhookConfiguration, ValidatingWebhookConfigurationList, Resource<ValidatingWebhookConfiguration>> validatingWebhookConfigurations();
+  NonNamespaceOperation<MutatingWebhookConfiguration, MutatingWebhookConfigurationList, Resource<MutatingWebhookConfiguration>> mutatingWebhookConfigurations();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1AdmissionRegistrationAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1AdmissionRegistrationAPIGroupClient.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MutatingWeb
 import io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingWebhookConfiguration;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingWebhookConfigurationList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.internal.admissionregistration.v1beta1.MutatingWebhookConfigurationOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.admissionregistration.v1beta1.ValidatingWebhookConfigurationOperationsImpl;
@@ -40,7 +41,7 @@ public class V1beta1AdmissionRegistrationAPIGroupClient extends BaseClient imple
   }
 
   @Override
-  public MixedOperation<MutatingWebhookConfiguration, MutatingWebhookConfigurationList, Resource<MutatingWebhookConfiguration>> mutatingWebhookConfigurations() {
+  public NonNamespaceOperation<MutatingWebhookConfiguration, MutatingWebhookConfigurationList, Resource<MutatingWebhookConfiguration>> mutatingWebhookConfigurations() {
     return new MutatingWebhookConfigurationOperationsImpl(httpClient, getConfiguration());
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1AdmissionRegistrationAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1AdmissionRegistrationAPIGroupDSL.java
@@ -20,9 +20,10 @@ import io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MutatingWeb
 import io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingWebhookConfiguration;
 import io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingWebhookConfigurationList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 
 public interface V1beta1AdmissionRegistrationAPIGroupDSL extends Client {
   MixedOperation<ValidatingWebhookConfiguration, ValidatingWebhookConfigurationList, Resource<ValidatingWebhookConfiguration>> validatingWebhookConfigurations();
-  MixedOperation<MutatingWebhookConfiguration, MutatingWebhookConfigurationList, Resource<MutatingWebhookConfiguration>> mutatingWebhookConfigurations();
+  NonNamespaceOperation<MutatingWebhookConfiguration, MutatingWebhookConfigurationList, Resource<MutatingWebhookConfiguration>> mutatingWebhookConfigurations();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1PolicyAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1PolicyAPIGroupDSL.java
@@ -34,5 +34,5 @@ public interface V1beta1PolicyAPIGroupDSL extends Client {
    *
    * @return {@link MixedOperation} for PodSecurityPolicy resource
    */
-  MixedOperation<PodSecurityPolicy, PodSecurityPolicyList, Resource<PodSecurityPolicy>> podSecurityPolicies();
+  NonNamespaceOperation<PodSecurityPolicy, PodSecurityPolicyList, Resource<PodSecurityPolicy>> podSecurityPolicies();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -232,7 +232,7 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
     delegate.close();
   }
 
-  public MixedOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses() {
+  public NonNamespaceOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses() {
 	return delegate.componentstatuses();
   }
 
@@ -297,7 +297,7 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   }
 
   @Override
-  public MixedOperation<APIService, APIServiceList, Resource<APIService>> apiServices() {
+  public NonNamespaceOperation<APIService, APIServiceList, Resource<APIService>> apiServices() {
     return delegate.apiServices();
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -661,7 +661,7 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   }
 
   @Override
-  public MixedOperation<APIService, APIServiceList, Resource<APIService>> apiServices() {
+  public NonNamespaceOperation<APIService, APIServiceList, Resource<APIService>> apiServices() {
     return delegate.apiServices();
   }
 


### PR DESCRIPTION
## Description
All Cluster Scoped Kubernetes resources should use NonNamespacedOperation #3325

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
