### PR TITLE
fix #3561: ensuring closure of okhttp resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 5.10-SNAPSHOT
 
 #### Bugs
+* Fix #3408: quote pod upload file paths to support special chars
+* Fix #3561: ensure okhttp resources are closed
 
 #### Improvements
 
@@ -21,7 +23,6 @@
 * Fix #3353: addressing extra quoting in quantity serialization
 * Fix #3509: notify reader when something is written in ExecWebSocketListener
 * Fix #3501: addressed NPE with default BuildConfig operations
-* Fix #3408: quote pod upload file paths to support special chars
 
 #### Improvements
 * Fix #3448 added methods for getting specific version information - `KubernetesClient.getKubernetesVersion`, `OpenShiftClient.getOpenShiftV3Version`, and `OpenShiftClient.getOpenShiftV3Version`

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -592,6 +592,9 @@ public class OperationSupport {
         if (numRetries < requestRetryBackoffLimit && response.code() >= 500) {
           retryInterval = retryIntervalCalculator.getInterval(numRetries);
           LOG.debug("HTTP operation on url: {} should be retried as the response code was {}, retrying after {} millis", request.url(), response.code(), retryInterval);
+          if (response.body() != null) {
+            response.body().close();
+          }
         } else {
           return response;
         }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/SSLUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/SSLUtils.java
@@ -61,7 +61,6 @@ public final class SSLUtils {
                 .withRequestTimeout(1000)
                 .withConnectionTimeout(1000)
                 .build();
-
         OkHttpClient client = HttpClientUtils.createHttpClient(config);
         try {
             Request request = new Request.Builder().get().url(sslConfig.getMasterUrl())
@@ -73,9 +72,7 @@ public final class SSLUtils {
         } catch (Throwable t) {
             LOG.warn("SSL handshake failed. Falling back to insecure connection.");
         } finally {
-            if (client != null && client.connectionPool() != null) {
-                client.connectionPool().evictAll();
-            }
+          HttpClientUtils.close(client);
         }
         return false;
     }
@@ -100,12 +97,15 @@ public final class SSLUtils {
         if (isTrustCerts) {
             return new TrustManager[]{
                 new X509TrustManager() {
+                    @Override
                     public void checkClientTrusted(X509Certificate[] chain, String s) {
                     }
 
+                    @Override
                     public void checkServerTrusted(X509Certificate[] chain, String s) {
                     }
 
+                    @Override
                     public X509Certificate[] getAcceptedIssuers() {
                         return new X509Certificate[0];
                     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
@@ -355,8 +355,12 @@ public class OpenIDConnectionUtils {
 
   private static String getOIDCProviderTokenEndpointAndRefreshToken(String issuer, String clientId, String refreshToken, String clientSecret, String accessToken, String idpCert) {
     OkHttpClient okHttpClient = getOkHttpClient(getSSLContext(idpCert), idpCert);
-    Map<String, Object> wellKnownOpenIdConfiguration = getOIDCDiscoveryDocumentAsMap(okHttpClient, issuer);
-    return getOIDCProviderTokenEndpointAndRefreshToken(okHttpClient, wellKnownOpenIdConfiguration, clientId, refreshToken, clientSecret, accessToken, true);
+    try {
+      Map<String, Object> wellKnownOpenIdConfiguration = getOIDCDiscoveryDocumentAsMap(okHttpClient, issuer);
+      return getOIDCProviderTokenEndpointAndRefreshToken(okHttpClient, wellKnownOpenIdConfiguration, clientId, refreshToken, clientSecret, accessToken, true);
+    } finally {
+      HttpClientUtils.close(okHttpClient);
+    }
   }
 
   private static boolean persistKubeConfigWithUpdatedToken(Map<String, Object> updatedAuthProviderConfig) throws IOException {


### PR DESCRIPTION
## Description
Addresses #3561 and other okhttp usage that is not closed.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
