### PR TITLE
fix #3349: adding consistency to the handling of option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Improvements
 * Fix #3316: allow locking deletion to resource version
 * Fix #3327: Removed generated ResourceHandlers
+* Fix #3349: ensuring that dsl context values always are applied over user ListOptions
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandler.java
@@ -22,7 +22,6 @@ import java.util.function.Predicate;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import okhttp3.OkHttpClient;
@@ -88,49 +87,6 @@ public interface ResourceHandler<T extends HasMetadata, V extends VisitableBuild
    */
   default Boolean delete(OkHttpClient client, Config config, String namespace, DeletionPropagation propagationPolicy, long gracePeriodSeconds, T item, boolean dryRun) {
     return resource(client, config, namespace, item).dryRun(dryRun).withPropagationPolicy(propagationPolicy).withGracePeriod(gracePeriodSeconds).delete();
-  }
-
-
-    /**
-     * Watches the specified resource for changes.
-     * @param client        An instance of the http client.
-     * @param config        The client config.
-     * @param namespace     The target namespace.
-     * @param item          The resource to delete.
-     * @param watcher       The {@link Watcher} to use.
-     * @return              The {@link Watch}
-     */
-  default Watch watch(OkHttpClient client, Config config, String namespace, T item, Watcher<T> watcher) {
-    return resource(client, config, namespace, item).watch(watcher);
-  }
-
-  /**
-   * Watches the specified resource for changes.
-   * @param client          An instance of the http client.
-   * @param config          The client config.
-   * @param namespace       The target namespace.
-   * @param item            The resource to delete.
-   * @param resourceVersion The resourceVersion of object
-   * @param watcher         The {@link Watcher} to use.
-   * @return                The {@link Watch}
-   */
-  default Watch watch(OkHttpClient client, Config config, String namespace, T item, String resourceVersion, Watcher<T> watcher) {
-    return resource(client, config, namespace, item).watch(resourceVersion, watcher);
-  }
-
-  /**
-   * Watches the specified resource for changes
-   *
-   * @param client         An instance of http client.
-   * @param config         The client config.
-   * @param namespace      The target namespace.
-   * @param item           The resource to delete.
-   * @param listOptions    The {@link io.fabric8.kubernetes.api.model.ListOptions} for available options
-   * @param watcher        The {@link Watcher} to use.
-   * @return               The {@link Watch}
-   */
-  default Watch watch(OkHttpClient client, Config config, String namespace, T item, ListOptions listOptions, Watcher<T> watcher) {
-    return resource(client, config, namespace, item).watch(listOptions, watcher);
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Listable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Listable.java
@@ -24,7 +24,6 @@ public interface Listable<T> {
    * List resources from APIServer.
    * @deprecated : Please use {@link #list(ListOptions)} instead
    *
-   *
    * @param limitVal number of resources to list
    * @param continueVal an offset to pick listing from
    * @return resource list
@@ -34,6 +33,9 @@ public interface Listable<T> {
 
   /**
    * List resource from Kubernetes API server.
+   * <p>The passed in options may be modified as a side-effect of this call.
+   * <br>Values that already exist at this context, such as the labels and fields will be overridden
+   *  on the passed in options regardless of initial values.
    *
    * @param listOptions ListOptions is the query options to a standard REST list call.
    * @return list of resource type

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Watchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Watchable.java
@@ -30,6 +30,9 @@ public interface Watchable<W> {
 
   /**
    * Watch returns {@link Watch} interface that watches requested resource
+   * <p>The passed in options may be modified as a side-effect of this call.
+   * <br>Values that already exist at this context, such as the labels, fields, 
+   * and resourceVersion will be overridden on the passed in options regardless of initial values.
    *
    * @param options options available for watch operation
    * @param watcher Watcher interface of Kubernetes resource

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationRequestBuilder.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationRequestBuilder.java
@@ -26,7 +26,6 @@ import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
-import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 
@@ -47,24 +46,6 @@ class BaseOperationRequestBuilder<T extends HasMetadata, L extends KubernetesRes
   
   public Request build(final String resourceVersion) {
     HttpUrl.Builder httpUrlBuilder = HttpUrl.get(requestUrl).newBuilder();
-
-    String labelQueryParam = baseOperation.getLabelQueryParam();
-    if (Utils.isNotNullOrEmpty(labelQueryParam)) {
-      httpUrlBuilder.addQueryParameter("labelSelector", labelQueryParam);
-    }
-
-    String fieldQueryString = baseOperation.getFieldQueryParam();
-    String name = baseOperation.getName();
-
-    if (name != null && name.length() > 0) {
-      if (fieldQueryString.length() > 0) {
-        fieldQueryString += ",";
-      }
-      fieldQueryString += "metadata.name=" + name;
-    }
-    if (Utils.isNotNullOrEmpty(fieldQueryString)) {
-      httpUrlBuilder.addQueryParameter("fieldSelector", fieldQueryString);
-    }
 
     listOptions.setResourceVersion(resourceVersion);
     HttpClientUtils.appendListOptionParams(httpUrlBuilder, listOptions);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.client.dsl.VisitFromServerWritable;
 import io.fabric8.kubernetes.client.utils.Utils;
 
 import java.util.function.Predicate;
-
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +44,7 @@ import io.fabric8.kubernetes.client.dsl.Deletable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.Readiable;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.VisitFromServerGetWatchDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.Waitable;
 import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
@@ -209,23 +209,23 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
 
   @Override
   public Watch watch(Watcher<HasMetadata> watcher) {
-    HasMetadata meta = get();
-    ResourceHandler<HasMetadata, ?> h = handlerOf(meta);
-    return h.watch(client, config, meta.getMetadata().getNamespace(), meta, watcher);
+    return getResource().watch(watcher);
   }
 
   @Override
   public Watch watch(String resourceVersion, Watcher<HasMetadata> watcher) {
-    HasMetadata meta = get();
-    ResourceHandler<HasMetadata, ?> h = handlerOf(meta);
-    return h.watch(client, config, meta.getMetadata().getNamespace(), meta, resourceVersion, watcher);
+    return getResource().watch(resourceVersion, watcher);
   }
 
   @Override
   public Watch watch(ListOptions options, Watcher<HasMetadata> watcher) {
+    return getResource().watch(options, watcher);
+  }
+  
+  Resource<HasMetadata> getResource() {
     HasMetadata meta = get();
     ResourceHandler<HasMetadata, ?> h = handlerOf(meta);
-    return h.watch(client, config, meta.getMetadata().getNamespace(), meta, options, watcher);
+    return h.resource(client, config, meta.getMetadata().getNamespace(), meta);
   }
 
   protected Readiness getReadiness() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ListerWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ListerWatcher.java
@@ -29,7 +29,7 @@ import io.fabric8.kubernetes.client.Watcher;
 public interface ListerWatcher<T, L> {
   Watch watch(ListOptions params, Watcher<T> watcher);
 
-  L list(ListOptions params);
+  L list();
 
   String getNamespace();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -50,7 +50,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
 
   protected L getList() {
-    return listerWatcher.list(new ListOptionsBuilder().build());
+    return listerWatcher.list();
   }
 
   public void stop() {
@@ -89,8 +89,9 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
     log.debug("Starting watcher for resource {} v{}", apiTypeClass, latestResourceVersion);
     // there's no need to stop the old watch, that will happen automatically when this call completes
     watch.set(
-      listerWatcher.watch(new ListOptionsBuilder()
-        .withWatch(Boolean.TRUE).withResourceVersion(latestResourceVersion).withTimeoutSeconds(null).build(), watcher));
+        listerWatcher.watch(new ListOptionsBuilder().withResourceVersion(latestResourceVersion)
+            .withTimeoutSeconds(null)
+            .build(), watcher));
     watching = true;
   }
   

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -81,16 +81,16 @@ public class HttpClientUtils {
       urlBuilder.addQueryParameter("continue", listOptions.getContinue());
     }
 
-    if (listOptions.getResourceVersion() != null) {
-      urlBuilder.addQueryParameter("resourceVersion", listOptions.getResourceVersion());
-    }
-
     if (listOptions.getFieldSelector() != null) {
       urlBuilder.addQueryParameter("fieldSelector", listOptions.getFieldSelector());
     }
 
     if (listOptions.getLabelSelector() != null) {
       urlBuilder.addQueryParameter("labelSelector", listOptions.getLabelSelector());
+    }
+    
+    if (listOptions.getResourceVersion() != null) {
+      urlBuilder.addQueryParameter("resourceVersion", listOptions.getResourceVersion());
     }
 
     if (listOptions.getTimeoutSeconds() != null) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/BaseOperationTest.java
@@ -143,21 +143,21 @@ class BaseOperationTest {
         .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
         .withFieldSelector("status.phase=Running")
         .build()).toString());
-    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&resourceVersion=210448&fieldSelector=status.phase%3DRunning"),
+    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&fieldSelector=status.phase%3DRunning&resourceVersion=210448"),
       operation.fetchListUrl(url, new ListOptionsBuilder()
         .withLimit(5L)
         .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
         .withFieldSelector("status.phase=Running")
         .withResourceVersion("210448")
         .build()).toString());
-    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&resourceVersion=210448&labelSelector=%21node-role.kubernetes.io%2Fmaster"),
+    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448"),
       operation.fetchListUrl(url, new ListOptionsBuilder()
         .withLimit(5L)
         .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
         .withLabelSelector("!node-role.kubernetes.io/master")
         .withResourceVersion("210448")
         .build()).toString());
-    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&resourceVersion=210448&labelSelector=%21node-role.kubernetes.io%2Fmaster&timeoutSeconds=10"),
+    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448&timeoutSeconds=10"),
       operation.fetchListUrl(url, new ListOptionsBuilder()
         .withLimit(5L)
         .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
@@ -165,7 +165,7 @@ class BaseOperationTest {
         .withResourceVersion("210448")
         .withTimeoutSeconds(10L)
         .build()).toString());
-    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&resourceVersion=210448&labelSelector=%21node-role.kubernetes.io%2Fmaster&timeoutSeconds=10&allowWatchBookmarks=true"),
+    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448&timeoutSeconds=10&allowWatchBookmarks=true"),
       operation.fetchListUrl(url, new ListOptionsBuilder()
         .withLimit(5L)
         .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
@@ -174,7 +174,7 @@ class BaseOperationTest {
         .withTimeoutSeconds(10L)
         .withAllowWatchBookmarks(true)
         .build()).toString());
-    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&resourceVersion=210448&labelSelector=%21node-role.kubernetes.io%2Fmaster&timeoutSeconds=10&allowWatchBookmarks=true&watch=true"),
+    assertEquals(URLUtils.join(url.toString(), "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448&timeoutSeconds=10&allowWatchBookmarks=true&watch=true"),
       operation.fetchListUrl(url, new ListOptionsBuilder()
         .withLimit(5L)
         .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
@@ -36,7 +36,7 @@ class ReflectorTest {
   void testStateFlags() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
-    Mockito.when(mock.list(Mockito.any())).thenReturn(list);
+    Mockito.when(mock.list()).thenReturn(list);
 
     Reflector<Pod, PodList> reflector =
         new Reflector<>(Pod.class, mock, Mockito.mock(SyncableStore.class));
@@ -70,7 +70,7 @@ class ReflectorTest {
   void testNonHttpGone() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
-    Mockito.when(mock.list(Mockito.any())).thenReturn(list);
+    Mockito.when(mock.list()).thenReturn(list);
 
     Reflector<Pod, PodList> reflector =
         new Reflector<>(Pod.class, mock, Mockito.mock(SyncableStore.class));

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -54,7 +54,7 @@ class InformTest {
         .withResourceVersion("1").endMetadata().build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?watch=false&labelSelector=my-label")
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();
@@ -108,7 +108,7 @@ class InformTest {
     list.setItems(Arrays.asList(dummy));
 
     server.expect()
-        .withPath("/apis/demos.fabric8.io/v1/namespaces/test/dummies?watch=false&labelSelector=my-label")
+        .withPath("/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label")
         .andReturn(HttpURLConnection.HTTP_OK, list)
         .once();
 
@@ -169,7 +169,7 @@ class InformTest {
         .withResourceVersion("1").endMetadata().build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=false")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -414,7 +414,7 @@ class PodTest {
       .endStatus()
       .build();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=false").andReturn(200, notReady).once();
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, notReady).once();
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
       .open()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
@@ -201,7 +201,7 @@ class ReplicaSetTest {
 
     // list for waiting
     server.expect()
-    .withPath("/apis/apps/v1/namespaces/test/replicasets?fieldSelector=metadata.name%3Drepl1&watch=false")
+    .withPath("/apis/apps/v1/namespaces/test/replicasets?fieldSelector=metadata.name%3Drepl1")
     .andReturn(200,
         new ReplicaSetListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
     .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
@@ -200,7 +200,7 @@ class ReplicationControllerTest {
 
     // list for waiting
     server.expect()
-      .withPath("/api/v1/namespaces/test/replicationcontrollers?fieldSelector=metadata.name%3Drepl1&watch=false")
+      .withPath("/api/v1/namespaces/test/replicationcontrollers?fieldSelector=metadata.name%3Drepl1")
       .andReturn(200,
         new ReplicationControllerListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
       .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -265,7 +265,7 @@ class ResourceTest {
   static void list(KubernetesMockServer server, Pod pod) {
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/"+pod.getMetadata().getNamespace()+"/pods?fieldSelector=metadata.name%3D"+pod.getMetadata().getName()+"&watch=false")
+        .withPath("/api/v1/namespaces/"+pod.getMetadata().getNamespace()+"/pods?fieldSelector=metadata.name%3D"+pod.getMetadata().getName())
         .andReturn(200,
             new PodListBuilder().withItems(pod).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
@@ -282,7 +282,7 @@ class ResourceTest {
     Pod ready = createReadyFrom(pod1, "True");
 
     // and again so that "periodicWatchUntilReady" successfully begins
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=false").andReturn(200, noReady).times(2);
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, noReady).times(2);
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true").andUpgradeToWebSocket()
       .open()
@@ -562,7 +562,7 @@ class ResourceTest {
   void testWaitNullDoesntExist() throws InterruptedException {
     server.expect()
       .get()
-      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&watch=false")
+      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
       .andReturn(200,
         new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
       .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
@@ -194,10 +194,10 @@ class ServiceTest {
         .addToPorts(new EndpointPortBuilder().withPort(8443).build())
         .build())
       .build();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/endpoints?fieldSelector=metadata.name%3Dsvc1&watch=false")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/endpoints?fieldSelector=metadata.name%3Dsvc1")
       .andReturn(HttpURLConnection.HTTP_OK, new EndpointsListBuilder().withItems(endpoint).withNewMetadata().withResourceVersion("1").endMetadata().build())
       .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dsvc1&watch=false")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dsvc1")
       .andReturn(HttpURLConnection.HTTP_OK, new ServiceListBuilder().withItems(svc1).withNewMetadata().withResourceVersion("1").endMetadata().build())
       .once();
     server.expect().get().withPath("/api/v1/namespaces/ns1/services/svc1")

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -216,7 +216,7 @@ public class StatefulSetTest {
 
     // list for waiting
     server.expect()
-      .withPath("/apis/apps/v1/namespaces/test/statefulsets?fieldSelector=metadata.name%3Drepl1&watch=false")
+      .withPath("/apis/apps/v1/namespaces/test/statefulsets?fieldSelector=metadata.name%3Drepl1")
       .andReturn(200,
         new StatefulSetListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
       .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -299,7 +299,7 @@ class DeploymentConfigTest {
       .endCondition()
       .withReplicas(1).withAvailableReplicas(1)
       .endStatus().build();
-    server.expect().get().withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs?fieldSelector=metadata.name%3Ddc1&watch=false")
+    server.expect().get().withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs?fieldSelector=metadata.name%3Ddc1")
       .andReturn(HttpURLConnection.HTTP_OK, new DeploymentConfigListBuilder().withItems(deploymentConfig).withMetadata(new ListMeta()).build())
       .always();
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImpl.java
@@ -32,7 +32,6 @@ import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.fabric8.openshift.api.model.BuildConfigList;
-import io.fabric8.openshift.api.model.BuildList;
 import io.fabric8.openshift.api.model.BuildRequest;
 import io.fabric8.openshift.api.model.WebHookTrigger;
 import io.fabric8.openshift.client.OpenShiftConfig;
@@ -160,40 +159,6 @@ public class BuildConfigOperationsImpl extends OpenShiftOperation<BuildConfig, B
   @Override
   public Triggerable<WebHookTrigger, Void> withType(String triggerType) {
     return new BuildConfigOperationsImpl(getContext().withTriggerType(triggerType));
-  }
-
-  @Override
-  public BuildConfigResource<BuildConfig, Void, Build> withResourceVersion(String resourceVersion) {
-    return new BuildConfigOperationsImpl(getContext().withResourceVersion(resourceVersion));
-  }
-
-  /*
-   * Labels are limited to 63 chars so need to first truncate the build config name (if required), retrieve builds with matching label,
-   * then check the build config name against the builds' build config annotation which have no such length restriction (but
-   * aren't usable for searching). Would be better if referenced build config was available via fields but it currently isn't...
-   */
-  private void deleteBuilds() {
-    if (getName() == null) {
-        return;
-    }
-    String buildConfigLabelValue = getName().substring(0, Math.min(getName().length(), 63));
-    BuildList matchingBuilds = new BuildOperationsImpl(client, (OpenShiftConfig) config).inNamespace(namespace).withLabel(BUILD_CONFIG_LABEL, buildConfigLabelValue).list();
-
-    if (matchingBuilds.getItems() != null) {
-
-      for (Build matchingBuild : matchingBuilds.getItems()) {
-
-        if (matchingBuild.getMetadata() != null &&
-          matchingBuild.getMetadata().getAnnotations() != null &&
-          getName().equals(matchingBuild.getMetadata().getAnnotations().get(BUILD_CONFIG_ANNOTATION))) {
-
-          new BuildOperationsImpl(client, (OpenShiftConfig) config).inNamespace(matchingBuild.getMetadata().getNamespace()).withName(matchingBuild.getMetadata().getName()).delete();
-
-        }
-
-      }
-
-    }
   }
 
   @Override


### PR DESCRIPTION
## Description
This is to address #3349.  After trying out the changes accepting a unaryoperator with the options, it seemed simpler to just have the context override whatever the user passes in - which is the expected behavior with forcing the watch property to true on a watch.  With this change that is being done consistently for the labels, fields, and resourceVersion as well, and the javadocs have been updated appropriately.

For consistency this means if you try to do something like
```
.withResourceVersion("x").watch("y", watcher);
```
that y is ignored (since that watch method was already deprecated that shouldn't be an issue).  Alternatively an exception could be thrown when the values conflict - similar to what happens when withName and the item name conflict.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
