### PR TITLE
fix #3484: ensuring that only one close method is called successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #3445: TokenRefreshInterceptor throws when running incluster config
 * Fix #3456: io.fabric8:crd-generator README should reference crd-generator-apt instead of now removed crd-generator artifact
 * Fix #3384: preventing NPE from being logged with pod execs.
+* Fix #3484: Ensuring that the informer isWatching flag is correctly reported
 
 #### Improvements
 * Fix #3398: Added javadocs explaining the wait parameter

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -122,7 +122,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
         throw new KubernetesClientException("Unrecognized resource");  
       }
       if (log.isDebugEnabled()) {
-        log.debug("Event received {} {}# resourceVersion {}", action.name(), resource.getKind(), resource.getMetadata().getResourceVersion());
+        log.debug("Event received {} {} resourceVersion {}", action.name(), resource.getKind(), resource.getMetadata().getResourceVersion());
       }
       switch (action) {
         case ERROR:

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -71,6 +71,24 @@ class AbstractWatchManagerTest {
     // Then
     assertThat(watcher.closeCount.get()).isEqualTo(1);
   }
+  
+  @Test
+  void closeEventWithExceptionIsIdempotentWithReconnecting() throws MalformedURLException {
+    // Given
+    final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<HasMetadata>() {
+      @Override
+      public boolean reconnecting() {
+        return true;
+      }
+    };
+    final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
+    // When
+    for (int it = 0; it < 10; it++) {
+      awm.close(new WatcherException("Mock"));
+    }
+    // Then
+    assertThat(watcher.closeCount.get()).isEqualTo(1);
+  }
 
   @Test
   @DisplayName("closeWebSocket, closes web socket with 1000 code (Normal Closure)")


### PR DESCRIPTION
## Description
fix for #3484 informers are reporting the wrong isWatching value because onClose(exception) and onClose are both being called for a single closure.  The latter toggles the isWatching flag to false after the new watch has been established.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
