### PR TITLE
fix #3378: returning the built-in operation for resources calls

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
@@ -92,6 +92,7 @@ import io.fabric8.kubernetes.client.dsl.StorageAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.V1APIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Waitable;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.internal.ClusterOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
@@ -414,9 +415,14 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
   }
   
   @Override
-  public <T extends HasMetadata, L extends KubernetesResourceList<T>> HasMetadataOperationsImpl<T, L> resources(
+  public <T extends HasMetadata, L extends KubernetesResourceList<T>> HasMetadataOperation<T, L, Resource<T>> resources(
       Class<T> resourceType, Class<L> listClass) {
-    return customResources(ResourceDefinitionContext.fromResourceType(resourceType), resourceType, listClass);
+    try {
+      return Handlers.getOperation(resourceType, listClass, httpClient, getConfiguration());
+    } catch (Exception e) {
+      //may be the wrong list type, try more general
+      return customResources(ResourceDefinitionContext.fromResourceType(resourceType), resourceType, listClass);
+    }
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -119,9 +119,7 @@ public interface KubernetesClient extends Client {
   <T extends CustomResource> MixedOperation<T, KubernetesResourceList<T>, Resource<T>> customResources(Class<T> resourceType);
   
   /**
-   * Typed API for managing resources. You would need to provide POJOs for
-   * into this and with it you would be able to instantiate a client
-   * specific to CustomResource.
+   * Typed API for managing resources. Any properly annotated POJO can be utilized as a resource.
    *
    * <p>
    *   Note: your resource POJO (T in this context) must implement
@@ -131,16 +129,14 @@ public interface KubernetesClient extends Client {
    * @param resourceType Class for resource
    * @param <T> T type represents resource type. If it's a namespaced resource, it must implement
    *           {@link io.fabric8.kubernetes.api.model.Namespaced}
-   * @return returns a MixedOperation object with which you can do basic resource operations
+   * @return returns a MixedOperation object with which you can do basic resource operations.  If the class is a known type the dsl operation logic will be used.
    */
   default <T extends HasMetadata> MixedOperation<T, KubernetesResourceList<T>, Resource<T>> resources(Class<T> resourceType) {
     return resources(resourceType, null);
   }
   
   /**
-   * Typed API for managing resources. You would need to provide POJOs for
-   * into this and with it you would be able to instantiate a client
-   * specific to CustomResource.
+   * Typed API for managing resources. Any properly annotated POJO can be utilized as a resource.
    *
    * <p>
    *   Note: your resource POJO (T in this context) must implement
@@ -151,7 +147,7 @@ public interface KubernetesClient extends Client {
    * @param <T> T type represents resource type. If it's a namespaced resource, it must implement
    *           {@link io.fabric8.kubernetes.api.model.Namespaced}
    * @param <L> L type represents resource list type
-   * @return returns a MixedOperation object with which you can do basic resource operations
+   * @return returns a MixedOperation object with which you can do basic resource operations.  If the class is a known type the dsl operation logic will be used.
    */
   <T extends HasMetadata, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> resources(Class<T> resourceType, Class<L> listClass);
 


### PR DESCRIPTION
## Description
Addressing #3378 so that calls to resources will use the existing operation if possible.

A change log isn't needed as the feature has not been released yet.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
