### PR TITLE
enhancement #3404: supporting generic resources with minimal metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Improvements
 * Fix #3448 added methods for getting specific version information - `KubernetesClient.getKubernetesVersion`, `OpenShiftClient.getOpenShiftV3Version`, and `OpenShiftClient.getOpenShiftV3Version`
+* Fix #3404 supporting generic resources in resource/resourceList with minimal metadata, as well as a new entry point `KubernetesClient.genericKubernetesResources(String apiVersion, String kind)`
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -31,8 +31,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-
-public abstract class BaseClient implements Client, HttpClientAware {
+public class BaseClient implements Client, HttpClientAware {
 
   public static final String APIS = "/apis";
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseKubernetesClient.java
@@ -24,6 +24,8 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsList;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
@@ -413,7 +415,17 @@ public abstract class BaseKubernetesClient<C extends Client> extends BaseClient 
   public <T extends CustomResource, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(Class<T> resourceType, Class<L> listClass) {
     return customResources(CustomResourceDefinitionContext.fromCustomResourceType(resourceType), resourceType, listClass);
   }
-
+  
+  @Override
+  public MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericKubernetesResources(
+      String apiVersion, String kind) {
+    ResourceDefinitionContext context = Handlers.getResourceDefinitionContext(apiVersion, kind, this);
+    if (context == null) {
+      throw new KubernetesClientException("Could not find the metadata for the given apiVersion and kind, please pass a ResourceDefinitionContext instead");
+    }
+    return genericKubernetesResources(context);
+  }
+  
   @Override
   public <T extends HasMetadata, L extends KubernetesResourceList<T>> HasMetadataOperation<T, L, Resource<T>> resources(
       Class<T> resourceType, Class<L> listClass) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Handlers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Handlers.java
@@ -17,15 +17,22 @@
 package io.fabric8.kubernetes.client;
 
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import io.fabric8.kubernetes.api.model.APIResourceList;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.dsl.NamespacedInOutCreateable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
+import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
+import io.fabric8.kubernetes.client.utils.ApiVersionUtil;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import okhttp3.OkHttpClient;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
@@ -33,6 +40,7 @@ import java.util.function.BiFunction;
 public final class Handlers {
 
   private static final Map<Class<?>, ResourceHandler<?, ?>> RESOURCE_HANDLER_MAP = new ConcurrentHashMap<>();
+  private static final Map<List<String>, ResourceDefinitionContext> GENERIC_RESOURCE_HANDLER_MAP = new ConcurrentHashMap<>();
   
   private Handlers() {
     //Utility
@@ -47,10 +55,73 @@ public final class Handlers {
   public static <T extends HasMetadata> void unregister(Class<T> type) {
     RESOURCE_HANDLER_MAP.remove(type);
   }
+  
+  /**
+   * Returns a {@link ResourceHandler} for the given item.  The client is optional, if it is supplied, then the server can be 
+   * consulted for resource metadata if a generic item is passed in.  The client is not needed at all for lookups related to 
+   * obtaining a builder - as there is no builder associated with generic resources. 
+   */
+  public static <T extends HasMetadata, V extends VisitableBuilder<T, V>> ResourceHandler<T, V> get(T meta, BaseClient client) {
+    Class<T> type = (Class<T>)meta.getClass();
+    
+    if (type.equals(GenericKubernetesResource.class)) {
+      ResourceDefinitionContext rdc = getResourceDefinitionContext((GenericKubernetesResource)meta, client);
+      
+      if (rdc != null) {
+        return new ResourceHandlerImpl(GenericKubernetesResource.class, GenericKubernetesResourceList.class, rdc);
+      }
+    }
+    
+    return get(type);
+  }
+  
+  public static ResourceDefinitionContext getResourceDefinitionContext(String apiVersion, String kind, BaseClient client) {
+    GenericKubernetesResource resource = new GenericKubernetesResource();
+    resource.setKind(kind);
+    resource.setApiVersion(apiVersion);
+    return getResourceDefinitionContext(resource, client);
+  }
 
-  public static <T extends HasMetadata, V extends VisitableBuilder<T, V>> ResourceHandler<T, V> get(T meta) {
-    // could try to return something here in the generic case, but there is no generic builder
-    return get((Class<T>)meta.getClass());
+  public static <T extends HasMetadata> ResourceDefinitionContext getResourceDefinitionContext(GenericKubernetesResource meta, BaseClient client) {
+    // check if it's built-in
+    Object value = Serialization.unmarshal(Serialization.asJson(meta));
+    Class<T> parsedType = (Class<T>) value.getClass();
+    
+    ResourceDefinitionContext rdc = null;
+    if (!parsedType.equals(GenericKubernetesResource.class)) {
+      rdc = ResourceDefinitionContext.fromResourceType(parsedType);
+    } else if (client != null) {
+      // if a client has been supplied, we can try to look this up from the server
+      String kind = meta.getKind();
+      String apiVersion = meta.getApiVersion();
+      if (kind == null || apiVersion == null) {
+        return null;
+      }
+      String api = ApiVersionUtil.trimGroupOrNull(apiVersion);
+      if (api == null) {
+        return null;
+      }
+      String version = ApiVersionUtil.trimVersion(apiVersion);
+      // assume that resource metadata won't change for the lifetime of the client
+      rdc = GENERIC_RESOURCE_HANDLER_MAP.computeIfAbsent(Arrays.asList(kind, apiVersion), k -> {
+        APIResourceList resourceList = client.getApiResources(apiVersion);
+        if (resourceList == null) {
+          return null;
+        }
+        return resourceList.getResources()
+            .stream()
+            .filter(r -> kind.equals(r.getKind()))
+            .findFirst()
+            .map(resource -> new ResourceDefinitionContext.Builder().withGroup(api)
+                .withKind(kind)
+                .withNamespaced(Boolean.TRUE.equals(resource.getNamespaced()))
+                .withPlural(resource.getName())
+                .withVersion(version)
+                .build())
+            .orElse(null);
+      });        
+    }
+    return rdc;
   }
 
   public static <T extends HasMetadata, V extends VisitableBuilder<T, V>> ResourceHandler<T, V> get(Class<T> type) {
@@ -62,6 +133,9 @@ public final class Handlers {
   
   public static <T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>> HasMetadataOperation<T, L, R> getOperation(Class<T> type, Class<L> listType, OkHttpClient client, Config config) {
     ResourceHandler<T, ?> resourceHandler = get(type);
+    if (resourceHandler == null) {
+      throw new IllegalStateException();
+    }
     return (HasMetadataOperation<T, L, R>) resourceHandler.operation(client, config, listType);
   }
   

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -207,6 +207,17 @@ public interface KubernetesClient extends Client {
       ResourceDefinitionContext context) {
     return customResources(context, GenericKubernetesResource.class, GenericKubernetesResourceList.class);
   }
+  
+  /**
+   * Semi-typed API for managing resources. 
+   * 
+   * Will perform a look-up if needed for additional metadata about the resource.
+   * 
+   * @param apiVersion the api/version 
+   * @param kind the resource kind
+   * @return returns a MixedOperation object with which you can do basic resource operations.
+   */
+  MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericKubernetesResources(String apiVersion, String kind);
 
   /**
    * Discovery API entrypoint for APIGroup discovery.k8s.io

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandlerImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandlerImpl.java
@@ -46,6 +46,14 @@ class ResourceHandlerImpl<T extends HasMetadata, V extends VisitableBuilder<T, V
     this.operationConstructor = operationConstructor;
   }
   
+  ResourceHandlerImpl(Class<T> type, Class<? extends KubernetesResourceList<T>> listClass, ResourceDefinitionContext context) {
+    this.type = type;
+    this.context = context;
+    this.defaultListClass = listClass;
+    this.builderClass = null;
+    this.operationConstructor = null;
+  }
+  
   @Override
   public V edit(T item) {
     if (this.builderClass == null) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.base;
 
-import io.fabric8.kubernetes.api.Pluralize;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.client.dsl.WritableOperation;
 import io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -88,7 +88,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
   }
   
   protected <V extends VisitableBuilder<T, V>> VisitableBuilder<T, V> createVisitableBuilder(T item) {
-    ResourceHandler<T, V> handler = Handlers.get(item);
+    ResourceHandler<T, V> handler = Handlers.get(item, null);
     if (handler != null) {
       return handler.edit(item);
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesListOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesListOperationsImpl.java
@@ -22,6 +22,7 @@ import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.client.BaseClient;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.ResourceHandler;
@@ -125,7 +126,7 @@ public class KubernetesListOperationsImpl
   }
 
   private Resource<HasMetadata> getResource(HasMetadata resource) {
-    ResourceHandler<HasMetadata, ?> handler = NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.handlerOf(resource);
+    ResourceHandler<HasMetadata, ?> handler = NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.handlerOf(resource, new BaseClient(this.context.getClient(), this.context.getConfig()));
     return handler.operation(context.getClient(), context.getConfig(), null).newInstance(context.withItem(resource));
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -24,6 +24,8 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsList;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LimitRange;
@@ -590,4 +592,11 @@ public class ManagedKubernetesClient extends BaseClient implements NamespacedKub
   public NonNamespaceOperation<RuntimeClass, RuntimeClassList, Resource<RuntimeClass>> runtimeClasses() {
     return delegate.runtimeClasses();
   }
+  
+  @Override
+  public MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericKubernetesResources(
+      String apiVersion, String kind) {
+    return delegate.genericKubernetesResources(apiVersion, kind);
+  }
+  
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ApiVersionUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ApiVersionUtil.java
@@ -31,7 +31,7 @@ public class ApiVersionUtil {
    */
   
   public static <T> String apiGroup(T item, String apiGroup) {
-        if (item instanceof HasMetadata && Utils.isNotNullOrEmpty(((HasMetadata) item).getApiVersion())) {
+    if (item instanceof HasMetadata && Utils.isNotNullOrEmpty(((HasMetadata) item).getApiVersion())) {
       return trimGroupOrNull(((HasMetadata) item).getApiVersion());
     } else if (apiGroup != null && !apiGroup.isEmpty()) {
       return trimGroup(apiGroup);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/HandlersTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/HandlersTest.java
@@ -45,10 +45,10 @@ public class HandlersTest {
   public void testRegister() {
     Handlers.register(MyPod.class, MyPodOperationsImpl::new);
 
-    assertThat(Handlers.get(new MyPod()).operation(null, null, null), Matchers.instanceOf(MyPodOperationsImpl.class));
+    assertThat(Handlers.get(new MyPod(), null).operation(null, null, null), Matchers.instanceOf(MyPodOperationsImpl.class));
     
     Handlers.unregister(MyPod.class);
     
-    assertThat(Handlers.get(new MyPod()).operation(null, null, null), Matchers.instanceOf(HasMetadataOperationsImpl.class));
+    assertThat(Handlers.get(new MyPod(), null).operation(null, null, null), Matchers.instanceOf(HasMetadataOperationsImpl.class));
   }
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
@@ -44,7 +44,7 @@ public class CustomResourceDefinitionIT {
   public static final AssumingK8sVersionAtLeast assumingK8sVersion =
     new AssumingK8sVersionAtLeast("1", "16");
 
-  public CustomResourceDefinition createCRD() {
+  public static CustomResourceDefinition createCRD() {
     return new CustomResourceDefinitionBuilder()
       .withApiVersion("apiextensions.k8s.io/v1")
       .withNewMetadata()
@@ -106,4 +106,5 @@ public class CustomResourceDefinitionIT {
     boolean bDeleted = client.apiextensions().v1().customResourceDefinitions().withName(crd1.getMetadata().getName()).delete();
     assertThat(bDeleted).isTrue();
   }
+
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericResourceIT.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes;
+
+import io.fabric8.commons.AssumingK8sVersionAtLeast;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class GenericResourceIT {
+
+  @ArquillianResource
+  KubernetesClient client;
+
+  @ArquillianResource
+  Session session;
+
+  @ClassRule
+  public static final AssumingK8sVersionAtLeast assumingK8sVersion =
+    new AssumingK8sVersionAtLeast("1", "16");
+
+  @Test
+  public void testGenericBuiltinResourceWithoutMetadata() {
+    GenericKubernetesResource configMap = new GenericKubernetesResource();
+    configMap.setKind("ConfigMap");
+    configMap.setApiVersion("v1");
+    configMap.setMetadata(new ObjectMetaBuilder().withName("my-map").build());
+    NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<GenericKubernetesResource> resource = client.resource(configMap);
+    GenericKubernetesResource result = resource.createOrReplace();
+    assertNotNull(result);
+
+    MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> resources =
+        client.genericKubernetesResources("v1", "ConfigMap");
+    assertTrue(!resources.list().getItems().isEmpty());
+  }
+
+  @Test
+  public void testGenericCustomResourceWithoutMetadata() {
+    CustomResourceDefinition crd1 = client.apiextensions().v1().customResourceDefinitions().createOrReplace(CustomResourceDefinitionIT.createCRD());
+
+    assertThat(crd1).isNotNull();
+
+    GenericKubernetesResource itest = new GenericKubernetesResource();
+    itest.setKind("Itest");
+    itest.setApiVersion("examples.fabric8.io/v1");
+    itest.setMetadata(new ObjectMetaBuilder().withName("my-itest").build());
+
+    NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<GenericKubernetesResource> resource = client.resource(itest);
+
+    GenericKubernetesResource result = resource.createOrReplace();
+    assertNotNull(result);
+  }
+
+}

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftAdapterSupport.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/OpenshiftAdapterSupport.java
@@ -57,7 +57,7 @@ public class OpenshiftAdapterSupport {
     }
     String url = config.getMasterUrl();
     return API_GROUPS_ENABLED_PER_URL.computeIfAbsent(url,
-        k -> new BaseClient(adaptOkHttpClient(client, config), config) {}.getApiGroups()
+        k -> new BaseClient(adaptOkHttpClient(client, config), config).getApiGroups()
             .getGroups()
             .stream()
             .anyMatch(g -> g.getName().endsWith("openshift.io")));

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -25,6 +25,8 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsList;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
@@ -1011,4 +1013,11 @@ public class ManagedOpenShiftClient extends BaseClient implements NamespacedOpen
   public boolean supportsOpenShiftAPIGroup(String apiGroup) {
     return delegate.supportsOpenShiftAPIGroup(apiGroup);
   }
+
+  @Override
+  public MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericKubernetesResources(
+      String apiVersion, String kind) {
+    return delegate.genericKubernetesResources(apiVersion, kind);
+  }
+
 }


### PR DESCRIPTION
## Description
Adds a new entry method KubernetesClient.genericKubernetesResources(String apiVersion, String kind) as well as automatically inferring the ResourceDefintionContext when using the .resource/resourceList methods.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
