### PR TITLE
Improve io.fabric8.kubernetes.client.mock.ErrorMessageTest to use assertThrows 

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ErrorMessageTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ErrorMessageTest.java
@@ -45,15 +45,14 @@ public class ErrorMessageTest {
     server.expect().withPath("/api/v1/namespaces/test/events/event1").andReturn(403, Boolean.FALSE).once();
 
 
-    try{
-      client.v1().events().inNamespace("test").delete();
-      fail();
-    } catch (Exception e){
-      System.out.println("exception: "+e);
-      Assertions.assertThat(e.getMessage().startsWith("Failure executing: DELETE"));
-      Assertions.assertThat(e.getMessage().contains("Message: MSG"));
-      Assertions.assertThat(not(e.getMessage().contains("Received status")));
-    }
+    NonNamespaceOperation<Event, EventList, Resource<Event>> eventOp = client.v1().events().inNamespace("test");
+    KubernetesClientException k8sException = assertThrows(KubernetesClientException.class, eventOp::delete);
+  
+  
+    assertThat(k8sException.getMessage())
+      .contains("Message: MSG")
+      .startsWith("Failure executing: DELETE")
+      .doesNotContain("Received status");
   }
 
   private void fail() {


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #3355 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->

#3355 
