### PR TITLE
feature: support of withField research

### DIFF
--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -312,23 +312,23 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
     return null;
   }
 
-  private static Attribute parseField(String label) {
-    Matcher m = LABEL_REQUIREMENT_EQUALITY.matcher(label);
+  private static Attribute parseField(String field) {
+    Matcher m = LABEL_REQUIREMENT_EQUALITY.matcher(field);
     if (m.matches()) {
       return new Attribute(m.group(KEY), m.group(VALUE));
     }
 
-    m = LABEL_REQUIREMENT_NOT_EQUALITY.matcher(label);
+    m = LABEL_REQUIREMENT_NOT_EQUALITY.matcher(field);
     if (m.matches()) {
       return new Attribute(m.group(KEY), m.group(VALUE), WITHOUT);
     }
 
-    m = LABEL_REQUIREMENT_EXISTS.matcher(label);
+    m = LABEL_REQUIREMENT_EXISTS.matcher(field);
     if (m.matches()) {
       return new Attribute(m.group(KEY), "", EXISTS);
     }
 
-    m = LABEL_REQUIREMENT_NOT_EXISTS.matcher(label);
+    m = LABEL_REQUIREMENT_NOT_EXISTS.matcher(field);
     if (m.matches()) {
       return new Attribute(m.group(KEY), "", NOT_EXISTS);
     }

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
@@ -111,7 +111,9 @@ public class KubernetesAttributesExtractorTest {
 		AttributeSet expected = new AttributeSet();
 		expected = expected.add(new Attribute("plural", "pods"));
 		expected = expected.add(new Attribute("namespace", "myns"));
+		expected = expected.add(new Attribute("metadata.namespace", "myns"));
 		expected = expected.add(new Attribute("name", "mypod"));
+		expected = expected.add(new Attribute("metadata.name", "mypod"));
 		expected = expected.add(new Attribute("version", "v1"));
 		assertTrue(attributes.matches(expected));
 		assertFalse(attributes.containsKey(KubernetesAttributesExtractor.API));
@@ -126,7 +128,9 @@ public class KubernetesAttributesExtractorTest {
 
     AttributeSet expected = new AttributeSet();
     expected = expected.add(new Attribute("namespace", "myns"));
+    expected = expected.add(new Attribute("metadata.namespace", "myns"));
     expected = expected.add(new Attribute("name", "myresource"));
+    expected = expected.add(new Attribute("metadata.name", "myresource"));
     expected = expected.add(new Attribute("version", "v1"));
     assertTrue(attributes.matches(expected));
     assertFalse(attributes.containsKey(KubernetesAttributesExtractor.API));
@@ -286,7 +290,7 @@ public class KubernetesAttributesExtractorTest {
   }
 
 	@Test
-	void shouldHandleLabelSelectorsWithOneLabel() {
+	void shouldHandleNamespacedResourceLabelSelectorsWithOneLabel() {
 		KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
 		AttributeSet attributes = extractor.fromPath("/api/v1/namespaces/myns/pods/mypod?labelSelector=name%3Dmyname");
 
@@ -295,7 +299,8 @@ public class KubernetesAttributesExtractorTest {
 		assertTrue(attributes.matches(expected));
 	}
 
-	@Test
+
+  @Test
 	void shouldHandleLabelSelectorsWithDoubleEquals() {
 		KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
 		AttributeSet attributes = extractor
@@ -317,6 +322,43 @@ public class KubernetesAttributesExtractorTest {
 		expected = expected.add(new Attribute("labels:age", "37"));
 		assertTrue(attributes.matches(expected));
 	}
+
+  @Test
+  void shouldHandleNamespacedResourceFieldSelectorsWithOneField() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    AttributeSet attributes = extractor.fromPath("/api/v1/namespaces/myns/pods/mypod?fieldSelector=testKey%3DtestValue");
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("plural", "pods"));
+    expected = expected.add(new Attribute("testKey", "testValue"));
+    assertTrue(attributes.matches(expected));
+  }
+
+
+  @Test
+  void shouldHandleFieldSelectorsWithDoubleEquals() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    AttributeSet attributes = extractor
+      .fromPath("/api/v1/namespaces/myns/pods/mypod?fieldSelector=testKey%3D%3DtestValue");
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("plural", "pods"));
+    expected = expected.add(new Attribute("testKey", "testValue"));
+    assertTrue(attributes.matches(expected));
+  }
+
+  @Test
+  void shouldHandleFieldSelectorsWithTwoLabels() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    AttributeSet attributes = extractor
+      .fromPath("/api/v1/namespaces/myns/pods/mypod?fieldSelector=keyOne%3DvalueOne,keyTwo%3DvalueTwo");
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("plural", "pods"));
+    expected = expected.add(new Attribute("keyOne", "valueOne"));
+    expected = expected.add(new Attribute("keyTwo", "valueTwo"));
+    assertTrue(attributes.matches(expected));
+  }
 
 	@Test
 	void shouldHandleLabelSelectorsWithADomain() {

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
@@ -79,16 +79,29 @@ public class KubernetesAttributesExtractorTest {
 	}
 
 	@Test
-	void shouldHandlePathWithParameters() {
+	void shouldHandlePathWithLabelSelectorParam() {
 	  KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
 	  AttributeSet attributes = extractor.fromPath("/api/v1/pods?labelSelector=testKey%3DtestValue");
 
 	  AttributeSet expected = new AttributeSet();
 	  expected = expected.add(new Attribute("plural", "pods"));
+	  expected = expected.add(new Attribute("labels:testKey", "testValue"));
 	  assertTrue(attributes.matches(expected));
 	}
 
-	@Test
+  @Test
+  void shouldHandlePathWithFieldSelectorParam() {
+    KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
+    AttributeSet attributes = extractor.fromPath("/api/v1/pods?fieldSelector=testKey%3DtestValue");
+
+    AttributeSet expected = new AttributeSet();
+    expected = expected.add(new Attribute("plural", "pods"));
+    expected = expected.add(new Attribute("testKey", "testValue"));
+    assertTrue(attributes.matches(expected));
+  }
+
+
+  @Test
 	void shouldHandleResource() {
 		KubernetesAttributesExtractor extractor = new KubernetesAttributesExtractor();
 		Pod pod = new PodBuilder().withNewMetadata().withName("mypod").withNamespace("myns").endMetadata().build();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
@@ -85,7 +85,7 @@ public class ServiceCrudTest {
   }
 
   @Test
-  public void shouldFindServiceBy() {
+  public void shouldFindServiceByName() {
     Service service1 = new ServiceBuilder().withNewMetadata().withName("svc1").addToLabels("foo", "bar").and().withNewSpec().and().build();
 
     client.services().inNamespace("ns1").create(service1);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
@@ -16,9 +16,7 @@
 
 package io.fabric8.kubernetes.client.mock;
 
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
@@ -27,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -83,5 +82,28 @@ public class ServiceCrudTest {
 
     assertNotNull(service2);
     assertEquals("value1", service2.getMetadata().getLabels().get("key1"));
+  }
+
+  @Test
+  public void shouldFindServiceBy() {
+    Service service1 = new ServiceBuilder().withNewMetadata().withName("svc1").addToLabels("foo", "bar").and().withNewSpec().and().build();
+
+    client.services().inNamespace("ns1").create(service1);
+
+    Service serviceByName = client.services().inNamespace("ns1").withName("svc1").get();
+    assertNotNull(serviceByName);
+    assertEquals(serviceByName.getMetadata().getName(),"svc1");
+
+    ServiceList servicesByLabel = client.services().inNamespace("ns1").withLabel("foo", "bar").list();
+    assertNotNull(servicesByLabel);
+    assertEquals(1, servicesByLabel.getItems().size());
+
+    ServiceList serviceByField = client.services().inNamespace("ns1").withField("metadata.name", "svc1").list();
+    assertNotNull(serviceByField);
+    assertEquals(1, serviceByField.getItems().size());
+
+    ServiceList serviceByNamespace = client.services().inNamespace("ns1").withField("metadata.namespace", "ns1").list();
+    assertNotNull(serviceByNamespace);
+    assertEquals(1, serviceByNamespace.getItems().size());
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
@@ -92,7 +92,7 @@ public class ServiceCrudTest {
 
     Service serviceByName = client.services().inNamespace("ns1").withName("svc1").get();
     assertNotNull(serviceByName);
-    assertEquals(serviceByName.getMetadata().getName(),"svc1");
+    assertEquals("svc1", serviceByName.getMetadata().getName());
 
     ServiceList servicesByLabel = client.services().inNamespace("ns1").withLabel("foo", "bar").list();
     assertNotNull(servicesByLabel);


### PR DESCRIPTION
I added the metadata.name and metadata.namespace to the `AttributesSet` to allow the research of resources with `withField` method. 