### PR TITLE
fix #3555 using the new builder for generic resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #3538: Update Plural rule to work with Prometheus
+* Fix #3555: using the new builder for generic resources
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Handlers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Handlers.java
@@ -58,8 +58,7 @@ public final class Handlers {
   
   /**
    * Returns a {@link ResourceHandler} for the given item.  The client is optional, if it is supplied, then the server can be 
-   * consulted for resource metadata if a generic item is passed in.  The client is not needed at all for lookups related to 
-   * obtaining a builder - as there is no builder associated with generic resources. 
+   * consulted for resource metadata if a generic item is passed in. 
    */
   public static <T extends HasMetadata, V extends VisitableBuilder<T, V>> ResourceHandler<T, V> get(T meta, BaseClient client) {
     Class<T> type = (Class<T>)meta.getClass();
@@ -124,7 +123,7 @@ public final class Handlers {
     return rdc;
   }
 
-  public static <T extends HasMetadata, V extends VisitableBuilder<T, V>> ResourceHandler<T, V> get(Class<T> type) {
+  private static <T extends HasMetadata, V extends VisitableBuilder<T, V>> ResourceHandler<T, V> get(Class<T> type) {
     if (type.equals(GenericKubernetesResource.class)) {
       return null;
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandlerImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/ResourceHandlerImpl.java
@@ -50,7 +50,7 @@ class ResourceHandlerImpl<T extends HasMetadata, V extends VisitableBuilder<T, V
     this.type = type;
     this.context = context;
     this.defaultListClass = listClass;
-    this.builderClass = null;
+    this.builderClass = KubernetesResourceUtil.inferBuilderType(type);
     this.operationConstructor = null;
   }
   

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.BaseClient;
 import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.ResourceHandler;
@@ -88,7 +89,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
   }
   
   protected <V extends VisitableBuilder<T, V>> VisitableBuilder<T, V> createVisitableBuilder(T item) {
-    ResourceHandler<T, V> handler = Handlers.get(item, null);
+    ResourceHandler<T, V> handler = Handlers.get(item, new BaseClient(this.client, this.config));
     if (handler != null) {
       return handler.edit(item);
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesListOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/KubernetesListOperationsImpl.java
@@ -22,7 +22,6 @@ import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.client.BaseClient;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.ResourceHandler;
@@ -126,7 +125,7 @@ public class KubernetesListOperationsImpl
   }
 
   private Resource<HasMetadata> getResource(HasMetadata resource) {
-    ResourceHandler<HasMetadata, ?> handler = NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.handlerOf(resource, new BaseClient(this.context.getClient(), this.context.getConfig()));
+    ResourceHandler<HasMetadata, ?> handler = NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.handlerOf(resource, context);
     return handler.operation(context.getClient(), context.getConfig(), null).newInstance(context.withItem(resource));
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -84,7 +84,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
     
     return asHasMetadata(item).stream()
         .map(meta -> NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.acceptVisitors(meta,
-            Collections.emptyList(), namespaceVisitOperationContext.getExplicitNamespace()))
+            Collections.emptyList(), namespaceVisitOperationContext.getExplicitNamespace(), this.context))
         .collect(Collectors.toList());
   }
   


### PR DESCRIPTION
## Description
For #3555 this wires in the generic builder, which is used implicitly for all client.load operations and resource inNamespace.

Fix #3555

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
