### PR TITLE
Fix #3372: Add generatedTypesPrefix option to Model Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #3350: Replace references to impls with interfaces in several places in the the dsl
 * Fix #3327: Removed generated ResourceHandlers
 * Fix #3349: ensuring that dsl context values always are applied over user ListOptions
+* Fix #3372: Add generatePackageSuffix option to Model Generator to allow flexible package names for generated model
 
 #### Dependency Upgrade
 

--- a/extensions/camel-k/generator-v1/cmd/generate/generate.go
+++ b/extensions/camel-k/generator-v1/cmd/generate/generate.go
@@ -82,7 +82,7 @@ func main() {
 		reflect.TypeOf(runtime.RawExtension{}): "java.util.Map<String, Object>",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/camel-k/v1/CamelKSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/camel-k/v1/CamelKSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/camel-k/generator-v1alpha1/cmd/generate/generate.go
+++ b/extensions/camel-k/generator-v1alpha1/cmd/generate/generate.go
@@ -82,7 +82,7 @@ func main() {
 		reflect.TypeOf(runtime.RawExtension{}): "java.util.Map<String, Object>",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/camel-k/v1alpha1/CamelKSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/camel-k/v1alpha1/CamelKSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/certmanager/generator-v1/cmd/generate/generate.go
+++ b/extensions/certmanager/generator-v1/cmd/generate/generate.go
@@ -73,7 +73,7 @@ func main() {
 		reflect.TypeOf(apiextensions.JSON{}): "com.fasterxml.jackson.databind.JsonNode",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/certmanager/generator-v1alpha2/cmd/generate/generate.go
+++ b/extensions/certmanager/generator-v1alpha2/cmd/generate/generate.go
@@ -73,7 +73,7 @@ func main() {
 		reflect.TypeOf(apiextensions.JSON{}): "com.fasterxml.jackson.databind.JsonNode",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/certmanager/generator-v1alpha3/cmd/generate/generate.go
+++ b/extensions/certmanager/generator-v1alpha3/cmd/generate/generate.go
@@ -73,7 +73,7 @@ func main() {
 		reflect.TypeOf(apiextensions.JSON{}): "com.fasterxml.jackson.databind.JsonNode",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/certmanager/generator-v1beta1/cmd/generate/generate.go
+++ b/extensions/certmanager/generator-v1beta1/cmd/generate/generate.go
@@ -73,7 +73,7 @@ func main() {
 		reflect.TypeOf(apiextensions.JSON{}): "com.fasterxml.jackson.databind.JsonNode",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/jetstack/CertManagerSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/chaosmesh/generator/cmd/generate/generate.go
+++ b/extensions/chaosmesh/generator/cmd/generate/generate.go
@@ -74,7 +74,7 @@ func main() {
 		reflect.TypeOf([]byte{}):               "java.lang.String",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/csi/ChaosMeshSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/csi/ChaosMeshSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/knative/generator/cmd/generate/generate.go
+++ b/extensions/knative/generator/cmd/generate/generate.go
@@ -136,7 +136,7 @@ func main() {
 		reflect.TypeOf(runtime.RawExtension{}): "java.util.Map<String, Object>",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/knative/KnativeSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/knative/KnativeSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/service-catalog/generator/cmd/generate/generate.go
+++ b/extensions/service-catalog/generator/cmd/generate/generate.go
@@ -73,7 +73,7 @@ func main() {
 		reflect.TypeOf([]byte{}):               "java.lang.String",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/knative/ServiceCatalogSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/knative/ServiceCatalogSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/tekton/generator-triggers/cmd/generate/generate.go
+++ b/extensions/tekton/generator-triggers/cmd/generate/generate.go
@@ -76,7 +76,7 @@ func main() {
 		reflect.TypeOf(v1apiextensions.JSON{}):             "java.lang.Object",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/tekton/triggers/TektonSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/tekton/triggers/TektonSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/tekton/generator-v1alpha1/cmd/generate/generate.go
+++ b/extensions/tekton/generator-v1alpha1/cmd/generate/generate.go
@@ -78,7 +78,7 @@ func main() {
 		reflect.TypeOf(machinery.Time{}): "java.lang.String",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/tekton/v1alpha1/TektonSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/tekton/v1alpha1/TektonSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/tekton/generator-v1beta1/cmd/generate/generate.go
+++ b/extensions/tekton/generator-v1beta1/cmd/generate/generate.go
@@ -76,7 +76,7 @@ func main() {
 		reflect.TypeOf(machinery.Time{}): "java.lang.String",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/tekton/v1beta1/TektonSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/tekton/v1beta1/TektonSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }

--- a/extensions/volumesnapshot/generator/cmd/generate/generate.go
+++ b/extensions/volumesnapshot/generator/cmd/generate/generate.go
@@ -70,7 +70,7 @@ func main() {
 		reflect.TypeOf([]byte{}):               "java.lang.String",
 	}
 
-	json := schemagen.GenerateSchema("http://fabric8.io/csi/VolumeSnapshotSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints)
+	json := schemagen.GenerateSchema("http://fabric8.io/csi/VolumeSnapshotSchema#", crdLists, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, "io.fabric8")
 
 	fmt.Println(json)
 }


### PR DESCRIPTION

## Description
Fix #3372 
Instead of assuming a hardcoded value "io.fabric8", allow this parameter
to be configured from the client which will be using the generator in
order to be more flexible in terms of generate model package naming.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
