### PR TITLE
MockWebServer bump, refactor and enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Improvements
 
 #### Dependency Upgrade
+* Fix #3562: Bump MockWebServer
 
 #### New Features
 * Fix #3430: Support Vertical Pod Autoscaler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #3562: Kubernetes Mock Server improvements
 
 #### Dependency Upgrade
 * Fix #3562: Bump MockWebServer

--- a/extensions/camel-k/mock/src/main/java/io/fabric8/camelk/mock/CamelKMockServerExtension.java
+++ b/extensions/camel-k/mock/src/main/java/io/fabric8/camelk/mock/CamelKMockServerExtension.java
@@ -17,17 +17,20 @@
 package io.fabric8.camelk.mock;
 
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.camelk.client.NamespacedCamelKClient;
 import io.fabric8.camelk.client.CamelKClient;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -57,8 +60,9 @@ public class CamelKMockServerExtension extends KubernetesMockServerExtension {
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableCamelKMockClient a = testClass.getAnnotation(EnableCamelKMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     camelKMockServer = a.crud()
-      ? new CamelKMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new CamelKMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new CamelKMockServer(a.https());
     camelKMockServer.init();
     camelKClient = camelKMockServer.createCamelKClient();

--- a/extensions/camel-k/mock/src/main/java/io/fabric8/camelk/mock/CamelKServer.java
+++ b/extensions/camel-k/mock/src/main/java/io/fabric8/camelk/mock/CamelKServer.java
@@ -16,13 +16,17 @@
 package io.fabric8.camelk.mock;
 
 import io.fabric8.camelk.client.CamelKClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class CamelKServer extends ExternalResource {
 
@@ -50,8 +54,9 @@ public class CamelKServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new CamelKMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new CamelKMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new CamelKMockServer(https);
     mock.init();
     client = mock.createCamelKClient();

--- a/extensions/camel-k/mock/src/main/java/io/fabric8/camelk/mock/CamelKServer.java
+++ b/extensions/camel-k/mock/src/main/java/io/fabric8/camelk/mock/CamelKServer.java
@@ -15,28 +15,25 @@
  */
 package io.fabric8.camelk.mock;
 
+import io.fabric8.camelk.client.CamelKClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.mockwebserver.Context;
-import io.fabric8.mockwebserver.ServerRequest;
-import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
-import io.fabric8.camelk.client.CamelKClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
-import java.util.Queue;
 
 public class CamelKServer extends ExternalResource {
 
   protected CamelKMockServer mock;
   private CamelKClient client;
 
-  private boolean https;
+  private final boolean https;
   // In this mode the mock web server will store, read, update and delete
   // kubernetes resources using an in memory map and will appear as a real api
   // server.
-  private boolean crudMode;
+  private final boolean crudMode;
 
   public CamelKServer() {
     this(true, false);
@@ -51,6 +48,7 @@ public class CamelKServer extends ExternalResource {
     this.crudMode = crudMode;
   }
 
+  @Override
   public void before() {
     mock = crudMode
       ? new CamelKMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
@@ -59,6 +57,7 @@ public class CamelKServer extends ExternalResource {
     client = mock.createCamelKClient();
   }
 
+  @Override
   public void after() {
     mock.destroy();
     client.close();
@@ -82,9 +81,5 @@ public class CamelKServer extends ExternalResource {
   @Deprecated
   public void expectAndReturnAsString(String path, int code, String body) {
     expect().withPath(path).andReturn(code, body).always();
-  }
-
-  public MockWebServer getMockServer() {
-    return mock.getServer();
   }
 }

--- a/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerMockServerExtension.java
+++ b/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerMockServerExtension.java
@@ -20,15 +20,18 @@ package io.fabric8.certmanager.server.mock;
 
 import io.fabric8.certmanager.client.CertManagerClient;
 import io.fabric8.certmanager.client.NamespacedCertManagerClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -58,8 +61,9 @@ public class CertManagerMockServerExtension extends KubernetesMockServerExtensio
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableCertManagerMockClient a = testClass.getAnnotation(EnableCertManagerMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     certManagerMockServer = a.crud()
-      ? new CertManagerMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new CertManagerMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new CertManagerMockServer(a.https());
     certManagerMockServer.init();
     certManagerClient = certManagerMockServer.createCertManager();

--- a/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerServer.java
+++ b/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerServer.java
@@ -16,13 +16,17 @@
 package io.fabric8.certmanager.server.mock;
 
 import io.fabric8.certmanager.client.CertManagerClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class CertManagerServer extends ExternalResource {
 
@@ -50,8 +54,9 @@ public class CertManagerServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new CertManagerMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new CertManagerMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new CertManagerMockServer(https);
     mock.init();
     client = mock.createCertManager();

--- a/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerServer.java
+++ b/extensions/certmanager/mock/src/main/java/io/fabric8/certmanager/server/mock/CertManagerServer.java
@@ -15,28 +15,25 @@
  */
 package io.fabric8.certmanager.server.mock;
 
+import io.fabric8.certmanager.client.CertManagerClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.mockwebserver.Context;
-import io.fabric8.mockwebserver.ServerRequest;
-import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
-import io.fabric8.certmanager.client.CertManagerClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
-import java.util.Queue;
 
 public class CertManagerServer extends ExternalResource {
 
   protected CertManagerMockServer mock;
   private CertManagerClient client;
 
-  private boolean https;
+  private final boolean https;
   // In this mode the mock web server will store, read, update and delete
   // kubernetes resources using an in memory map and will appear as a real api
   // server.
-  private boolean crudMode;
+  private final boolean crudMode;
 
   public CertManagerServer() {
     this(true, false);
@@ -51,6 +48,7 @@ public class CertManagerServer extends ExternalResource {
     this.crudMode = crudMode;
   }
 
+  @Override
   public void before() {
     mock = crudMode
       ? new CertManagerMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
@@ -59,6 +57,7 @@ public class CertManagerServer extends ExternalResource {
     client = mock.createCertManager();
   }
 
+  @Override
   public void after() {
     mock.destroy();
     client.close();

--- a/extensions/chaosmesh/mock/src/main/java/io/fabric8/chaosmesh/server/mock/ChaosMeshMockServerExtension.java
+++ b/extensions/chaosmesh/mock/src/main/java/io/fabric8/chaosmesh/server/mock/ChaosMeshMockServerExtension.java
@@ -18,17 +18,20 @@
 package io.fabric8.chaosmesh.server.mock;
 
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.chaosmesh.client.NamespacedChaosMeshClient;
 import io.fabric8.chaosmesh.client.ChaosMeshClient;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -58,8 +61,9 @@ public class ChaosMeshMockServerExtension extends KubernetesMockServerExtension 
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableChaosMeshMockClient a = testClass.getAnnotation(EnableChaosMeshMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     chaosMeshMockServer = a.crud()
-      ? new ChaosMeshMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new ChaosMeshMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new ChaosMeshMockServer(a.https());
     chaosMeshMockServer.init();
     chaosMeshClient = chaosMeshMockServer.createChaosMeshClient();

--- a/extensions/chaosmesh/mock/src/main/java/io/fabric8/chaosmesh/server/mock/ChaosMeshServer.java
+++ b/extensions/chaosmesh/mock/src/main/java/io/fabric8/chaosmesh/server/mock/ChaosMeshServer.java
@@ -16,13 +16,17 @@
 package io.fabric8.chaosmesh.server.mock;
 
 import io.fabric8.chaosmesh.client.ChaosMeshClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class ChaosMeshServer extends ExternalResource {
 
@@ -47,8 +51,9 @@ public class ChaosMeshServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new ChaosMeshMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new ChaosMeshMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new ChaosMeshMockServer(https);
     mock.init();
     client = mock.createChaosMeshClient();

--- a/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeMockServerExtension.java
+++ b/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeMockServerExtension.java
@@ -19,15 +19,18 @@ package io.fabric8.knative.mock;
 
 import io.fabric8.knative.client.KnativeClient;
 import io.fabric8.knative.client.NamespacedKnativeClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -57,8 +60,9 @@ public class KnativeMockServerExtension extends KubernetesMockServerExtension {
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableKnativeMockClient a = testClass.getAnnotation(EnableKnativeMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     knativeMockServer = a.crud()
-      ? new KnativeMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new KnativeMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new KnativeMockServer(a.https());
   knativeMockServer.init();
    knativeClient = knativeMockServer.createKnative();

--- a/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeServer.java
+++ b/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeServer.java
@@ -16,13 +16,17 @@
 package io.fabric8.knative.mock;
 
 import io.fabric8.knative.client.KnativeClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class KnativeServer extends ExternalResource {
 
@@ -50,8 +54,9 @@ public class KnativeServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new KnativeMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new KnativeMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new KnativeMockServer(https);
     mock.init();
     client = mock.createKnative();

--- a/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeServer.java
+++ b/extensions/knative/mock/src/main/java/io/fabric8/knative/mock/KnativeServer.java
@@ -15,28 +15,25 @@
  */
 package io.fabric8.knative.mock;
 
+import io.fabric8.knative.client.KnativeClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.mockwebserver.Context;
-import io.fabric8.mockwebserver.ServerRequest;
-import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
-import io.fabric8.knative.client.KnativeClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
-import java.util.Queue;
 
 public class KnativeServer extends ExternalResource {
 
   protected KnativeMockServer mock;
   private KnativeClient client;
 
-  private boolean https;
+  private final boolean https;
   // In this mode the mock web server will store, read, update and delete
   // kubernetes resources using an in memory map and will appear as a real api
   // server.
-  private boolean crudMode;
+  private final boolean crudMode;
 
   public KnativeServer() {
     this(true, false);
@@ -51,6 +48,7 @@ public class KnativeServer extends ExternalResource {
     this.crudMode = crudMode;
   }
 
+  @Override
   public void before() {
     mock = crudMode
       ? new KnativeMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
@@ -59,16 +57,15 @@ public class KnativeServer extends ExternalResource {
     client = mock.createKnative();
   }
 
+  @Override
   public void after() {
     mock.destroy();
     client.close();
   }
 
-
   public KnativeClient getKnativeClient() {
     return client;
   }
-
 
   public MockServerExpectation expect() {
     return mock.expect();
@@ -82,9 +79,5 @@ public class KnativeServer extends ExternalResource {
   @Deprecated
   public void expectAndReturnAsString(String path, int code, String body) {
     expect().withPath(path).andReturn(code, body).always();
-  }
-
-  public MockWebServer getMockServer() {
-    return mock.getServer();
   }
 }

--- a/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogMockServerExtension.java
+++ b/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogMockServerExtension.java
@@ -18,17 +18,20 @@
 package io.fabric8.servicecatalog.server.mock;
 
 
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.servicecatalog.client.ServiceCatalogClient;
 import io.fabric8.servicecatalog.client.NamespacedServiceCatalogClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -58,8 +61,9 @@ public class ServiceCatalogMockServerExtension extends KubernetesMockServerExten
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableServiceCatalogMockClient a = testClass.getAnnotation(EnableServiceCatalogMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     serviceCatalogMockServer = a.crud()
-      ? new ServiceCatalogMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new ServiceCatalogMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new ServiceCatalogMockServer(a.https());
     serviceCatalogMockServer.init();
     serviceCatalogClient = serviceCatalogMockServer.createServiceCatalog();

--- a/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogServer.java
+++ b/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogServer.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.servicecatalog.server.mock;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
@@ -25,6 +25,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Queue;
 
 public class ServiceCatalogServer extends ExternalResource {
@@ -53,8 +54,9 @@ public class ServiceCatalogServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new ServiceCatalogMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new ServiceCatalogMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new ServiceCatalogMockServer(https);
     mock.init();
     client = mock.createServiceCatalog();

--- a/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogServer.java
+++ b/extensions/service-catalog/mock/src/main/java/io/fabric8/servicecatalog/server/mock/ServiceCatalogServer.java
@@ -32,11 +32,11 @@ public class ServiceCatalogServer extends ExternalResource {
   protected ServiceCatalogMockServer mock;
   private ServiceCatalogClient client;
 
-  private boolean https;
+  private final boolean https;
   // In this mode the mock web server will store, read, update and delete
   // kubernetes resources using an in memory map and will appear as a real api
   // server.
-  private boolean crudMode;
+  private final boolean crudMode;
 
   public ServiceCatalogServer() {
     this(true, false);
@@ -51,6 +51,7 @@ public class ServiceCatalogServer extends ExternalResource {
     this.crudMode = crudMode;
   }
 
+  @Override
   public void before() {
     mock = crudMode
       ? new ServiceCatalogMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
@@ -59,11 +60,11 @@ public class ServiceCatalogServer extends ExternalResource {
     client = mock.createServiceCatalog();
   }
 
+  @Override
   public void after() {
     mock.destroy();
     client.close();
   }
-
 
   public ServiceCatalogClient getServiceCatalogClient() {
     return client;
@@ -82,9 +83,5 @@ public class ServiceCatalogServer extends ExternalResource {
   @Deprecated
   public void expectAndReturnAsString(String path, int code, String body) {
     expect().withPath(path).andReturn(code, body).always();
-  }
-
-  public MockWebServer getMockServer() {
-    return mock.getServer();
   }
 }

--- a/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonMockServerExtension.java
+++ b/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonMockServerExtension.java
@@ -17,18 +17,20 @@
 
 package io.fabric8.tekton.mock;
 
-
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.tekton.client.NamespacedTektonClient;
 import io.fabric8.tekton.client.TektonClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -58,8 +60,9 @@ public class TektonMockServerExtension extends KubernetesMockServerExtension {
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableTektonMockClient a = testClass.getAnnotation(EnableTektonMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     tektonMockServer = a.crud()
-      ? new TektonMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new TektonMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new TektonMockServer(a.https());
     tektonMockServer.init();
     tektonClient = tektonMockServer.createTekton();

--- a/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonServer.java
+++ b/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonServer.java
@@ -15,14 +15,18 @@
  */
 package io.fabric8.tekton.mock;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.tekton.client.TektonClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class TektonServer extends ExternalResource {
 
@@ -50,8 +54,9 @@ public class TektonServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new TektonMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new TektonMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new TektonMockServer(https);
     mock.init();
     client = mock.createTekton();

--- a/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonServer.java
+++ b/extensions/tekton/mock/src/main/java/io/fabric8/tekton/mock/TektonServer.java
@@ -17,26 +17,23 @@ package io.fabric8.tekton.mock;
 
 import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.mockwebserver.Context;
-import io.fabric8.mockwebserver.ServerRequest;
-import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.tekton.client.TektonClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
-import java.util.Queue;
 
 public class TektonServer extends ExternalResource {
 
   protected TektonMockServer mock;
   private TektonClient client;
 
-  private boolean https;
+  private final boolean https;
   // In this mode the mock web server will store, read, update and delete
   // kubernetes resources using an in memory map and will appear as a real api
   // server.
-  private boolean crudMode;
+  private final boolean crudMode;
 
   public TektonServer() {
     this(true, false);
@@ -51,6 +48,7 @@ public class TektonServer extends ExternalResource {
     this.crudMode = crudMode;
   }
 
+  @Override
   public void before() {
     mock = crudMode
       ? new TektonMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
@@ -59,6 +57,7 @@ public class TektonServer extends ExternalResource {
     client = mock.createTekton();
   }
 
+  @Override
   public void after() {
     mock.destroy();
     client.close();
@@ -68,7 +67,6 @@ public class TektonServer extends ExternalResource {
   public TektonClient getTektonClient() {
     return client;
   }
-
 
   public MockServerExpectation expect() {
     return mock.expect();
@@ -82,9 +80,5 @@ public class TektonServer extends ExternalResource {
   @Deprecated
   public void expectAndReturnAsString(String path, int code, String body) {
     expect().withPath(path).andReturn(code, body).always();
-  }
-
-  public MockWebServer getMockServer() {
-    return mock.getServer();
   }
 }

--- a/extensions/verticalpodautoscaler/mock/src/main/java/io/fabric8/verticalpodautoscaler/server/mock/VerticalPodAutoscalerMockServerExtension.java
+++ b/extensions/verticalpodautoscaler/mock/src/main/java/io/fabric8/verticalpodautoscaler/server/mock/VerticalPodAutoscalerMockServerExtension.java
@@ -18,17 +18,20 @@
 package io.fabric8.verticalpodautoscaler.server.mock;
 
 
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.verticalpodautoscaler.client.VerticalPodAutoscalerClient;
 import io.fabric8.verticalpodautoscaler.client.NamespacedVerticalPodAutoscalerClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -58,8 +61,9 @@ public class VerticalPodAutoscalerMockServerExtension extends KubernetesMockServ
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableVerticalPodAutoscalerMockClient a = testClass.getAnnotation(EnableVerticalPodAutoscalerMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     verticalPodAutoscalerMockServer = a.crud()
-      ? new VerticalPodAutoscalerMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new VerticalPodAutoscalerMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new VerticalPodAutoscalerMockServer(a.https());
     verticalPodAutoscalerMockServer.init();
     verticalPodAutoscalerClient = verticalPodAutoscalerMockServer.createVerticalPodAutoscaler();

--- a/extensions/verticalpodautoscaler/mock/src/main/java/io/fabric8/verticalpodautoscaler/server/mock/VerticalPodAutoscalerServer.java
+++ b/extensions/verticalpodautoscaler/mock/src/main/java/io/fabric8/verticalpodautoscaler/server/mock/VerticalPodAutoscalerServer.java
@@ -15,14 +15,18 @@
  */
 package io.fabric8.verticalpodautoscaler.server.mock;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.verticalpodautoscaler.client.VerticalPodAutoscalerClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class VerticalPodAutoscalerServer extends ExternalResource {
 
@@ -50,8 +54,9 @@ public class VerticalPodAutoscalerServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new VerticalPodAutoscalerMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new VerticalPodAutoscalerMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new VerticalPodAutoscalerMockServer(https);
     mock.init();
     client = mock.createVerticalPodAutoscaler();

--- a/extensions/volumesnapshot/mock/src/main/java/io/fabric8/volumesnapshot/server/mock/VolumeSnapshotMockServerExtension.java
+++ b/extensions/volumesnapshot/mock/src/main/java/io/fabric8/volumesnapshot/server/mock/VolumeSnapshotMockServerExtension.java
@@ -17,17 +17,20 @@
 package io.fabric8.volumesnapshot.server.mock;
 
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.volumesnapshot.client.NamespacedVolumeSnapshotClient;
 import io.fabric8.volumesnapshot.client.VolumeSnapshotClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -57,8 +60,9 @@ public class VolumeSnapshotMockServerExtension extends KubernetesMockServerExten
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableVolumeSnapshotMockClient a = testClass.getAnnotation(EnableVolumeSnapshotMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     volumeSnapshotMockServer= a.crud()
-      ? new VolumeSnapshotMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new VolumeSnapshotMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new VolumeSnapshotMockServer(a.https());
     volumeSnapshotMockServer.init();
     volumeSnapshotClient = volumeSnapshotMockServer.createVolumeSnapshot();

--- a/extensions/volumesnapshot/mock/src/main/java/io/fabric8/volumesnapshot/server/mock/VolumeSnapshotServer.java
+++ b/extensions/volumesnapshot/mock/src/main/java/io/fabric8/volumesnapshot/server/mock/VolumeSnapshotServer.java
@@ -15,14 +15,18 @@
  */
 package io.fabric8.volumesnapshot.server.mock;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.volumesnapshot.client.VolumeSnapshotClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class VolumeSnapshotServer extends ExternalResource {
 
@@ -47,8 +51,9 @@ public class VolumeSnapshotServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new VolumeSnapshotMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true)
+      ? new VolumeSnapshotMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), true)
       : new VolumeSnapshotMockServer(https);
     mock.init();
     client = mock.createVolumeSnapshot();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/server/mock/KubernetesMockServer.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/server/mock/KubernetesMockServer.java
@@ -20,8 +20,8 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
-import io.fabric8.mockwebserver.ContextBuilder;
 import io.fabric8.mockwebserver.DefaultMockServer;
 import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
@@ -38,15 +38,14 @@ import static okhttp3.TlsVersion.TLS_1_2;
 // The class has moved under mvn:io.fabric8:kubernetes-server-mock in package: io.fabric8.client.server.mock
 public class KubernetesMockServer extends DefaultMockServer {
 
-    private static final Context context = new ContextBuilder()
-            .build();
+    private static final Context context = new Context(Serialization.jsonMapper());
 
     public KubernetesMockServer() {
         this(true);
     }
 
     public KubernetesMockServer(boolean useHttps) {
-        this(new MockWebServer(), new HashMap(), useHttps);
+        this(new MockWebServer(), new HashMap<>(), useHttps);
     }
 
     public KubernetesMockServer(MockWebServer server, Map<ServerRequest, Queue<ServerResponse>> responses, boolean useHttps) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/server/mock/KubernetesServer.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/server/mock/KubernetesServer.java
@@ -17,7 +17,6 @@ package io.fabric8.kubernetes.server.mock;
 
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
-import okhttp3.mockwebserver.MockWebServer;
 import org.junit.rules.ExternalResource;
 
 @Deprecated
@@ -25,7 +24,7 @@ import org.junit.rules.ExternalResource;
 public class KubernetesServer extends ExternalResource {
   private KubernetesMockServer mock;
   private NamespacedKubernetesClient client;
-  private boolean https;
+  private final boolean https;
 
   public KubernetesServer() {
     this(true);
@@ -69,9 +68,5 @@ public class KubernetesServer extends ExternalResource {
   @Deprecated
   public void expectAndReturnAsString(String method, String path, int code, String body) {
     expect().withPath(path).andReturn(code, body).always();
-  }
-
-  public MockWebServer getMockServer() {
-    return mock.getServer();
   }
 }

--- a/kubernetes-server-mock/pom.xml
+++ b/kubernetes-server-mock/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/CustomResourceDefinitionProcessor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/CustomResourceDefinitionProcessor.java
@@ -30,7 +30,7 @@ public class CustomResourceDefinitionProcessor {
   private static final String V1BETA1_PATH = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions";
   private static final String V1_PATH = "/apis/apiextensions.k8s.io/v1/customresourcedefinitions";
 
-  private KubernetesAttributesExtractor extractor;
+  private final KubernetesAttributesExtractor extractor;
 
   public CustomResourceDefinitionProcessor(KubernetesAttributesExtractor extractor) {
     this.extractor = extractor;

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -44,7 +44,7 @@ import static io.fabric8.mockwebserver.crud.AttributeType.EXISTS;
 import static io.fabric8.mockwebserver.crud.AttributeType.NOT_EXISTS;
 import static io.fabric8.mockwebserver.crud.AttributeType.WITHOUT;
 
-public class KubernetesAttributesExtractor implements AttributeExtractor<HasMetadata> {
+public class KubernetesAttributesExtractor implements AttributeExtractor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesAttributesExtractor.class);
 
@@ -88,7 +88,7 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
   private static final String SCHEME = "http";
   private static final String HOST = "localhost";
 
-  private Map<List<String>, CustomResourceDefinitionContext> crdContexts;
+  private final Map<List<String>, CustomResourceDefinitionContext> crdContexts;
 
   public KubernetesAttributesExtractor() {
     this(Collections.emptyList());
@@ -160,12 +160,6 @@ public class KubernetesAttributesExtractor implements AttributeExtractor<HasMeta
     return new AttributeSet();
   }
 
-  @Override
-  public AttributeSet extract(String s) {
-    return fromPath(s);
-  }
-
-  @Override
   public AttributeSet extract(HasMetadata hasMetadata) {
     AttributeSet metadataAttributes = new AttributeSet();
     String apiVersion = hasMetadata.getApiVersion();

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.server.mock;
 
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.HttpMethod;
@@ -24,6 +25,8 @@ import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 
@@ -42,9 +45,14 @@ public class KubernetesMixedDispatcher extends Dispatcher {
   private final KubernetesCrudDispatcher kubernetesCrudDispatcher;
 
   public KubernetesMixedDispatcher(Map<ServerRequest, Queue<ServerResponse>> responses) {
+    this(responses, Collections.emptyList());
+  }
+
+  public KubernetesMixedDispatcher(
+    Map<ServerRequest, Queue<ServerResponse>> responses, List<CustomResourceDefinitionContext> crdContexts) {
     this.responses = responses;
     mockDispatcher = new MockDispatcher(responses);
-    kubernetesCrudDispatcher = new KubernetesCrudDispatcher();
+    kubernetesCrudDispatcher = new KubernetesCrudDispatcher(crdContexts);
   }
 
   @Override

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcher.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
+import io.fabric8.mockwebserver.dsl.HttpMethod;
+import io.fabric8.mockwebserver.internal.MockDispatcher;
+import io.fabric8.mockwebserver.internal.SimpleRequest;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.util.Map;
+import java.util.Queue;
+
+/**
+ * A composite dispatcher consistent of a {@link MockDispatcher} and a {@link KubernetesCrudDispatcher}.
+ *
+ * <p> Any request matching a pre-recorded response for the MockDispatcher is handled by the MockDispatcher.
+ * The rest of requests are forwarded to the KubernetesCrudDispatcher.
+ *
+ * <p> This dispatcher is useful to use the KubernetesMockServer in a mixed CRUD mode.
+ */
+public class KubernetesMixedDispatcher extends Dispatcher {
+
+  private final Map<ServerRequest, Queue<ServerResponse>> responses;
+  private final MockDispatcher mockDispatcher;
+  private final KubernetesCrudDispatcher kubernetesCrudDispatcher;
+
+  public KubernetesMixedDispatcher(Map<ServerRequest, Queue<ServerResponse>> responses) {
+    this.responses = responses;
+    mockDispatcher = new MockDispatcher(responses);
+    kubernetesCrudDispatcher = new KubernetesCrudDispatcher();
+  }
+
+  @Override
+  public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+    final Queue<ServerResponse> responseQueue = responses.get(
+      new SimpleRequest(HttpMethod.valueOf(request.getMethod()), request.getPath()));
+    if (responseQueue != null && !responseQueue.isEmpty()) {
+      return mockDispatcher.dispatch(request);
+    }
+    return kubernetesCrudDispatcher.dispatch(request);
+  }
+}

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -18,13 +18,16 @@ package io.fabric8.kubernetes.client.server.mock;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -85,8 +88,9 @@ public class KubernetesMockServerExtension implements AfterEachCallback, AfterAl
 
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableKubernetesMockClient a = testClass.getAnnotation(EnableKubernetesMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = a.crud()
-      ? new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new KubernetesMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new KubernetesMockServer(a.https());
     mock.init();
     client = mock.createClient();

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
@@ -18,6 +18,8 @@ package io.fabric8.kubernetes.client.server.mock;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -27,6 +29,8 @@ import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 
 public class KubernetesServer extends ExternalResource {
 
@@ -67,8 +71,9 @@ public class KubernetesServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(crdContextList), https)
+      ? new KubernetesMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses, crdContextList), https)
       : new KubernetesMockServer(https);
     mock.init(address, port);
     client = mock.createClient();

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
@@ -32,14 +32,14 @@ public class KubernetesServer extends ExternalResource {
 
   private KubernetesMockServer mock;
   private NamespacedKubernetesClient client;
-  private boolean https;
+  private final boolean https;
   // In this mode the mock web server will store, read, update and delete
   // kubernetes resources using an in memory map and will appear as a real api
   // server.
-  private boolean crudMode;
+  private final boolean crudMode;
   private final InetAddress address;
-  private int port;
-  private List<CustomResourceDefinitionContext> crdContextList;
+  private final int port;
+  private final List<CustomResourceDefinitionContext> crdContextList;
 
   public KubernetesServer() {
     this(true);
@@ -65,6 +65,7 @@ public class KubernetesServer extends ExternalResource {
     this.crdContextList = crdContextList;
   }
 
+  @Override
   public void before() {
     mock = crudMode
       ? new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(crdContextList), https)
@@ -73,6 +74,7 @@ public class KubernetesServer extends ExternalResource {
     client = mock.createClient();
   }
 
+  @Override
   public void after() {
     mock.destroy();
     client.close();
@@ -103,16 +105,7 @@ public class KubernetesServer extends ExternalResource {
     expect().withPath(path).andReturn(code, body).always();
   }
 
-  public MockWebServer getMockServer() {
-    return mock.getServer();
-  }
-
   public RecordedRequest getLastRequest() throws InterruptedException {
-    int count = mock.getServer().getRequestCount();
-    RecordedRequest request = null;
-    while (count-- > 0) {
-      request = mock.getServer().takeRequest();
-    }
-    return request;
+    return mock.getLastRequest();
   }
 }

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcherTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMixedDispatcherTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
+import io.fabric8.mockwebserver.dsl.HttpMethod;
+import io.fabric8.mockwebserver.internal.SimpleRequest;
+import io.fabric8.mockwebserver.internal.SimpleResponse;
+import okhttp3.Headers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KubernetesMixedDispatcherTest {
+
+  private static final Headers EMPTY_HEADERS = new Headers.Builder().build();
+
+  private Map<ServerRequest, Queue<ServerResponse>> responses;
+  private KubernetesMixedDispatcher dispatcher;
+
+  private Socket socket;
+
+  @BeforeEach
+  void setUp() {
+    responses = new HashMap<>();
+    dispatcher = new KubernetesMixedDispatcher(responses);
+    socket = Mockito.mock(Socket.class, Mockito.RETURNS_DEEP_STUBS);
+  }
+
+  @Test
+  @DisplayName("dispatch, with matching expectation, returns expectation")
+  void dispatchWithMatchingExpectation() throws Exception {
+    // Given
+    responses.compute(new SimpleRequest(HttpMethod.GET, "/api/v1/resources/my-resource"), (k, v) -> new ArrayDeque<>())
+      .add(new SimpleResponse(true, 200, "resourceBody", null));
+    // When
+    final MockResponse result = dispatcher.dispatch(new RecordedRequest(
+      "GET /api/v1/resources/my-resource HTTP/1.1", EMPTY_HEADERS, Collections.emptyList(),
+      0, new Buffer(), 0, socket));
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("status", "HTTP/1.1 200 OK")
+      .extracting(MockResponse::getBody).extracting(Buffer::readUtf8)
+      .isEqualTo("resourceBody");
+  }
+
+  @Test
+  @DisplayName("dispatch, with existing CRUD resource, returns CRUD resource")
+  void dispatchWithCrudExistentResource() throws Exception {
+    // Given
+    final Buffer requestBody = new Buffer();
+    requestBody.writeString("{\"kind\": \"Resource\", \"apiVersion\": \"v1\",\"metadata\": {\"name\": \"my-resource\"}}", StandardCharsets.UTF_8);
+    requestBody.flush();
+    dispatcher.dispatch(new RecordedRequest(
+        "POST /api/v1/resources HTTP/1.1", EMPTY_HEADERS, Collections.emptyList(),
+        requestBody.size(), requestBody, 0, socket));
+    // When
+    final MockResponse result = dispatcher.dispatch(new RecordedRequest(
+      "GET /api/v1/resources/my-resource HTTP/1.1", EMPTY_HEADERS, Collections.emptyList(),
+      0, new Buffer(), 0, socket));
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("status", "HTTP/1.1 200 OK")
+      .extracting(MockResponse::getBody).extracting(Buffer::readUtf8)
+      .extracting(Serialization::unmarshal)
+      .isInstanceOf(GenericKubernetesResource.class)
+      .hasFieldOrPropertyWithValue("metadata.name", "my-resource");
+  }
+}

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionStaticTests.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionStaticTests.java
@@ -21,15 +21,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @EnableKubernetesMockClient(crud = true)
-public class KubernetesMockServerExtensionStaticTests {
+class KubernetesMockServerExtensionStaticTests {
 
-	static KubernetesClient client;
+  static KubernetesClient client;
 
-	@Test
-	void testExample() {
-		Assertions.assertNotNull(client);
+  @Test
+  void testExample() {
+    Assertions.assertNotNull(client);
     Assertions.assertNull(client.getConfiguration().getOauthToken());
     Assertions.assertNull(client.getConfiguration().getCurrentContext());
     Assertions.assertTrue(client.getConfiguration().getContexts().isEmpty());
-	}
+  }
 }

--- a/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/MasterProtocolTest.java
+++ b/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/MasterProtocolTest.java
@@ -22,20 +22,19 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
 import java.util.Locale;
 
 import static okhttp3.TlsVersion.TLS_1_2;
 
-public class MasterProtocolTest {
+class MasterProtocolTest {
 
     @Test
-    public void testWithSSL() throws IOException {
+    void testWithSSL() {
         KubernetesMockServer sslServer = new KubernetesMockServer();
         sslServer.init();
 
         String host = sslServer.getHostName();
-        Integer port = sslServer.getPort();
+        int port = sslServer.getPort();
         Config config = new ConfigBuilder()
                 .withMasterUrl(host + ":" +port)
                 .withTlsVersions(TLS_1_2)
@@ -47,11 +46,11 @@ public class MasterProtocolTest {
     }
 
     @Test
-    public void testWithoutSSL() throws IOException {
+    void testWithoutSSL() {
         KubernetesMockServer plainServer = new KubernetesMockServer(false);
         plainServer.init();
         String host = plainServer.getHostName();
-        Integer port = plainServer.getPort();
+        int port = plainServer.getPort();
         Config config = new ConfigBuilder()
                 .withMasterUrl(host + ":" +port)
                 .build();

--- a/kubernetes-tests/pom.xml
+++ b/kubernetes-tests/pom.xml
@@ -120,8 +120,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>
             <KUBERNETES_MASTER />

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MixedCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MixedCrudTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.VersionInfo;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MixedCrudTest {
+
+  private KubernetesMockServer server;
+  private KubernetesClient client;
+
+  @BeforeAll
+  static void beforeAll() {
+  }
+
+  @BeforeEach
+  void setUp() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
+    server = new KubernetesMockServer(new Context(Serialization.jsonMapper()),
+      new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), false);
+    client = server.createClient();
+  }
+
+  @AfterEach
+  void tearDown() {
+    client.close();
+    server.destroy();
+  }
+
+  @Test
+  @DisplayName("client.getKubernetesVersion, with no expectations, should throw Exception")
+  void versionWithNoExpectationsShouldFail() {
+    // When
+    final RuntimeException exception = assertThrows(RuntimeException.class, client::getKubernetesVersion);
+    // Then
+    assertThat(exception).isNotNull().isInstanceOf(KubernetesClientException.class);
+  }
+
+  @Test
+  @DisplayName("client.getKubernetesVersion, with expectation for version, should return version")
+  void versionWithExpectationsShouldReturnVersion() {
+    // Given
+    server.expect().get().withPath("/version")
+      .andReturn(200, "{\"major\": \"13\", \"minor\": \"37\"}").always();
+    // When
+    final VersionInfo result = client.getKubernetesVersion();
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("major", "13")
+      .hasFieldOrPropertyWithValue("minor", "37");
+  }
+
+  @Test
+  @DisplayName("CRUD get, with no expectations, should return managed resource")
+  void crudGetWithNoExpectations() {
+    // Given
+    client.pods().inNamespace("ns")
+      .create(new PodBuilder().editOrNewMetadata().withName("my-pod").addToAnnotations("my", "pod").endMetadata().build());
+    // When
+    final Pod result = client.pods().inNamespace("ns").withName("my-pod").get();
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("metadata.annotations.my", "pod")
+      .hasFieldOrPropertyWithValue("metadata.generation", 1L);
+  }
+
+  @Test
+  @DisplayName("CRUD get, with expectations, should return expectation")
+  void crudGetWithExpectations() {
+    // Given
+    client.pods().inNamespace("ns")
+      .create(new PodBuilder().editOrNewMetadata().withName("my-pod").addToAnnotations("my", "pod").endMetadata().build());
+    server.expect().get().withPath("/api/v1/namespaces/ns/pods/my-pod")
+      .andReturn(200, "{\"metadata\": {\"name\": \"override\"}}").always();
+    // When
+    final Pod result = client.pods().inNamespace("ns").withName("my-pod").get();
+    // Then
+    assertThat(result)
+      .hasFieldOrPropertyWithValue("metadata.name", "override")
+      .hasFieldOrPropertyWithValue("metadata.generation", null);
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -29,13 +30,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @EnableKubernetesMockClient
-public class VersionInfoTest {
+class VersionInfoTest {
 
   KubernetesMockServer server;
   KubernetesClient client;
 
+  @BeforeEach
+  void setUp() {
+    server.clearExpectations();
+  }
+
   @Test
-  public void testClusterVersioning() throws ParseException {
+  void testClusterVersioning() throws ParseException {
     server.expect().withPath("/version").andReturn(200, "{" +
       "    \"buildDate\": \"2018-03-01T14:27:17Z\"," +
       "    \"gitCommit\": \"e6301f88a8\"," +
@@ -54,7 +60,7 @@ public class VersionInfoTest {
   }
 
   @Test
-  public void testClusterVersioningWithMissingBuildDate() {
+  void testClusterVersioningWithMissingBuildDate() {
     server.expect().withPath("/version").andReturn(200, "{" +
       "    \"gitCommit\": \"e6301f88a8\"," +
       "    \"gitVersion\": \"v1.6.1+5115d708d7\"," +

--- a/kubernetes-tests/src/test/java/io/fabric8/servicecatalog/client/mock/ServiceCatalogCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/servicecatalog/client/mock/ServiceCatalogCrudTest.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.servicecatalog.client.mock;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
@@ -28,6 +28,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.*;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Queue;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -45,11 +46,12 @@ class ServiceCatalogCrudTest {
   public ServiceCatalogClient client = null;
   @BeforeEach
   void setUp(){
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     server =  new ServiceCatalogMockServer(
       new Context(),
       new MockWebServer(),
-      new HashMap<ServerRequest, Queue<ServerResponse>>(),
-      new KubernetesCrudDispatcher(),
+      responses,
+      new KubernetesMixedDispatcher(responses),
       true
     );
     client = server.createServiceCatalog();

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -167,8 +167,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>
             <KUBERNETES_MASTER />

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
@@ -58,8 +58,4 @@ public class OpenShiftServer extends ExternalResource {
   public void expectAndReturnAsString(String path, int code, String body) {
     expect().withPath(path).andReturn(code, body).always();
   }
-
-  public MockWebServer getMockServer() {
-    return mock.getServer();
-  }
 }

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
@@ -15,17 +15,20 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
@@ -55,8 +58,9 @@ public class OpenShiftMockServerExtension extends KubernetesMockServerExtension 
   @Override
   protected void initializeKubernetesClientAndMockServer(Class<?> testClass) {
     EnableOpenShiftMockClient a = testClass.getAnnotation(EnableOpenShiftMockClient.class);
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     openShiftMockServer = a.crud()
-      ? new OpenShiftMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(Collections.emptyList()), a.https())
+      ? new OpenShiftMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), a.https())
       : new OpenShiftMockServer(a.https());
     openShiftMockServer.init();
     openShiftClient = openShiftMockServer.createOpenShiftClient();

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
@@ -16,8 +16,10 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMixedDispatcher;
 import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.dsl.MockServerExpectation;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import okhttp3.mockwebserver.MockWebServer;
@@ -25,6 +27,8 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 public class OpenShiftServer extends ExternalResource {
 
@@ -52,8 +56,9 @@ public class OpenShiftServer extends ExternalResource {
 
   @Override
   public void before() {
+    final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = crudMode
-      ? new OpenShiftMockServer(new Context(), new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), https)
+      ? new OpenShiftMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses), https)
       : new OpenShiftMockServer(https);
     mock.init();
     client = mock.createOpenShiftClient();

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <okio.version>1.15.0</okio.version>
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
     <jackson.version>2.13.0</jackson.version>
-    <mockwebserver.version>0.1.8</mockwebserver.version>
+    <mockwebserver.version>0.2.2</mockwebserver.version>
 
     <!-- API versions -->
     <jsr305.version>3.0.2</jsr305.version>


### PR DESCRIPTION
## Description

- deps: bump mockwebserver
- Removed usage of deprecated methods
- Introduced KubernetesMixedDispatcher, allows using CRUD mode and expectation mode simultaneously
- Replaced usaged of KubernetesCrudDispatcher with KubernetesMixedDispatcher
- Added default expectation for `/version` (fix #3536)

The new KubernetesMixedDispatcher allows the user to create expectations on top of the default CRUD KubernetesMockServer behavior. This way non-resource endpoints (such as /version), can be mocked while the rest of the CRUD features are preserved (/cc @metacosm) 

~~With the current approach, a user still needs to create a manual expectation for the version endpoint:~~
```java
    server.expect().get().withPath("/version")
      .andReturn(200, "{\"major\": \"13\", \"minor\": \"37\"}").always();
```
~~This can be further improved if we add a hardcoded expectation here:~~
https://github.com/fabric8io/kubernetes-client/blob/ace88b1bb01ca3b443698a9f378d90e8fd6dd179/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java#L65
~~But I'm not sure if that would bother the rest of users.~~

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
