### PR TITLE
Fixed the lack of diamond operator in the instantiation of "additionalProperties" Map

### DIFF
--- a/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerServer.java
+++ b/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerServer.java
@@ -53,7 +53,7 @@ public class CertManagerServer extends ExternalResource {
 
   public void before() {
     mock = crudMode
-      ? new CertManagerMockServer(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new KubernetesCrudDispatcher(), true)
+      ? new CertManagerMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
       : new CertManagerMockServer(https);
     mock.init();
     client = mock.createCertManager();

--- a/extensions/certmanager/model-v1/src/main/java/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01Ingress.java
+++ b/extensions/certmanager/model-v1/src/main/java/io/fabric8/certmanager/api/model/acme/v1/ACMEChallengeSolverHTTP01Ingress.java
@@ -71,7 +71,7 @@ public class ACMEChallengeSolverHTTP01Ingress implements KubernetesResource
   @JsonProperty("serviceType")
   private java.lang.String serviceType;
   @JsonIgnore
-  private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+  private Map<java.lang.String, Object> additionalProperties = new HashMap<>();
 
   /**
    * No args constructor for use in serialization


### PR DESCRIPTION
## Description
I have fixed the lack of diamond operator in the instantiation of `additionalProperties` Map.
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
#3163 