### PR TITLE
test: fix: CRD IT uses its own resources

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: v1.23.0
+          minikube version: v1.23.2
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=metrics-server --force'

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
@@ -25,18 +25,21 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresKubernetes
 public class CustomResourceDefinitionIT {
+
   @ArquillianResource
   KubernetesClient client;
 
@@ -44,67 +47,120 @@ public class CustomResourceDefinitionIT {
   public static final AssumingK8sVersionAtLeast assumingK8sVersion =
     new AssumingK8sVersionAtLeast("1", "16");
 
-  public static CustomResourceDefinition createCRD() {
-    return new CustomResourceDefinitionBuilder()
-      .withApiVersion("apiextensions.k8s.io/v1")
-      .withNewMetadata()
-      .withName("itests.examples.fabric8.io")
-      .endMetadata()
+  private String name;
+  private String singular;
+  private String plural;
+  private String group;
+  private CustomResourceDefinition crd;
+
+  @Before
+  public void setUp(){
+    singular = "a" + UUID.randomUUID().toString().replace("-", "");
+    plural = singular + "s";
+    group = "examples.fabric8.io";
+    name = plural + "." + group;
+    crd = createCRD();
+  }
+
+  @After
+  public void tearDown() {
+    deleteCRD();
+  }
+
+  @Test
+  public void load() {
+    // When
+    final CustomResourceDefinition result = client.apiextensions().v1().customResourceDefinitions()
+      .load(getClass().getResourceAsStream("/test-crd.yml")).get();
+    // Then
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  public void get() {
+    // When
+    final CustomResourceDefinition result = client.apiextensions().v1().customResourceDefinitions()
+      .withName(name).get();
+    // Then
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  public void list() {
+    // When
+    final CustomResourceDefinitionList result = client.apiextensions().v1().customResourceDefinitions()
+      .list();
+    // Then
+    assertThat(result.getItems())
+      .hasSizeGreaterThan(0)
+      .anyMatch(crd -> crd.getMetadata().getName().equals(name));
+  }
+
+  @Test
+  public void create() {
+    // Then
+    assertThat(crd)
+      .hasFieldOrPropertyWithValue("metadata.name", name)
+      .extracting("metadata.creationTimestamp")
+      .isNotNull();
+  }
+
+  @Test
+  public void update() {
+    // When
+    final CustomResourceDefinition result = client.apiextensions().v1().customResourceDefinitions()
+      .withName(name).edit(c -> new CustomResourceDefinitionBuilder(c)
+        .editSpec().editOrNewNames().addNewShortName("its").endNames().endSpec().build());
+    // Then
+    assertThat(result.getSpec().getNames().getShortNames())
+      .containsExactlyInAnyOrder("its");
+  }
+
+  @Test
+  public void delete() {
+    // When
+    final boolean result = client.apiextensions().v1().customResourceDefinitions()
+      .withName(name).delete();
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  private CustomResourceDefinition createCRD() {
+    return client.apiextensions().v1().customResourceDefinitions().create(new CustomResourceDefinitionBuilder()
+      .withNewMetadata().withName(name).endMetadata()
       .withNewSpec()
-      .withGroup("examples.fabric8.io")
+      .withGroup(group)
       .addAllToVersions(Collections.singletonList(new CustomResourceDefinitionVersionBuilder()
         .withName("v1")
         .withServed(true)
         .withStorage(true)
         .withNewSchema()
-          .withNewOpenAPIV3Schema()
+        .withNewOpenAPIV3Schema()
+        .withType("object")
+        .addToProperties("spec", new JSONSchemaPropsBuilder()
           .withType("object")
-          .addToProperties("spec", new JSONSchemaPropsBuilder()
-            .withType("object")
-            .addToProperties("field", new JSONSchemaPropsBuilder()
-              .withType("string")
-              .build())
+          .addToProperties("field", new JSONSchemaPropsBuilder()
+            .withType("string")
             .build())
-          .endOpenAPIV3Schema()
+          .build())
+        .endOpenAPIV3Schema()
         .endSchema()
         .build()))
       .withScope("Namespaced")
       .withNewNames()
-      .withPlural("itests")
-      .withSingular("itest")
+      .withPlural(plural)
+      .withSingular(singular)
       .withKind("Itest")
-      .withShortNames("it")
       .endNames()
       .endSpec()
-      .build();
+      .build());
   }
 
-  @Test
-  public void testCrdOperations() {
-    // Load
-    CustomResourceDefinition crd1 = client.apiextensions().v1().customResourceDefinitions().load(getClass().getResourceAsStream("/test-crd.yml")).get();
-    assertThat(crd1).isNotNull();
-
-    // Create
-    crd1 = client.apiextensions().v1().customResourceDefinitions().create(createCRD());
-    assertNotNull(crd1);
-
-    // Get
-    crd1 = client.apiextensions().v1().customResourceDefinitions().withName(crd1.getMetadata().getName()).get();
-    assertThat(crd1).isNotNull();
-
-    // List
-    CustomResourceDefinitionList crdList = client.apiextensions().v1().customResourceDefinitions().list();
-    assertThat(crdList).isNotNull();
-    assertThat(crdList.getItems().size()).isPositive();
-
-    // Update
-    CustomResourceDefinition updatedCrd = client.apiextensions().v1().customResourceDefinitions().withName(crd1.getMetadata().getName()).edit(c -> new CustomResourceDefinitionBuilder(c).editSpec().editOrNewNames().addNewShortName("its").endNames().endSpec().build());
-    assertThat(updatedCrd.getSpec().getNames().getShortNames().size()).isEqualTo(2);
-
-    // Delete
-    boolean bDeleted = client.apiextensions().v1().customResourceDefinitions().withName(crd1.getMetadata().getName()).delete();
-    assertThat(bDeleted).isTrue();
+  private void deleteCRD() {
+    try {
+      client.apiextensions().v1().customResourceDefinitions().delete(crd);
+    } catch (Exception e) {
+      // ignore
+    }
   }
-
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericResourceIT.java
@@ -21,6 +21,9 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable;
@@ -34,6 +37,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +75,7 @@ public class GenericResourceIT {
 
   @Test
   public void testGenericCustomResourceWithoutMetadata() {
-    CustomResourceDefinition crd1 = client.apiextensions().v1().customResourceDefinitions().createOrReplace(CustomResourceDefinitionIT.createCRD());
+    CustomResourceDefinition crd1 = client.apiextensions().v1().customResourceDefinitions().createOrReplace(createCRD());
 
     assertThat(crd1).isNotNull();
 
@@ -88,4 +92,39 @@ public class GenericResourceIT {
     assertNotNull(result);
   }
 
+
+  public static CustomResourceDefinition createCRD() {
+    return new CustomResourceDefinitionBuilder()
+      .withApiVersion("apiextensions.k8s.io/v1")
+      .withNewMetadata()
+      .withName("itests.examples.fabric8.io")
+      .endMetadata()
+      .withNewSpec()
+      .withGroup("examples.fabric8.io")
+      .addAllToVersions(Collections.singletonList(new CustomResourceDefinitionVersionBuilder()
+        .withName("v1")
+        .withServed(true)
+        .withStorage(true)
+        .withNewSchema()
+        .withNewOpenAPIV3Schema()
+        .withType("object")
+        .addToProperties("spec", new JSONSchemaPropsBuilder()
+          .withType("object")
+          .addToProperties("field", new JSONSchemaPropsBuilder()
+            .withType("string")
+            .build())
+          .build())
+        .endOpenAPIV3Schema()
+        .endSchema()
+        .build()))
+      .withScope("Namespaced")
+      .withNewNames()
+      .withPlural("itests")
+      .withSingular("itest")
+      .withKind("Itest")
+      .withShortNames("it")
+      .endNames()
+      .endSpec()
+      .build();
+  }
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -116,7 +116,7 @@ public class PodIT {
   }
 
   @Test
-  public void evict() throws InterruptedException {
+  public void evict() {
     Pod pod1 = client.pods().inNamespace(session.getNamespace()).withName("pod-standard").get();
     String pdbScope = pod1.getMetadata().getLabels().get("pdb-scope");
     assertNotNull("pdb-scope label is null. is pod1 misconfigured?", pdbScope);


### PR DESCRIPTION
## Description
test: fix: CRD IT uses its own resources

CustomResourceDefinitionIT should no longer fail as it's not using resources shared across other test suites

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
