### PR TITLE
fix: Extension annotator doesn't generate XxxEditable classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,21 @@
 #### Bugs
 #### Improvements
 #### Dependency Upgrade
-  * Upgrade Sundrio to 0.50.1
 #### New Features
 #### _**Note**_: Breaking changes in the API
+
+### 5.7.3
+
+#### Bugs
+* Fix: Extension annotator doesn't generate XxxEditable classes
+
+#### Dependency Upgrade
+* Fix #3438: Upgrade Sundrio to 0.50.1
 
 ### 5.7.2 (2021-09-02)
 
 #### Dependency Upgrade
-* Fix: Revert #3427 bump jandex from 2.3.1.Final to 2.4.0.Final
+* Fix #3441: Revert #3427 bump jandex from 2.3.1.Final to 2.4.0.Final
 
 ### 5.7.1 (2021-09-01)
 

--- a/extensions/knative/tests/src/test/java/io/fabric8/knative/test/ResourceTest.java
+++ b/extensions/knative/tests/src/test/java/io/fabric8/knative/test/ResourceTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.knative.test;
+
+import io.fabric8.knative.serving.v1.Service;
+import io.fabric8.knative.serving.v1.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableKubernetesMockClient(crud = true)
+class ResourceTest {
+
+  KubernetesClient client;
+
+  // https://github.com/quarkusio/quarkus/issues/19950
+  @Test
+  @DisplayName("resource, with Knative model in namespace, can createOrReplace")
+  void resourceInNamespaceCreate() {
+    // Given
+    final Service service = new ServiceBuilder().withNewMetadata().withName("service-resource").endMetadata().build();
+    // When
+    final HasMetadata hm = client.resource(service).inNamespace("default").createOrReplace();
+    // Then
+    assertNotNull(hm);
+  }
+}

--- a/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
+++ b/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
@@ -54,7 +54,7 @@ public class ModelAnnotator extends AbstractAnnotator {
       clazz.annotate(EqualsAndHashCode.class);
 
       JAnnotationUse buildable = clazz.annotate(Buildable.class)
-        .param("editableEnabled", true)
+        .param("editableEnabled", false)
         .param("validationEnabled", false)
         .param("generateBuilderPackage", false)
         .param("builderPackage", "io.fabric8.kubernetes.api.builder");


### PR DESCRIPTION
## Description
Partial fix for #3433. The end goal should be to use a single annotator for every generator module.

Relates to https://github.com/quarkusio/quarkus/issues/19950

cc: @Fabian-K 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
