### PR TITLE
fix #3384: addressing that in can be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #3445: TokenRefreshInterceptor throws when running incluster config
 * Fix #3456: io.fabric8:crd-generator README should reference crd-generator-apt instead of now removed crd-generator artifact
+* Fix #3384: preventing NPE from being logged with pod execs.
 
 #### Improvements
 * Fix #3398: Added javadocs explaining the wait parameter

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -175,11 +175,11 @@ public class ExecWebSocketListener extends WebSocketListener implements ExecWatc
             }
 
             webSocketRef.set(webSocket);
-            if (!executorService.isShutdown()) {
+            if (in != null && !executorService.isShutdown()) {
               // the task will be cancelled via shutdownNow
               InputStreamPumper.pump(InputStreamPumper.asInterruptible(in), this::send, executorService);
-              startedFuture.complete(null);
             }
+            startedFuture.complete(null);
         } catch (IOException e) {
           startedFuture.completeExceptionally(new KubernetesClientException(OperationSupport.createStatus(response)));
         } finally {
@@ -268,22 +268,27 @@ public class ExecWebSocketListener extends WebSocketListener implements ExecWatc
         }
     }
 
+    @Override
     public OutputStream getInput() {
         return input;
     }
 
+    @Override
     public InputStream getOutput() {
         return output;
     }
 
+    @Override
     public InputStream getError() {
         return error;
     }
 
+    @Override
     public InputStream getErrorChannel() {
         return errorChannel;
     }
 
+    @Override
     public void resize(int cols, int rows) {
       if (cols < 0 || rows < 0) {
         return;


### PR DESCRIPTION
## Description
fixes #3384 with a null check

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
