### PR TITLE
chore: bump sundrio to 0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 #### Improvements
 #### Dependency Upgrade
+  * Upgrade Sundrio to 0.50.1
 #### New Features
 #### _**Note**_: Breaking changes in the API
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -22,13 +22,27 @@ import io.fabric8.kubernetes.api.model.Duration;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.sundr.builder.internal.functions.TypeAs;
-import io.sundr.codegen.functions.ClassTo;
 import io.sundr.model.*;
 import io.sundr.utils.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+
+import static io.sundr.model.utils.Types.BOOLEAN;
+import static io.sundr.model.utils.Types.BOOLEAN_REF;
+
+import static io.sundr.model.utils.Types.STRING;
+import static io.sundr.model.utils.Types.STRING_REF;
+
+import static io.sundr.model.utils.Types.INT;
+import static io.sundr.model.utils.Types.INT_REF;
+
+import static io.sundr.model.utils.Types.LONG;
+import static io.sundr.model.utils.Types.LONG_REF;
+
+import static io.sundr.model.utils.Types.DOUBLE;
+import static io.sundr.model.utils.Types.DOUBLE_REF;
 
 /**
  * Encapsulates the common logic supporting OpenAPI schema generation for CRD generation.
@@ -40,27 +54,16 @@ public abstract class AbstractJsonSchema<T, B> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJsonSchema.class);
 
-  protected static final TypeDef QUANTITY = ClassTo.TYPEDEF.apply(Quantity.class);
-  protected static final TypeDef DURATION = ClassTo.TYPEDEF.apply(Duration.class);
-  protected static final TypeDef INT_OR_STRING = ClassTo.TYPEDEF.apply(IntOrString.class);
+  protected static final TypeDef QUANTITY = TypeDef.forName(Quantity.class.getName());
+  protected static final TypeDef DURATION = TypeDef.forName(Duration.class.getName());
+  protected static final TypeDef INT_OR_STRING =TypeDef.forName(IntOrString.class.getName());  
 
-
-  protected static final TypeDef BOOLEAN = ClassTo.TYPEDEF.apply(Boolean.class);
-  protected static final TypeDef STRING = ClassTo.TYPEDEF.apply(String.class);
-  protected static final TypeDef INT = ClassTo.TYPEDEF.apply(Integer.class);
-  protected static final TypeDef LONG = ClassTo.TYPEDEF.apply(Long.class);
-  protected static final TypeDef DOUBLE = ClassTo.TYPEDEF.apply(Double.class);
-  protected static final TypeDef DATE = ClassTo.TYPEDEF.apply(Date.class);
   protected static final TypeRef QUANTITY_REF = QUANTITY.toReference();
   protected static final TypeRef DURATION_REF = DURATION.toReference();
   protected static final TypeRef INT_OR_STRING_REF = INT_OR_STRING.toReference();
 
 
-  protected static final TypeRef BOOLEAN_REF = BOOLEAN.toReference();
-  protected static final TypeRef STRING_REF = STRING.toReference();
-  protected static final TypeRef INT_REF = INT.toReference();
-  protected static final TypeRef LONG_REF = LONG.toReference();
-  protected static final TypeRef DOUBLE_REF = DOUBLE.toReference();
+  protected static final TypeDef DATE = TypeDef.forName(Date.class.getName());
   protected static final TypeRef DATE_REF = DATE.toReference();
 
   private static final String INT_OR_STRING_MARKER = "int_or_string";

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/utils/Types.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/utils/Types.java
@@ -17,8 +17,8 @@ package io.fabric8.crd.generator.utils;
 
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.sundr.adapter.api.AdapterContext;
 import io.sundr.adapter.api.Adapters;
-import io.sundr.adapter.reflect.ReflectionContext;
 import io.sundr.builder.TypedVisitor;
 import io.sundr.model.ClassRef;
 import io.sundr.model.ClassRefBuilder;
@@ -56,11 +56,10 @@ public class Types {
   private static final Logger LOGGER = LoggerFactory.getLogger(Types.class);
   private static final String NAMESPACED = Namespaced.class.getName();
   public static final String JAVA_LANG_VOID = "java.lang.Void";
-  public static final ReflectionContext REFLECTION_CONTEXT = new ReflectionContext(DefinitionRepository.getRepository());
-
+  public static final AdapterContext REFLECTION_CONTEXT = AdapterContext.create(DefinitionRepository.getRepository());
 
   public static TypeDef typeDefFrom(Class<?> clazz) {
-    return unshallow(Adapters.adapt(clazz, REFLECTION_CONTEXT));
+    return unshallow(Adapters.adaptType(clazz, REFLECTION_CONTEXT));
   }
 
   public static TypeDef unshallow(TypeDef definition) {

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/visitor/SpecReplicasPathDetectorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/visitor/SpecReplicasPathDetectorTest.java
@@ -20,16 +20,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.fabric8.crd.example.webserver.WebServerWithSpec;
 import io.fabric8.crd.example.webserver.WebServerWithStatusProperty;
-import io.sundr.codegen.functions.ClassTo;
+import io.sundr.adapter.api.AdapterContext;
+import io.sundr.adapter.api.Adapters;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
+import io.sundr.model.repo.DefinitionRepository;
+
 import org.junit.jupiter.api.Test;
 
 class SpecReplicasPathDetectorTest {
 
+  public static final AdapterContext CONTEXT = AdapterContext.create(DefinitionRepository.getRepository());
+
   @Test
   public void shoudDetectSpecReplicasPath() throws Exception {
-    TypeDef def = ClassTo.TYPEDEF.apply(WebServerWithStatusProperty.class);
+    TypeDef def = Adapters.adaptType(WebServerWithStatusProperty.class, CONTEXT);
     SpecReplicasPathDetector detector = new SpecReplicasPathDetector();
     def = new TypeDefBuilder(def).accept(detector).build();
     assertTrue(detector.getPath().isPresent());
@@ -39,7 +44,7 @@ class SpecReplicasPathDetectorTest {
 
   @Test
   public void shoudDetectNestedSpecReplicasPath() throws Exception {
-    TypeDef def = ClassTo.TYPEDEF.apply(WebServerWithSpec.class);
+    TypeDef def = Adapters.adaptType(WebServerWithSpec.class, CONTEXT);
     SpecReplicasPathDetector detector = new SpecReplicasPathDetector();
     def = new TypeDefBuilder(def).accept(detector).build();
     assertTrue(detector.getPath().isPresent());

--- a/crd-generator/apt/src/main/java/io/fabric8/crd/generator/apt/CustomResourceAnnotationProcessor.java
+++ b/crd-generator/apt/src/main/java/io/fabric8/crd/generator/apt/CustomResourceAnnotationProcessor.java
@@ -26,7 +26,6 @@ import io.fabric8.kubernetes.model.Scope;
 import io.fabric8.kubernetes.model.annotation.*;
 import io.sundr.adapter.api.Adapters;
 import io.sundr.adapter.apt.AptContext;
-import io.sundr.codegen.CodegenContext;
 import io.sundr.model.TypeDef;
 import io.sundr.model.repo.DefinitionRepository;
 
@@ -62,7 +61,6 @@ public class CustomResourceAnnotationProcessor extends AbstractProcessor {
 
     // make sure we create the context before using it
     AptContext.create(processingEnv.getElementUtils(), processingEnv.getTypeUtils(), DefinitionRepository.getRepository());
-    CodegenContext.create(processingEnv.getElementUtils(), processingEnv.getTypeUtils());
 
     //Collect all annotated types.
     for (TypeElement annotation : annotations) {
@@ -77,7 +75,7 @@ public class CustomResourceAnnotationProcessor extends AbstractProcessor {
   }
   
   private CustomResourceInfo toCustomResourceInfo(TypeElement customResource) {
-    TypeDef definition = Adapters.adapt(customResource, AptContext.getContext());
+    TypeDef definition = Adapters.adaptType(customResource, AptContext.getContext());
     definition = Types.unshallow(definition);
     
     if (CustomResourceInfo.DESCRIBE_TYPE_DEFS) {

--- a/extensions/camel-k/model-v1/pom.xml
+++ b/extensions/camel-k/model-v1/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/camel-k/model-v1alpha1/pom.xml
+++ b/extensions/camel-k/model-v1alpha1/pom.xml
@@ -53,6 +53,10 @@
         <artifactId>transform-annotations</artifactId>
       </dependency>
       <dependency>
+        <groupId>io.sundr</groupId>
+        <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+      </dependency>
+      <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-model-core</artifactId>
       </dependency>

--- a/extensions/certmanager/model-v1/pom.xml
+++ b/extensions/certmanager/model-v1/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/certmanager/model-v1alpha2/pom.xml
+++ b/extensions/certmanager/model-v1alpha2/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/certmanager/model-v1alpha3/pom.xml
+++ b/extensions/certmanager/model-v1alpha3/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/certmanager/model-v1beta1/pom.xml
+++ b/extensions/certmanager/model-v1beta1/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/chaosmesh/model/pom.xml
+++ b/extensions/chaosmesh/model/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -54,6 +54,10 @@
       <groupId>io.sundr</groupId>
       <artifactId>transform-annotations</artifactId>
     </dependency>
+        <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>

--- a/extensions/service-catalog/model/pom.xml
+++ b/extensions/service-catalog/model/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/tekton/model-triggers/pom.xml
+++ b/extensions/tekton/model-triggers/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/tekton/model-v1alpha1/pom.xml
+++ b/extensions/tekton/model-v1alpha1/pom.xml
@@ -53,6 +53,10 @@
         <artifactId>transform-annotations</artifactId>
       </dependency>
       <dependency>
+        <groupId>io.sundr</groupId>
+        <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+      </dependency>
+      <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-model-core</artifactId>
       </dependency>

--- a/extensions/tekton/model-v1beta1/pom.xml
+++ b/extensions/tekton/model-v1beta1/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/extensions/volumesnapshot/model/pom.xml
+++ b/extensions/volumesnapshot/model/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>transform-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-core</artifactId>
     </dependency>

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
@@ -25,7 +25,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,6 +51,8 @@ import java.util.Map;
  */
 public class OpenIDConnectionUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenIDConnectionUtils.class);
+
+  public static final String EMPTY = "";
   public static final String ID_TOKEN_KUBECONFIG = "id-token";
   public static final String ISSUER_KUBECONFIG = "idp-issuer-url";
   public static final String REFRESH_TOKEN_KUBECONFIG = "refresh-token";
@@ -240,7 +241,7 @@ public class OpenIDConnectionUtils {
     } else {
       LOGGER.warn("oidc: oidc: discovery object doesn't contain a {}", key);
     }
-    return StringUtils.EMPTY;
+    return EMPTY;
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -18,11 +18,11 @@ package io.fabric8.kubernetes.client;
 
 import io.fabric8.kubernetes.api.model.ExecConfig;
 import io.fabric8.kubernetes.api.model.ExecConfigBuilder;
+import io.fabric8.kubernetes.client.lib.FileSystem;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
-import org.apache.commons.lang.SystemUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -501,11 +501,13 @@ public class ConfigTest {
 
   @Test
   void honorClientAuthenticatorCommands() throws Exception {
-    if (SystemUtils.IS_OS_WINDOWS) {
-      System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_WIN_FILE);
-    } else {
-      Files.setPosixFilePermissions(Paths.get(TEST_TOKEN_GENERATOR_FILE), PosixFilePermissions.fromString("rwxrwxr-x"));
-      System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_FILE);
+    switch (FileSystem.getCurrent()) {
+      case WINDOWS:
+        System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_WIN_FILE);
+        break;
+      default:
+        Files.setPosixFilePermissions(Paths.get(TEST_TOKEN_GENERATOR_FILE), PosixFilePermissions.fromString("rwxrwxr-x"));
+        System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_FILE);
     }
 
     Config config = Config.autoConfigure(null);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/UtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/UtilsTest.java
@@ -70,6 +70,7 @@ import io.fabric8.kubernetes.api.model.storage.StorageClass;
 import io.fabric8.kubernetes.api.model.storage.VolumeAttachment;
 import io.fabric8.kubernetes.api.model.storage.v1beta1.CSIDriver;
 import io.fabric8.kubernetes.api.model.storage.v1beta1.CSINode;
+import io.fabric8.kubernetes.client.lib.FileSystem;
 import io.fabric8.kubernetes.client.utils.Utils;
 import java.io.File;
 import java.util.Collections;
@@ -80,7 +81,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadFactory;
 
-import org.apache.commons.lang.SystemUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -366,12 +366,14 @@ class UtilsTest {
 
     assertNotNull(commandPrefix);
     assertEquals(2, commandPrefix.size());
-    if (SystemUtils.IS_OS_WINDOWS) {
-      assertEquals("cmd.exe", commandPrefix.get(0));
-      assertEquals("/c", commandPrefix.get(1));
-    } else {
-      assertEquals("sh", commandPrefix.get(0));
-      assertEquals("-c", commandPrefix.get(1));
+    switch (FileSystem.getCurrent()) {
+      case WINDOWS:
+        assertEquals("cmd.exe", commandPrefix.get(0));
+        assertEquals("/c", commandPrefix.get(1));
+        break;
+      default:
+        assertEquals("sh", commandPrefix.get(0));
+        assertEquals("-c", commandPrefix.get(1));
     }
   }
   

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1/MutatingWebhookConfiguration.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1/MutatingWebhookConfiguration.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("admissionregistration.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
 })
 public class MutatingWebhookConfiguration implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1/ValidatingWebhookConfiguration.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1/ValidatingWebhookConfiguration.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("admissionregistration.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
 })
 public class ValidatingWebhookConfiguration implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1beta1/MutatingWebhookConfiguration.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1beta1/MutatingWebhookConfiguration.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("admissionregistration.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
 })
 public class MutatingWebhookConfiguration implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1beta1/ValidatingWebhookConfiguration.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admissionregistration/v1beta1/ValidatingWebhookConfiguration.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("admissionregistration.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "admissionregistration.properties", gather = true)
 })
 public class ValidatingWebhookConfiguration implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/CustomResourceDefinition.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/CustomResourceDefinition.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("apiextensions.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "apiextensions.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "apiextensions.properties", gather = true)
 })
 public class CustomResourceDefinition implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1beta1/CustomResourceDefinition.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1beta1/CustomResourceDefinition.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("apiextensions.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "apiextensions.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "apiextensions.properties", gather = true)
 })
 public class CustomResourceDefinition implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/ControllerRevision.java
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/ControllerRevision.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("apps")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
 })
 public class ControllerRevision implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/DaemonSet.java
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/DaemonSet.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("apps")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
 })
 public class DaemonSet implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/Deployment.java
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/Deployment.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("apps")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
 })
 public class Deployment implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/ReplicaSet.java
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/ReplicaSet.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("apps")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
 })
 public class ReplicaSet implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/StatefulSet.java
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/StatefulSet.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("apps")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "apps.properties", gather = true)
 })
 public class StatefulSet implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v1/HorizontalPodAutoscaler.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v1/HorizontalPodAutoscaler.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("autoscaling")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "autoscaling.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "autoscaling.properties", gather = true)
 })
 public class HorizontalPodAutoscaler implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2beta1/HorizontalPodAutoscaler.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2beta1/HorizontalPodAutoscaler.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v2beta1")
 @Group("autoscaling")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "autoscaling.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "autoscaling.properties", gather = true)
 })
 public class HorizontalPodAutoscaler implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2beta2/HorizontalPodAutoscaler.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2beta2/HorizontalPodAutoscaler.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v2beta2")
 @Group("autoscaling")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "autoscaling.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "autoscaling.properties", gather = true)
 })
 public class HorizontalPodAutoscaler implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated/java/io/fabric8/kubernetes/api/model/batch/v1/CronJob.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated/java/io/fabric8/kubernetes/api/model/batch/v1/CronJob.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("batch")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "batch.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "batch.properties", gather = true)
 })
 public class CronJob implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated/java/io/fabric8/kubernetes/api/model/batch/v1/Job.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated/java/io/fabric8/kubernetes/api/model/batch/v1/Job.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("batch")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "batch.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "batch.properties", gather = true)
 })
 public class Job implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-batch/src/generated/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJob.java
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/generated/java/io/fabric8/kubernetes/api/model/batch/v1beta1/CronJob.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("batch")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "batch.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "batch.properties", gather = true)
 })
 public class CronJob implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1/CertificateSigningRequest.java
+++ b/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1/CertificateSigningRequest.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("certificates.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "certificates.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "certificates.properties", gather = true)
 })
 public class CertificateSigningRequest implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1beta1/CertificateSigningRequest.java
+++ b/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1beta1/CertificateSigningRequest.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("certificates.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "certificates.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "certificates.properties", gather = true)
 })
 public class CertificateSigningRequest implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-coordination/src/generated/java/io/fabric8/kubernetes/api/model/coordination/v1/Lease.java
+++ b/kubernetes-model-generator/kubernetes-model-coordination/src/generated/java/io/fabric8/kubernetes/api/model/coordination/v1/Lease.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("coordination.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "coordination.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "coordination.properties", gather = true)
 })
 public class Lease implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIGroup.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIGroup.java
@@ -15,8 +15,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -36,8 +36,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class APIGroup implements KubernetesResource
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIService.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIService.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("apiregistration.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class APIService implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ComponentStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ComponentStatus.java
@@ -15,8 +15,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -33,8 +33,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class ComponentStatus implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ConfigMap.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ConfigMap.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -33,8 +33,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class ConfigMap implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Endpoints.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Endpoints.java
@@ -15,8 +15,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -33,8 +33,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class Endpoints implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Event.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Event.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -44,8 +44,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class Event implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/LimitRange.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/LimitRange.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -31,8 +31,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class LimitRange implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Namespace.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Namespace.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class Namespace implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Node.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Node.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class Node implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolume.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolume.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class PersistentVolume implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolumeClaim.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolumeClaim.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class PersistentVolumeClaim implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Pod.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Pod.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class Pod implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PodTemplate.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PodTemplate.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -31,8 +31,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class PodTemplate implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ReplicationController.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ReplicationController.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class ReplicationController implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceQuota.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceQuota.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class ResourceQuota implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Secret.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Secret.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -34,8 +34,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class Secret implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Service.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Service.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +32,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class Service implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ServiceAccount.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ServiceAccount.java
@@ -15,8 +15,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -35,8 +35,8 @@ import lombok.ToString;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "core.properties", gather = true)
 })
 public class ServiceAccount implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1/EndpointSlice.java
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1/EndpointSlice.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -56,8 +56,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("discovery.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "discovery.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "discovery.properties", gather = true)
 })
 public class EndpointSlice implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/EndpointSlice.java
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/EndpointSlice.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -56,8 +56,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("discovery.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "discovery.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "discovery.properties", gather = true)
 })
 public class EndpointSlice implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-events/src/generated/java/io/fabric8/kubernetes/api/model/events/v1/Event.java
+++ b/kubernetes-model-generator/kubernetes-model-events/src/generated/java/io/fabric8/kubernetes/api/model/events/v1/Event.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -66,8 +66,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("events.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "events.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "events.properties", gather = true)
 })
 public class Event implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-events/src/generated/java/io/fabric8/kubernetes/api/model/events/v1beta1/Event.java
+++ b/kubernetes-model-generator/kubernetes-model-events/src/generated/java/io/fabric8/kubernetes/api/model/events/v1beta1/Event.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -66,8 +66,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("events.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "events.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "events.properties", gather = true)
 })
 public class Event implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/DaemonSet.java
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/DaemonSet.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("extensions")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
 })
 public class DaemonSet implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/Deployment.java
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/Deployment.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("extensions")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
 })
 public class Deployment implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/Ingress.java
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/Ingress.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("extensions")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
 })
 public class Ingress implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/NetworkPolicy.java
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/NetworkPolicy.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("extensions")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
 })
 public class NetworkPolicy implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/ReplicaSet.java
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/ReplicaSet.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("extensions")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "extensions.properties", gather = true)
 })
 public class ReplicaSet implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-flowcontrol/src/generated/java/io/fabric8/kubernetes/api/model/flowcontrol/v1beta1/FlowSchema.java
+++ b/kubernetes-model-generator/kubernetes-model-flowcontrol/src/generated/java/io/fabric8/kubernetes/api/model/flowcontrol/v1beta1/FlowSchema.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("flowcontrol.apiserver.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "flowcontrol.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "flowcontrol.properties", gather = true)
 })
 public class FlowSchema implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-flowcontrol/src/generated/java/io/fabric8/kubernetes/api/model/flowcontrol/v1beta1/PriorityLevelConfiguration.java
+++ b/kubernetes-model-generator/kubernetes-model-flowcontrol/src/generated/java/io/fabric8/kubernetes/api/model/flowcontrol/v1beta1/PriorityLevelConfiguration.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("flowcontrol.apiserver.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "flowcontrol.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "flowcontrol.properties", gather = true)
 })
 public class PriorityLevelConfiguration implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/KubernetesCoreTypeAnnotator.java
+++ b/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/KubernetesCoreTypeAnnotator.java
@@ -29,8 +29,8 @@ import com.sun.codemodel.JFormatter;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.jsonschema2pojo.GenerationConfig;
@@ -170,9 +170,9 @@ public class KubernetesCoreTypeAnnotator extends Jackson2Annotator {
   protected void addClassesToPropertyFiles(JDefinedClass clazz) {
     String packageCategory = getPackageCategory(clazz.getPackage().name());
     if (moduleName.equals(packageCategory) /*&& shouldIncludeClass(clazz.name())*/) {
-      JAnnotationArrayMember arrayMember = clazz.annotate(VelocityTransformations.class)
+      JAnnotationArrayMember arrayMember = clazz.annotate(TemplateTransformations.class)
         .paramArray(ANNOTATION_VALUE);
-      arrayMember.annotate(VelocityTransformation.class).param(ANNOTATION_VALUE, "/manifest.vm")
+      arrayMember.annotate(TemplateTransformation.class).param(ANNOTATION_VALUE, "/manifest.vm")
         .param("outputPath", moduleName + ".properties").param("gather", true);
     }
   }

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetrics.java
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetrics.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -56,8 +56,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("metrics.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "metrics.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "metrics.properties", gather = true)
 })
 public class NodeMetrics implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/PodMetrics.java
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/PodMetrics.java
@@ -27,8 +27,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -57,8 +57,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("metrics.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "metrics.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "metrics.properties", gather = true)
 })
 public class PodMetrics implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1/Ingress.java
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1/Ingress.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("networking.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
 })
 public class Ingress implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1/IngressClass.java
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1/IngressClass.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("networking.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
 })
 public class IngressClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1/NetworkPolicy.java
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1/NetworkPolicy.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("networking.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
 })
 public class NetworkPolicy implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1beta1/Ingress.java
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1beta1/Ingress.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("networking.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
 })
 public class Ingress implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1beta1/IngressClass.java
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/generated/java/io/fabric8/kubernetes/api/model/networking/v1beta1/IngressClass.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("networking.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "networking.properties", gather = true)
 })
 public class IngressClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1/RuntimeClass.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1/RuntimeClass.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("node.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "node.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "node.properties", gather = true)
 })
 public class RuntimeClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1alpha1/RuntimeClass.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1alpha1/RuntimeClass.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("node.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "node.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "node.properties", gather = true)
 })
 public class RuntimeClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1beta1/RuntimeClass.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1beta1/RuntimeClass.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("node.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "node.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "node.properties", gather = true)
 })
 public class RuntimeClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1/PodDisruptionBudget.java
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1/PodDisruptionBudget.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("policy")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "policy.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "policy.properties", gather = true)
 })
 public class PodDisruptionBudget implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1beta1/PodDisruptionBudget.java
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1beta1/PodDisruptionBudget.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("policy")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "policy.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "policy.properties", gather = true)
 })
 public class PodDisruptionBudget implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1beta1/PodSecurityPolicy.java
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1beta1/PodSecurityPolicy.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("policy")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "policy.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "policy.properties", gather = true)
 })
 public class PodSecurityPolicy implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/ClusterRole.java
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/ClusterRole.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,8 +54,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("rbac.authorization.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
 })
 public class ClusterRole implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/ClusterRoleBinding.java
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/ClusterRoleBinding.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,8 +54,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("rbac.authorization.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
 })
 public class ClusterRoleBinding implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/Role.java
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/Role.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,8 +54,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("rbac.authorization.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
 })
 public class Role implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/RoleBinding.java
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/generated/java/io/fabric8/kubernetes/api/model/rbac/RoleBinding.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -55,8 +55,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("rbac.authorization.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "rbac.properties", gather = true)
 })
 public class RoleBinding implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/kubernetes-model-scheduling/src/generated/java/io/fabric8/kubernetes/api/model/scheduling/v1/PriorityClass.java
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/src/generated/java/io/fabric8/kubernetes/api/model/scheduling/v1/PriorityClass.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,8 +54,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("scheduling.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "scheduling.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "scheduling.properties", gather = true)
 })
 public class PriorityClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-scheduling/src/generated/java/io/fabric8/kubernetes/api/model/scheduling/v1beta1/PriorityClass.java
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/src/generated/java/io/fabric8/kubernetes/api/model/scheduling/v1beta1/PriorityClass.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,8 +54,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("scheduling.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "scheduling.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "scheduling.properties", gather = true)
 })
 public class PriorityClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/CSIDriver.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/CSIDriver.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("storage.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
 })
 public class CSIDriver implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/CSINode.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/CSINode.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("storage.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
 })
 public class CSINode implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/StorageClass.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/StorageClass.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -60,8 +60,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("storage.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
 })
 public class StorageClass implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/VolumeAttachment.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/VolumeAttachment.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("storage.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
 })
 public class VolumeAttachment implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1beta1/CSIDriver.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1beta1/CSIDriver.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("storage.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
 })
 public class CSIDriver implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1beta1/CSINode.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1beta1/CSINode.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("storage.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
 })
 public class CSINode implements HasMetadata
 {

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1beta1/CSIStorageCapacity.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1beta1/CSIStorageCapacity.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -55,8 +55,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("storage.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storage.properties", gather = true)
 })
 public class CSIStorageCapacity implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-clusterautoscaling/src/generated/java/io/fabric8/openshift/api/model/clusterautoscaling/v1/ClusterAutoscaler.java
+++ b/kubernetes-model-generator/openshift-model-clusterautoscaling/src/generated/java/io/fabric8/openshift/api/model/clusterautoscaling/v1/ClusterAutoscaler.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("autoscaling.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "clusterautoscaling.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "clusterautoscaling.properties", gather = true)
 })
 public class ClusterAutoscaler implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-clusterautoscaling/src/generated/java/io/fabric8/openshift/api/model/clusterautoscaling/v1beta1/MachineAutoscaler.java
+++ b/kubernetes-model-generator/openshift-model-clusterautoscaling/src/generated/java/io/fabric8/openshift/api/model/clusterautoscaling/v1beta1/MachineAutoscaler.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("autoscaling.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "clusterautoscaling.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "clusterautoscaling.properties", gather = true)
 })
 public class MachineAutoscaler implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleCLIDownload.java
+++ b/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleCLIDownload.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("console.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
 })
 public class ConsoleCLIDownload implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleExternalLogLink.java
+++ b/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleExternalLogLink.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("console.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
 })
 public class ConsoleExternalLogLink implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleLink.java
+++ b/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleLink.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("console.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
 })
 public class ConsoleLink implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleNotification.java
+++ b/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleNotification.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("console.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
 })
 public class ConsoleNotification implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleQuickStart.java
+++ b/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleQuickStart.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("console.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
 })
 public class ConsoleQuickStart implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleYAMLSample.java
+++ b/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1/ConsoleYAMLSample.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("console.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
 })
 public class ConsoleYAMLSample implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1alpha1/ConsolePlugin.java
+++ b/kubernetes-model-generator/openshift-model-console/src/generated/java/io/fabric8/openshift/api/model/console/v1alpha1/ConsolePlugin.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("console.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "console.properties", gather = true)
 })
 public class ConsolePlugin implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/Machine.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/Machine.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("machine.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machine.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machine.properties", gather = true)
 })
 public class Machine implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/MachineHealthCheck.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/MachineHealthCheck.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("machine.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machine.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machine.properties", gather = true)
 })
 public class MachineHealthCheck implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/MachineSet.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/MachineSet.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("machine.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machine.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machine.properties", gather = true)
 })
 public class MachineSet implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/ContainerRuntimeConfig.java
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/ContainerRuntimeConfig.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("machineconfiguration.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
 })
 public class ContainerRuntimeConfig implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/ControllerConfig.java
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/ControllerConfig.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("machineconfiguration.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
 })
 public class ControllerConfig implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/KubeletConfig.java
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/KubeletConfig.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("machineconfiguration.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
 })
 public class KubeletConfig implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/MachineConfig.java
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/MachineConfig.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("machineconfiguration.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
 })
 public class MachineConfig implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/MachineConfigPool.java
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/MachineConfigPool.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("machineconfiguration.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "machineconfig.properties", gather = true)
 })
 public class MachineConfigPool implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/cloudcredential/v1/CredentialsRequest.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/cloudcredential/v1/CredentialsRequest.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("cloudcredential.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
 })
 public class CredentialsRequest implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/cncf/cni/v1/NetworkAttachmentDefinition.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/cncf/cni/v1/NetworkAttachmentDefinition.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("k8s.cni.cncf.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
 })
 public class NetworkAttachmentDefinition implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/imageregistry/operator/v1/Config.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/imageregistry/operator/v1/Config.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("imageregistry.operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
 })
 public class Config implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHost.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHost.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("metal3.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
 })
 public class BareMetalHost implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/network/operator/v1/OperatorPKI.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/network/operator/v1/OperatorPKI.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("network.operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "miscellaneous.properties", gather = true)
 })
 public class OperatorPKI implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Alertmanager.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Alertmanager.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class Alertmanager implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PodMonitor.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PodMonitor.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class PodMonitor implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Probe.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Probe.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class Probe implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Prometheus.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Prometheus.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class Prometheus implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusRule.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusRule.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class PrometheusRule implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ServiceMonitor.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ServiceMonitor.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class ServiceMonitor implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosRuler.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosRuler.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class ThanosRuler implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/AlertmanagerConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/AlertmanagerConfig.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("monitoring.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "monitoring.properties", gather = true)
 })
 public class AlertmanagerConfig implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/controlplane/v1alpha1/PodNetworkConnectivityCheck.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/controlplane/v1alpha1/PodNetworkConnectivityCheck.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("controlplane.operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class PodNetworkConnectivityCheck implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Authentication.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Authentication.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class Authentication implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CSISnapshotController.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CSISnapshotController.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class CSISnapshotController implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CloudCredential.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CloudCredential.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class CloudCredential implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ClusterCSIDriver.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ClusterCSIDriver.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class ClusterCSIDriver implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Config.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Config.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class Config implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Console.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Console.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class Console implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/DNS.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/DNS.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class DNS implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/DNSRecord.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/DNSRecord.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("ingress.operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class DNSRecord implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Etcd.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Etcd.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class Etcd implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ImagePruner.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ImagePruner.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("imageregistry.operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class ImagePruner implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/IngressController.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/IngressController.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class IngressController implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeAPIServer.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeAPIServer.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class KubeAPIServer implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeControllerManager.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeControllerManager.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class KubeControllerManager implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeScheduler.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeScheduler.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class KubeScheduler implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeStorageVersionMigrator.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeStorageVersionMigrator.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class KubeStorageVersionMigrator implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Network.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Network.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class Network implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftAPIServer.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftAPIServer.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class OpenShiftAPIServer implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftControllerManager.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftControllerManager.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class OpenShiftControllerManager implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCA.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCA.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class ServiceCA implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogAPIServer.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogAPIServer.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class ServiceCatalogAPIServer implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogControllerManager.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogControllerManager.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class ServiceCatalogControllerManager implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Storage.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/Storage.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class Storage implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1alpha1/ImageContentSourcePolicy.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1alpha1/ImageContentSourcePolicy.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("operator.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operator.properties", gather = true)
 })
 public class ImageContentSourcePolicy implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/lifecyclemanager/v1/PackageManifest.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/lifecyclemanager/v1/PackageManifest.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("packages.operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class PackageManifest implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1/Operator.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1/Operator.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class Operator implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1/OperatorCondition.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1/OperatorCondition.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class OperatorCondition implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1/OperatorGroup.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1/OperatorGroup.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class OperatorGroup implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/CatalogSource.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/CatalogSource.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class CatalogSource implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/ClusterServiceVersion.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/ClusterServiceVersion.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class ClusterServiceVersion implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/InstallPlan.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/InstallPlan.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class InstallPlan implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/Subscription.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/Subscription.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("operators.coreos.com")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "operatorhub.properties", gather = true)
 })
 public class Subscription implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-storageversionmigrator/src/generated/java/io/fabric8/openshift/api/model/storageversionmigrator/v1alpha1/StorageState.java
+++ b/kubernetes-model-generator/openshift-model-storageversionmigrator/src/generated/java/io/fabric8/openshift/api/model/storageversionmigrator/v1alpha1/StorageState.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("migration.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storageversionmigrator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storageversionmigrator.properties", gather = true)
 })
 public class StorageState implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-storageversionmigrator/src/generated/java/io/fabric8/openshift/api/model/storageversionmigrator/v1alpha1/StorageVersionMigration.java
+++ b/kubernetes-model-generator/openshift-model-storageversionmigrator/src/generated/java/io/fabric8/openshift/api/model/storageversionmigrator/v1alpha1/StorageVersionMigration.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("migration.k8s.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "storageversionmigrator.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "storageversionmigrator.properties", gather = true)
 })
 public class StorageVersionMigration implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model-tuned/src/generated/java/io/fabric8/openshift/api/model/tuned/v1/Profile.java
+++ b/kubernetes-model-generator/openshift-model-tuned/src/generated/java/io/fabric8/openshift/api/model/tuned/v1/Profile.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("tuned.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "tuned.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "tuned.properties", gather = true)
 })
 public class Profile implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-tuned/src/generated/java/io/fabric8/openshift/api/model/tuned/v1/Tuned.java
+++ b/kubernetes-model-generator/openshift-model-tuned/src/generated/java/io/fabric8/openshift/api/model/tuned/v1/Tuned.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("tuned.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "tuned.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "tuned.properties", gather = true)
 })
 public class Tuned implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-whereabouts/src/generated/java/io/fabric8/openshift/api/model/whereabouts/v1alpha1/IPPool.java
+++ b/kubernetes-model-generator/openshift-model-whereabouts/src/generated/java/io/fabric8/openshift/api/model/whereabouts/v1alpha1/IPPool.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("whereabouts.cni.cncf.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "whereabouts.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "whereabouts.properties", gather = true)
 })
 public class IPPool implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model-whereabouts/src/generated/java/io/fabric8/openshift/api/model/whereabouts/v1alpha1/OverlappingRangeIPReservation.java
+++ b/kubernetes-model-generator/openshift-model-whereabouts/src/generated/java/io/fabric8/openshift/api/model/whereabouts/v1alpha1/OverlappingRangeIPReservation.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1alpha1")
 @Group("whereabouts.cni.cncf.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "whereabouts.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "whereabouts.properties", gather = true)
 })
 public class OverlappingRangeIPReservation implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/APIServer.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/APIServer.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class APIServer implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/AppliedClusterResourceQuota.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/AppliedClusterResourceQuota.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("quota.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class AppliedClusterResourceQuota implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Authentication.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Authentication.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Authentication implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BrokerTemplateInstance.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BrokerTemplateInstance.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -51,8 +51,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("template.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class BrokerTemplateInstance implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Build.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Build.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("build.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Build implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BuildConfig.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BuildConfig.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("build.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class BuildConfig implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterNetwork.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterNetwork.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -59,8 +59,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("network.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ClusterNetwork implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterOperator.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterOperator.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ClusterOperator implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterResourceQuota.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterResourceQuota.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("quota.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ClusterResourceQuota implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterRole.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterRole.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -55,8 +55,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("authorization.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ClusterRole implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterRoleBinding.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterRoleBinding.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -55,8 +55,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("authorization.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ClusterRoleBinding implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterVersion.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterVersion.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ClusterVersion implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Console.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Console.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Console implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DNS.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DNS.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class DNS implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentConfig.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentConfig.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("apps.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class DeploymentConfig implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/EgressNetworkPolicy.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/EgressNetworkPolicy.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("network.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class EgressNetworkPolicy implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/FeatureGate.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/FeatureGate.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class FeatureGate implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Group.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Group.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @io.fabric8.kubernetes.model.annotation.Group("user.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Group implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/HelmChartRepository.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/HelmChartRepository.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1beta1")
 @Group("helm.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class HelmChartRepository implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/HostSubnet.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/HostSubnet.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -57,8 +57,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("network.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class HostSubnet implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Identity.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Identity.java
@@ -22,8 +22,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("user.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Identity implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Image.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Image.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Version;
 import io.fabric8.openshift.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -62,8 +62,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("image.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Image implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageStream.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageStream.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("image.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ImageStream implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageStreamTag.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageStreamTag.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -58,8 +58,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("image.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ImageStreamTag implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageTag.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageTag.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,8 +54,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("image.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class ImageTag implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Infrastructure.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Infrastructure.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Infrastructure implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Ingress.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Ingress.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Ingress implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/NetNamespace.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/NetNamespace.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -55,8 +55,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("network.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class NetNamespace implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Network.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Network.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Network implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuth.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuth.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class OAuth implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthAccessToken.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthAccessToken.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -62,8 +62,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("oauth.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class OAuthAccessToken implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthAuthorizeToken.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthAuthorizeToken.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -62,8 +62,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("oauth.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class OAuthAuthorizeToken implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthClient.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthClient.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -61,8 +61,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("oauth.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class OAuthClient implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthClientAuthorization.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OAuthClientAuthorization.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -56,8 +56,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("oauth.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class OAuthClientAuthorization implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OperatorHub.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/OperatorHub.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class OperatorHub implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Project.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Project.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("project.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Project implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Proxy.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Proxy.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Proxy implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/RangeAllocation.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/RangeAllocation.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("security.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class RangeAllocation implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Role.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Role.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,8 +54,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("authorization.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Role implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/RoleBinding.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/RoleBinding.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -56,8 +56,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("authorization.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class RoleBinding implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/RoleBindingRestriction.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/RoleBindingRestriction.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("authorization.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class RoleBindingRestriction implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Route.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Route.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("route.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Route implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Scheduler.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Scheduler.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -52,8 +52,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("config.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Scheduler implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/SecurityContextConstraints.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/SecurityContextConstraints.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -77,8 +77,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("security.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class SecurityContextConstraints implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/TemplateInstance.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/TemplateInstance.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -53,8 +53,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("template.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class TemplateInstance implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/User.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/User.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -56,8 +56,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("user.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class User implements HasMetadata, Namespaced
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/UserOAuthAccessToken.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/UserOAuthAccessToken.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -61,8 +61,8 @@ import lombok.ToString;
 })
 @Version("v1")
 @Group("oauth.openshift.io")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class UserOAuthAccessToken implements HasMetadata
 {

--- a/kubernetes-model-generator/openshift-model/src/main/java/io/fabric8/openshift/api/model/Template.java
+++ b/kubernetes-model-generator/openshift-model/src/main/java/io/fabric8/openshift/api/model/Template.java
@@ -30,8 +30,8 @@ import io.fabric8.kubernetes.api.model.HasMetadataComparator;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -64,8 +64,8 @@ import java.util.Map;
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage=false, builderPackage = "io.fabric8.kubernetes.api.builder")
 @Version("v1")
 @Group("")
-@VelocityTransformations({
-    @VelocityTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "openshift.properties", gather = true)
 })
 public class Template implements HasMetadata, Namespaced {
 

--- a/kubernetes-model-generator/pom.xml
+++ b/kubernetes-model-generator/pom.xml
@@ -94,7 +94,10 @@
       <groupId>io.sundr</groupId>
       <artifactId>transform-annotations</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
+++ b/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
@@ -24,8 +24,8 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import io.sundr.transform.annotations.VelocityTransformation;
-import io.sundr.transform.annotations.VelocityTransformations;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.jsonschema2pojo.AbstractAnnotator;
@@ -76,9 +76,9 @@ public class ModelAnnotator extends AbstractAnnotator {
       }
 
       if (isCRD(clazz, propertiesNode)) { // include in model.properties (only CRDs not Lists!)
-        JAnnotationArrayMember arrayMember = clazz.annotate(VelocityTransformations.class)
+        JAnnotationArrayMember arrayMember = clazz.annotate(TemplateTransformations.class)
           .paramArray("value");
-        arrayMember.annotate(VelocityTransformation.class)
+        arrayMember.annotate(TemplateTransformation.class)
           .param("value", "/manifest.vm")
           .param("outputPath", "model.properties")
           .param("gather", true);

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Core versions -->
-    <sundrio.version>0.40.1</sundrio.version>
+    <sundrio.version>0.50.1</sundrio.version>
     <okhttp.version>3.12.12</okhttp.version>
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>
@@ -460,6 +460,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>io.sundr</groupId>
+        <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+        <version>${sundrio.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
@@ -749,7 +755,7 @@
         <groupId>io.sundr</groupId>
         <artifactId>sundr-maven-plugin</artifactId>
         <version>${sundrio.version}</version>
-        <dependencies>
+        <!--dependencies>
           <dependency>
             <groupId>io.sundr</groupId>
             <artifactId>sundr-codegen</artifactId>
@@ -761,7 +767,7 @@
               </exclusion>
             </exclusions>
           </dependency>
-        </dependencies>
+        </dependencies-->
         <configuration>
           <boms>
             <bom>


### PR DESCRIPTION
The pull request bumps sundrio to 0.50.1.

Important things about this version upgrade:
- Builder annotations no longer use:
   -  Velocity
   - Apache Commons Lang
   - Github Java Parser
- Transform no longer use:
  -  Velocity

So velocity is now explicitly added as a shaded uberjar: `io.sundr:sundr-codegen-velocity-nodeps`.
A potential lighter alternative that uses `String Template 4` is available at: `io.sundr:sundr-codegen-st4-nodeps`. So, we might consider converting at some point.
