### PR TITLE
fix: Add KubernetesMockServer accessor to JUnit4 KubernetesServer rules

### DIFF
--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesServer.java
@@ -110,6 +110,10 @@ public class KubernetesServer extends ExternalResource {
     expect().withPath(path).andReturn(code, body).always();
   }
 
+  public KubernetesMockServer getKubernetesMockServer() {
+    return mock;
+  }
+
   public RecordedRequest getLastRequest() throws InterruptedException {
     return mock.getLastRequest();
   }

--- a/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
+++ b/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftServer.java
@@ -92,6 +92,10 @@ public class OpenShiftServer extends ExternalResource {
     expect().withPath(path).andReturn(code, body).always();
   }
 
+  public OpenShiftMockServer getOpenShiftMockServer() {
+    return mock;
+  }
+
   public RecordedRequest getLastRequest() throws InterruptedException {
     return mock.getLastRequest();
   }


### PR DESCRIPTION
## Description

fix: Add KubernetesMockServer accessor to JUnit4 KubernetesServer rules

Related to: https://github.com/quarkusio/quarkus/pull/21362

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
