### PR TITLE
fix #3460: support for deserializing templates with non-string params

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -32,7 +32,6 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import io.fabric8.kubernetes.api.KubernetesResourceMappingProvider;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -49,6 +49,9 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
     private static final String API_VERSION = "apiVersion";
 
     private static final Mapping mapping = new Mapping();
+
+    // template deserialization can fail if unless we use generic resources
+    private static ThreadLocal<Boolean> IN_TEMPLATE = ThreadLocal.withInitial(() -> false);
 
     @Override
     public KubernetesResource deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
@@ -84,7 +87,23 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
             if (resourceType == null) {
               return jp.getCodec().treeToValue(node, GenericKubernetesResource.class);
             } else if (KubernetesResource.class.isAssignableFrom(resourceType)){
-                return jp.getCodec().treeToValue(node, resourceType);
+                boolean inTemplate = IN_TEMPLATE.get();
+                if (!inTemplate && "io.fabric8.openshift.api.model.Template".equals(resourceType.getName())) {
+                    inTemplate = true;
+                    IN_TEMPLATE.set(true);
+                }
+                try {
+                    return jp.getCodec().treeToValue(node, resourceType);
+                } catch (InvalidFormatException e) {
+                    if (!inTemplate) {
+                        throw e;
+                    }
+                    return jp.getCodec().treeToValue(node, GenericKubernetesResource.class);
+                } finally {
+                    if (inTemplate) {
+                        IN_TEMPLATE.remove();
+                    }
+                }
             }
         }
         return null;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.utils.IOHelpers;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.ParameterBuilder;
 import io.fabric8.openshift.api.model.Template;
 import io.fabric8.openshift.api.model.TemplateBuilder;
@@ -183,6 +184,13 @@ class TemplateTest {
     map.put("PORT", "8080");
     KubernetesList list = client.templates().withParameters(map).load(getClass().getResourceAsStream("/template-with-number-params.yml")).processLocally(map);
     assertListIsServiceWithPort8080(list);
+  }
+
+  @Test
+  void shouldGetTemplateWithNumberParameters() {
+    OpenShiftClient client = new DefaultOpenShiftClient(new OpenShiftConfigBuilder().withDisableApiGroupCheck(true).build());
+    Template template = client.templates().load(getClass().getResourceAsStream("/template-with-number-params.yml")).get();
+    assertTrue(Serialization.asYaml(template.getObjects().get(0)).contains("{PORT}"));
   }
 
   protected void assertListIsServiceWithPort8080(KubernetesList list) {


### PR DESCRIPTION
## Description
Took another look at the template deserialization issue and thought it would be worth proposing this solution - there does not seem to be a great way to trap this error using other jackson mechanisms.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
