### PR TITLE
Replaced C-Style array declarations with Java-Style

### DIFF
--- a/extensions/certmanager/examples/src/main/java/io/fabric8/certmanager/examples/ClientFactory.java
+++ b/extensions/certmanager/examples/src/main/java/io/fabric8/certmanager/examples/ClientFactory.java
@@ -52,7 +52,7 @@ public class ClientFactory {
     return new DefaultCertManagerClient(config.build());
   }
 
-  public static String getOptions(String args[], String name, String defaultValue) {
+  public static String getOptions(String[] args, String name, String defaultValue) {
     for (int i = 0; i < args.length - 1; i++) {
       String key = args[i];
       String value = args[i + 1];

--- a/extensions/knative/examples/src/main/java/io/fabric8/knative/api/examples/ClientFactory.java
+++ b/extensions/knative/examples/src/main/java/io/fabric8/knative/api/examples/ClientFactory.java
@@ -52,7 +52,7 @@ public class ClientFactory {
       return new DefaultKnativeClient(config.build());
   }
 
-    public static String getOptions(String args[], String name, String defaultValue) {
+    public static String getOptions(String[] args, String name, String defaultValue) {
         for (int i = 0; i < args.length - 1; i++) {
             String key = args[i];
             String value = args[i + 1];

--- a/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ClientFactory.java
+++ b/extensions/service-catalog/examples/src/main/java/io/fabric8/servicecatalog/examples/ClientFactory.java
@@ -52,7 +52,7 @@ public class ClientFactory {
       return new DefaultServiceCatalogClient(config.build());
   }
 
-    public static String getOptions(String args[], String name, String defaultValue) {
+    public static String getOptions(String[] args, String name, String defaultValue) {
         for (int i = 0; i < args.length - 1; i++) {
             String key = args[i];
             String value = args[i + 1];

--- a/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/ClientFactory.java
+++ b/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/ClientFactory.java
@@ -52,7 +52,7 @@ public class ClientFactory {
       return new DefaultTektonClient(config.build());
   }
 
-    public static String getOptions(String args[], String name, String defaultValue) {
+    public static String getOptions(String[] args, String name, String defaultValue) {
         for (int i = 0; i < args.length - 1; i++) {
             String key = args[i];
             String value = args[i + 1];

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/KubernetesVersionExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/KubernetesVersionExample.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class KubernetesVersionExample {
   private static final Logger logger = LoggerFactory.getLogger(KubernetesVersionExample.class);
 
-  public static void main(String args[]) {
+  public static void main(String[] args) {
     final ConfigBuilder configBuilder = new ConfigBuilder();
     if (args.length > 0) {
       configBuilder.withMasterUrl(args[0]);


### PR DESCRIPTION
## Description
Fix #3400

I have replaced the C-Style array declarations with Java-Style array declarations. 

Example:
```java
public static void main(String args[]) { 
```
has become:
```java
public static void main(String[] args) {
```


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->

