### PR TITLE
Support auto generation of interfaces by providing implementations

### DIFF
--- a/generator/pkg/schemagen/generate.go
+++ b/generator/pkg/schemagen/generate.go
@@ -175,6 +175,9 @@ func (g *schemaGenerator) jsonDescriptor(t reflect.Type) *JSONDescriptor {
 		return &JSONDescriptor{Type: "boolean"}
 	case reflect.String:
 		return &JSONDescriptor{Type: "string"}
+	case reflect.Interface:
+		// When having something like: Tag interface{}, it should be mapped into "Tag Object".
+		return &JSONDescriptor{Type: "object"}
 	}
 
 	panic("Nothing for " + t.Name())
@@ -563,6 +566,11 @@ func (g *schemaGenerator) fieldCategory(field reflect.StructField) FieldType {
 	case reflect.Map:
 		return MAP
 	case reflect.Interface:
+		// Special case when "interface {}" is a Interface kind, but meant to be mapped to Objects
+		if fieldType.String() == "interface {}" {
+			return SIMPLE
+		}
+
 		return INTERFACE
 
 	default:

--- a/generator/pkg/schemagen/json.go
+++ b/generator/pkg/schemagen/json.go
@@ -57,6 +57,10 @@ type JavaTypeDescriptor struct {
 	JavaType string `json:"javaType"`
 }
 
+type JavaInterfaceDescriptor struct {
+	InterfaceType string `json:"interfaceType"`
+}
+
 type ExistingJavaTypeDescriptor struct {
 	ExistingJavaType string `json:"existingJavaType"`
 }
@@ -79,6 +83,7 @@ type JSONPropertyDescriptor struct {
 	*JavaTypeDescriptor
 	*ExistingJavaTypeDescriptor
 	*JavaInterfacesDescriptor
+	*JavaInterfaceDescriptor
 	JavaExtends *JavaExtendsDescriptor `json:"extends,omitempty"`
 }
 

--- a/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/Fabric8ObjectRule.java
+++ b/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/Fabric8ObjectRule.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.jsonschema2pojo;
+
+import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.rules.ObjectRule;
+import org.jsonschema2pojo.rules.RuleFactory;
+import org.jsonschema2pojo.util.ParcelableHelper;
+import org.jsonschema2pojo.util.ReflectionHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
+
+/**
+ * Class that extend the object rule to add support of interfaces.
+ */
+public class Fabric8ObjectRule extends ObjectRule {
+  private static final String INTERFACE_TYPE_PROPERTY = "interfaceType";
+
+  private final RuleFactory ruleFactory;
+
+  protected Fabric8ObjectRule(RuleFactory ruleFactory, ParcelableHelper parcelableHelper, ReflectionHelper reflectionHelper) {
+    super(ruleFactory, parcelableHelper, reflectionHelper);
+
+    this.ruleFactory = ruleFactory;
+  }
+
+  @Override
+  public JType apply(String nodeName, JsonNode node, JsonNode parent, JPackage _package, Schema schema) {
+    if (node.has(INTERFACE_TYPE_PROPERTY)) {
+      // interface
+      return createInterface(node, _package);
+    }
+
+    // rest of types
+    return super.apply(nodeName, node, parent, _package, schema);
+  }
+
+  private JType createInterface(JsonNode node, JPackage _package) {
+    String fqn = node.path(INTERFACE_TYPE_PROPERTY).asText();
+    int index = fqn.lastIndexOf(".") + 1;
+
+    JDefinedClass newType;
+    try {
+      newType = _package._interface(fqn.substring(index));
+    } catch (JClassAlreadyExistsException ex) {
+      return ex.getExistingClass();
+    }
+
+    this.ruleFactory.getAnnotator().typeInfo(newType, node);
+    this.ruleFactory.getAnnotator().propertyInclusion(newType, node);
+    return newType;
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/Fabric8RuleFactory.java
+++ b/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/Fabric8RuleFactory.java
@@ -18,8 +18,13 @@ package io.fabric8.kubernetes.jsonschema2pojo;
 import org.jsonschema2pojo.DefaultGenerationConfig;
 import org.jsonschema2pojo.Jackson2Annotator;
 import org.jsonschema2pojo.SchemaStore;
+import org.jsonschema2pojo.rules.Rule;
 import org.jsonschema2pojo.rules.RuleFactory;
 import org.jsonschema2pojo.util.NameHelper;
+import org.jsonschema2pojo.util.ParcelableHelper;
+
+import com.sun.codemodel.JPackage;
+import com.sun.codemodel.JType;
 
 public class Fabric8RuleFactory extends RuleFactory {
 
@@ -33,5 +38,10 @@ public class Fabric8RuleFactory extends RuleFactory {
   @Override
   public NameHelper getNameHelper() {
     return nameHelper;
+  }
+
+  @Override
+  public Rule<JPackage, JType> getObjectRule() {
+    return new Fabric8ObjectRule(this, new ParcelableHelper(), getReflectionHelper());
   }
 }

--- a/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
+++ b/model-annotator/src/main/java/io/fabric8/kubernetes/ModelAnnotator.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,6 +44,7 @@ import java.util.Set;
 public class ModelAnnotator extends AbstractAnnotator {
 
   private static final String BUILDABLE_REFERENCE_VALUE = "value";
+  private static final String INTERFACE_TYPE_PROPERTY = "interfaceType";
 
   private final Set<String> handledClasses = new HashSet<>();
 
@@ -106,6 +108,11 @@ public class ModelAnnotator extends AbstractAnnotator {
 
     if (propertyNode.has("javaOmitEmpty") && propertyNode.get("javaOmitEmpty").asBoolean(false)) {
       field.annotate(JsonInclude.class).param("value", JsonInclude.Include.NON_EMPTY);
+    }
+
+    // Annotate JsonUnwrapped for interfaces as they cannot be created when no implementations
+    if (propertyNode.hasNonNull(INTERFACE_TYPE_PROPERTY)) {
+      field.annotate(JsonUnwrapped.class);
     }
   }
 


### PR DESCRIPTION
Given the Golang model:

Go type `Tracing_CustomTag` that uses a field `Type` which is an interface `isTracing_CustomTag_Type`:
```go
type Tracing_CustomTag struct {
	Type                 isTracing_CustomTag_Type `protobuf_oneof:"type"`
}
```

Where the interface is defined in:

```go
type isTracing_CustomTag_Type interface {
	isTracing_CustomTag_Type()
	MarshalTo([]byte) (int, error)
	Size() int
}
```

The implementations of this interface are defined in:

```go
type Tracing_CustomTag_Literal struct {
	Literal *Tracing_Literal `protobuf:"bytes,1,opt,name=literal,proto3,oneof" json:"literal,omitempty"`
}
type Tracing_CustomTag_Environment struct {
	Environment *Tracing_Environment `protobuf:"bytes,2,opt,name=environment,proto3,oneof" json:"environment,omitempty"`
}
type Tracing_CustomTag_Header struct {
	Header *Tracing_RequestHeader `protobuf:"bytes,3,opt,name=header,proto3,oneof" json:"header,omitempty"`
}
```

At the moment, the generator won't inspect all the types to find the implementations, but users would need to specify the implementations in the generator golang program like:

```go
// types for interfaces
	interfacesMapping := map[string][]reflect.Type{
		"istio.io/api/telemetry/v1alpha1/isTracing_CustomTag_Type":     {reflect.TypeOf(api_telemetry_v1alpha1.Tracing_CustomTag_Literal{}), reflect.TypeOf(api_telemetry_v1alpha1.Tracing_CustomTag_Environment{}), reflect.TypeOf(api_telemetry_v1alpha1.Tracing_CustomTag_Header{})},
	}
```

Additionally, as json2pojo does not support the generation of interfaces, we need to use an custom registry. In the pom.xml of the model:

```xml
      <plugin>
        <groupId>org.jsonschema2pojo</groupId>
        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
        <version>${jsonschema2pojo.version}</version>
        <configuration>
          <sourceDirectory>${project.basedir}/src/main/resources/schema</sourceDirectory>
          <targetPackage>io.fabric8.istio.api</targetPackage>
          <includeConstructors>true</includeConstructors>
          <includeJsr303Annotations>false</includeJsr303Annotations>
          <includeToString>false</includeToString>
          <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
          <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
          <customRuleFactory>io.fabric8.kubernetes.jsonschema2pojo.Fabric8RuleFactory</customRuleFactory><!-- HERE -->
```

Finally, to use the new API, we need to use a new method to generate the schema with all the options:

```go
json := schemagen.GenerateSchemaWithAllOptions("http://fabric8.io/istio/IstioSchema#", crdLists, typesDescriptors, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, interfacesMapping, "io.fabric8")
```

This has been tested using this branch: https://github.com/Sgitario/kubernetes-client/tree/add_istio. Concretely, in the new extension for Istio: https://github.com/Sgitario/kubernetes-client/tree/add_istio/extensions/istio
