### PR TITLE
Support enums in generator

### DIFF
--- a/generator/pkg/schemagen/generate.go
+++ b/generator/pkg/schemagen/generate.go
@@ -18,10 +18,22 @@ package schemagen
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"reflect"
+	"strconv"
 	"strings"
 )
+
+type EnumDescriptor struct {
+	Type   string
+	Values []EnumValueDescriptor
+}
+
+type EnumValueDescriptor struct {
+	Name  string
+	Value interface{}
+}
 
 type ProvidedType struct {
 	GoType    reflect.Type
@@ -53,6 +65,7 @@ type schemaGenerator struct {
 	constraints          map[reflect.Type]map[string]*Constraint // type -> field name -> constraint
 	interfacesMapping    map[string][]reflect.Type               // interface -> list of implementations
 	javaNameStrategy     JavaNameStrategyMapping                 // java name strategy by extension
+	enumTypes            map[reflect.Type]EnumDescriptor         // enum -> json descriptor
 	generatedTypesPrefix string
 }
 
@@ -70,10 +83,10 @@ const (
 )
 
 func GenerateSchema(schemaId string, crdLists map[reflect.Type]CrdScope, providedPackages map[string]string, manualTypeMap map[reflect.Type]string, packageMapping map[string]PackageInformation, mappingSchema map[string]string, providedTypes []ProvidedType, constraints map[reflect.Type]map[string]*Constraint, generatedTypesPrefix string) string {
-	return GenerateSchemaWithAllOptions(schemaId, crdLists, make(map[reflect.Type]*JSONObjectDescriptor), providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, make(map[string][]reflect.Type), JavaNameStrategyMapping{}, generatedTypesPrefix)
+	return GenerateSchemaWithAllOptions(schemaId, crdLists, make(map[reflect.Type]*JSONObjectDescriptor), providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, make(map[string][]reflect.Type), JavaNameStrategyMapping{}, make(map[reflect.Type]EnumDescriptor), generatedTypesPrefix)
 }
 
-func GenerateSchemaWithAllOptions(schemaId string, crdLists map[reflect.Type]CrdScope, typesDescriptors map[reflect.Type]*JSONObjectDescriptor, providedPackages map[string]string, manualTypeMap map[reflect.Type]string, packageMapping map[string]PackageInformation, mappingSchema map[string]string, providedTypes []ProvidedType, constraints map[reflect.Type]map[string]*Constraint, interfacesMapping map[string][]reflect.Type, javaNameStrategy JavaNameStrategyMapping, generatedTypesPrefix string) string {
+func GenerateSchemaWithAllOptions(schemaId string, crdLists map[reflect.Type]CrdScope, typesDescriptors map[reflect.Type]*JSONObjectDescriptor, providedPackages map[string]string, manualTypeMap map[reflect.Type]string, packageMapping map[string]PackageInformation, mappingSchema map[string]string, providedTypes []ProvidedType, constraints map[reflect.Type]map[string]*Constraint, interfacesMapping map[string][]reflect.Type, javaNameStrategy JavaNameStrategyMapping, enumTypes map[reflect.Type]EnumDescriptor, generatedTypesPrefix string) string {
 	g := &schemaGenerator{
 		crdLists:             crdLists,
 		types:                typesDescriptors,
@@ -86,6 +99,7 @@ func GenerateSchemaWithAllOptions(schemaId string, crdLists map[reflect.Type]Crd
 		generatedTypesPrefix: generatedTypesPrefix,
 		interfacesMapping:    interfacesMapping,
 		javaNameStrategy:     javaNameStrategy,
+		enumTypes:            enumTypes,
 	}
 	schema, err := g.generate(schemaId, crdLists)
 
@@ -403,6 +417,40 @@ func (g *schemaGenerator) generate(schemaId string, crdLists map[reflect.Type]Cr
 
 	}
 
+	for enumType, enumDescriptor := range g.enumTypes {
+		enumTypeName := g.qualifiedName(enumType)
+
+		enumValues := make([]interface{}, 0)
+		javaEnums := make([]JSONJavaEnumDescriptor, 0)
+
+		for _, enumValue := range enumDescriptor.Values {
+			enumValues = append(enumValues, enumValue.Value)
+			javaEnums = append(javaEnums, JSONJavaEnumDescriptor{
+				Name: enumValue.Name,
+			})
+		}
+
+		s.Definitions[enumTypeName] = JSONPropertyDescriptor{
+			JSONDescriptor: &JSONDescriptor{
+				Type:      enumDescriptor.Type,
+				Enum:      enumValues,
+				JavaEnums: javaEnums,
+			},
+			JavaTypeDescriptor: &JavaTypeDescriptor{
+				JavaType: g.resolveJavaClassUsingMappingSchema(enumType),
+			},
+		}
+
+		s.Properties[enumTypeName] = JSONPropertyDescriptor{
+			JSONReferenceDescriptor: &JSONReferenceDescriptor{
+				Reference: g.generateReference(enumType),
+			},
+			JavaTypeDescriptor: &JavaTypeDescriptor{
+				JavaType: g.resolveJavaClassUsingMappingSchema(enumType),
+			},
+		}
+	}
+
 	return &s, nil
 }
 
@@ -415,6 +463,7 @@ const (
 	INTERFACE FieldType = "I"
 	SIMPLE    FieldType = "S"
 	LIST      FieldType = "L"
+	ENUM      FieldType = "N"
 )
 
 func (g *schemaGenerator) getFields(t reflect.Type) []reflect.StructField {
@@ -477,6 +526,38 @@ func (g *schemaGenerator) getStructProperties(t reflect.Type) map[string]JSONPro
 	return result
 }
 
+func (g *schemaGenerator) getEnumDescriptor(t reflect.Type) EnumDescriptor {
+	instance := reflect.New(t).Elem()
+	enumValues := make([]EnumValueDescriptor, 0)
+
+	// Note that at the moment, this only supports "string" types, for others, it must be
+	// defined in the extensions using the "enumTypes"
+	var index int64
+	end := false
+	index = 0
+	for !end {
+		instance.SetInt(index)
+		enumJavaName := fmt.Sprintf("%v", instance.Interface())
+		if enumJavaName == strconv.FormatInt(index, 10) {
+			end = true
+		} else {
+			enumValues = append(enumValues, EnumValueDescriptor{
+				Name: enumJavaName,
+				// For "string" type, the Value is the same as the Name
+				// but for "integer" type, the Value would be the index, so we need both fields.
+				Value: enumJavaName,
+			})
+		}
+
+		index++
+	}
+
+	return EnumDescriptor{
+		Type:   "string", // TODO: To be auto discovered.
+		Values: enumValues,
+	}
+}
+
 func (g *schemaGenerator) propertyDescriptor(field reflect.StructField, parentType reflect.Type) JSONPropertyDescriptor {
 
 	// type might have manual overwrite
@@ -507,6 +588,10 @@ func (g *schemaGenerator) propertyDescriptor(field reflect.StructField, parentTy
 
 	if fieldCategory == INTERFACE {
 		return g.propertyDescriptorForInterface(field)
+	}
+
+	if fieldCategory == ENUM {
+		return g.propertyDescriptorForEnum(field)
 	}
 
 	panic("Failed to get property descriptor for field")
@@ -542,6 +627,7 @@ func (g *schemaGenerator) fieldCategory(field reflect.StructField) FieldType {
 	fieldType := g.resolvePointer(field.Type)
 
 	jsonTag := field.Tag.Get("json")
+	protobufTag := field.Tag.Get("protobuf")
 
 	jsonFieldName := g.jsonFieldName(field)
 
@@ -554,6 +640,13 @@ func (g *schemaGenerator) fieldCategory(field reflect.StructField) FieldType {
 
 	if field.Anonymous && (jsonTag == "" || strings.Contains(jsonTag, "inline") || jsonFieldName == "") {
 		return EMBEDDED
+	}
+
+	// enum examples:
+	// - Mode    PeerAuthenticationMode `protobuf:"varint,1,opt,name=mode,proto3,enum=package.to.type.PeerAuthenticationMode" json:"mode,omitempty"`
+
+	if strings.Contains(protobufTag, "enum") {
+		return ENUM
 	}
 
 	switch fieldType.Kind() {
@@ -873,6 +966,23 @@ func (g *schemaGenerator) propertyDescriptorForInterface(field reflect.StructFie
 		JSONReferenceDescriptor: g.referenceDescriptor(fieldType),
 		JavaInterfaceDescriptor: &JavaInterfaceDescriptor{
 			InterfaceType: g.javaType(fieldType),
+		},
+	}
+}
+
+func (g *schemaGenerator) propertyDescriptorForEnum(field reflect.StructField) JSONPropertyDescriptor {
+	fieldType := g.resolvePointer(field.Type)
+
+	// Check whether it was already defined
+	_, ok := g.enumTypes[fieldType]
+	if !ok {
+		g.enumTypes[fieldType] = g.getEnumDescriptor(fieldType)
+	}
+
+	return JSONPropertyDescriptor{
+		JSONReferenceDescriptor: g.referenceDescriptor(fieldType),
+		JavaTypeDescriptor: &JavaTypeDescriptor{
+			JavaType: g.resolveJavaClassUsingMappingSchema(fieldType),
 		},
 	}
 }

--- a/generator/pkg/schemagen/json.go
+++ b/generator/pkg/schemagen/json.go
@@ -25,19 +25,20 @@ type JSONSchema struct {
 }
 
 type JSONDescriptor struct {
-	Type          string        `json:"type"`
-	Description   string        `json:"description,omitempty"`
-	Default       string        `json:"default,omitempty"`
-	Required      bool          `json:"required,omitempty"`
-	Minimum       float32       `json:"minimum,omitempty"`
-	Maximum       float32       `json:"maximum,omitempty"`
-	MinItems      int           `json:"minItems,omitempty"`
-	MaxItems      int           `json:"maxItems,omitempty"`
-	MinLength     int           `json:"minLength,omitempty"`
-	MaxLength     int           `json:"maxLength,omitempty"`
-	Pattern       string        `json:"pattern,omitempty"`
-	Enum          []interface{} `json:"enum,omitempty"`
-	JavaOmitEmpty bool          `json:"javaOmitEmpty,omitempty"`
+	Type          string                   `json:"type"`
+	Description   string                   `json:"description,omitempty"`
+	Default       string                   `json:"default,omitempty"`
+	Required      bool                     `json:"required,omitempty"`
+	Minimum       float32                  `json:"minimum,omitempty"`
+	Maximum       float32                  `json:"maximum,omitempty"`
+	MinItems      int                      `json:"minItems,omitempty"`
+	MaxItems      int                      `json:"maxItems,omitempty"`
+	MinLength     int                      `json:"minLength,omitempty"`
+	MaxLength     int                      `json:"maxLength,omitempty"`
+	Pattern       string                   `json:"pattern,omitempty"`
+	JavaEnums     []JSONJavaEnumDescriptor `json:"javaEnums,omitempty"`
+	Enum          []interface{}            `json:"enum,omitempty"`
+	JavaOmitEmpty bool                     `json:"javaOmitEmpty,omitempty"`
 }
 
 type JSONObjectDescriptor struct {
@@ -89,4 +90,8 @@ type JSONPropertyDescriptor struct {
 
 type JSONMapDescriptor struct {
 	MapValueType JSONPropertyDescriptor `json:"additionalProperties"`
+}
+
+type JSONJavaEnumDescriptor struct {
+	Name string `json:"name"`
 }


### PR DESCRIPTION
Given the Golang model:

Golang type `PeerAuthentication_MutualTLS` that uses a const:
```go
type PeerAuthentication_MutualTLS_Mode int32

type PeerAuthentication_MutualTLS struct {
	// Defines the mTLS mode used for peer authentication.
	Mode                 PeerAuthentication_MutualTLS_Mode `protobuf:"varint,1,opt,name=mode,proto3,enum=istio.security.v1beta1.PeerAuthentication_MutualTLS_Mode" json:"mode,omitempty"`
}
```

Where the const is:

```go
type PeerAuthentication_MutualTLS_Mode int32

const (
	// Inherit from parent, if has one. Otherwise treated as PERMISSIVE.
	PeerAuthentication_MutualTLS_UNSET PeerAuthentication_MutualTLS_Mode = 0
	// Connection is not tunneled.
	PeerAuthentication_MutualTLS_DISABLE PeerAuthentication_MutualTLS_Mode = 1
	// Connection can be either plaintext or mTLS tunnel.
	PeerAuthentication_MutualTLS_PERMISSIVE PeerAuthentication_MutualTLS_Mode = 2
	// Connection is an mTLS tunnel (TLS with client cert must be presented).
	PeerAuthentication_MutualTLS_STRICT PeerAuthentication_MutualTLS_Mode = 3
)
```

The resulting Java model now contains an auto generated enum:

```
// ...
public class PeerAuthentication_MutualTLS implements KubernetesResource
{

    @JsonProperty("mode")
    private PeerAuthentication_MutualTLS_Mode mode;
    // ...
}
```

```java
public enum PeerAuthentication_MutualTLS_Mode {
        // Inherit from parent, if has one. Otherwise treated as PERMISSIVE.
	UNSET("UNSET"),
	// Connection is not tunneled.
	DISABLE("DISABLE"),
	// Connection can be either plaintext or mTLS tunnel.
	PERMISSIVE("PERMISSIVE"),
	// Connection is an mTLS tunnel (TLS with client cert must be presented).
	STRICT("STRICT");
}
```

Note that all the enumerators are auto discovered when the target type is a String, which means that if we want to achieve the following enumerator:

public enum PeerAuthentication_MutualTLS_Mode {
        // Inherit from parent, if has one. Otherwise treated as PERMISSIVE.
	UNSET(1),
	// Connection is not tunneled.
	DISABLE(2),
	// Connection can be either plaintext or mTLS tunnel.
	PERMISSIVE(3),
	// Connection is an mTLS tunnel (TLS with client cert must be presented).
	STRICT(4);
}
```

Then, the extension need to provide the enum values manually:

```go
enumMapping := map[reflect.Type]schemagen.EnumDescriptor{
  reflect.TypeOf(type.MyEnum{}):schemagen.EnumDescriptor{
    Type: "integer"
    Values: []schemagen.EnumValueDescriptor{
        schemagen.EnumValueDescriptor{ Name: "STRICT", Value: 1},
        schemagen.EnumValueDescriptor{ Name: "PERMISSIVE", Value: 2},
....
    }
}
}

	json := schemagen.GenerateSchemaWithAllOptions("http://fabric8.io/istio/IstioSchema#", crdLists, typesDescriptors, providedPackages, manualTypeMap, packageMapping, mappingSchema, providedTypes, constraints, interfacesMapping, javaNameStrategyMapping, enumMapping, "io.fabric8")
```

Fix https://github.com/fabric8io/kubernetes-client/issues/3592