### PR TITLE
fix: added BOOKMARK as a type in Watcher enum

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Watcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Watcher.java
@@ -44,7 +44,7 @@ public interface Watcher<T> {
   void onClose(WatcherException cause);
 
   enum Action {
-    ADDED, MODIFIED, DELETED, ERROR
+    ADDED, MODIFIED, DELETED, ERROR, BOOKMARK
   }
 
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -288,7 +288,7 @@ class WatchTest {
       .andUpgradeToWebSocket().open()
       .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "BOOKMARK"))
       .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(outdatedEvent()).done().once();
-    final CountDownLatch deleteLatch = new CountDownLatch(1);
+    final CountDownLatch bookmarkLatch = new CountDownLatch(1);
     final CountDownLatch closeLatch = new CountDownLatch(1);
     final Watcher<Pod> watcher = new Watcher<Pod>() {
       @Override
@@ -296,7 +296,7 @@ class WatchTest {
         if (action != BOOKMARK) {
           fail();
         }
-        deleteLatch.countDown();
+        bookmarkLatch.countDown();
       }
 
       @Override
@@ -309,7 +309,7 @@ class WatchTest {
     try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(watcher)) {
       // Then
       assertNotNull(watch);
-      assertTrue(deleteLatch.await(10, TimeUnit.SECONDS));
+      assertTrue(bookmarkLatch.await(10, TimeUnit.SECONDS));
       assertTrue(closeLatch.await(10, TimeUnit.SECONDS));
     }
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static io.fabric8.kubernetes.client.Watcher.Action.DELETED;
+import static io.fabric8.kubernetes.client.Watcher.Action.BOOKMARK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -275,5 +276,41 @@ class WatchTest {
         .withMessage(
         "410: The event in requested index is outdated and cleared (the requested history has been cleared [3/1]) [2]")
       .build()).build();
+  }
+
+
+  @Test
+  @DisplayName("TryWithResources, connects and receives event then receives GONE, should receive first event and then close")
+  void testTryWithResourcesConnectsThenReceivesEventBookmark() throws InterruptedException {
+    // Given
+    server.expect()
+      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
+      .andUpgradeToWebSocket().open()
+      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "BOOKMARK"))
+      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(outdatedEvent()).done().once();
+    final CountDownLatch deleteLatch = new CountDownLatch(1);
+    final CountDownLatch closeLatch = new CountDownLatch(1);
+    final Watcher<Pod> watcher = new Watcher<Pod>() {
+      @Override
+      public void eventReceived(Action action, Pod resource) {
+        if (action != BOOKMARK) {
+          fail();
+        }
+        deleteLatch.countDown();
+      }
+
+      @Override
+      public void onClose(WatcherException cause) {
+        assertTrue(cause.isHttpGone());
+        closeLatch.countDown();
+      }
+    };
+    // When
+    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(watcher)) {
+      // Then
+      assertNotNull(watch);
+      assertTrue(deleteLatch.await(10, TimeUnit.SECONDS));
+      assertTrue(closeLatch.await(10, TimeUnit.SECONDS));
+    }
   }
 }


### PR DESCRIPTION
## Description
Fix  #2171 - Support BOOKMARK events



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
