### PR TITLE
Fix #3450: Cast to String for specific annotations in CRD Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 #### Bugs
 * Fix: Extension annotator doesn't generate XxxEditable classes
+* Fix #3450: CRD generator fails with ClassCastException in some cases
 
 #### Dependency Upgrade
 * Fix #3438: Upgrade Sundrio to 0.50.1

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -190,19 +190,20 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public void process() {
       annotations.forEach(a -> {
-        final String fromAnnotation = (String) a.getParameters().get("value");
         switch (a.getClassRef().getFullyQualifiedName()) {
           case ANNOTATION_NOT_NULL:
             required = true;
             break;
           case ANNOTATION_JSON_PROPERTY:
-            if (!Strings.isNullOrEmpty(fromAnnotation) && !propertyName.equals(fromAnnotation)) {
-              renamedTo = fromAnnotation;
+            final String nameFromAnnotation = (String) a.getParameters().get("value");
+            if (!Strings.isNullOrEmpty(nameFromAnnotation) && !propertyName.equals(nameFromAnnotation)) {
+              renamedTo = nameFromAnnotation;
             }
             break;
           case ANNOTATION_JSON_PROPERTY_DESCRIPTION:
-            if (!Strings.isNullOrEmpty(fromAnnotation)) {
-              description = fromAnnotation;
+            final String descriptionFromAnnotation = (String) a.getParameters().get("value");
+            if (!Strings.isNullOrEmpty(descriptionFromAnnotation)) {
+              description = descriptionFromAnnotation;
             }
             break;
         }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -18,6 +18,7 @@ package io.fabric8.crd.example.annotated;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 public class AnnotatedSpec {
@@ -30,6 +31,8 @@ public class AnnotatedSpec {
   @NotNull
   private boolean emptySetter;
   private AnnotatedEnum anEnum;
+  @Min(0) // a non-string value attribute
+  private int sizedField;
 
   @JsonProperty("from-getter")
   @JsonPropertyDescription("from-getter-description")

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -75,7 +75,7 @@ class JsonSchemaTest {
     assertEquals(2, properties.size());
     final JSONSchemaProps specSchema = properties.get("spec");
     Map<String, JSONSchemaProps> spec = specSchema.getProperties();
-    assertEquals(5, spec.size());
+    assertEquals(6, spec.size());
 
     // check descriptions are present
     assertTrue(spec.containsKey("from-field"));


### PR DESCRIPTION
## Description
When looping through annotated fields/methods, the current code assumes a `String` type `value` attribute. This fails with a `ClassCastException` if any annotation uses a different type.

`JsonSchemaTest` fails with a
```
java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.String
```
error without the fix; passes with the fix.

Fixes #3450

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift