### PR TITLE
Fix deserialization of interfaces in the generated model

### DIFF
--- a/generator/pkg/schemagen/generate.go
+++ b/generator/pkg/schemagen/generate.go
@@ -335,26 +335,13 @@ func (g *schemaGenerator) generate(schemaId string, crdLists map[reflect.Type]Cr
 		// register interface
 		interfaceJavaClass := g.resolveFqnJavaTypeUsingMappingSchema(interfaceName)
 		interfaceKey := g.qualifiedNameForString(interfaceName)
-		s.Definitions[interfaceKey] = JSONPropertyDescriptor{
-			JSONDescriptor: &JSONDescriptor{
-				Type: "object",
-			},
-			JavaInterfaceDescriptor: &JavaInterfaceDescriptor{
-				InterfaceType: g.adaptJavaClassName(interfaceJavaClass),
-			},
-		}
-		s.Properties[interfaceKey] = JSONPropertyDescriptor{
-			JSONReferenceDescriptor: &JSONReferenceDescriptor{
-				Reference: g.generateReferenceForString(interfaceKey),
-			},
-			JavaInterfaceDescriptor: &JavaInterfaceDescriptor{
-				InterfaceType: g.adaptJavaClassName(interfaceJavaClass),
-			},
-		}
+		interfaceImplementations := make([]string, 0)
 
 		// register implementations
 		for _, implementation := range implementations {
 			implementationName := g.qualifiedName(implementation)
+			implementationJavaName := g.javaType(implementation)
+			interfaceImplementations = append(interfaceImplementations, implementationJavaName)
 
 			s.Definitions[implementationName] = JSONPropertyDescriptor{
 				JSONDescriptor: &JSONDescriptor{
@@ -364,7 +351,7 @@ func (g *schemaGenerator) generate(schemaId string, crdLists map[reflect.Type]Cr
 					Properties: g.getStructProperties(implementation),
 				},
 				JavaTypeDescriptor: &JavaTypeDescriptor{
-					JavaType: g.javaType(implementation),
+					JavaType: implementationJavaName,
 				},
 				JavaInterfacesDescriptor: &JavaInterfacesDescriptor{
 					JavaInterfaces: []string{g.adaptJavaClassName(interfaceJavaClass)},
@@ -375,9 +362,28 @@ func (g *schemaGenerator) generate(schemaId string, crdLists map[reflect.Type]Cr
 					Reference: g.generateReference(implementation),
 				},
 				JavaTypeDescriptor: &JavaTypeDescriptor{
-					JavaType: g.javaType(implementation),
+					JavaType: implementationJavaName,
 				},
 			}
+		}
+
+		// register interface
+		s.Definitions[interfaceKey] = JSONPropertyDescriptor{
+			JSONDescriptor: &JSONDescriptor{
+				Type: "object",
+			},
+			JavaInterfaceDescriptor: &JavaInterfaceDescriptor{
+				InterfaceType:   g.adaptJavaClassName(interfaceJavaClass),
+				Implementations: interfaceImplementations,
+			},
+		}
+		s.Properties[interfaceKey] = JSONPropertyDescriptor{
+			JSONReferenceDescriptor: &JSONReferenceDescriptor{
+				Reference: g.generateReferenceForString(interfaceKey),
+			},
+			JavaInterfaceDescriptor: &JavaInterfaceDescriptor{
+				InterfaceType: g.adaptJavaClassName(interfaceJavaClass),
+			},
 		}
 
 	}

--- a/generator/pkg/schemagen/json.go
+++ b/generator/pkg/schemagen/json.go
@@ -59,7 +59,8 @@ type JavaTypeDescriptor struct {
 }
 
 type JavaInterfaceDescriptor struct {
-	InterfaceType string `json:"interfaceType"`
+	InterfaceType   string   `json:"interfaceType"`
+	Implementations []string `json:"interfaceImpls,omitempty"`
 }
 
 type ExistingJavaTypeDescriptor struct {

--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/JsonUnwrappedDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/JsonUnwrappedDeserializer.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.model.jackson;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TreeTraversingParser;
+import com.fasterxml.jackson.databind.util.NameTransformer;
+
+/**
+ * Desc: this is a workaround on the problem that Jackson's @JsonUnwrapped doesn't work with
+ * polymorphism (@JsonTypeInfo)
+ * Adapted from https://stackoverflow.com/questions/37423848/deserializing-polymorphic-types-with-jsonunwrapped-using-jackson
+ */
+public class JsonUnwrappedDeserializer<T> extends JsonDeserializer<T> implements ContextualDeserializer {
+
+  private static JsonUnwrapped cancelUnwrappedAnnotation;
+
+  static {
+    try {
+      cancelUnwrappedAnnotation = CancelUnwrapped.class.getField("dummy").getAnnotation(JsonUnwrapped.class);
+    } catch (NoSuchFieldException ex) {
+      // this exception will never happen, though:
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private JsonDeserializer<T> beanDeserializer;
+  private Set<String> ownPropertyNames;
+  private String unwrappedPropertyName;
+  private NameTransformer nameTransformer;
+
+  /*
+   * Needed by Jackson
+   */
+  public JsonUnwrappedDeserializer() {
+  }
+
+  public JsonUnwrappedDeserializer(DeserializationContext deserializationContext) throws JsonMappingException {
+    JavaType type = deserializationContext.getContextualType();
+
+    BeanDescription description = deserializationContext.getConfig().introspect(type);
+
+    final JsonUnwrapped[] tempUnwrappedAnnotation = {null};
+
+    List<BeanPropertyDefinition> unwrappedProperties = description.findProperties().stream().filter(prop ->
+      Arrays.asList(prop.getConstructorParameter(), prop.getMutator(), prop.getField()).stream()
+        .filter(Objects::nonNull)
+        .anyMatch(member -> {
+          JsonUnwrapped unwrappedAnnotation = member.getAnnotation(JsonUnwrapped.class);
+          if (unwrappedAnnotation != null) {
+            tempUnwrappedAnnotation[0] = unwrappedAnnotation;
+            member.getAllAnnotations().add(cancelUnwrappedAnnotation);
+          }
+          return unwrappedAnnotation != null;
+        })).collect(Collectors.toList());
+
+    if (unwrappedProperties.isEmpty()) {
+      throw new UnsupportedOperationException("@JsonUnwrapped properties not found in " + type.getTypeName());
+    } else if (unwrappedProperties.size() > 1) {
+      throw new UnsupportedOperationException("Multiple @JsonUnwrapped properties found in " + type.getTypeName());
+    }
+
+    BeanPropertyDefinition unwrappedProperty = unwrappedProperties.get(0);
+
+    nameTransformer = NameTransformer.simpleTransformer(tempUnwrappedAnnotation[0].prefix(), tempUnwrappedAnnotation[0].suffix());
+
+    unwrappedPropertyName = unwrappedProperty.getName();
+
+    ownPropertyNames = description.findProperties().stream().map(BeanPropertyDefinition::getName).collect(Collectors.toSet());
+    ownPropertyNames.remove(unwrappedPropertyName);
+    ownPropertyNames.removeAll(description.getIgnoredPropertyNames());
+
+    JsonDeserializer<Object> rawBeanDeserializer = deserializationContext.getFactory().createBeanDeserializer(deserializationContext, type, description);
+    ((ResolvableDeserializer) rawBeanDeserializer).resolve(deserializationContext);
+    beanDeserializer = (JsonDeserializer<T>) rawBeanDeserializer;
+  }
+
+  @Override
+  public JsonDeserializer<?> createContextual(DeserializationContext deserializationContext, BeanProperty beanProperty) throws JsonMappingException {
+    return new JsonUnwrappedDeserializer<>(deserializationContext);
+  }
+
+  @Override
+  public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+    ObjectNode node = jsonParser.readValueAsTree();
+
+    ObjectNode ownNode = deserializationContext.getNodeFactory().objectNode();
+    ObjectNode unwrappedNode = deserializationContext.getNodeFactory().objectNode();
+
+    node.fields().forEachRemaining(entry -> {
+      String key = entry.getKey();
+      JsonNode value = entry.getValue();
+
+      String transformed = nameTransformer.reverse(key);
+
+      if (transformed != null && !ownPropertyNames.contains(key)) {
+        unwrappedNode.replace(transformed, value);
+      } else {
+        ownNode.replace(key, value);
+      }
+    });
+
+    ownNode.replace(unwrappedPropertyName, unwrappedNode);
+
+    try (TreeTraversingParser syntheticParser = new TreeTraversingParser(ownNode, jsonParser.getCodec())) {
+      syntheticParser.nextToken();
+      return beanDeserializer.deserialize(syntheticParser, deserializationContext);
+    }
+  }
+
+  private static class CancelUnwrapped {
+    @JsonUnwrapped(enabled = false)
+    public Object dummy;
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/UnwrappedTypeResolverBuilder.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/UnwrappedTypeResolverBuilder.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.model.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
+
+public class UnwrappedTypeResolverBuilder extends StdTypeResolverBuilder {
+  @Override
+  public TypeSerializer buildTypeSerializer(SerializationConfig config, JavaType baseType,
+    Collection<NamedType> subtypes) {
+    // To force Jackson to go through all the properties
+    return null;
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/JsonUnwrappedDeserializerTest.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/JsonUnwrappedDeserializerTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.model.jackson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+public class JsonUnwrappedDeserializerTest {
+
+  private static final String EXPECTED_VALUE_A = "Value A";
+  private static final String EXPECTED_VALUE_B = "Value B";
+  private static final String EXPECTED_VALUE_C = "Value C";
+
+  @Test
+  public void shouldDeserializeInterfacesWithJsonWrapped() throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    RootClass instance = mapper.readValue("{ \"stringField\": \"" + EXPECTED_VALUE_A + "\", "
+      + "\"extendedField\": \"" + EXPECTED_VALUE_B + "\", "
+      + "\"nestedField\": \"" + EXPECTED_VALUE_C + "\" }", RootClass.class);
+    // Verify normal fields works along to the json-wrapped fields
+    assertEquals(EXPECTED_VALUE_A, instance.stringField);
+
+    // Verify interfaces are supported at root level
+    assertNotNull(instance.rootInterface, "Interface was not deserialized!");
+    assertTrue(instance.rootInterface instanceof RootImplementation);
+    RootImplementation rootImplementation = ((RootImplementation) instance.rootInterface);
+    assertEquals(EXPECTED_VALUE_B, rootImplementation.extendedField);
+
+    // Verify nested interfaces are also supported
+    assertTrue(rootImplementation.nestedInterface instanceof NestedImplementation);
+    assertEquals(EXPECTED_VALUE_C, ((NestedImplementation) rootImplementation.nestedInterface).nestedField);
+  }
+
+  @JsonDeserialize(using = io.fabric8.kubernetes.model.jackson.JsonUnwrappedDeserializer.class)
+  public static class RootClass {
+
+    private String stringField;
+
+    @JsonUnwrapped
+    private RootInterface rootInterface;
+
+    public RootClass() {
+
+    }
+
+    public String getStringField() {
+      return stringField;
+    }
+
+    public void setStringField(String stringField) {
+      this.stringField = stringField;
+    }
+
+    public RootInterface getRootInterface() {
+      return rootInterface;
+    }
+
+    public void setRootInterface(RootInterface rootInterface) {
+      this.rootInterface = rootInterface;
+    }
+  }
+
+  @JsonSubTypes(@JsonSubTypes.Type(RootImplementation.class))
+  @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+  interface RootInterface {
+
+  }
+
+  @JsonDeserialize(using = io.fabric8.kubernetes.model.jackson.JsonUnwrappedDeserializer.class)
+  public static class RootImplementation implements RootInterface {
+
+    private String extendedField;
+    @JsonUnwrapped
+    private NestedInterface nestedInterface;
+
+    public RootImplementation() {
+
+    }
+
+    public String getExtendedField() {
+      return extendedField;
+    }
+
+    public void setExtendedField(String extendedField) {
+      this.extendedField = extendedField;
+    }
+  }
+
+  @JsonSubTypes(@JsonSubTypes.Type(NestedImplementation.class))
+  @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+  interface NestedInterface {
+
+  }
+
+  public static class NestedImplementation implements NestedInterface {
+    private String nestedField;
+
+    public NestedImplementation() {
+
+    }
+
+    public String getNestedField() {
+      return nestedField;
+    }
+
+    public void setNestedField(String nestedField) {
+      this.nestedField = nestedField;
+    }
+  }
+}


### PR DESCRIPTION
## Description
As part of https://github.com/fabric8io/kubernetes-client/pull/3594, the go generator will generate the interfaces and their implementations. Example:

Go type `Tracing_CustomTag` that uses a field `Type` which is an interface `isTracing_CustomTag_Type`:
```go
type Tracing_CustomTag struct {
	Type                 isTracing_CustomTag_Type `protobuf_oneof:"type"`
}
```

Where the interface is defined in:

```go
type isTracing_CustomTag_Type interface {
	isTracing_CustomTag_Type()
	MarshalTo([]byte) (int, error)
	Size() int
}
```

The implementations of this interface are defined in:

```go
type Tracing_CustomTag_Literal struct {
	Literal *Tracing_Literal `protobuf:"bytes,1,opt,name=literal,proto3,oneof" json:"literal,omitempty"`
}
type Tracing_CustomTag_Environment struct {
	Environment *Tracing_Environment `protobuf:"bytes,2,opt,name=environment,proto3,oneof" json:"environment,omitempty"`
}
type Tracing_CustomTag_Header struct {
	Header *Tracing_RequestHeader `protobuf:"bytes,3,opt,name=header,proto3,oneof" json:"header,omitempty"`
}
```

The go generator will handle the generation of the Java interface and their implementations. However, this PR fixes the deserialization of the fields that are interfaces. This is when using the client to load a model from the cluster and this model has an interface. 

At the moment, the field that is an interface will be deserialized to null, so we need to annotate the interface with:

```java
@JsonInclude(JsonInclude.Include.NON_NULL)
@JsonTypeResolver(io.fabric8.kubernetes.model.jackson.UnwrappedTypeResolverBuilder.class) (1)
@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION) (2)
@JsonSubTypes({
    @JsonSubTypes.Type(TracingCustomTagEnvironment.class),
    @JsonSubTypes.Type(TracingCustomTagHeaderName.class),
    // ...
})
public interface IsTracing_CustomTag_Type {
}
```

Using the DEDUCTION mode (2), the jackson deserializer will deduct what is the right implementation to pick.
The problem is that this annotation also affects the serialization, so we need the annotation in (1) to ignore these annotations when serialization.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
