### PR TITLE
fix: TokenRefreshInterceptor throws when running incluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 5.8-SNAPSHOT
 
 #### Bugs
+* Fix #3445: TokenRefreshInterceptor throws when running incluster config
+
 #### Improvements
 #### Dependency Upgrade
 #### New Features

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ System properties are preferred over environment variables. The following system
 | `kubernetes.certs.client.key.passphrase` / `KUBERNETES_CERTS_CLIENT_KEY_PASSPHRASE` | | |
 | `kubernetes.auth.basic.username` / `KUBERNETES_AUTH_BASIC_USERNAME` | | |
 | `kubernetes.auth.basic.password` / `KUBERNETES_AUTH_BASIC_PASSWORD` | | |
+| `kubernetes.auth.serviceAccount.token` / `KUBERNETES_AUTH_SERVICEACCOUNT_TOKEN` | Name of the service account token file | `/var/run/secrets/kubernetes.io/serviceaccount/token`|
 | `kubernetes.auth.tryKubeConfig` / `KUBERNETES_AUTH_TRYKUBECONFIG` | Configure client using Kubernetes config | `true` |
 | `kubeconfig` / `KUBECONFIG` | Name of the kubernetes config file to read | `~/.kube/config` |
 | `kubernetes.auth.tryServiceAccount` / `KUBERNETES_AUTH_TRYSERVICEACCOUNT` | Configure client from Service account | `true` |

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -484,14 +484,14 @@ public class Config {
     if (Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, true)) {
       boolean serviceAccountCaCertExists = Files.isRegularFile(new File(caCertPath).toPath());
       if (serviceAccountCaCertExists) {
-        LOGGER.debug("Found service account ca cert at: ["+caCertPath+"].");
+        LOGGER.debug("Found service account ca cert at: [{}}].", caCertPath);
         config.setCaCertFile(caCertPath);
       } else {
-        LOGGER.debug("Did not find service account ca cert at: ["+caCertPath+"].");
+        LOGGER.debug("Did not find service account ca cert at: [{}}].", caCertPath);
       }
       try {
         String serviceTokenCandidate = new String(Files.readAllBytes(new File(saTokenPath).toPath()));
-        LOGGER.debug("Found service account token at: ["+saTokenPath+"].");
+        LOGGER.debug("Found service account token at: [{}].", saTokenPath);
         config.setOauthToken(serviceTokenCandidate);
         String txt = "Configured service account doesn't have access. Service account may have been revoked.";
         config.getErrorMessages().put(401, "Unauthorized! " + txt);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.fabric8.kubernetes.api.model.AuthInfo;
+import io.fabric8.kubernetes.api.model.AuthProviderConfig;
 import io.fabric8.kubernetes.api.model.Cluster;
 import io.fabric8.kubernetes.api.model.ConfigBuilder;
 import io.fabric8.kubernetes.api.model.Context;
@@ -83,6 +84,7 @@ public class Config {
   public static final String KUBERNETES_AUTH_BASIC_PASSWORD_SYSTEM_PROPERTY = "kubernetes.auth.basic.password";
   public static final String KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY = "kubernetes.auth.tryKubeConfig";
   public static final String KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY = "kubernetes.auth.tryServiceAccount";
+  public static final String KUBERNETES_AUTH_SERVICEACCOUNT_TOKEN_FILE_SYSTEM_PROPERTY = "kubernetes.auth.serviceAccount.token";
   public static final String KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY = "kubernetes.auth.token";
   public static final String KUBERNETES_WATCH_RECONNECT_INTERVAL_SYSTEM_PROPERTY = "kubernetes.watch.reconnectInterval";
   public static final String KUBERNETES_WATCH_RECONNECT_LIMIT_SYSTEM_PROPERTY = "kubernetes.watch.reconnectLimit";
@@ -169,6 +171,7 @@ public class Config {
   private String trustStorePassphrase;
   private String keyStoreFile;
   private String keyStorePassphrase;
+  private AuthProviderConfig authProvider;
 
   private RequestConfig requestConfig = new RequestConfig();
 
@@ -470,22 +473,25 @@ public class Config {
     LOGGER.debug("Trying to configure client from service account...");
     String masterHost = Utils.getSystemPropertyOrEnvVar(KUBERNETES_SERVICE_HOST_PROPERTY, (String) null);
     String masterPort = Utils.getSystemPropertyOrEnvVar(KUBERNETES_SERVICE_PORT_PROPERTY, (String) null);
+    String saTokenPath = Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_SERVICEACCOUNT_TOKEN_FILE_SYSTEM_PROPERTY, KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH);
+    String caCertPath = Utils.getSystemPropertyOrEnvVar(KUBERNETES_CA_CERTIFICATE_FILE_SYSTEM_PROPERTY, KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH);
+
     if (masterHost != null && masterPort != null) {
       String hostPort = joinHostPort(masterHost, masterPort);
       LOGGER.debug("Found service account host and port: {}", hostPort);
       config.setMasterUrl("https://" + hostPort);
     }
     if (Utils.getSystemPropertyOrEnvVar(KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, true)) {
-      boolean serviceAccountCaCertExists = Files.isRegularFile(new File(KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH).toPath());
+      boolean serviceAccountCaCertExists = Files.isRegularFile(new File(caCertPath).toPath());
       if (serviceAccountCaCertExists) {
-        LOGGER.debug("Found service account ca cert at: ["+KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH+"].");
-        config.setCaCertFile(KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH);
+        LOGGER.debug("Found service account ca cert at: ["+caCertPath+"].");
+        config.setCaCertFile(caCertPath);
       } else {
-        LOGGER.debug("Did not find service account ca cert at: ["+KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH+"].");
+        LOGGER.debug("Did not find service account ca cert at: ["+caCertPath+"].");
       }
       try {
-        String serviceTokenCandidate = new String(Files.readAllBytes(new File(KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH).toPath()));
-        LOGGER.debug("Found service account token at: ["+KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH+"].");
+        String serviceTokenCandidate = new String(Files.readAllBytes(new File(saTokenPath).toPath()));
+        LOGGER.debug("Found service account token at: ["+saTokenPath+"].");
         config.setOauthToken(serviceTokenCandidate);
         String txt = "Configured service account doesn't have access. Service account may have been revoked.";
         config.getErrorMessages().put(401, "Unauthorized! " + txt);
@@ -493,7 +499,7 @@ public class Config {
         return true;
       } catch (IOException e) {
         // No service account token available...
-        LOGGER.warn("Error reading service account token from: [{}]. Ignoring.", KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH);
+        LOGGER.warn("Error reading service account token from: [{}]. Ignoring.", saTokenPath);
       }
     }
     return false;
@@ -619,6 +625,7 @@ public class Config {
 
           if (Utils.isNullOrEmpty(config.getOauthToken()) && currentAuthInfo.getAuthProvider() != null) {
             if (currentAuthInfo.getAuthProvider().getConfig() != null) {
+              config.setAuthProvider(currentAuthInfo.getAuthProvider());
               if (!Utils.isNullOrEmpty(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN))) {
                 // GKE token
                 config.setOauthToken(currentAuthInfo.getAuthProvider().getConfig().get(ACCESS_TOKEN));
@@ -1341,4 +1348,11 @@ public class Config {
     return Readiness.getInstance();
   }
 
+  public void setAuthProvider(AuthProviderConfig authProvider) {
+    this.authProvider = authProvider;
+  }
+
+  public AuthProviderConfig getAuthProvider() {
+    return authProvider;
+  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
@@ -67,7 +67,7 @@ public class TokenRefreshInterceptorTest {
   }
 
   @Test
-  public void shouldReloadInClusterServiceAccount() throws IOException {
+  void shouldReloadInClusterServiceAccount() throws IOException {
     try {
       // Write service account token file with value "expired" in it,
       // Set properties for it to be used instead of kubeconfig.

--- a/kubernetes-client/src/test/resources/test-kubeconfig-tokeninterceptor-oidc
+++ b/kubernetes-client/src/test/resources/test-kubeconfig-tokeninterceptor-oidc
@@ -1,0 +1,43 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: testns/ca.pem
+    insecure-skip-tls-verify: true
+    server: https://172.28.128.4:8443
+  name: 172-28-128-4:8443
+contexts:
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: testns
+    user: user/172-28-128-4:8443
+  name: testns/172-28-128-4:8443/user
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: production
+    user: root/172-28-128-4:8443
+  name: production/172-28-128-4:8443/root
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: production
+    user: mmosley
+  name: production/172-28-128-4:8443/mmosley
+current-context: production/172-28-128-4:8443/mmosley
+kind: Config
+preferences: {}
+users:
+- name: user/172-28-128-4:8443
+  user:
+    token: token
+- name: root/172-28-128-4:8443
+  user:
+    token: supertoken
+- name: mmosley
+  user:
+    auth-provider:
+      config:
+        client-id: kubernetes
+        client-secret: 1db158f6-177d-4d9c-8a8b-d36869918ec5
+        id-token: renewed
+        idp-certificate-authority: /root/ca.pem
+        idp-issuer-url: https://oidcidp.tremolo.lan:8443/auth/idp/OidcIdP
+      name: oidc


### PR DESCRIPTION
## Description

Token refresh was unsuccessful after failed authentication when running incluster. The reason was that TokenRefreshInterceptor was expecting kubeconfig file to exists, even though in incluster mode it does not exist.

* Removes kubeconfig handling from TokenRefreshInterceptor and re-uses existing logic in autoconfig instead, which is prepared for both in/out-of-cluster use cases.
* Adds system property for previously hardcoded token path to facilitate unit testing.
* Adds copy of auth-provider from model to config to avoid config parsing in TokenRefreshInterceptor.

Fixes #3312

Signed-off-by: Tero Saarni <tero.saarni@est.tech>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
