### PR TITLE
fix #3501: addressed NPE with default BuildConfig operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #3482: sanitizeName now truncate names to be less than 63 chars and makes sure first and last charaters are letters
 * Fix #3353: addressing extra quoting in quantity serialization
 * Fix #3509: notify reader when something is written in ExecWebSocketListener
+* Fix #3501: addressed NPE with default BuildConfig operations
 
 #### Improvements
 * Fix #3448 added methods for getting specific version information - `KubernetesClient.getKubernetesVersion`, `OpenShiftClient.getOpenShiftV3Version`, and `OpenShiftClient.getOpenShiftV3Version`

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
@@ -191,31 +191,22 @@ class BuildConfigTest {
     assertTrue(deleted);
   }
 
-  private BuildConfig getBuildConfig() {
-    return new BuildConfigBuilder()
-      .withNewMetadata().withName("ruby-sample-build").endMetadata()
-      .withNewSpec()
-      .withRunPolicy("Serial")
-      .addNewTrigger().withType("GitHub").withNewGithub().withSecret("secret101").endGithub().endTrigger()
-      .addNewTrigger().withType("Generic").withNewGeneric().withSecret("secret101").endGeneric().endTrigger()
-      .addNewTrigger().withType("ImageChange").endTrigger()
-      .withNewSource()
-      .withNewGit().withUri("https://github.com/openshift/ruby-hello-world").endGit()
-      .endSource()
-      .withNewStrategy()
-      .withNewSourceStrategy()
-      .withNewFrom()
-      .withKind("ImageStreamTag")
-      .withName("ruby-20-centos7:latest")
-      .endFrom()
-      .endSourceStrategy()
-      .endStrategy()
-      .withNewOutput()
-      .withNewTo().withKind("ImageStreamTag").withName("origin-ruby-sample:latest").endTo()
-      .endOutput()
-      .withNewPostCommit().withScript("bundle exec rake test").endPostCommit()
-      .endSpec()
-      .build();
+  @Test
+  void testBinaryBuildFromFileWithDefaults() throws IOException {
+    File warFile = new File("target/test.war");
+    warFile.createNewFile();
+
+    server.expect().post().withPath("/apis/build.openshift.io/v1/namespaces/ns1/buildconfigs/bc2/instantiatebinary?name=bc2&namespace=ns1")
+      .andReturn(201, new BuildBuilder()
+      .withNewMetadata().withName("bc2").endMetadata().build()).once();
+
+    Build build = client.buildConfigs()
+      .inNamespace("ns1")
+      .withName("bc2")
+      .instantiateBinary()
+      .fromFile(warFile);
+    assertNotNull(build);
+    assertEquals("bc2", build.getMetadata().getName());
   }
 
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationContext.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/BuildConfigOperationContext.java
@@ -31,7 +31,7 @@ public class BuildConfigOperationContext {
   private String asFile;
 
   private long timeout;
-  private TimeUnit timeoutUnit;
+  private TimeUnit timeoutUnit = TimeUnit.MILLISECONDS;
 
   public BuildConfigOperationContext() {
   }


### PR DESCRIPTION
## Description
Address the npe by adding a default for the timeout unit.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
