### PR TITLE
[MO] - replace fixed value to websocket timeout when wait for connection

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -77,7 +77,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   }
 
   public void waitUntilReady() {
-    getListener().waitUntilReady();
+    getListener().waitUntilReady(this.client.readTimeoutMillis());
   }
 
   synchronized WatcherWebSocketListener<T> getListener() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
@@ -115,8 +115,8 @@ class WatcherWebSocketListener<T extends HasMetadata> extends WebSocketListener 
     logger.debug("WebSocket close received. code: {}, reason: {}", code, reason);
     manager.scheduleReconnect();
   }
-  
-  protected void waitUntilReady() {
-    Utils.waitUntilReadyOrFail(startedFuture, 10, TimeUnit.SECONDS);
+
+  protected void waitUntilReady(final int readTimeoutMs) {
+    Utils.waitUntilReadyOrFail(startedFuture, readTimeoutMs, TimeUnit.MILLISECONDS);
   }
 }


### PR DESCRIPTION
## Description

This PR replace the fixed value when waiting on connection with the WebSocket timeout value provided by the env variable.  

Why?
In my case, I am deploying around 20 verticles, where my machine (container has only 4 CPUs). This results in the case when each thread waits only `10s`, which is really small timeout. I have tested this on my minikube and OCP (multi-node cluster).
```
2021-11-02 17:25:13 ERROR Main:153 - Cluster Operator verticle in namespace infra-namespace failed to start
io.fabric8.kubernetes.client.KubernetesClientException: not ready after 10 SECONDS
	at io.fabric8.kubernetes.client.utils.Utils.waitUntilReadyOrFail(Utils.java:176) ~[io.fabric8.kubernetes-client-5.9.0.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.WatcherWebSocketListener.waitUntilReady(WatcherWebSocketListener.java:120) ~[io.fabric8.kubernetes-client-5.9.0.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager.waitUntilReady(WatchConnectionManager.java:80) ~[io.fabric8.kubernetes-client-5.9.0.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.watch(BaseOperation.java:662) ~[io.fabric8.kubernetes-client-5.9.0.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.watch(BaseOperation.java:637) ~[io.fabric8.kubernetes-client-5.9.0.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.watch(BaseOperation.java:87) ~[io.fabric8.kubernetes-client-5.9.0.jar:?]
	at io.strimzi.operator.common.operator.resource.AbstractWatchableResourceOperator.watch(AbstractWatchableResourceOperator.java:61) ~[io.strimzi.operator-common-0.27.0-SNAPSHOT.jar:0.27.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.KafkaRebalanceAssemblyOperator.lambda$createRebalanceWatch$0(KafkaRebalanceAssemblyOperator.java:210) ~[io.strimzi.cluster-operator-0.27.0-SNAPSHOT.jar:0.27.0-SNAPSHOT]
	at io.strimzi.operator.common.Util.lambda$async$0(Util.java:76) ~[io.strimzi.operator-common-0.27.0-SNAPSHOT.jar:0.27.0-SNAPSHOT]
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:159) ~[io.vertx.vertx-core-4.1.5.jar:4.1.5]
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100) ~[io.vertx.vertx-core-4.1.5.jar:4.1.5]
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:157) ~[io.vertx.vertx-core-4.1.5.jar:4.1.5]
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76) ~[io.vertx.vertx-core-4.1.5.jar:4.1.5]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.68.Final.jar:4.1.68.Final]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request is ready for review
-->
