### PR TITLE
Fix Issue #3535: Not identifying ECDSA client key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #3538: Update Plural rule to work with Prometheus
 * Fix #3555: using the new builder for generic resources
+* Fix #3535: ensure clientKeyAlgo is set properly when loading config YAML from `fromKubeconfig`
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -617,6 +617,7 @@ public class Config {
           config.setClientCertData(currentAuthInfo.getClientCertificateData());
           config.setClientKeyFile(clientKeyFile);
           config.setClientKeyData(currentAuthInfo.getClientKeyData());
+          config.setClientKeyAlgo(getKeyAlgorithm(config.getClientKeyFile(), config.getClientKeyData()));
           config.setOauthToken(currentAuthInfo.getToken());
           config.setUsername(currentAuthInfo.getUsername());
           config.setPassword(currentAuthInfo.getPassword());

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -55,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ConfigTest {
 
   private static final String TEST_KUBECONFIG_FILE = Utils.filePath(ConfigTest.class.getResource("/test-kubeconfig"));
+  private static final String TEST_EC_KUBECONFIG_FILE = Utils.filePath(ConfigTest.class.getResource("/test-ec-kubeconfig"));
   private static final String TEST_NAMESPACE_FILE = Utils.filePath(ConfigTest.class.getResource("/test-namespace"));
 
   private static final String TEST_CONFIG_YML_FILE = Utils.filePath(ConfigTest.class.getResource("/test-config.yml"));
@@ -330,6 +331,14 @@ public class ConfigTest {
     final String configYAML = String.join("\n", Files.readAllLines(configFile.toPath()));
     final Config config = Config.fromKubeconfig(configYAML);
     assertEquals("https://172.28.128.4:8443", config.getMasterUrl());
+  }
+
+  @Test
+  void testFromKubeconfigKeyAlgo() throws IOException {
+    File configFile = new File(TEST_EC_KUBECONFIG_FILE);
+    final String configYAML = String.join("\n", Files.readAllLines(configFile.toPath()));
+    final Config config = Config.fromKubeconfig(configYAML);
+    assertEquals("EC", config.getClientKeyAlgo());
   }
 
   @Test

--- a/kubernetes-client/src/test/resources/test-ec-kubeconfig
+++ b/kubernetes-client/src/test/resources/test-ec-kubeconfig
@@ -1,0 +1,39 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: testns/ca.pem
+    server: https://172.28.128.4:8443
+  name: 172-28-128-4:8443
+contexts:
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: default
+    user: user/172-28-128-4:8443
+  name: default/172-28-128-4:8443/user
+current-context: default/172-28-128-4:8443/user
+kind: Config
+preferences: {}
+users:
+- name: user/172-28-128-4:8443
+  user:
+    client-certificate-data: -----BEGIN CERTIFICATE-----
+                        MIICUDCCATigAwIBAgIRAP5Y0VEn43LepIIhGBgZCm4wDQYJKoZIhvcNAQELBQAw
+                        FTETMBEGA1UEAxMKbWluaWt1YmVDQTAeFw0yMTExMDEwOTIyMThaFw0yMjExMDEw
+                        OTIyMThaMCUxEzARBgNVBAoTCmRldmVsb3BlcnMxDjAMBgNVBAMTBXV6YWlyMFkw
+                        EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkAMD3WlBNsN0tiNCZSC8gK/5O4rxmkgj
+                        953kvWgv11/AorgxDFZpr2+azYJAN6ZNt8hXoBlsrBtDDzKnfPJszqNWMFQwDgYD
+                        VR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAw
+                        HwYDVR0jBBgwFoAU4qycWT5q7c/4OgWIHdKILxBhjS8wDQYJKoZIhvcNAQELBQAD
+                        ggEBANTomS4AL4z0cxd0KZQhts2ADlbgJQUmI7TU8+I70qoQhdvFC3xFuQM3KHVQ
+                        kt4amj+ahz74ZMGB8FH7SHvdLdb9yIsZQJttw6MVyrC3/GavRBQM3KwAB0CVMEQf
+                        RL/PYTXJSmPiicQH9BLUW9RzJwP4gnIlEj2yjLnAPyilH4LSiBvjE93nPBHdY0SF
+                        /v1/Jy3pnpcih05eHahFtMrE3FH1YaVCL2ncUGif//x9TNhR7WX2w0+X+fqY4w0Q
+                        4xmJCGW/DvYqBGqavdEYU1FMXvlhqQkRueYOGbU8P2VlhU5qd0Wdfdg8FokkdozL
+                        RUgkCbcwxOTea1Lit2iuDGzJezI=
+                        -----END CERTIFICATE-----
+
+    client-key-data: -----BEGIN EC PRIVATE KEY-----
+                MHcCAQEEIICkeBChzRrBMifb5r9rzdq4FphWRzPz1eDmRTnqBugJoAoGCCqGSM49
+                AwEHoUQDQgAEkAMD3WlBNsN0tiNCZSC8gK/5O4rxmkgj953kvWgv11/AorgxDFZp
+                r2+azYJAN6ZNt8hXoBlsrBtDDzKnfPJszg==
+                -----END EC PRIVATE KEY-----


### PR DESCRIPTION
## Description
Currently when Config object is created using `Config.fromKubeConfig` and loading from a YAML string, the keyAlgorithm doesn't get updated it defaults to RSA and hence the issue #3535 , this PR seems to fix this.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
