### PR TITLE
fix #3294 #3303 exposing apigroups and apiresource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 #### Improvements
 #### Dependency Upgrade
 #### New Features
+* Fix #3294: Support fetching APIGroupList
+* Fix #3303: Support fetching APIResourceList
+
 #### _**Note**_: Breaking changes in the API
 
 ### 5.7.3 (2021-09-09)

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Client.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Client.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.kubernetes.client;
 
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIResourceList;
 import io.fabric8.kubernetes.api.model.RootPaths;
 
 import java.io.Closeable;
@@ -48,5 +51,26 @@ public interface Client extends ConfigAware, Closeable {
    */
   boolean supportsApiPath(String path);
 
+  @Override
   void close();
+  
+  /**
+   * Returns the api groups
+   * @return the {@link APIGroupList} metadata
+   */
+  APIGroupList getApiGroups();
+  
+  /**
+   * Return a single api group
+   * @param name of the group
+   * @return the {@link APIGroup} metadata
+   */
+  APIGroup getApiGroup(String name);
+  
+  /**
+   * Return the api resource metadata for the given groupVersion
+   * @param the groupVersion - group/version
+   * @return the {@link APIResourceList} for the groupVersion
+   */
+  APIResourceList getApiResources(String groupVersion);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -55,6 +55,7 @@ import io.fabric8.kubernetes.client.utils.IOHelpers;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
+import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1341,4 +1342,8 @@ public class Config {
     return Readiness.getInstance();
   }
 
+  public OkHttpClient adaptClient(OkHttpClient httpClient) {
+    return httpClient;
+  }
+  
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -195,10 +195,18 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
  }
 
   public RootPaths getRootPaths() {
+    return restCall(RootPaths.class);
+  }
+  
+  public <Res> Res restCall(Class<Res> result, String... path) {
     try {
       URL requestUrl = new URL(config.getMasterUrl());
-      Request.Builder req = new Request.Builder().get().url(requestUrl);
-      return handleResponse(req, RootPaths.class);
+      String url = requestUrl.toString();
+      if (path != null && path.length > 0) {
+        url = URLUtils.join(url, URLUtils.pathJoin(path));
+      }
+      Request.Builder req = new Request.Builder().get().url(url);
+      return handleResponse(req, result);
     } catch (KubernetesClientException e) {
       if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
         throw e;

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class ApiGroupResourceListsIT {
+
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  @Test
+  public void testApiGroups() throws InterruptedException {
+    APIGroupList list = client.getApiGroups();
+
+    assertTrue(list.getGroups().stream().anyMatch(g -> "apps".equals(g.getName())));
+  }
+
+  @Test
+  public void testApiGroup() throws InterruptedException {
+    APIGroup group = client.getApiGroup("apps");
+
+    assertNotNull(group);
+
+    group = client.getApiGroup("apps-that-wont-exist");
+
+    assertNull(group);
+  }
+
+  @Test
+  public void testApiResources() throws InterruptedException {
+    APIResourceList list = client.getApiResources("apps/v1");
+
+    assertTrue(list.getResources().stream().anyMatch(r -> "deployments".equals(r.getName())));
+  }
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/EventsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/EventsIT.java
@@ -28,9 +28,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/kubernetes-model-generator/kubernetes-model-core/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-core/cmd/generate/generate.go
@@ -39,6 +39,8 @@ type Schema struct {
 	Info                 apimachineryversion.Info
 	APIGroup             metav1.APIGroup
 	APIGroupList         metav1.APIGroupList
+	APIResource          metav1.APIResource
+	APIResourceList      metav1.APIResourceList
 	BaseKubernetesList   metav1.List
 	ObjectMeta           metav1.ObjectMeta
 	TypeMeta             metav1.TypeMeta

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResource.java
@@ -1,0 +1,210 @@
+
+package io.fabric8.kubernetes.api.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "categories",
+    "group",
+    "name",
+    "namespaced",
+    "shortNames",
+    "singularName",
+    "storageVersionHash",
+    "verbs",
+    "version"
+})
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class APIResource implements KubernetesResource
+{
+
+    @JsonProperty("categories")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> categories = new ArrayList<String>();
+    @JsonProperty("group")
+    private String group;
+    @JsonProperty("kind")
+    private String kind;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("namespaced")
+    private Boolean namespaced;
+    @JsonProperty("shortNames")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> shortNames = new ArrayList<String>();
+    @JsonProperty("singularName")
+    private String singularName;
+    @JsonProperty("storageVersionHash")
+    private String storageVersionHash;
+    @JsonProperty("verbs")
+    private List<String> verbs = new ArrayList<String>();
+    @JsonProperty("version")
+    private String version;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public APIResource() {
+    }
+
+    /**
+     * 
+     * @param shortNames
+     * @param kind
+     * @param name
+     * @param storageVersionHash
+     * @param verbs
+     * @param categories
+     * @param version
+     * @param namespaced
+     * @param group
+     * @param singularName
+     */
+    public APIResource(List<String> categories, String group, String kind, String name, Boolean namespaced, List<String> shortNames, String singularName, String storageVersionHash, List<String> verbs, String version) {
+        super();
+        this.categories = categories;
+        this.group = group;
+        this.kind = kind;
+        this.name = name;
+        this.namespaced = namespaced;
+        this.shortNames = shortNames;
+        this.singularName = singularName;
+        this.storageVersionHash = storageVersionHash;
+        this.verbs = verbs;
+        this.version = version;
+    }
+
+    @JsonProperty("categories")
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    @JsonProperty("categories")
+    public void setCategories(List<String> categories) {
+        this.categories = categories;
+    }
+
+    @JsonProperty("group")
+    public String getGroup() {
+        return group;
+    }
+
+    @JsonProperty("group")
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("namespaced")
+    public Boolean getNamespaced() {
+        return namespaced;
+    }
+
+    @JsonProperty("namespaced")
+    public void setNamespaced(Boolean namespaced) {
+        this.namespaced = namespaced;
+    }
+
+    @JsonProperty("shortNames")
+    public List<String> getShortNames() {
+        return shortNames;
+    }
+
+    @JsonProperty("shortNames")
+    public void setShortNames(List<String> shortNames) {
+        this.shortNames = shortNames;
+    }
+
+    @JsonProperty("singularName")
+    public String getSingularName() {
+        return singularName;
+    }
+
+    @JsonProperty("singularName")
+    public void setSingularName(String singularName) {
+        this.singularName = singularName;
+    }
+
+    @JsonProperty("storageVersionHash")
+    public String getStorageVersionHash() {
+        return storageVersionHash;
+    }
+
+    @JsonProperty("storageVersionHash")
+    public void setStorageVersionHash(String storageVersionHash) {
+        this.storageVersionHash = storageVersionHash;
+    }
+
+    @JsonProperty("verbs")
+    public List<String> getVerbs() {
+        return verbs;
+    }
+
+    @JsonProperty("verbs")
+    public void setVerbs(List<String> verbs) {
+        this.verbs = verbs;
+    }
+
+    @JsonProperty("version")
+    public String getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResourceList.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResourceList.java
@@ -1,0 +1,147 @@
+
+package io.fabric8.kubernetes.api.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "groupVersion",
+    "resources"
+})
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class APIResourceList implements KubernetesResource
+{
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    private String apiVersion = "v1";
+    @JsonProperty("groupVersion")
+    private String groupVersion;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    private String kind = "APIResourceList";
+    @JsonProperty("resources")
+    private List<APIResource> resources = new ArrayList<APIResource>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public APIResourceList() {
+    }
+
+    /**
+     * 
+     * @param apiVersion
+     * @param kind
+     * @param groupVersion
+     * @param resources
+     */
+    public APIResourceList(String apiVersion, String groupVersion, String kind, List<APIResource> resources) {
+        super();
+        this.apiVersion = apiVersion;
+        this.groupVersion = groupVersion;
+        this.kind = kind;
+        this.resources = resources;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @JsonProperty("groupVersion")
+    public String getGroupVersion() {
+        return groupVersion;
+    }
+
+    @JsonProperty("groupVersion")
+    public void setGroupVersion(String groupVersion) {
+        this.groupVersion = groupVersion;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("resources")
+    public List<APIResource> getResources() {
+        return resources;
+    }
+
+    @JsonProperty("resources")
+    public void setResources(List<APIResource> resources) {
+        this.resources = resources;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
@@ -23,6 +23,8 @@ import lombok.ToString;
     "metadata",
     "APIGroup",
     "APIGroupList",
+    "APIResource",
+    "APIResourceList",
     "APIService",
     "APIServiceList",
     "BaseKubernetesList",
@@ -92,6 +94,10 @@ public class KubeSchema {
     private APIGroup aPIGroup;
     @JsonProperty("APIGroupList")
     private APIGroupList aPIGroupList;
+    @JsonProperty("APIResource")
+    private APIResource aPIResource;
+    @JsonProperty("APIResourceList")
+    private APIResourceList aPIResourceList;
     @JsonProperty("APIService")
     private APIService aPIService;
     @JsonProperty("APIServiceList")
@@ -239,6 +245,7 @@ public class KubeSchema {
      * @param groupVersionResource
      * @param limitRangeList
      * @param toleration
+     * @param aPIResourceList
      * @param nodeList
      * @param groupVersionKind
      * @param node
@@ -269,6 +276,7 @@ public class KubeSchema {
      * @param microTime
      * @param podExecOptions
      * @param serviceAccount
+     * @param aPIResource
      * @param resourceQuotaList
      * @param topologySelectorTerm
      * @param createOptions
@@ -284,10 +292,12 @@ public class KubeSchema {
      * @param endpointPort
      * @param config
      */
-    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, APIService aPIService, APIServiceList aPIServiceList, BaseKubernetesList baseKubernetesList, Binding binding, ComponentStatus componentStatus, ComponentStatusList componentStatusList, Condition condition, Config config, ConfigMap configMap, ConfigMapList configMapList, ContainerStatus containerStatus, CreateOptions createOptions, DeleteOptions deleteOptions, EndpointPort endpointPort, Endpoints endpoints, EndpointsList endpointsList, EnvVar envVar, Event event, EventList eventList, EventSeries eventSeries, EventSource eventSource, GetOptions getOptions, GroupVersionKind groupVersionKind, GroupVersionResource groupVersionResource, Info info, LimitRangeList limitRangeList, ListOptions listOptions, MicroTime microTime, Namespace namespace, NamespaceList namespaceList, Node node, NodeList nodeList, ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, PersistentVolume persistentVolume, PersistentVolumeClaim persistentVolumeClaim, PersistentVolumeClaimList persistentVolumeClaimList, PersistentVolumeList persistentVolumeList, PodExecOptions podExecOptions, PodList podList, PodTemplateList podTemplateList, Quantity quantity, ReplicationControllerList replicationControllerList, ResourceQuota resourceQuota, ResourceQuotaList resourceQuotaList, RootPaths rootPaths, Secret secret, SecretList secretList, ServiceAccount serviceAccount, ServiceAccountList serviceAccountList, ServiceList serviceList, Status status, String time, Toleration toleration, TopologySelectorTerm topologySelectorTerm, TypeMeta typeMeta, UpdateOptions updateOptions, WatchEvent watchEvent) {
+    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, APIResource aPIResource, APIResourceList aPIResourceList, APIService aPIService, APIServiceList aPIServiceList, BaseKubernetesList baseKubernetesList, Binding binding, ComponentStatus componentStatus, ComponentStatusList componentStatusList, Condition condition, Config config, ConfigMap configMap, ConfigMapList configMapList, ContainerStatus containerStatus, CreateOptions createOptions, DeleteOptions deleteOptions, EndpointPort endpointPort, Endpoints endpoints, EndpointsList endpointsList, EnvVar envVar, Event event, EventList eventList, EventSeries eventSeries, EventSource eventSource, GetOptions getOptions, GroupVersionKind groupVersionKind, GroupVersionResource groupVersionResource, Info info, LimitRangeList limitRangeList, ListOptions listOptions, MicroTime microTime, Namespace namespace, NamespaceList namespaceList, Node node, NodeList nodeList, ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, PersistentVolume persistentVolume, PersistentVolumeClaim persistentVolumeClaim, PersistentVolumeClaimList persistentVolumeClaimList, PersistentVolumeList persistentVolumeList, PodExecOptions podExecOptions, PodList podList, PodTemplateList podTemplateList, Quantity quantity, ReplicationControllerList replicationControllerList, ResourceQuota resourceQuota, ResourceQuotaList resourceQuotaList, RootPaths rootPaths, Secret secret, SecretList secretList, ServiceAccount serviceAccount, ServiceAccountList serviceAccountList, ServiceList serviceList, Status status, String time, Toleration toleration, TopologySelectorTerm topologySelectorTerm, TypeMeta typeMeta, UpdateOptions updateOptions, WatchEvent watchEvent) {
         super();
         this.aPIGroup = aPIGroup;
         this.aPIGroupList = aPIGroupList;
+        this.aPIResource = aPIResource;
+        this.aPIResourceList = aPIResourceList;
         this.aPIService = aPIService;
         this.aPIServiceList = aPIServiceList;
         this.baseKubernetesList = baseKubernetesList;
@@ -367,6 +377,26 @@ public class KubeSchema {
     @JsonProperty("APIGroupList")
     public void setAPIGroupList(APIGroupList aPIGroupList) {
         this.aPIGroupList = aPIGroupList;
+    }
+
+    @JsonProperty("APIResource")
+    public APIResource getAPIResource() {
+        return aPIResource;
+    }
+
+    @JsonProperty("APIResource")
+    public void setAPIResource(APIResource aPIResource) {
+        this.aPIResource = aPIResource;
+    }
+
+    @JsonProperty("APIResourceList")
+    public APIResourceList getAPIResourceList() {
+        return aPIResourceList;
+    }
+
+    @JsonProperty("APIResourceList")
+    public void setAPIResourceList(APIResourceList aPIResourceList) {
+        this.aPIResourceList = aPIResourceList;
     }
 
     @JsonProperty("APIService")

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/kube-schema.json
@@ -231,6 +231,87 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_pkg_apis_APIResource": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespaced": {
+          "type": "boolean"
+        },
+        "shortNames": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "singularName": {
+          "type": "string"
+        },
+        "storageVersionHash": {
+          "type": "string"
+        },
+        "verbs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_apimachinery_pkg_apis_APIResourceList": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "v1",
+          "required": true
+        },
+        "groupVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "default": "APIResourceList",
+          "required": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResourceList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_pkg_apis_Condition": {
       "type": "object",
       "properties": {
@@ -7391,6 +7472,14 @@
     "APIGroupList": {
       "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIGroupList",
       "existingJavaType": "io.fabric8.kubernetes.api.model.APIGroupList"
+    },
+    "APIResource": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+    },
+    "APIResourceList": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResourceList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResourceList"
     },
     "APIService": {
       "$ref": "#/definitions/kubernetes_aggregator_APIService",

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/validation-schema.json
@@ -231,6 +231,87 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_pkg_apis_APIResource": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespaced": {
+          "type": "boolean"
+        },
+        "shortNames": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "singularName": {
+          "type": "string"
+        },
+        "storageVersionHash": {
+          "type": "string"
+        },
+        "verbs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_apimachinery_pkg_apis_APIResourceList": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "v1",
+          "required": true
+        },
+        "groupVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "default": "APIResourceList",
+          "required": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResourceList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_pkg_apis_Condition": {
       "type": "object",
       "properties": {
@@ -7392,6 +7473,14 @@
       "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIGroupList",
       "existingJavaType": "io.fabric8.kubernetes.api.model.APIGroupList"
     },
+    "APIResource": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+    },
+    "APIResourceList": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResourceList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResourceList"
+    },
     "APIService": {
       "$ref": "#/definitions/kubernetes_aggregator_APIService",
       "existingJavaType": "io.fabric8.kubernetes.api.model.APIService"
@@ -7703,6 +7792,77 @@
           "type": "string",
           "default": "APIGroupList",
           "required": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "apiresource": {
+      "properties": {
+        "categories": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespaced": {
+          "type": "boolean"
+        },
+        "shortNames": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "singularName": {
+          "type": "string"
+        },
+        "storageVersionHash": {
+          "type": "string"
+        },
+        "verbs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "apiresourcelist": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "v1",
+          "required": true
+        },
+        "groupVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "default": "APIResourceList",
+          "required": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+          }
         }
       },
       "additionalProperties": true

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/NamespacedOpenShiftExtensionAdapter.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/NamespacedOpenShiftExtensionAdapter.java
@@ -16,8 +16,6 @@
 
 package io.fabric8.openshift.client;
 
-import okhttp3.OkHttpClient;
-import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.ExtensionAdapter;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
@@ -32,11 +30,4 @@ public class NamespacedOpenShiftExtensionAdapter extends OpenshiftAdapterSupport
     return NamespacedOpenShiftClient.class;
   }
 
-  @Override
-  public NamespacedOpenShiftClient adapt(Client client) {
-    if (!isAdaptable(client)) {
-      throw new OpenShiftNotAvailableException("OpenShift is not available. Root paths at: " + client.getMasterUrl() + " do not include /oapi or the new /apis/*.openshift.io APIs.");
-    }
-    return new DefaultOpenShiftClient(client.adapt(OkHttpClient.class), OpenShiftConfig.wrap(client.getConfiguration()));
-  }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftExtensionAdapter.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftExtensionAdapter.java
@@ -16,7 +16,6 @@
 
 package io.fabric8.openshift.client;
 
-import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.ExtensionAdapter;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
@@ -50,7 +49,6 @@ import io.fabric8.openshift.client.dsl.internal.project.ProjectOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.security.SecurityContextConstraintsOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.user.GroupOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.user.UserOperationsImpl;
-import okhttp3.OkHttpClient;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
 
@@ -83,12 +81,4 @@ public class OpenShiftExtensionAdapter extends OpenshiftAdapterSupport implement
     return OpenShiftClient.class;
   }
 
-
-  @Override
-  public OpenShiftClient adapt(Client client) {
-    if (!isAdaptable(client)) {
-      throw new OpenShiftNotAvailableException("OpenShift is not available. Root paths at: " + client.getMasterUrl() + " do not include oapi.");
-    }
-    return new DefaultOpenShiftClient(client.adapt(OkHttpClient.class), OpenShiftConfig.wrap(client.getConfiguration()));
-  }
 }


### PR DESCRIPTION
## Description
Adds client methods for apigroups and apiresources.  Also consolidates existing logic about openshift adapting.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
