### PR TITLE
Exposing apigroups and apiresources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@
 * Fix #3303: Support fetching APIResourceList
 
 #### _**Note**_: Breaking changes in the API
-* OpenShiftConfig#disableApiGroupCheck is now considered when assessing if the cluster is OpenShift compatible or not.
-  Previously, this value was negated and was enabling the API group check instead of disabling it. The value is now
-  taken into account, so by default DefaultOpenShiftClient now **does check** if it has compatible API groups.
+* OpenShiftConfig#openshiftApiGroupsEnabled is deprecated and no longer used.
+* OpenShiftConfig#disableApiGroupCheck is used only to determine if a client is adaptable to the OpenShiftClient and is generally only needed in mock scenarios.  It will be set automatically on clients obtained from an openshift mock server.
 
 ### 5.8.0 (2021-09-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Fix #3303: Support fetching APIResourceList
 
 #### _**Note**_: Breaking changes in the API
+* OpenShiftConfig#disableApiGroupCheck is now considered when assessing if the cluster is OpenShift compatible or not.
+  Previously, this value was negated and was enabling the API group check instead of disabling it. The value is now
+  taken into account, so by default DefaultOpenShiftClient now **does check** if it has compatible API groups.
 
 ### 5.8.0 (2021-09-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 #### Dependency Upgrade
 
 #### New Features
+* Fix #3294: Support fetching APIGroupList
+* Fix #3303: Support fetching APIResourceList
 
 #### _**Note**_: Breaking changes in the API
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -16,8 +16,7 @@
 
 package io.fabric8.kubernetes.client;
 
-import io.fabric8.kubernetes.client.dsl.base.OperationContext;
-
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
@@ -25,7 +24,6 @@ import io.fabric8.kubernetes.api.model.APIGroup;
 import io.fabric8.kubernetes.api.model.APIGroupList;
 import io.fabric8.kubernetes.api.model.APIResourceList;
 import io.fabric8.kubernetes.api.model.RootPaths;
-import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 
@@ -139,11 +137,7 @@ public abstract class BaseClient implements Client, HttpClientAware {
 
   @Override
   public RootPaths rootPaths() {
-    return newBaseOperation(httpClient, configuration).getRootPaths();
-  }
-
-  static BaseOperation<?, ?, ?> newBaseOperation(OkHttpClient httpClient, Config configuration) {
-    return new BaseOperation(new OperationContext().withOkhttpClient(httpClient).withConfig(configuration)) {};
+    return new OperationSupport(httpClient, configuration).restCall(RootPaths.class);
   }
 
   @Override
@@ -164,17 +158,17 @@ public abstract class BaseClient implements Client, HttpClientAware {
 
   @Override
   public APIGroupList getApiGroups() {
-    return newBaseOperation(httpClient, configuration).restCall(APIGroupList.class, APIS);
+    return new OperationSupport(httpClient, configuration).restCall(APIGroupList.class, APIS);
   }
 
   @Override
   public APIGroup getApiGroup(String name) {
-    return newBaseOperation(httpClient, configuration).restCall(APIGroup.class, APIS, name);
+    return new OperationSupport(httpClient, configuration).restCall(APIGroup.class, APIS, name);
   }
 
   @Override
   public APIResourceList getApiResources(String groupVersion) {
-    return newBaseOperation(httpClient, configuration).restCall(APIResourceList.class, APIS, groupVersion);
+    return new OperationSupport(httpClient, configuration).restCall(APIResourceList.class, APIS, groupVersion);
   }
 
   protected OkHttpClient adaptOkHttpClient(OkHttpClient okHttpClient) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ExecutorService;
 
 
 public abstract class BaseClient implements Client, HttpClientAware {
-  
+
   public static final String APIS = "/apis";
 
   protected OkHttpClient httpClient;
@@ -58,9 +58,9 @@ public abstract class BaseClient implements Client, HttpClientAware {
 
   public BaseClient(final OkHttpClient httpClient, Config config) {
     try {
-      this.httpClient = config.adaptClient(httpClient);
-      this.namespace = config.getNamespace();
       this.configuration = config;
+      this.httpClient = adaptOkHttpClient(httpClient);
+      this.namespace = config.getNamespace();
       this.apiVersion = config.getApiVersion();
       if (config.getMasterUrl() == null) {
         throw new KubernetesClientException("Unknown Kubernetes master URL - " +
@@ -161,19 +161,23 @@ public abstract class BaseClient implements Client, HttpClientAware {
     }
     return false;
   }
-  
+
   @Override
   public APIGroupList getApiGroups() {
     return newBaseOperation(httpClient, configuration).restCall(APIGroupList.class, APIS);
   }
-  
+
   @Override
   public APIGroup getApiGroup(String name) {
     return newBaseOperation(httpClient, configuration).restCall(APIGroup.class, APIS, name);
   }
-  
+
   @Override
   public APIResourceList getApiResources(String groupVersion) {
     return newBaseOperation(httpClient, configuration).restCall(APIResourceList.class, APIS, groupVersion);
+  }
+
+  protected OkHttpClient adaptOkHttpClient(OkHttpClient okHttpClient) {
+    return okHttpClient;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
@@ -124,7 +124,7 @@ import java.util.concurrent.ExecutorService;
  * It is thread safe.
  */
 public abstract class BaseKubernetesClient<C extends Client> extends BaseClient implements GenericKubernetesClient<C> {
-  
+
   static {
     Handlers.register(Pod.class, PodOperationsImpl::new);
     Handlers.register(Job.class, JobOperationsImpl::new);
@@ -181,7 +181,7 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
   public NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> resourceList(KubernetesResourceList item) {
     return resourceListFor(item);
   }
-  
+
   public NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl resourceListFor(Object item) {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(httpClient, getConfiguration(), item);
   }
@@ -412,7 +412,7 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
   public <T extends CustomResource, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(Class<T> resourceType, Class<L> listClass) {
     return customResources(CustomResourceDefinitionContext.fromCustomResourceType(resourceType), resourceType, listClass);
   }
-  
+
   @Override
   public <T extends HasMetadata, L extends KubernetesResourceList<T>> HasMetadataOperation<T, L, Resource<T>> resources(
       Class<T> resourceType, Class<L> listClass) {
@@ -591,5 +591,5 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
   public NonNamespaceOperation<RuntimeClass, RuntimeClassList, Resource<RuntimeClass>> runtimeClasses() {
     return Handlers.getOperation(RuntimeClass.class, RuntimeClassList.class, httpClient, getConfiguration());
   }
-  
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Client.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Client.java
@@ -16,6 +16,9 @@
 
 package io.fabric8.kubernetes.client;
 
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIResourceList;
 import io.fabric8.kubernetes.api.model.RootPaths;
 
 import java.io.Closeable;
@@ -48,5 +51,26 @@ public interface Client extends ConfigAware, Closeable {
    */
   boolean supportsApiPath(String path);
 
+  @Override
   void close();
+  
+  /**
+   * Returns the api groups
+   * @return the {@link APIGroupList} metadata
+   */
+  APIGroupList getApiGroups();
+  
+  /**
+   * Return a single api group
+   * @param name of the group
+   * @return the {@link APIGroup} metadata
+   */
+  APIGroup getApiGroup(String name);
+  
+  /**
+   * Return the api resource metadata for the given groupVersion
+   * @param the groupVersion - group/version
+   * @return the {@link APIResourceList} for the groupVersion
+   */
+  APIResourceList getApiResources(String groupVersion);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Client.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Client.java
@@ -53,23 +53,23 @@ public interface Client extends ConfigAware, Closeable {
 
   @Override
   void close();
-  
+
   /**
    * Returns the api groups
    * @return the {@link APIGroupList} metadata
    */
   APIGroupList getApiGroups();
-  
+
   /**
    * Return a single api group
    * @param name of the group
    * @return the {@link APIGroup} metadata
    */
   APIGroup getApiGroup(String name);
-  
+
   /**
    * Return the api resource metadata for the given groupVersion
-   * @param the groupVersion - group/version
+   * @param groupVersion the groupVersion - group/version
    * @return the {@link APIResourceList} for the groupVersion
    */
   APIResourceList getApiResources(String groupVersion);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -56,6 +56,7 @@ import io.fabric8.kubernetes.client.utils.IOHelpers;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
+import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1354,5 +1355,9 @@ public class Config {
 
   public AuthProviderConfig getAuthProvider() {
     return authProvider;
+  }
+
+  public OkHttpClient adaptClient(OkHttpClient httpClient) {
+    return httpClient;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -16,30 +16,10 @@
 
 package io.fabric8.kubernetes.client;
 
-import static okhttp3.TlsVersion.TLS_1_2;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.fabric8.kubernetes.api.model.AuthInfo;
 import io.fabric8.kubernetes.api.model.AuthProviderConfig;
 import io.fabric8.kubernetes.api.model.Cluster;
@@ -56,8 +36,25 @@ import io.fabric8.kubernetes.client.utils.IOHelpers;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
-import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static okhttp3.TlsVersion.TLS_1_2;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true, allowGetters = true, allowSetters = true)
@@ -527,7 +524,7 @@ public class Config {
     return new File(relativeTo.getParentFile(), filename).getAbsolutePath();
   }
 
-  public static Config fromKubeconfig(String kubeconfigContents) throws IOException {
+  public static Config fromKubeconfig(String kubeconfigContents) {
     return fromKubeconfig(null, kubeconfigContents, null);
   }
 
@@ -1357,7 +1354,4 @@ public class Config {
     return authProvider;
   }
 
-  public OkHttpClient adaptClient(OkHttpClient httpClient) {
-    return httpClient;
-  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -28,7 +28,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
-import io.fabric8.kubernetes.api.model.RootPaths;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
@@ -192,32 +191,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       throw KubernetesClientException.launderThrowable(forOperationType("get"), ie);
     } catch (ExecutionException | IOException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("get"), e);
-    }
- }
-
-  public RootPaths getRootPaths() {
-    return restCall(RootPaths.class);
-  }
-  
-  public <Res> Res restCall(Class<Res> result, String... path) {
-    try {
-      URL requestUrl = new URL(config.getMasterUrl());
-      String url = requestUrl.toString();
-      if (path != null && path.length > 0) {
-        url = URLUtils.join(url, URLUtils.pathJoin(path));
-      }
-      Request.Builder req = new Request.Builder().get().url(url);
-      return handleResponse(req, result);
-    } catch (KubernetesClientException e) {
-      if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-        throw e;
-      }
-      return null;
-    } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
-      throw KubernetesClientException.launderThrowable(ie);
-    } catch (ExecutionException | IOException e) {
-      throw KubernetesClientException.launderThrowable(e);
     }
  }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -196,10 +196,18 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
  }
 
   public RootPaths getRootPaths() {
+    return restCall(RootPaths.class);
+  }
+  
+  public <Res> Res restCall(Class<Res> result, String... path) {
     try {
       URL requestUrl = new URL(config.getMasterUrl());
-      Request.Builder req = new Request.Builder().get().url(requestUrl);
-      return handleResponse(req, RootPaths.class);
+      String url = requestUrl.toString();
+      if (path != null && path.length > 0) {
+        url = URLUtils.join(url, URLUtils.pathJoin(path));
+      }
+      Request.Builder req = new Request.Builder().get().url(url);
+      return handleResponse(req, result);
     } catch (KubernetesClientException e) {
       if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
         throw e;

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
@@ -42,14 +42,14 @@ public class ApiGroupResourceListsIT {
   Session session;
 
   @Test
-  public void testApiGroups() throws InterruptedException {
+  public void testApiGroups() {
     APIGroupList list = client.getApiGroups();
 
     assertTrue(list.getGroups().stream().anyMatch(g -> "apps".equals(g.getName())));
   }
 
   @Test
-  public void testApiGroup() throws InterruptedException {
+  public void testApiGroup() {
     APIGroup group = client.getApiGroup("apps");
 
     assertNotNull(group);
@@ -60,7 +60,7 @@ public class ApiGroupResourceListsIT {
   }
 
   @Test
-  public void testApiResources() throws InterruptedException {
+  public void testApiResources() {
     APIResourceList list = client.getApiResources("apps/v1");
 
     assertTrue(list.getResources().stream().anyMatch(r -> "deployments".equals(r.getName())));

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class ApiGroupResourceListsIT {
+
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  @Test
+  public void testApiGroups() throws InterruptedException {
+    APIGroupList list = client.getApiGroups();
+
+    assertTrue(list.getGroups().stream().anyMatch(g -> "apps".equals(g.getName())));
+  }
+
+  @Test
+  public void testApiGroup() throws InterruptedException {
+    APIGroup group = client.getApiGroup("apps");
+
+    assertNotNull(group);
+
+    group = client.getApiGroup("apps-that-wont-exist");
+
+    assertNull(group);
+  }
+
+  @Test
+  public void testApiResources() throws InterruptedException {
+    APIResourceList list = client.getApiResources("apps/v1");
+
+    assertTrue(list.getResources().stream().anyMatch(r -> "deployments".equals(r.getName())));
+  }
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/EventsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/EventsIT.java
@@ -28,9 +28,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/kubernetes-model-generator/kubernetes-model-core/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-core/cmd/generate/generate.go
@@ -39,6 +39,8 @@ type Schema struct {
 	Info                 apimachineryversion.Info
 	APIGroup             metav1.APIGroup
 	APIGroupList         metav1.APIGroupList
+	APIResource          metav1.APIResource
+	APIResourceList      metav1.APIResourceList
 	BaseKubernetesList   metav1.List
 	ObjectMeta           metav1.ObjectMeta
 	TypeMeta             metav1.TypeMeta

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResource.java
@@ -1,0 +1,210 @@
+
+package io.fabric8.kubernetes.api.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "categories",
+    "group",
+    "name",
+    "namespaced",
+    "shortNames",
+    "singularName",
+    "storageVersionHash",
+    "verbs",
+    "version"
+})
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class APIResource implements KubernetesResource
+{
+
+    @JsonProperty("categories")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> categories = new ArrayList<String>();
+    @JsonProperty("group")
+    private String group;
+    @JsonProperty("kind")
+    private String kind;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("namespaced")
+    private Boolean namespaced;
+    @JsonProperty("shortNames")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> shortNames = new ArrayList<String>();
+    @JsonProperty("singularName")
+    private String singularName;
+    @JsonProperty("storageVersionHash")
+    private String storageVersionHash;
+    @JsonProperty("verbs")
+    private List<String> verbs = new ArrayList<String>();
+    @JsonProperty("version")
+    private String version;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public APIResource() {
+    }
+
+    /**
+     * 
+     * @param shortNames
+     * @param kind
+     * @param name
+     * @param storageVersionHash
+     * @param verbs
+     * @param categories
+     * @param version
+     * @param namespaced
+     * @param group
+     * @param singularName
+     */
+    public APIResource(List<String> categories, String group, String kind, String name, Boolean namespaced, List<String> shortNames, String singularName, String storageVersionHash, List<String> verbs, String version) {
+        super();
+        this.categories = categories;
+        this.group = group;
+        this.kind = kind;
+        this.name = name;
+        this.namespaced = namespaced;
+        this.shortNames = shortNames;
+        this.singularName = singularName;
+        this.storageVersionHash = storageVersionHash;
+        this.verbs = verbs;
+        this.version = version;
+    }
+
+    @JsonProperty("categories")
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    @JsonProperty("categories")
+    public void setCategories(List<String> categories) {
+        this.categories = categories;
+    }
+
+    @JsonProperty("group")
+    public String getGroup() {
+        return group;
+    }
+
+    @JsonProperty("group")
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("namespaced")
+    public Boolean getNamespaced() {
+        return namespaced;
+    }
+
+    @JsonProperty("namespaced")
+    public void setNamespaced(Boolean namespaced) {
+        this.namespaced = namespaced;
+    }
+
+    @JsonProperty("shortNames")
+    public List<String> getShortNames() {
+        return shortNames;
+    }
+
+    @JsonProperty("shortNames")
+    public void setShortNames(List<String> shortNames) {
+        this.shortNames = shortNames;
+    }
+
+    @JsonProperty("singularName")
+    public String getSingularName() {
+        return singularName;
+    }
+
+    @JsonProperty("singularName")
+    public void setSingularName(String singularName) {
+        this.singularName = singularName;
+    }
+
+    @JsonProperty("storageVersionHash")
+    public String getStorageVersionHash() {
+        return storageVersionHash;
+    }
+
+    @JsonProperty("storageVersionHash")
+    public void setStorageVersionHash(String storageVersionHash) {
+        this.storageVersionHash = storageVersionHash;
+    }
+
+    @JsonProperty("verbs")
+    public List<String> getVerbs() {
+        return verbs;
+    }
+
+    @JsonProperty("verbs")
+    public void setVerbs(List<String> verbs) {
+        this.verbs = verbs;
+    }
+
+    @JsonProperty("version")
+    public String getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResourceList.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/APIResourceList.java
@@ -1,0 +1,147 @@
+
+package io.fabric8.kubernetes.api.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "groupVersion",
+    "resources"
+})
+@ToString
+@EqualsAndHashCode
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class APIResourceList implements KubernetesResource
+{
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    private String apiVersion = "v1";
+    @JsonProperty("groupVersion")
+    private String groupVersion;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    private String kind = "APIResourceList";
+    @JsonProperty("resources")
+    private List<APIResource> resources = new ArrayList<APIResource>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public APIResourceList() {
+    }
+
+    /**
+     * 
+     * @param apiVersion
+     * @param kind
+     * @param groupVersion
+     * @param resources
+     */
+    public APIResourceList(String apiVersion, String groupVersion, String kind, List<APIResource> resources) {
+        super();
+        this.apiVersion = apiVersion;
+        this.groupVersion = groupVersion;
+        this.kind = kind;
+        this.resources = resources;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @JsonProperty("groupVersion")
+    public String getGroupVersion() {
+        return groupVersion;
+    }
+
+    @JsonProperty("groupVersion")
+    public void setGroupVersion(String groupVersion) {
+        this.groupVersion = groupVersion;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("resources")
+    public List<APIResource> getResources() {
+        return resources;
+    }
+
+    @JsonProperty("resources")
+    public void setResources(List<APIResource> resources) {
+        this.resources = resources;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
@@ -23,6 +23,8 @@ import lombok.ToString;
     "metadata",
     "APIGroup",
     "APIGroupList",
+    "APIResource",
+    "APIResourceList",
     "APIService",
     "APIServiceList",
     "BaseKubernetesList",
@@ -92,6 +94,10 @@ public class KubeSchema {
     private APIGroup aPIGroup;
     @JsonProperty("APIGroupList")
     private APIGroupList aPIGroupList;
+    @JsonProperty("APIResource")
+    private APIResource aPIResource;
+    @JsonProperty("APIResourceList")
+    private APIResourceList aPIResourceList;
     @JsonProperty("APIService")
     private APIService aPIService;
     @JsonProperty("APIServiceList")
@@ -239,6 +245,7 @@ public class KubeSchema {
      * @param groupVersionResource
      * @param limitRangeList
      * @param toleration
+     * @param aPIResourceList
      * @param nodeList
      * @param groupVersionKind
      * @param node
@@ -269,6 +276,7 @@ public class KubeSchema {
      * @param microTime
      * @param podExecOptions
      * @param serviceAccount
+     * @param aPIResource
      * @param resourceQuotaList
      * @param topologySelectorTerm
      * @param createOptions
@@ -284,10 +292,12 @@ public class KubeSchema {
      * @param endpointPort
      * @param config
      */
-    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, APIService aPIService, APIServiceList aPIServiceList, BaseKubernetesList baseKubernetesList, Binding binding, ComponentStatus componentStatus, ComponentStatusList componentStatusList, Condition condition, Config config, ConfigMap configMap, ConfigMapList configMapList, ContainerStatus containerStatus, CreateOptions createOptions, DeleteOptions deleteOptions, EndpointPort endpointPort, Endpoints endpoints, EndpointsList endpointsList, EnvVar envVar, Event event, EventList eventList, EventSeries eventSeries, EventSource eventSource, GetOptions getOptions, GroupVersionKind groupVersionKind, GroupVersionResource groupVersionResource, Info info, LimitRangeList limitRangeList, ListOptions listOptions, MicroTime microTime, Namespace namespace, NamespaceList namespaceList, Node node, NodeList nodeList, ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, PersistentVolume persistentVolume, PersistentVolumeClaim persistentVolumeClaim, PersistentVolumeClaimList persistentVolumeClaimList, PersistentVolumeList persistentVolumeList, PodExecOptions podExecOptions, PodList podList, PodTemplateList podTemplateList, Quantity quantity, ReplicationControllerList replicationControllerList, ResourceQuota resourceQuota, ResourceQuotaList resourceQuotaList, RootPaths rootPaths, Secret secret, SecretList secretList, ServiceAccount serviceAccount, ServiceAccountList serviceAccountList, ServiceList serviceList, Status status, String time, Toleration toleration, TopologySelectorTerm topologySelectorTerm, TypeMeta typeMeta, UpdateOptions updateOptions, WatchEvent watchEvent) {
+    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, APIResource aPIResource, APIResourceList aPIResourceList, APIService aPIService, APIServiceList aPIServiceList, BaseKubernetesList baseKubernetesList, Binding binding, ComponentStatus componentStatus, ComponentStatusList componentStatusList, Condition condition, Config config, ConfigMap configMap, ConfigMapList configMapList, ContainerStatus containerStatus, CreateOptions createOptions, DeleteOptions deleteOptions, EndpointPort endpointPort, Endpoints endpoints, EndpointsList endpointsList, EnvVar envVar, Event event, EventList eventList, EventSeries eventSeries, EventSource eventSource, GetOptions getOptions, GroupVersionKind groupVersionKind, GroupVersionResource groupVersionResource, Info info, LimitRangeList limitRangeList, ListOptions listOptions, MicroTime microTime, Namespace namespace, NamespaceList namespaceList, Node node, NodeList nodeList, ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, PersistentVolume persistentVolume, PersistentVolumeClaim persistentVolumeClaim, PersistentVolumeClaimList persistentVolumeClaimList, PersistentVolumeList persistentVolumeList, PodExecOptions podExecOptions, PodList podList, PodTemplateList podTemplateList, Quantity quantity, ReplicationControllerList replicationControllerList, ResourceQuota resourceQuota, ResourceQuotaList resourceQuotaList, RootPaths rootPaths, Secret secret, SecretList secretList, ServiceAccount serviceAccount, ServiceAccountList serviceAccountList, ServiceList serviceList, Status status, String time, Toleration toleration, TopologySelectorTerm topologySelectorTerm, TypeMeta typeMeta, UpdateOptions updateOptions, WatchEvent watchEvent) {
         super();
         this.aPIGroup = aPIGroup;
         this.aPIGroupList = aPIGroupList;
+        this.aPIResource = aPIResource;
+        this.aPIResourceList = aPIResourceList;
         this.aPIService = aPIService;
         this.aPIServiceList = aPIServiceList;
         this.baseKubernetesList = baseKubernetesList;
@@ -367,6 +377,26 @@ public class KubeSchema {
     @JsonProperty("APIGroupList")
     public void setAPIGroupList(APIGroupList aPIGroupList) {
         this.aPIGroupList = aPIGroupList;
+    }
+
+    @JsonProperty("APIResource")
+    public APIResource getAPIResource() {
+        return aPIResource;
+    }
+
+    @JsonProperty("APIResource")
+    public void setAPIResource(APIResource aPIResource) {
+        this.aPIResource = aPIResource;
+    }
+
+    @JsonProperty("APIResourceList")
+    public APIResourceList getAPIResourceList() {
+        return aPIResourceList;
+    }
+
+    @JsonProperty("APIResourceList")
+    public void setAPIResourceList(APIResourceList aPIResourceList) {
+        this.aPIResourceList = aPIResourceList;
     }
 
     @JsonProperty("APIService")

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/kube-schema.json
@@ -231,6 +231,87 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_pkg_apis_APIResource": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespaced": {
+          "type": "boolean"
+        },
+        "shortNames": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "singularName": {
+          "type": "string"
+        },
+        "storageVersionHash": {
+          "type": "string"
+        },
+        "verbs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_apimachinery_pkg_apis_APIResourceList": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "v1",
+          "required": true
+        },
+        "groupVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "default": "APIResourceList",
+          "required": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResourceList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_pkg_apis_Condition": {
       "type": "object",
       "properties": {
@@ -7397,6 +7478,14 @@
     "APIGroupList": {
       "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIGroupList",
       "existingJavaType": "io.fabric8.kubernetes.api.model.APIGroupList"
+    },
+    "APIResource": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+    },
+    "APIResourceList": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResourceList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResourceList"
     },
     "APIService": {
       "$ref": "#/definitions/kubernetes_aggregator_APIService",

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/validation-schema.json
@@ -231,6 +231,87 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_pkg_apis_APIResource": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespaced": {
+          "type": "boolean"
+        },
+        "shortNames": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "singularName": {
+          "type": "string"
+        },
+        "storageVersionHash": {
+          "type": "string"
+        },
+        "verbs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_apimachinery_pkg_apis_APIResourceList": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "v1",
+          "required": true
+        },
+        "groupVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "default": "APIResourceList",
+          "required": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.APIResourceList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_pkg_apis_Condition": {
       "type": "object",
       "properties": {
@@ -7398,6 +7479,14 @@
       "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIGroupList",
       "existingJavaType": "io.fabric8.kubernetes.api.model.APIGroupList"
     },
+    "APIResource": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+    },
+    "APIResourceList": {
+      "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResourceList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.APIResourceList"
+    },
     "APIService": {
       "$ref": "#/definitions/kubernetes_aggregator_APIService",
       "existingJavaType": "io.fabric8.kubernetes.api.model.APIService"
@@ -7709,6 +7798,77 @@
           "type": "string",
           "default": "APIGroupList",
           "required": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "apiresource": {
+      "properties": {
+        "categories": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespaced": {
+          "type": "boolean"
+        },
+        "shortNames": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "singularName": {
+          "type": "string"
+        },
+        "storageVersionHash": {
+          "type": "string"
+        },
+        "verbs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "apiresourcelist": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "v1",
+          "required": true
+        },
+        "groupVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "default": "APIResourceList",
+          "required": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_APIResource",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.APIResource"
+          }
         }
       },
       "additionalProperties": true

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/LoadAsTemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/LoadAsTemplateTest.java
@@ -116,7 +116,7 @@ class LoadAsTemplateTest {
   }
 
   private static DefaultOpenShiftClient createOpenShiftClientWithNoServer() {
-    return new DefaultOpenShiftClient(new OpenShiftConfigBuilder().build());
+    return new DefaultOpenShiftClient(new OpenShiftConfigBuilder().withDisableApiGroupCheck(true).build());
   }
 
   //Check that the processed template is as expected

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -178,7 +178,7 @@ class TemplateTest {
 
   @Test
   void shouldLoadTemplateWithNumberParameters() {
-    OpenShiftClient client = new DefaultOpenShiftClient(new OpenShiftConfigBuilder().build());
+    OpenShiftClient client = new DefaultOpenShiftClient(new OpenShiftConfigBuilder().withDisableApiGroupCheck(true).build());
     Map<String, String> map = new HashMap<>();
     map.put("PORT", "8080");
     KubernetesList list = client.templates().withParameters(map).load(getClass().getResourceAsStream("/template-with-number-params.yml")).processLocally(map);

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -499,8 +499,7 @@ public class DefaultOpenShiftClient extends BaseKubernetesClient<NamespacedOpenS
 
   @Override
   public NamespacedOpenShiftClient inNamespace(String namespace) {
-    OpenShiftConfig updated = new OpenShiftConfigBuilder(new OpenShiftConfig(getConfiguration()))
-      .withOpenShiftUrl(openShiftUrl.toString())
+    OpenShiftConfig updated = new OpenShiftConfigBuilder(getConfiguration())
       .withNamespace(namespace)
       .build();
     return new DefaultOpenShiftClient(httpClient, updated);

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -675,4 +675,9 @@ public class DefaultOpenShiftClient extends BaseKubernetesClient<NamespacedOpenS
     return false;
   }
 
+  @Override
+  protected OkHttpClient adaptOkHttpClient(OkHttpClient okHttpClient) {
+    return OpenshiftAdapterSupport.adaptOkHttpClient(okHttpClient, getConfiguration());
+  }
+
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/NamespacedOpenShiftExtensionAdapter.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/NamespacedOpenShiftExtensionAdapter.java
@@ -16,8 +16,6 @@
 
 package io.fabric8.openshift.client;
 
-import okhttp3.OkHttpClient;
-import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.ExtensionAdapter;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
@@ -32,11 +30,4 @@ public class NamespacedOpenShiftExtensionAdapter extends OpenshiftAdapterSupport
     return NamespacedOpenShiftClient.class;
   }
 
-  @Override
-  public NamespacedOpenShiftClient adapt(Client client) {
-    if (!isAdaptable(client)) {
-      throw new OpenShiftNotAvailableException("OpenShift is not available. Root paths at: " + client.getMasterUrl() + " do not include /oapi or the new /apis/*.openshift.io APIs.");
-    }
-    return new DefaultOpenShiftClient(client.adapt(OkHttpClient.class), OpenShiftConfig.wrap(client.getConfiguration()));
-  }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -73,7 +73,7 @@ public class OpenShiftConfig extends Config {
     this.openShiftUrl = openShiftUrl;
     this.buildTimeout = buildTimeout;
     this.openshiftApiGroupsEnabled = openshiftApiGroupsEnabled;
-    this.disableApiGroupCheck = openshiftApiGroupsEnabled ? false : disableApiGroupCheck;
+    this.disableApiGroupCheck = disableApiGroupCheck;
 
     if (this.openShiftUrl == null || this.openShiftUrl.isEmpty()) {
       this.openShiftUrl = URLUtils.join(getMasterUrl(), "oapi", this.oapiVersion);
@@ -136,6 +136,7 @@ public class OpenShiftConfig extends Config {
     }
   }
 
+  @Deprecated
   public OpenShiftConfig withOpenshiftApiGroupsEnabled(boolean openshiftApiGroupsEnabled) {
     return new OpenShiftConfigBuilder(this).withOpenshiftApiGroupsEnabled(openshiftApiGroupsEnabled).build();
   }
@@ -184,10 +185,12 @@ public class OpenShiftConfig extends Config {
     this.disableApiGroupCheck = disableApiGroupCheck;
   }
 
+  @Deprecated
   public boolean isOpenshiftApiGroupsEnabled() {
     return openshiftApiGroupsEnabled;
   }
 
+  @Deprecated
   public void setOpenshiftApiGroupsEnabled(boolean openshiftApiGroupsEnabled) {
     this.openshiftApiGroupsEnabled = openshiftApiGroupsEnabled;
   }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -136,6 +136,9 @@ public class OpenShiftConfig extends Config {
     }
   }
 
+  /**
+   * @deprecated openshiftApiGroupsEnabled is no longer honored
+   */
   @Deprecated
   public OpenShiftConfig withOpenshiftApiGroupsEnabled(boolean openshiftApiGroupsEnabled) {
     return new OpenShiftConfigBuilder(this).withOpenshiftApiGroupsEnabled(openshiftApiGroupsEnabled).build();
@@ -185,11 +188,17 @@ public class OpenShiftConfig extends Config {
     this.disableApiGroupCheck = disableApiGroupCheck;
   }
 
+  /**
+   * @deprecated openshiftApiGroupsEnabled is no longer honored
+   */
   @Deprecated
   public boolean isOpenshiftApiGroupsEnabled() {
     return openshiftApiGroupsEnabled;
   }
 
+  /**
+   * @deprecated openshiftApiGroupsEnabled is no longer honored
+   */
   @Deprecated
   public void setOpenshiftApiGroupsEnabled(boolean openshiftApiGroupsEnabled) {
     this.openshiftApiGroupsEnabled = openshiftApiGroupsEnabled;

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -15,28 +15,23 @@
  */
 package io.fabric8.openshift.client;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.OAuthTokenProvider;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
-import io.fabric8.kubernetes.client.utils.BackwardsCompatibilityInterceptor;
-import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
-import io.fabric8.openshift.client.internal.OpenShiftOAuthInterceptor;
 import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import okhttp3.Authenticator;
-import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true, allowGetters = true, allowSetters = true)
@@ -200,19 +195,6 @@ public class OpenShiftConfig extends Config {
   @Override
   public Readiness getReadiness() {
     return OpenShiftReadiness.getInstance();
-  }
-
-  @Override
-  public OkHttpClient adaptClient(OkHttpClient httpClient) {
-    OkHttpClient.Builder builder = httpClient != null ?
-        httpClient.newBuilder().authenticator(Authenticator.NONE) :
-        new OkHttpClient.Builder().authenticator(Authenticator.NONE);
-
-      builder.interceptors().clear();
-      return builder.addInterceptor(new OpenShiftOAuthInterceptor(httpClient, this))
-        .addInterceptor(new ImpersonatorInterceptor(this))
-        .addInterceptor(new BackwardsCompatibilityInterceptor())
-        .build();
   }
 
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftExtensionAdapter.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenShiftExtensionAdapter.java
@@ -16,7 +16,6 @@
 
 package io.fabric8.openshift.client;
 
-import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.ExtensionAdapter;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
@@ -50,7 +49,6 @@ import io.fabric8.openshift.client.dsl.internal.project.ProjectOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.security.SecurityContextConstraintsOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.user.GroupOperationsImpl;
 import io.fabric8.openshift.client.dsl.internal.user.UserOperationsImpl;
-import okhttp3.OkHttpClient;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
 
@@ -83,12 +81,4 @@ public class OpenShiftExtensionAdapter extends OpenshiftAdapterSupport implement
     return OpenShiftClient.class;
   }
 
-
-  @Override
-  public OpenShiftClient adapt(Client client) {
-    if (!isAdaptable(client)) {
-      throw new OpenShiftNotAvailableException("OpenShift is not available. Root paths at: " + client.getMasterUrl() + " do not include oapi.");
-    }
-    return new DefaultOpenShiftClient(client.adapt(OkHttpClient.class), OpenShiftConfig.wrap(client.getConfiguration()));
-  }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftAdapterSupport.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftAdapterSupport.java
@@ -35,7 +35,7 @@ public class OpenshiftAdapterSupport {
 
   public Boolean isAdaptable(Client client) {
     OpenShiftConfig config = OpenShiftConfig.wrap(client.getConfiguration());
-    return hasCustomOpenShiftUrl(config) || isOpenShift(client.adapt(OkHttpClient.class), config);
+    return hasCustomOpenShiftUrl(config) || isOpenShiftAPIGroups(client.adapt(OkHttpClient.class), config);
   }
 
   public DefaultOpenShiftClient adapt(Client client) {
@@ -46,12 +46,12 @@ public class OpenshiftAdapterSupport {
   }
 
   /**
-   * Check if OpenShift is available.
+   * Check if OpenShift API Groups are available
    * @param client   The client.
    * @param config {@link OpenShiftConfig} OpenShift Configuration
    * @return         True if oapi is found in the root paths.
    */
-  public static boolean isOpenShift(OkHttpClient client, OpenShiftConfig config) {
+  public static boolean isOpenShiftAPIGroups(OkHttpClient client, OpenShiftConfig config) {
     if (config.isDisableApiGroupCheck()) {
       return true;
     }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
+import io.fabric8.openshift.client.OpenshiftAdapterSupport;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -62,7 +63,7 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
   }
 
   private static OperationContext getOpenShiftOperationContext(OpenShiftConfig config, OperationContext context, String oapiVersion) {
-    if (config.isOpenshiftApiGroupsEnabled()) {
+    if (config.isOpenshiftApiGroupsEnabled() || OpenshiftAdapterSupport.isOpenShift(context.getClient(), config)) {
       return getOperationContextWithApiGroupVersion(config, context, oapiVersion);
     } else {
       String apiGroupUrl = URLUtils.join(config.getMasterUrl(), "oapi", oapiVersion);

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
-import io.fabric8.openshift.client.OpenshiftAdapterSupport;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -55,30 +54,13 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
 
   static OperationContext getOperationContextWithApiGroupName(OpenShiftConfig config, OperationContext context, String oapiVersion) {
     String apiGroupVersionFromConfig = Utils.isNotNullOrEmpty(context.getApiGroupVersion()) ? context.getApiGroupVersion() : oapiVersion;
-    if (isOpenShiftApiGroup(context.getApiGroupName())) {
-      return getOpenShiftOperationContext(config, context, apiGroupVersionFromConfig);
-    } else {
-      return getOperationContextWithApiGroupVersion(config, context, apiGroupVersionFromConfig);
-    }
-  }
-
-  private static OperationContext getOpenShiftOperationContext(OpenShiftConfig config, OperationContext context, String oapiVersion) {
-    if (config.isOpenshiftApiGroupsEnabled() || OpenshiftAdapterSupport.isOpenShift(context.getClient(), config)) {
-      return getOperationContextWithApiGroupVersion(config, context, oapiVersion);
-    } else {
-      String apiGroupUrl = URLUtils.join(config.getMasterUrl(), "oapi", oapiVersion);
-      return context.withConfig(new OpenShiftConfigBuilder(config).withOpenShiftUrl(apiGroupUrl).build()).withApiGroupName(context.getApiGroupName()).withApiGroupVersion(oapiVersion);
-    }
+    return getOperationContextWithApiGroupVersion(config, context, apiGroupVersionFromConfig);
   }
 
   private static OperationContext getOperationContextWithApiGroupVersion(OpenShiftConfig config, OperationContext context, String version) {
     String apiGroupUrl = URLUtils.join(config.getMasterUrl(), "apis", context.getApiGroupName(), version);
     String apiGroupVersion = URLUtils.join(context.getApiGroupName(), version);
     return context.withConfig(new OpenShiftConfigBuilder(config).withOpenShiftUrl(apiGroupUrl).build()).withApiGroupName(context.getApiGroupName()).withApiGroupVersion(apiGroupVersion);
-  }
-
-  private static boolean isOpenShiftApiGroup(String apiGroupName) {
-    return apiGroupName.contains(OPENSHIFT_APIGROUP_SUFFIX);
   }
 
   @Override

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/OpenShiftConfigTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/OpenShiftConfigTest.java
@@ -19,12 +19,9 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.utils.Serialization;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.net.MalformedURLException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -81,15 +78,15 @@ class OpenShiftConfigTest {
   }
 
   @Test
-  void shouldInstantiateClientUsingSerializeDeserialize() throws MalformedURLException {
+  void shouldInstantiateClientUsingSerializeDeserialize() {
     DefaultOpenShiftClient original = new DefaultOpenShiftClient();
     String json = Serialization.asJson(original.getConfiguration());
     DefaultOpenShiftClient copy = DefaultOpenShiftClient.fromConfig(json);
 
-    Assert.assertEquals(original.getConfiguration().getMasterUrl(), copy.getConfiguration().getMasterUrl());
-    Assert.assertEquals(original.getConfiguration().getOauthToken(), copy.getConfiguration().getOauthToken());
-    Assert.assertEquals(original.getConfiguration().getNamespace(), copy.getConfiguration().getNamespace());
-    Assert.assertEquals(original.getConfiguration().getUsername(), copy.getConfiguration().getUsername());
-    Assert.assertEquals(original.getConfiguration().getPassword(), copy.getConfiguration().getPassword());
+    assertEquals(original.getConfiguration().getMasterUrl(), copy.getConfiguration().getMasterUrl());
+    assertEquals(original.getConfiguration().getOauthToken(), copy.getConfiguration().getOauthToken());
+    assertEquals(original.getConfiguration().getNamespace(), copy.getConfiguration().getNamespace());
+    assertEquals(original.getConfiguration().getUsername(), copy.getConfiguration().getUsername());
+    assertEquals(original.getConfiguration().getPassword(), copy.getConfiguration().getPassword());
   }
 }

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/AdaptTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/AdaptTest.java
@@ -37,6 +37,15 @@ class AdaptTest {
   }
 
   @Test
+  void testAdaptDisabledCheck() {
+    // Given
+    OpenShiftClient client = new DefaultOpenShiftClient(new OpenShiftConfigBuilder().withDisableApiGroupCheck(true).build());
+
+    // When + Then
+    assertTrue(client.isAdaptable(OpenShiftClient.class));
+  }
+
+  @Test
   void testAdaptDSLs() {
     // Given
     OpenShiftClient client = new DefaultOpenShiftClient(

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/AdaptTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/AdaptTest.java
@@ -17,6 +17,7 @@ package io.fabric8.openshift.client.dsl;
 
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AdaptTest {
+
   @Test
   void testAdaptToHttpClient() {
     // Given
@@ -37,7 +39,8 @@ class AdaptTest {
   @Test
   void testAdaptDSLs() {
     // Given
-    OpenShiftClient client = new DefaultOpenShiftClient();
+    OpenShiftClient client = new DefaultOpenShiftClient(
+      new OpenShiftConfigBuilder().withDisableApiGroupCheck(true).build());
 
     assertNotNull(client.v1());
     assertNotNull(client.apps());

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperationTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperationTest.java
@@ -28,7 +28,6 @@ class OpenShiftOperationTest {
     // Given
     OperationContext context = new OperationContext()
       .withConfig(new OpenShiftConfigBuilder()
-        .withOpenshiftApiGroupsEnabled(true)
         .build())
       .withApiGroupName("apps.openshift.io")
       .withApiGroupVersion("v1");
@@ -46,7 +45,6 @@ class OpenShiftOperationTest {
     // Given
     OperationContext context = new OperationContext()
       .withConfig(new OpenShiftConfigBuilder()
-        .withOpenshiftApiGroupsEnabled(false)
         .build())
       .withApiGroupName("")
       .withApiGroupVersion("v1");
@@ -64,7 +62,6 @@ class OpenShiftOperationTest {
     // Given
     OperationContext context = new OperationContext()
       .withConfig(new OpenShiftConfigBuilder()
-        .withOpenshiftApiGroupsEnabled(false)
         .build())
       .withApiGroupName("operators.coreos.com")
       .withApiGroupVersion("v1alpha1");
@@ -82,7 +79,6 @@ class OpenShiftOperationTest {
     // Given
     OperationContext context = new OperationContext()
       .withConfig(new OpenShiftConfigBuilder()
-        .withOpenshiftApiGroupsEnabled(true)
         .build())
       .withApiGroupName("operator.openshift.io")
       .withApiGroupVersion("v1alpha1");

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServer.java
@@ -50,6 +50,8 @@ public class OpenShiftMockServer extends KubernetesMockServer {
       .withTrustCerts(true)
       .withTlsVersions(TLS_1_2)
       .build();
-    return new DefaultOpenShiftClient(createHttpClientForMockServer(config), new OpenShiftConfig(config));
+    OpenShiftConfig openShiftConfig = new OpenShiftConfig(config);
+    openShiftConfig.setDisableApiGroupCheck(true);
+    return new DefaultOpenShiftClient(createHttpClientForMockServer(config), openShiftConfig);
   }
 }


### PR DESCRIPTION
## Description
Supersedes #3405
Fixes #3294
Fixes #3303 

Fixes issue when compiling in JDK 8.

Sundrio has an issue when traversing the AST path for OkHttpClient (return type in previos Config#adaptClient).
The new commits on top of #3405 remove the adaptClient from the Config classes and places a similar method in the BaseClient class. The Config class is a little more anemic but at least OkHttpClient adaptation has been abstracted :shrug:. 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
