### PR TITLE
Fix: Add volcano dep into root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,22 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>volcano-model-v1beta1</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>volcano-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>volcano-server-mock</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- Jackson dependencies, imported as a BOM -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
## Description
Volcano extension have been introduced In https://github.com/fabric8io/kubernetes-client/pull/3580 , but didn't add dependcy to kubernetes-client to root pom.

It's used to align the version of volcano extension dependency with that of the kubernetes client

So, we should add the Volcano dependency like other extensions:

https://github.com/fabric8io/kubernetes-client/blob/de4468047e844ab4b5879bccf7be59ee6dd7ebfe/pom.xml#L372-L432

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->

Closes: https://github.com/fabric8io/kubernetes-client/issues/3610
