### PR TITLE
fix #3509: Notify reader when something is written in ExecWebSocketListener

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -224,6 +224,7 @@ public class ExecWebSocketListener extends WebSocketListener implements ExecWatc
                     case 1:
                         if (out != null) {
                             out.write(byteString.toByteArray());
+                            out.flush();
                         }
                         break;
                     case 2:


### PR DESCRIPTION
Signed-off-by: Luca Stocchi <lstocchi@redhat.com>

## Description
it resolves #3509 . 
The PipedInputStream reads from the buffer if it's not empty, if it's empty it loops and wait using a `wait(1000)` until there is some data in it. The PipedWriter writes the data correctly but because it doesn't flush after writing, the reader is not notified there is actually something to read and it keeps waiting until 1s is elapsed. 

The solution flushes the output stream so the reader is notified when there is something to read.

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

