### PR TITLE
update mock server to increment generation on spec updates

### DIFF
--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenerationIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenerationIT.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class GenerationIT {
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  @Test
+  public void testCreatedObjectHasGeneration() {
+    ConfigMap configMap = new ConfigMapBuilder()
+      .withNewMetadata().withName(getTestResourcePrefix() + "-configmap").endMetadata()
+      .build();
+
+    assertNull(configMap.getMetadata().getGeneration());
+    configMap = client.configMaps().inNamespace(session.getNamespace()).createOrReplace(configMap);
+    assertEquals(configMap.getMetadata().getGeneration().longValue(), 1L);
+  }
+
+  @Test
+  public void testUpdatedSpecIncrementsGeneration() {
+    ConfigMap configMap = new ConfigMapBuilder()
+        .withNewMetadata().withName(getTestResourcePrefix() + "-configmap").endMetadata()
+        .build();
+
+    configMap = client.configMaps().inNamespace(session.getNamespace()).createOrReplace(configMap);
+    assertEquals(configMap.getMetadata().getGeneration().longValue(), 1L);
+
+    Map<String, String> configMapData = new HashMap<>();
+    configMapData.put("key", "value");
+    configMap.setData(configMapData);
+
+    configMap = client.configMaps().inNamespace(session.getNamespace()).createOrReplace(configMap);
+    assertEquals(configMap.getMetadata().getGeneration().longValue(), 2L);
+  }
+
+  @Test
+  public void testUpdatingMetadataDoesNotIncrementGeneration() {
+    ConfigMap configMap = new ConfigMapBuilder()
+        .withNewMetadata().withName(getTestResourcePrefix() + "-configmap").endMetadata()
+        .build();
+
+    configMap = client.configMaps().inNamespace(session.getNamespace()).createOrReplace(configMap);
+    assertEquals(configMap.getMetadata().getGeneration().longValue(), 1L);
+
+    configMap.getMetadata().getAnnotations().put("new-annotation", "new-value");
+
+    configMap = client.configMaps().inNamespace(session.getNamespace()).createOrReplace(configMap);
+    assertEquals(configMap.getMetadata().getGeneration().longValue(), 1L);
+  }
+
+  private String getTestResourcePrefix() {
+    return getClass().getSimpleName().toLowerCase();
+  }
+
+  @After
+  public void cleanup() {
+    client.configMaps().inNamespace(session.getNamespace()).withName(getTestResourcePrefix() + "-configmap").delete();
+  }
+
+}


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

While working on our operators we noticed the mock server current returns a hardcoded `generation` value each time. This PR adds in `generation` handling, incrementing the value each time a `spec` update is observed (metadata/status updates should not update an object's generation). This should more accurately model working against the Kube API.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
