### PR TITLE
Fix #3287: Add support for field descriptions in CRD Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Improvements
 * Fix #3414: Add equals and hashCode implementations for CustomResource
+* Fix #3287: Add support for field descriptions in CRD Generator
 
 #### Dependency Upgrade
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -102,4 +102,11 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   protected JSONSchemaProps enumProperty(JsonNode... enumValues) {
     return new JSONSchemaPropsBuilder().withType("string").withEnum(enumValues).build();
   }
+
+  @Override
+  protected JSONSchemaProps addDescription(JSONSchemaProps schema, String description) {
+    return new JSONSchemaPropsBuilder(schema)
+      .withDescription(description)
+      .build();
+  }
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -105,4 +105,11 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   protected JSONSchemaProps enumProperty(JsonNode... enumValues) {
     return new JSONSchemaPropsBuilder().withType("string").withEnum(enumValues).build();
   }
+
+  @Override
+  protected JSONSchemaProps addDescription(JSONSchemaProps schema, String description) {
+    return new JSONSchemaPropsBuilder(schema)
+      .withDescription(description)
+      .build();
+  }
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -16,9 +16,11 @@
 package io.fabric8.crd.example.annotated;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class AnnotatedSpec {
   @JsonProperty("from-field")
+  @JsonPropertyDescription("from-field-description")
   private String field;
   private int foo;
   @JsonProperty
@@ -26,6 +28,7 @@ public class AnnotatedSpec {
   private boolean emptySetter;
 
   @JsonProperty("from-getter")
+  @JsonPropertyDescription("from-getter-description")
   public int getFoo() {
     return foo;
   }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequestSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequestSpec.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.example.joke;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 
 public class JokeRequestSpec {
@@ -39,6 +40,7 @@ public class JokeRequestSpec {
   }
 
   @PrinterColumn(name = "jokeCategory")
+  @JsonPropertyDescription("category-description")
   private Category category = Category.Any;
   @PrinterColumn(name = "excludedTopics")
   private ExcludedTopic[] excluded = new ExcludedTopic[]{ExcludedTopic.nsfw, ExcludedTopic.racist,

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -289,6 +289,7 @@ class CRDGeneratorTest {
       JSONSchemaProps category = specProps.get("category");
       assertEquals("string", category.getType());
       assertEquals(7, category.getEnum().size());
+      assertEquals("category-description", category.getDescription());
       JSONSchemaProps excluded = specProps.get("excluded");
       assertEquals("array", excluded.getType());
       assertEquals("string", excluded.getItems().getSchema().getType());

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -17,6 +17,7 @@ package io.fabric8.crd.generator.v1;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -80,6 +81,33 @@ class JsonSchemaTest {
     assertTrue(spec.containsKey("from-getter"));
     assertTrue(spec.containsKey("unnamed"));
     assertTrue(spec.containsKey("emptySetter"));
+  }
+
+  @Test
+  void shouldHaveDescriptionIfJacksonAnnotated() {
+    // Given
+    TypeDef annotated = Types.typeDefFrom(Annotated.class);
+    // When
+    JSONSchemaProps schema = JsonSchema.from(annotated);
+    // Then
+    assertNotNull(schema);
+    Map<String, JSONSchemaProps> properties = schema.getProperties();
+    assertEquals(2, properties.size());
+    Map<String, JSONSchemaProps> spec = properties.get("spec").getProperties();
+    // should have description
+    assertTrue(spec.containsKey("from-field"));
+    JSONSchemaProps fromField = spec.get("from-field");
+    assertNotNull(fromField.getDescription(), "description cannot be null");
+    assertEquals("from-field-description", fromField.getDescription());
+    assertTrue(spec.containsKey("from-getter"));
+    JSONSchemaProps fromGetter = spec.get("from-getter");
+    assertNotNull(fromGetter.getDescription(), "description cannot be null");
+    assertEquals("from-getter-description", fromGetter.getDescription());
+    // should not have description
+    assertTrue(spec.containsKey("unnamed"));
+    assertNull(spec.get("unnamed").getDescription());
+    assertTrue(spec.containsKey("emptySetter"));
+    assertNull(spec.get("emptySetter").getDescription());
   }
 
 }


### PR DESCRIPTION
## Description

Add annotation based support for field descriptions in the CRD Generator using `JsonPropertyDescription`

The code already supports overriding property names using `JsonProperty`: use the same pattern for supporting descriptions.

- snipped output from the test Joke CRD
```
            properties:
              category:
                description: category-description
                type: string
```

Fixes #3287

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
