### PR TITLE
UnmatchedFieldTypeModule to deal with mismatched target types for fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Improvements
 * Fix #3562: Kubernetes Mock Server improvements
+* Fix #3574: support for deserialization of properties that don't match the target field's type
 
 #### Dependency Upgrade
 * Fix #3562: Bump MockWebServer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@
 * Fix #3430: Support Vertical Pod Autoscaler
 
 #### _**Note**_: Breaking changes in the API
-
+##### Tools Changes:
+- Serialization: Those KubernetesResources that include entries in the additionalProperties Map that override a field
+  of the resource instance, will no longer be duplicated. The values present in the additionalProperties Map take
+  precedence.
 
 ### 5.9.0 (2021-10-14)
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -60,14 +60,47 @@ public class Serialization {
 
   private static final String DOCUMENT_DELIMITER = "---";
 
+  /**
+   * {@link ObjectMapper} singleton instance used internally by the Kubernetes client.
+   *
+   * <p> The ObjectMapper has an {@link UnmatchedFieldTypeModule} module registered. This module allows the client
+   * to work with Resources that contain properties that don't match the target field type. This is especially useful
+   * and necessary to work with OpenShift Templates.
+   *
+   * <p> n.b. the use of this module gives precedence to properties present in the additionalProperties Map present
+   * in most KubernetesResource instances. If a property is both defined in the Map and in the original field, the
+   * one from the additionalProperties Map will be serialized.
+   */
   public static ObjectMapper jsonMapper() {
     return JSON_MAPPER;
   }
 
+  /**
+   * {@link ObjectMapper} singleton instance used internally by the Kubernetes client.
+   *
+   * <p> The ObjectMapper has an {@link UnmatchedFieldTypeModule} module registered. This module allows the client
+   * to work with Resources that contain properties that don't match the target field type. This is especially useful
+   * and necessary to work with OpenShift Templates.
+   *
+   * <p> n.b. the use of this module gives precedence to properties present in the additionalProperties Map present
+   * in most KubernetesResource instances. If a property is both defined in the Map and in the original field, the
+   * one from the additionalProperties Map will be serialized.
+   */
   public static ObjectMapper yamlMapper() {
     return YAML_MAPPER;
   }
 
+  /**
+   * Returns a JSON representation of the given object.
+   *
+   * <p> If the provided object contains a JsonAnyGetter annotated method with a Map that contains an entry that
+   * overrides a field of the provided object, the Map entry will take precedence upon serialization. Properties won't
+   * be duplicated.
+   *
+   * @param object the object to serialize.
+   * @param <T> the type of the object being serialized.
+   * @return a String containing a JSON representation of the provided object.
+   */
   public static <T> String asJson(T object) {
     try {
       return JSON_MAPPER.writeValueAsString(object);
@@ -76,6 +109,17 @@ public class Serialization {
     }
   }
 
+  /**
+   * Returns a YAML representation of the given object.
+   *
+   * <p> If the provided object contains a JsonAnyGetter annotated method with a Map that contains an entry that
+   * overrides a field of the provided object, the Map entry will take precedence upon serialization. Properties won't
+   * be duplicated.
+   *
+   * @param object the object to serialize.
+   * @param <T> the type of the object being serialized.
+   * @return a String containing a JSON representation of the provided object.
+   */
   public static <T> String asYaml(T object) {
     try {
       return YAML_MAPPER.writeValueAsString(object);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -44,16 +44,18 @@ import org.yaml.snakeyaml.Yaml;
 public class Serialization {
   private Serialization() { }
 
+  public static final UnmatchedFieldTypeModule UNMATCHED_FIELD_TYPE_MODULE = new UnmatchedFieldTypeModule();
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   static {
-    JSON_MAPPER.registerModules(new JavaTimeModule(), new UnmatchedFieldTypeModule());
+    JSON_MAPPER.registerModules(new JavaTimeModule(), UNMATCHED_FIELD_TYPE_MODULE);
   }
 
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
     new YAMLFactory().disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID)
   );
   static {
-    YAML_MAPPER.registerModules(new UnmatchedFieldTypeModule());
+    YAML_MAPPER.registerModules(UNMATCHED_FIELD_TYPE_MODULE);
   }
 
   private static final String DOCUMENT_DELIMITER = "---";

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.client.utils.serialization.UnmatchedFieldTypeModule;
 import org.yaml.snakeyaml.Yaml;
 
 public class Serialization {
@@ -44,12 +46,15 @@ public class Serialization {
 
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   static {
-    JSON_MAPPER.registerModule(new JavaTimeModule());
+    JSON_MAPPER.registerModules(new JavaTimeModule(), new UnmatchedFieldTypeModule());
   }
 
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
     new YAMLFactory().disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID)
   );
+  static {
+    YAML_MAPPER.registerModules(new UnmatchedFieldTypeModule());
+  }
 
   private static final String DOCUMENT_DELIMITER = "---";
 
@@ -144,7 +149,7 @@ public class Serialization {
       throw KubernetesClientException.launderThrowable(e);
     }
   }
-  
+
   /**
    * Unmarshals a {@link String}
    * @param str   The {@link String}.
@@ -326,7 +331,7 @@ public class Serialization {
     }
     return JSON_MAPPER.readerFor(KubernetesResource.class).readValue(jsonString);
   }
-  
+
   /**
    * Create a copy of the resource via serialization.
    * @return a deep clone of the resource

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/BeanPropertyWriterDelegate.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/BeanPropertyWriterDelegate.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Variant of {@link BeanPropertyWriter} which prevents property values present in the {@link AnnotatedMember} anyGetter
+ * to be serialized twice.
+ *
+ * <p> Any property that's present in the anyGetter is ignored upon serialization. The values present in the anyGetter
+ * take precedence over those stored in the Bean's fields.
+ *
+ * <p> This BeanPropertyWriter implementation is intended to be used in combination with
+ * the {@link SettableBeanPropertyDelegate} to allow the propagation of deserialized properties that don't match the
+ * target field types.
+ */
+public class BeanPropertyWriterDelegate extends BeanPropertyWriter {
+
+  private final BeanPropertyWriter delegate;
+  private final AnnotatedMember anyGetter;
+
+  BeanPropertyWriterDelegate(BeanPropertyWriter delegate, AnnotatedMember anyGetter) {
+    super(delegate);
+    this.delegate = delegate;
+    this.anyGetter = anyGetter;
+  }
+
+  @Override
+  public void serializeAsField(Object bean, JsonGenerator gen, SerializerProvider prov) throws Exception {
+    if (shouldSerializeProperty(bean)) {
+      delegate.serializeAsField(bean, gen, prov);
+    }
+  }
+
+  private boolean shouldSerializeProperty(Object bean) {
+    return !Optional.ofNullable(anyGetter)
+      .map(ag -> ag.getValue(bean))
+      .map(Map.class::cast)
+      .map(m -> m.get(delegate.getName()))
+      .isPresent();
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegate.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegate.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.deser.NullValueProvider;
+import com.fasterxml.jackson.databind.deser.SettableAnyProperty;
+import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+
+/**
+ * This concrete sub-class encapsulates a {@link SettableBeanProperty} delegate that is always tried first.
+ *
+ * <p> A fall-back mechanism is implemented in the deserializeAndSet methods to allow field values that don't match the
+ * target type to be preserved in the anySetter method if exists.
+ */
+public class SettableBeanPropertyDelegate extends SettableBeanProperty {
+
+  private final SettableBeanProperty delegate;
+  private final SettableAnyProperty anySetter;
+
+  SettableBeanPropertyDelegate(SettableBeanProperty delegate, SettableAnyProperty anySetter) {
+    super(delegate);
+    this.delegate = delegate;
+    this.anySetter = anySetter;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SettableBeanProperty withValueDeserializer(JsonDeserializer<?> deser) {
+    return new SettableBeanPropertyDelegate(delegate.withValueDeserializer(deser), anySetter);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SettableBeanProperty withName(PropertyName newName) {
+    return new SettableBeanPropertyDelegate(delegate.withName(newName), anySetter);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SettableBeanProperty withNullProvider(NullValueProvider nva) {
+    return new SettableBeanPropertyDelegate(delegate.withNullProvider(nva), anySetter);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public AnnotatedMember getMember() {
+    return delegate.getMember();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <A extends Annotation> A getAnnotation(Class<A> acls) {
+    return delegate.getAnnotation(acls);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void fixAccess(DeserializationConfig config) {
+    delegate.fixAccess(config);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void markAsIgnorable() {
+    delegate.markAsIgnorable();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isIgnorable() {
+    return delegate.isIgnorable();
+  }
+
+  /**
+   * Method called to deserialize appropriate value, given parser (and context), and set it using appropriate mechanism.
+   *
+   * <p> Deserialization is first tried through the delegate. In case a {@link MismatchedInputException} is caught,
+   * the field is stored in the bean's {@link SettableAnyProperty} anySetter field if it exists.
+   *
+   * <p> This allows deserialization processes propagate values that initially don't match the target bean type for the
+   * applicable field.
+   *
+   * <p> An example use-case is the use of placeholders (e.g. {@code ${aValue}}) in a field.
+   */
+  @Override
+  public void deserializeAndSet(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
+    try {
+      delegate.deserializeAndSet(p, ctxt, instance);
+    } catch (MismatchedInputException ex) {
+      if (anySetter != null) {
+        anySetter.set(instance, delegate.getName(), p.getText());
+      } else {
+        throw ex;
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Object deserializeSetAndReturn(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
+    try {
+      return delegate.deserializeSetAndReturn(p, ctxt, instance);
+    } catch (MismatchedInputException ex) {
+      deserializeAndSet(p, ctxt, instance);
+    }
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void set(Object instance, Object value) throws IOException {
+    delegate.set(instance, value);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Object setAndReturn(Object instance, Object value) throws IOException {
+    return delegate.setAndReturn(instance, value);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModule.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModule.java
@@ -38,19 +38,21 @@ import java.util.stream.Collectors;
 public class UnmatchedFieldTypeModule extends SimpleModule {
 
   private boolean logWarnings;
+  private boolean restrictToTemplates;
 
   public UnmatchedFieldTypeModule() {
-    this(true);
+    this(true, true);
   }
 
-  public UnmatchedFieldTypeModule(boolean logWarnings) {
+  public UnmatchedFieldTypeModule(boolean logWarnings, boolean restrictToTemplates) {
     this.logWarnings = logWarnings;
+    this.restrictToTemplates = restrictToTemplates;
     setDeserializerModifier(new BeanDeserializerModifier() {
 
       @Override
       public BeanDeserializerBuilder updateBuilder(DeserializationConfig config, BeanDescription beanDesc, BeanDeserializerBuilder builder) {
         builder.getProperties().forEachRemaining(p ->
-          builder.addOrReplaceProperty(new SettableBeanPropertyDelegate(p, builder.getAnySetter()) {
+          builder.addOrReplaceProperty(new SettableBeanPropertyDelegate(p, builder.getAnySetter(), UnmatchedFieldTypeModule.this::isRestrictToTemplates) {
           }, true));
         return builder;
       }
@@ -77,5 +79,18 @@ public class UnmatchedFieldTypeModule extends SimpleModule {
    */
   public void setLogWarnings(boolean logWarnings) {
     this.logWarnings = logWarnings;
+  }
+
+  boolean isRestrictToTemplates() {
+    return restrictToTemplates;
+  }
+
+  /**
+   * Sets if the DeserializerModifier should only be applied to Templates or object trees contained in Templates.
+   *
+   * @param restrictToTemplates if true, the DeserializerModifier will only be applicable for Templates.
+   */
+  public void setRestrictToTemplates(boolean restrictToTemplates) {
+    this.restrictToTemplates = restrictToTemplates;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModule.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModule.java
@@ -37,7 +37,14 @@ import java.util.stream.Collectors;
  */
 public class UnmatchedFieldTypeModule extends SimpleModule {
 
+  private boolean logWarnings;
+
   public UnmatchedFieldTypeModule() {
+    this(true);
+  }
+
+  public UnmatchedFieldTypeModule(boolean logWarnings) {
+    this.logWarnings = logWarnings;
     setDeserializerModifier(new BeanDeserializerModifier() {
 
       @Override
@@ -52,9 +59,23 @@ public class UnmatchedFieldTypeModule extends SimpleModule {
       @Override
       public BeanSerializerBuilder updateBuilder(SerializationConfig config, BeanDescription beanDesc, BeanSerializerBuilder builder) {
         builder.setProperties(builder.getProperties().stream().map(p ->
-          new BeanPropertyWriterDelegate(p, builder.getBeanDescription().findAnyGetter())).collect(Collectors.toList()));
+          new BeanPropertyWriterDelegate(p, builder.getBeanDescription().findAnyGetter(), UnmatchedFieldTypeModule.this::isLogWarnings))
+          .collect(Collectors.toList()));
         return builder;
       }
     });
+  }
+
+  boolean isLogWarnings() {
+    return logWarnings;
+  }
+
+  /**
+   * Set if warnings should be logged for ambiguous serializer and deserializer situations.
+   *
+   * @param logWarnings if true, warnings will be logged.
+   */
+  public void setLogWarnings(boolean logWarnings) {
+    this.logWarnings = logWarnings;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModule.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModule.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils.serialization;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerBuilder;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+
+import java.util.stream.Collectors;
+
+/**
+ * Class that registers the capability of deserializing and serializing objects with properties that don't match the
+ * target's bean field types.
+ *
+ * <pre>{@code
+ * ObjectMapper mapper = new ObjectMapper();
+ * mapper.registerModule(new UnmatchedFieldTypeModule());
+ * }</pre>
+ */
+public class UnmatchedFieldTypeModule extends SimpleModule {
+
+  public UnmatchedFieldTypeModule() {
+    setDeserializerModifier(new BeanDeserializerModifier() {
+
+      @Override
+      public BeanDeserializerBuilder updateBuilder(DeserializationConfig config, BeanDescription beanDesc, BeanDeserializerBuilder builder) {
+        builder.getProperties().forEachRemaining(p ->
+          builder.addOrReplaceProperty(new SettableBeanPropertyDelegate(p, builder.getAnySetter()) {
+          }, true));
+        return builder;
+      }
+    });
+    setSerializerModifier(new BeanSerializerModifier() {
+      @Override
+      public BeanSerializerBuilder updateBuilder(SerializationConfig config, BeanDescription beanDesc, BeanSerializerBuilder builder) {
+        builder.setProperties(builder.getProperties().stream().map(p ->
+          new BeanPropertyWriterDelegate(p, builder.getBeanDescription().findAnyGetter())).collect(Collectors.toList()));
+        return builder;
+      }
+    });
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegateTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegateTest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.deser.SettableAnyProperty;
+import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SettableBeanPropertyDelegateTest {
+
+  private SettableBeanProperty delegateMock;
+  private SettableAnyProperty anySetterMock;
+  private SettableBeanPropertyDelegate settableBeanPropertyDelegate;
+
+  @BeforeEach
+  void setUp() {
+    delegateMock = mock(SettableBeanProperty.class, RETURNS_DEEP_STUBS);
+    anySetterMock = mock(SettableAnyProperty.class);
+    settableBeanPropertyDelegate = new SettableBeanPropertyDelegate(delegateMock, anySetterMock);
+  }
+
+  @Test
+  @DisplayName("withValueDeserializer, should return a new instance")
+  void withValueDeserializer() {
+    // Given
+    doReturn(delegateMock).when(delegateMock).withValueDeserializer(any());
+    // When
+    final SettableBeanProperty result = settableBeanPropertyDelegate.withValueDeserializer(null);
+    // Then
+    assertThat(result)
+      .isInstanceOf(SettableBeanPropertyDelegate.class)
+      .isNotSameAs(settableBeanPropertyDelegate)
+      .hasFieldOrPropertyWithValue("anySetter", anySetterMock)
+      .hasFieldOrPropertyWithValue("delegate", delegateMock);
+  }
+
+  @Test
+  @DisplayName("withName, should return a new instance")
+  void withName() {
+    // Given
+    doReturn(delegateMock).when(delegateMock).withName(any());
+    // When
+    final SettableBeanProperty result = settableBeanPropertyDelegate.withName(null);
+    // Then
+    assertThat(result)
+      .isInstanceOf(SettableBeanPropertyDelegate.class)
+      .isNotSameAs(settableBeanPropertyDelegate)
+      .hasFieldOrPropertyWithValue("anySetter", anySetterMock)
+      .hasFieldOrPropertyWithValue("delegate", delegateMock);
+  }
+
+  @Test
+  @DisplayName("withNullProvider, should return a new instance")
+  void withNullProvider() {
+    // Given
+    doReturn(delegateMock).when(delegateMock).withNullProvider(any());
+    // When
+    final SettableBeanProperty result = settableBeanPropertyDelegate.withNullProvider(null);
+    // Then
+    assertThat(result)
+      .isInstanceOf(SettableBeanPropertyDelegate.class)
+      .isNotSameAs(settableBeanPropertyDelegate)
+      .hasFieldOrPropertyWithValue("anySetter", anySetterMock)
+      .hasFieldOrPropertyWithValue("delegate", delegateMock);
+  }
+
+  @Test
+  @DisplayName("getMember, should return delegate's Member")
+  void getMember() {
+    // Given
+    when(delegateMock.getMember().getName()).thenReturn("the-member");
+    // When
+    final String result = settableBeanPropertyDelegate.getMember().getName();
+    // Then
+    assertThat(result).isEqualTo("the-member");
+  }
+
+  @Test
+  @DisplayName("getAnnotation, should return delegate's Annotation")
+  void getAnnotation() {
+    // When
+    settableBeanPropertyDelegate.getAnnotation(null);
+    // Then
+    verify(delegateMock, times(1)).getAnnotation(null);
+  }
+
+  @Test
+  @DisplayName("fixAccess, should invoke fixAccess in delegate")
+  void fixAccess() {
+    // When
+    settableBeanPropertyDelegate.fixAccess(null);
+    // Then
+    verify(delegateMock, times(1)).fixAccess(null);
+  }
+
+  @Test
+  @DisplayName("markAsIgnorable, should invoke markAsIgnorable in delegate")
+  void markAsIgnorable() {
+    // When
+    settableBeanPropertyDelegate.markAsIgnorable();
+    // Then
+    verify(delegateMock, times(1)).markAsIgnorable();
+  }
+
+  @Test
+  @DisplayName("isIgnorable, should return isIgnorable result in delegate")
+  void isIgnorable() {
+    // Given
+    when(delegateMock.isIgnorable()).thenReturn(true);
+    // When
+    final boolean result = settableBeanPropertyDelegate.isIgnorable();
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("set, should set in delegate")
+  void set() throws IOException {
+    // Given
+    final Object o1 = new Object();
+    final Object o2 = new Object();
+    // When
+    settableBeanPropertyDelegate.set(o1, o2);
+    // Then
+    verify(delegateMock, times(1)).set(o1, o2);
+  }
+
+  @Test
+  @DisplayName("setAndReturn, should setAndReturn in delegate")
+  void setAndReturn() throws IOException {
+    // Given
+    final Object o1 = new Object();
+    final Object o2 = new Object();
+    // When
+    settableBeanPropertyDelegate.setAndReturn(o1, o2);
+    // Then
+    verify(delegateMock, times(1)).setAndReturn(o1, o2);
+  }
+
+  @Test
+  @DisplayName("deserializeSetAndReturn, should deserializeSetAndReturn in delegate")
+  void deserializeSetAndReturn() throws IOException {
+    // Given
+    final Object instance = new Object();
+    when(delegateMock.deserializeSetAndReturn(any(), any(), eq(instance))).thenReturn("the-set-value");
+    // When
+    final Object result = settableBeanPropertyDelegate.deserializeSetAndReturn(null, null, instance);
+    // Then
+    assertThat(result).isEqualTo("the-set-value");
+  }
+
+  @Test
+  @DisplayName("deserializeSetAndReturn, throws Exception, should try anySetter or rethrow")
+  void deserializeSetAndReturnWithException() throws IOException {
+    // Given
+    final Object instance = new Object();
+    when(delegateMock.getName()).thenReturn("the-property");
+    when(delegateMock.deserializeSetAndReturn(any(), any(), eq(instance)))
+      .thenThrow(MismatchedInputException.from(null, Integer.class, "The Mocked Exception"));
+    doThrow(MismatchedInputException.from(null, Integer.class, "The Mocked Exception"))
+      .when(delegateMock).deserializeAndSet(any(), any(), eq(instance));
+    // When
+    final Object result = settableBeanPropertyDelegate.deserializeSetAndReturn(mock(JsonParser.class), null, instance);
+    // Then
+    assertThat(result).isNull();
+    verify(anySetterMock, times(1)).set(eq(instance), eq("the-property"), any());
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegateTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegateTest.java
@@ -46,7 +46,7 @@ class SettableBeanPropertyDelegateTest {
   void setUp() {
     delegateMock = mock(SettableBeanProperty.class, RETURNS_DEEP_STUBS);
     anySetterMock = mock(SettableAnyProperty.class);
-    settableBeanPropertyDelegate = new SettableBeanPropertyDelegate(delegateMock, anySetterMock);
+    settableBeanPropertyDelegate = new SettableBeanPropertyDelegate(delegateMock, anySetterMock, () -> false);
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModuleTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModuleTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils.serialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UnmatchedFieldTypeModuleTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new UnmatchedFieldTypeModule());
+  }
+
+  @Test
+  @DisplayName("readValue, with unknown fields, values are set in additionalProperties map")
+  void readValueWithUnknownFields() throws JsonProcessingException {
+    // Given
+    final String json =
+      "{\"kind\": \"ConfigMap\"," +
+        "\"apiVersion\": \"v1\"," +
+        "\"metadata\":{\"name\":\"the-name\"}," +
+        "\"data\":{\"key\":\"value\"}," +
+        "\"unknownField\":\"unknownValue\"}";
+    // When
+    final KubernetesResource result = objectMapper.readValue(json, KubernetesResource.class);
+    // Then
+    assertThat(result)
+      .isInstanceOf(ConfigMap.class)
+      .hasFieldOrPropertyWithValue("metadata.name", "the-name")
+      .hasFieldOrPropertyWithValue("data.key", "value")
+      .hasFieldOrPropertyWithValue("additionalProperties.unknownField", "unknownValue");
+  }
+
+  @Test
+  @DisplayName("readValue, with unmatched type fields, values are set in additionalProperties map")
+  void readValueWithUnmatchedTypeFields() throws JsonProcessingException {
+    // Given
+    final String json =
+      "{\"kind\": \"ConfigMap\"," +
+        "\"apiVersion\": \"v1\"," +
+        "\"metadata\":{\"name\":\"the-name\"}," +
+        "\"data\":{\"key\":\"value\"}," +
+        "\"unknownField\":\"unknownValue\"," +
+        "\"immutable\":\"${immutable}\"}";
+    // When
+    final KubernetesResource result = objectMapper.readValue(json, KubernetesResource.class);
+    // Then
+    assertThat(result)
+      .isInstanceOf(ConfigMap.class)
+      .hasFieldOrPropertyWithValue("metadata.name", "the-name")
+      .hasFieldOrPropertyWithValue("immutable", null)
+      .hasFieldOrPropertyWithValue("additionalProperties.unknownField", "unknownValue")
+      .hasFieldOrPropertyWithValue("additionalProperties.immutable", "${immutable}");
+  }
+
+  @Test
+  @DisplayName("readValue, with unmatched type nested fields, values are set in additionalProperties map")
+  void readValueWithUnmatchedTypeNestedFields() throws JsonProcessingException {
+    // Given
+    final String json =
+      "{\"kind\": \"Deployment\"," +
+        "\"apiVersion\": \"apps/v1\"," +
+        "\"metadata\":{\"name\":\"deployment\", \"annotations\": \"${annotations}\"}," +
+        "\"spec\":{\"replicas\":\"${replicas}\",\"paused\":true}," +
+        "\"unknownField\":\"unknownValue\"}";
+    // When
+    final KubernetesResource result = objectMapper.readValue(json, KubernetesResource.class);
+    // Then
+    assertThat(result)
+      .isInstanceOf(Deployment.class)
+      .hasFieldOrPropertyWithValue("metadata.name", "deployment")
+      .hasFieldOrPropertyWithValue("metadata.annotations", null)
+      .hasFieldOrPropertyWithValue("metadata.additionalProperties.annotations", "${annotations}")
+      .hasFieldOrPropertyWithValue("spec.paused", true)
+      .hasFieldOrPropertyWithValue("spec.replicas", null)
+      .hasFieldOrPropertyWithValue("spec.additionalProperties.replicas", "${replicas}")
+      .hasFieldOrPropertyWithValue("additionalProperties.unknownField", "unknownValue");
+  }
+
+  @Test
+  @DisplayName("readValue, with no anySetter, should throw Exception")
+  void readValueWithNoAnySetterShouldThrowException()  {
+    // Given
+    final String json = "{\"value\": false}";
+    // When
+    final MismatchedInputException result = assertThrows(MismatchedInputException.class, () ->
+      objectMapper.readValue(json, Example.class));
+    // Then
+    assertThat(result).hasMessageStartingWith("Cannot deserialize value of type `int` from Boolean value");
+  }
+
+  @Test
+  @DisplayName("writeValueAsString, with unmatched type fields, values are set in additionalProperties map")
+  void marshalWithAdditionalPropertiesOverridingFields() throws JsonProcessingException {
+    // Given
+    final ConfigMap configMap = new ConfigMapBuilder()
+      .withNewMetadata().withName("name").addToAnnotations("key", "ignored").addToLabels("lKey", "value").endMetadata()
+      .withImmutable(true)
+      .build();
+    configMap.getAdditionalProperties().put("unknownField", "unknownValue");
+    configMap.getAdditionalProperties().put("immutable", "${immutable}");
+    configMap.getMetadata().getAdditionalProperties().put("annotations", "${annotations}");
+    // When
+    final String result = objectMapper.writeValueAsString(configMap);
+    // Then
+    assertThat(result).isEqualTo("{" +
+      "\"apiVersion\":\"v1\"," +
+      "\"kind\":\"ConfigMap\"," +
+      "\"metadata\":{\"labels\":{\"lKey\":\"value\"},\"name\":\"name\",\"annotations\":\"${annotations}\"}," +
+      "\"immutable\":\"${immutable}\"," +
+      "\"unknownField\":\"unknownValue\"" +
+      "}");
+  }
+
+  private static class Example {
+    public int value;
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -16,7 +16,6 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
-import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
@@ -27,7 +26,6 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.utils.IOHelpers;
-import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.ParameterBuilder;
 import io.fabric8.openshift.api.model.Template;
 import io.fabric8.openshift.api.model.TemplateBuilder;
@@ -199,9 +197,9 @@ class TemplateTest {
     assertThat(template)
       .extracting(Template::getObjects).asList()
       .singleElement()
-      .isInstanceOf(GenericKubernetesResource.class)
-      .extracting("additionalProperties.spec.ports").asList().singleElement()
-      .hasFieldOrPropertyWithValue("port", "${PORT}");
+      .isInstanceOf(Service.class)
+      .extracting("spec.ports").asList().singleElement()
+      .hasFieldOrPropertyWithValue("additionalProperties.port", "${PORT}");
   }
 
   protected void assertListIsServiceWithPort8080(KubernetesList list) {

--- a/kubernetes-tests/src/test/resources/template-with-multiple-objects.yml
+++ b/kubernetes-tests/src/test/resources/template-with-multiple-objects.yml
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: foo
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: bar
+  spec:
+    ports:
+    - port: ${PORT}
+    selector:
+      cheese: edam
+    type: ExternalName
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: baz
+  spec:
+    ports:
+    - port: ${BAZ_PORT}
+    selector:
+      cheese: edam
+    type: ExternalName
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: qux
+  immutable: ${IMMUTABLE}


### PR DESCRIPTION
## Description

This is a partial implementation of what's described in https://github.com/fabric8io/kubernetes-client/issues/3460#issuecomment-925729235

The new behavior is as follows (edited after https://github.com/fabric8io/kubernetes-client/pull/3574#issuecomment-963379719):
1. A resource is deserialized into a KubernetesResource instance.
2. The resource can contain unknown fields and/or fields with mismatched types (e.g. DesploymentSpec#replicas with a String instead of an Integer)
3. Properties matching any of the categories mentioned in the previous step can stored in the `additionalProperties` Map (if present)
  a. By default, this unmatched types deserialization is enabled only for Templates
  b. Behavior can be enabled for all types by `Serialization.UNMATCHED_FIELD_TYPE_MODULE.setRestrictToTemplates(false);`
4. The resource is deserialized as a valid KubernetesResource instance (if applicable), no need to fallback into a GenericKubernetesResource
5. The object instance can now be processed as usual.
6. The object instance is serialized into a YAML/JSON representation
7. The object fields are persisted **unless** a property matching the field name is defined in the `additionalProperties` Map. In that case the field value is **ignored**.
  a. A warning will be logged if the situation is detected, indicating that a field is being ignored.
  b. Log can be opted-out by: `Serialization.UNMATCHED_FIELD_TYPE_MODULE.setLogWarnings(false);` 
8. **All** properties defined in the `additionalProperties` Map are serialized.

All of this logic is implemented in the  `UnmatchedFieldTypeModule` Jackson module that sets a serializer and a deserializer modifier. The second commit enables this module by default.

The only drawback when enabling the module is that Exceptions when deserializing input resources that have properties that don't match the target field type  won't be thrown. Any user relying on this to validate an Input will lose this functionality (I'm not sure if this is an extended approach).

I would like to know if we should preserve the second commit (where the module is automatically enabled), or revert it and just provide the module as an opt-in feature. (@shawkins, @metacosm, @rohanKanojia, @oscerd, @iocanel) 

The second commit also reverts the fallback implemented in #3526 which should no longer be necessary.

### Relates to:
- #448 
- #959
- #1979
- https://github.com/eclipse/jkube/issues/778

## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
