### PR TITLE
WIP fix #3587: adding a construct between a Watch and an Informer

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/TargetedInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/TargetedInformer.java
@@ -1,0 +1,154 @@
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
+import io.fabric8.kubernetes.client.informers.ListerWatcher;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
+import io.fabric8.kubernetes.client.utils.Utils;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * Due to several design issues I haven't heavily refactored the informer to support this logic yet
+ * It also does not protect against exceptions when calling the actual handler
+ */
+public class TargetedInformer<T extends HasMetadata> implements Watcher<T>, Watch {
+  
+  private ListerWatcher<T, ? extends KubernetesResourceList<T>> listerWatcher;
+  private Long batchSize;
+  private ResourceEventHandler<T> handler;
+  private Function<T, String> keyFunction;
+  
+  private AtomicBoolean closed = new AtomicBoolean();
+  private volatile Watch watch;
+  private volatile ConcurrentHashMap<String, T> resources = new ConcurrentHashMap<>();
+  private UnaryOperator<T> stateFunction;
+  
+  public TargetedInformer(ListerWatcher<T, ? extends KubernetesResourceList<T>> listerWatcher, Long batchSize, Function<T, String> keyFunction, ResourceEventHandler<T> handler, UnaryOperator<T> stateFunction) {
+    this.listerWatcher = listerWatcher;
+    this.batchSize = batchSize;
+    this.handler = handler;
+    this.stateFunction = stateFunction;
+    this.keyFunction = keyFunction;
+    listAndWatch();
+  }
+
+  @Override
+  public void eventReceived(Action action, T resource) {
+    String resourceVersion = resource.getMetadata().getResourceVersion();
+    String key = keyFunction.apply(resource); 
+    switch (action) {
+    case ADDED:
+    case MODIFIED:
+      updated(resource, resourceVersion, key);
+      break;
+    case DELETED:
+      if (resources.remove(key) != null) {
+        handler.onDelete(resource, false);
+      }
+      break;
+    default:
+      break;
+    }
+  }
+
+  private void updated(T resource, String resourceVersion, String key) {
+    T previous = resources.put(key, storeResource(resource));
+    if (previous == null) {
+      handler.onAdd(resource);
+    } else if (!Objects.equals(resourceVersion, previous.getMetadata().getResourceVersion())) {
+      handler.onUpdate(resource, previous);
+    }
+  }
+  
+  public T getLastKnownState(String key) {
+    return this.resources.get(key);
+  }
+
+  // could also store as a string to save memory?
+  private T storeResource(T resource) {
+    T result = stateFunction.apply(resource);
+    if (result == null) {
+      try {
+        result = (T) resource.getClass().getDeclaredConstructor().newInstance();
+      } catch (Exception e) {
+        throw KubernetesClientException.launderThrowable(e);
+      }
+    }
+    // at least retain the uid and resourceVersion
+    KubernetesResourceUtil.setResourceVersion(result, resource.getMetadata().getResourceVersion());
+    result.getMetadata().setUid(resource.getMetadata().getUid());
+    return result;
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      watch.close();
+    }
+  }
+  
+  @Override
+  public void onClose(WatcherException cause) {
+    if (closed.get()) {
+      return;
+    }
+    if (!cause.isHttpGone()) {
+      close();
+      return;
+    }
+    listAndWatch();
+    if (closed.get()) {
+      watch.close();
+    }
+  }
+  
+  public boolean isClosed() {
+    return closed.get();
+  }
+  
+  /**
+   * Since we don't expose the resources, they are modified as needed
+   */
+  private void listAndWatch() {
+    ConcurrentHashMap<String, T> next = new ConcurrentHashMap<>();
+    String continueVal = null;
+    String resourceVersion = null;
+
+    // if there's an exception while we do this, we'll simply retry
+    // could consider increasing the batch size for the next run
+    do {
+      KubernetesResourceList<T> result = listerWatcher.list(new ListOptionsBuilder().withLimit(batchSize).withContinue(continueVal).build());
+      result.getItems().forEach(i -> {
+        String key = keyFunction.apply(i);
+        String itemResourceVersion = i.getMetadata().getResourceVersion();
+        // process the updates immediately so we don't need to hold the item
+        updated(i, itemResourceVersion, key);
+        next.put(key, storeResource(i));
+      });
+      resourceVersion = result.getMetadata().getResourceVersion();
+      continueVal = result.getMetadata().getContinue();
+    } while (Utils.isNotNullOrEmpty(continueVal));
+    
+    // process the special case deletes
+    resources.keySet().removeAll(next.keySet());
+    resources.forEach((k, v) -> this.handler.onDelete(v, true));
+    
+    resources = next; 
+    
+    watch = listerWatcher.watch(
+        new ListOptionsBuilder().withResourceVersion(resourceVersion).withAllowWatchBookmarks(true).build(), this);
+  }
+  
+  @Override
+  public boolean reconnecting() {
+    return true;
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ListerWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ListerWatcher.java
@@ -29,7 +29,7 @@ import io.fabric8.kubernetes.client.Watcher;
 public interface ListerWatcher<T, L> {
   Watch watch(ListOptions params, Watcher<T> watcher);
 
-  L list();
+  L list(ListOptions listOptions);
 
   String getNamespace();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.informers.cache;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
@@ -50,7 +51,7 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   }
 
   protected L getList() {
-    return listerWatcher.list();
+    return listerWatcher.list(new ListOptions());
   }
 
   public void stop() {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
@@ -36,7 +36,7 @@ class ReflectorTest {
   void testStateFlags() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
-    Mockito.when(mock.list()).thenReturn(list);
+    Mockito.when(mock.list(Mockito.any())).thenReturn(list);
 
     Reflector<Pod, PodList> reflector =
         new Reflector<>(Pod.class, mock, Mockito.mock(SyncableStore.class));
@@ -70,7 +70,7 @@ class ReflectorTest {
   void testNonHttpGone() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
-    Mockito.when(mock.list()).thenReturn(list);
+    Mockito.when(mock.list(Mockito.any())).thenReturn(list);
 
     Reflector<Pod, PodList> reflector =
         new Reflector<>(Pod.class, mock, Mockito.mock(SyncableStore.class));


### PR DESCRIPTION
## Description
This is a rough cut of supporting something in-between a Watch and an Informer.  For now it's easier to develop/show this independently of the informer code as to avoid larger refactorings.  This will be rebased after #3609 as there will be some shared changes.  

The result is a never ending watch that the user interacts with using a Watcher with an additional method: deletedStateUnknown(String key, String resourceVersion) that conveys that a particular resource has been deleted prior to the relist, so you don't know its full state - more on this below.

This would be constructed off the same context as Informable possibly via new interface (I haven't added that just yet).  The key function could always be the uid - note the choice of function affects what shows up in the deletedStateUnknown.

The only other new piece of information needed is a batchSize, which is used to control the pagination size of the batched list fetching.

So this could be as simple as:
```
client.pods().longWatch(100L /*batch size*/, new LongWatcher() {
  @Override
  public void deletedStateUnknown(String key, String resourceVersion) {
    // not where it needs to be yet
  }

  @Override
  public void eventReceived(Action action, HasMetadata resource) {
    // do something
  }
}); 
```

A couple of thoughts / alternatives - the handling of deletedStateUnknown could be done like a bookmark.  Then rather than passing a key function, we'd assume the use of uid and instead lookup the builder for resource to construct a new instance.  Then we'd call deletedStateUnknown(resourceWithUidAndVersion).

Building on that, I think that for delete with unknown state to be useful we need more state - for a typical dependent resource scenario that would at least be the owner references.  That could be assumed, or supported via accepting a Unary function for stripping the resource down to only what is needed in the delete case.  So you still end up with an in-memory cache, but it will be much smaller than keeping the full objects - likely just uid, resourceVersion, and ownerReferences.

So we can either keep refining this or look to merge some of this into what informers support - at the very least batching.

@attilapiros @manusa @rohanKanojia WDYT?

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
