### PR TITLE
feat: Get method for GenericKubernetesResource

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -57,6 +59,8 @@ public class GenericKubernetesResource implements HasMetadata {
   private static final Pattern ARRAY_PROPERTY_PATTERN = Pattern.compile("^(.+?)((?:\\[\\d+])+)$");
   private static final Pattern ARRAY_PATTERN = Pattern.compile("\\[(\\d+)]");
 
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
   @JsonProperty("apiVersion")
   private String apiVersion;
   @JsonProperty("kind")
@@ -78,6 +82,11 @@ public class GenericKubernetesResource implements HasMetadata {
   @JsonAnySetter
   public void setAdditionalProperty(String name, Object value) {
     this.additionalProperties.put(name, value);
+  }
+
+  @JsonIgnore
+  public JsonNode getAdditionalPropertiesNode() {
+    return MAPPER.convertValue(getAdditionalProperties(), JsonNode.class);
   }
 
   /**

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
@@ -99,6 +99,9 @@ public class GenericKubernetesResource implements HasMetadata {
    * <p> In addition, fields that contain collections/arrays can also be traversed
    * <pre>{@code resource.get("path.collectionField[1].nested.array[0].field");}</pre>
    *
+   * <p> {@code .} may be escaped with {@code \\.}
+   * Any other appearance of {@code \\} will be treated as itself.
+   *
    * @param path of the field to retrieve.
    * @param <T> type of the returned object.
    * @return the value of the traversed path or null if the field does not exist.
@@ -107,9 +110,10 @@ public class GenericKubernetesResource implements HasMetadata {
   public <T> T get(String... path) {
     Object current = null;
     int it = 0;
-    final List<String> properties = Stream.of(path).map(p -> p.split("\\.")).flatMap(Stream::of)
+    final List<String> properties = Stream.of(path).map(p -> p.split("(?<!\\\\)\\.")).flatMap(Stream::of)
       .collect(Collectors.toList());
     for (String p : properties) {
+      p = p.replace("\\.", ".");
       if (it++ == 0) {
         current = getAdditionalProperties().get(p);
       } else {

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
@@ -106,11 +106,11 @@ public class GenericKubernetesResource implements HasMetadata {
   @SuppressWarnings("unchecked")
   public <T> T get(String... path) {
     Object current = null;
-    int firstPropertyMarker = 0;
+    int it = 0;
     final List<String> properties = Stream.of(path).map(p -> p.split("\\.")).flatMap(Stream::of)
       .collect(Collectors.toList());
     for (String p : properties) {
-      if (firstPropertyMarker++ == 0) {
+      if (it++ == 0) {
         current = getAdditionalProperties().get(p);
       } else {
         final Matcher arrayMatcher = ARRAY_PROPERTY_PATTERN.matcher(p);
@@ -122,7 +122,9 @@ public class GenericKubernetesResource implements HasMetadata {
         } else if (current instanceof Map) {
           current = ((Map<String, Object>) current).get(p);
         } else {
-          throw new IllegalArgumentException("Cannot get property " + String.join(".", properties) + " from " + getApiVersion() + " " + getKind());
+          throw new IllegalArgumentException("Cannot get property '" + String.join(".", properties) +
+            "' from " + getApiVersion() + " " + getKind() +
+            " (missing segment '" + String.join(".", properties.subList(it - 1, properties.size())) + "')");
         }
       }
     }

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
@@ -202,7 +202,8 @@ class GenericKubernetesResourceTest {
       gkr.get("spec", "field.nested.not.here"));
     // Then
     assertThat(result)
-      .hasMessageContaining("Cannot get property spec.field.nested.not.here");
+      .hasMessageContaining("Cannot get property 'spec.field.nested.not.here'")
+      .hasMessageContaining("(missing segment 'not.here')");
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
@@ -291,15 +291,59 @@ class GenericKubernetesResourceTest {
   }
 
   @Test
+  @DisplayName("get, with with 2D array, should return value")
+  void getWith2DArrayInFieldFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("nested",
+        Collections.singletonMap("2dList", Arrays.asList(
+          Arrays.asList(
+            Collections.singletonMap("entry", 0),
+            Collections.singletonMap("entry", 1),
+            Collections.singletonMap("entry", 2)
+          ),
+          Collections.singletonList(Collections.singletonMap("entry", 3))
+        )))));
+    // When
+    final int result = gkr.get("spec.nested.2dList[1][0].entry");
+    // Then
+    assertThat(result).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("get, with with multidimensional array, should return value")
+  void getWithMultidimensionalArrayInFieldFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("nested",
+        Collections.singletonMap("multidimensional", Collections.singletonList(
+          Collections.singletonList(
+            Collections.singletonList(
+              Arrays.asList(
+                Collections.singletonMap("entry", 0),
+                Collections.singletonMap("entry", 1),
+                Collections.singletonMap("entry", 2)
+              )
+            )))))));
+    // When
+    final int result = gkr.get("spec.nested.multidimensional[0][0][0][2].entry");
+    // Then
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
   @DisplayName("get, with complex-structure-resource, should return queried values")
   void getWithComplexStructureShouldRetrieveQueried() throws Exception {
     // Given
-    final GenericKubernetesResource gkr = objectMapper
-      .readValue(load("complex-structure-resource.json"), GenericKubernetesResource.class);
     // When
-    final int result = gkr.get("spec.dot\\.in\\.field");
+    final GenericKubernetesResource result = objectMapper
+      .readValue(load("complex-structure-resource.json"), GenericKubernetesResource.class);
     // Then
-    assertThat(result).isEqualTo(42);
+    assertThat(result)
+      .returns(42, gkr -> gkr.get("spec.dot\\.in\\.field"))
+      .returns(3, gkr -> gkr.get("spec.nested.2dList[1][0].entry"));
   }
 
   private static InputStream load(String resource) {

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
@@ -275,6 +275,33 @@ class GenericKubernetesResourceTest {
       .hasMessageContaining("Collection");
   }
 
+  @Test
+  @DisplayName("get, with dots in field, should return value")
+  void getWithDotsInFieldFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field.with.dots",
+        Collections.singletonMap("check", "mate")
+      )));
+    // When
+    final String result = gkr.get("spec", "field\\.with\\.dots.check");
+    // Then
+    assertThat(result).isEqualTo("mate");
+  }
+
+  @Test
+  @DisplayName("get, with complex-structure-resource, should return queried values")
+  void getWithComplexStructureShouldRetrieveQueried() throws Exception {
+    // Given
+    final GenericKubernetesResource gkr = objectMapper
+      .readValue(load("complex-structure-resource.json"), GenericKubernetesResource.class);
+    // When
+    final int result = gkr.get("spec.dot\\.in\\.field");
+    // Then
+    assertThat(result).isEqualTo(42);
+  }
+
   private static InputStream load(String resource) {
     return GenericKubernetesResource.class.getResourceAsStream("/generic-kubernetes-resource/" + resource);
   }

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
@@ -22,10 +22,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GenericKubernetesResourceTest {
 
@@ -134,6 +136,142 @@ class GenericKubernetesResourceTest {
       .hasFieldOrPropertyWithValue("apiVersion", "the-cr.example.com/v1")
       .hasFieldOrPropertyWithValue("metadata.namespace", "ns1")
       .hasFieldOrPropertyWithValue("metadata.name", "foo");
+  }
+
+  @Test
+  @DisplayName("get with dot notation, with nested Maps, should return value")
+  void getDotNotationWithNestedMapsFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field", Collections.singletonMap("nested", 42))));
+    // When
+    final int result = gkr.get("spec.field.nested");
+    // Then
+    assertThat(result).isEqualTo(42);
+  }
+
+  @Test
+  @DisplayName("get with path/varargs notation, with nested Maps, should return value")
+  void getPathNotationWithNestedMapsFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field", Collections.singletonMap("nested", 42))));
+    // When
+    final int result = gkr.get("spec", "field", "nested");
+    // Then
+    assertThat(result).isEqualTo(42);
+  }
+
+  @Test
+  @DisplayName("get with mixed notation, with nested Maps, should return value")
+  void getMixedNotationWithNestedMapsFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field", Collections.singletonMap("nested", 42))));
+    // When
+    final int result = gkr.get("spec", "field.nested");
+    // Then
+    assertThat(result).isEqualTo(42);
+  }
+
+  @Test
+  @DisplayName("get with mixed notation, with nested Maps and last path property missing, should return null")
+  void getMixedNotationWithNestedMapsNotFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field", Collections.singletonMap("nested", 42))));
+    // When
+    final Object result = gkr.get("spec", "field.not-here");
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  @DisplayName("get with mixed notation, with nested Maps and traversed path property missing,  should throw Exception")
+  void getMixedNotationWithNestedMapsException() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field", Collections.singletonMap("nested", 42))));
+    // When
+    final IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () ->
+      gkr.get("spec", "field.nested.not.here"));
+    // Then
+    assertThat(result)
+      .hasMessageContaining("Cannot get property spec.field.nested.not.here");
+  }
+
+  @Test
+  @DisplayName("get with wrong notation, with nested Maps and Arrays, should throw Exception")
+  void getWrongNotationWithNestedMapsAndArraysException() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field",
+        Collections.singletonMap("nested", Arrays.asList(
+          true, false, 1337
+        )))));
+    // When
+    final NumberFormatException result = assertThrows(NumberFormatException.class, () ->
+      gkr.get("spec", "field.nested["+(Integer.MAX_VALUE+1L)+"]"));
+    // Then
+    assertThat(result)
+      .hasMessageContaining("For input string")
+      .hasMessageContaining("2147483648");
+  }
+
+  @Test
+  @DisplayName("get, with nested Maps and Arrays, should return value")
+  void getWithNestedMapsAndArraysFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field",
+        Collections.singletonMap("nested", Arrays.asList(
+          true, false, 1337
+        )))));
+    // When
+    final boolean result = gkr.get("spec", "field.nested[1]");
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("get, with nested Maps and Arrays with Maps, should return value")
+  void getWithNestedMapsAndArraysWithMapsFound() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field",
+        Collections.singletonMap("nested", Arrays.asList(
+          Collections.singletonMap("objectField", "Atomic"),
+          Collections.singletonMap("objectField", "Particles")
+        )))));
+    // When
+    final String result = gkr.get("spec", "field.nested[1].objectField");
+    // Then
+    assertThat(result).isEqualTo("Particles");
+  }
+
+  @Test
+  @DisplayName("get, with nested Maps and invalid array reference, should throw Exception")
+  void getWithNestedMapsAndInvalidArrayReferenceShouldThrowException() {
+    // Given
+    final GenericKubernetesResource gkr = new GenericKubernetesResource();
+    gkr.setAdditionalProperties(Collections.singletonMap("spec",
+      Collections.singletonMap("field", Collections.singletonMap("nested",
+        Collections.singletonMap("not", "an-array")))));
+    // When
+    final ClassCastException result = assertThrows(ClassCastException.class, () ->
+      gkr.get("spec", "field.nested[1].not"));
+    // Then
+    assertThat(result)
+      .hasMessageContaining("cannot be cast to")
+      .hasMessageContaining("Collection");
   }
 
   private static InputStream load(String resource) {

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
@@ -438,6 +438,19 @@ class GenericKubernetesResourceTest {
       .returns(true, gkr -> gkr.get("status.reconciled"));
   }
 
+  @Test
+  @DisplayName("getAdditionalPropertiesNode, with complex-structure-resource, should return queried values")
+  void getAdditionalPropertiesNodeWithComplexStructureShouldRetrieveQueried() throws Exception {
+    // When
+    final GenericKubernetesResource result = objectMapper
+      .readValue(load("complex-structure-resource.json"), GenericKubernetesResource.class);
+    // Then
+    assertThat(result)
+      .extracting(GenericKubernetesResource::getAdditionalPropertiesNode)
+      .returns("value", node -> node.get("spec").get("field").asText())
+      .returns(2, node -> node.get("spec").get("nested").get("list").get(1).get("entry").asInt());
+  }
+
   private static InputStream load(String resource) {
     return GenericKubernetesResource.class.getResourceAsStream("/generic-kubernetes-resource/" + resource);
   }

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/GenericKubernetesResourceTest.java
@@ -191,19 +191,16 @@ class GenericKubernetesResourceTest {
   }
 
   @Test
-  @DisplayName("get with mixed notation, with nested Maps and traversed path property missing,  should throw Exception")
-  void getMixedNotationWithNestedMapsException() {
+  @DisplayName("get with mixed notation, with nested Maps and traversed path property missing, should return null")
+  void getMixedNotationWithNestedMapsTraversedNotFound() {
     // Given
     final GenericKubernetesResource gkr = new GenericKubernetesResource();
     gkr.setAdditionalProperties(Collections.singletonMap("spec",
       Collections.singletonMap("field", Collections.singletonMap("nested", 42))));
     // When
-    final IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () ->
-      gkr.get("spec", "field.nested.not.here"));
+    final Object result = gkr.get("spec", "field.nested.not.here");
     // Then
-    assertThat(result)
-      .hasMessageContaining("Cannot get property 'spec.field.nested.not.here'")
-      .hasMessageContaining("(missing segment 'not.here')");
+    assertThat(result).isNull();
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "the-cr.example.com/v1",
+  "kind": "SomeCustomResource",
+  "metadata": {
+    "name": "custom-resource-example"
+  },
+  "spec": {
+    "field": "value",
+    "dot.in.field": 42,
+    "nested": {
+      "list": [
+        {"entry":  1},
+        {"entry":  2},
+        {"entry":  3}
+      ],
+      "2dList": [
+        [{"entry":  1}, {"entry":  2}],
+        [{"entry":  1}, {"entry":  2}]
+      ]
+    }
+  },
+  "status": {
+    "reconciled": true
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
@@ -15,7 +15,7 @@
       ],
       "2dList": [
         [{"entry":  1}, {"entry":  2}],
-        [{"entry":  1}, {"entry":  2}]
+        [{"entry":  3}, {"entry":  4}]
       ]
     }
   },

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
@@ -13,6 +13,7 @@
         {"entry":  2},
         {"entry":  3}
       ],
+      "list[0]": {"entry":  "ambiguous"},
       "2dList": [
         [{"entry":  1}, {"entry":  2}],
         [{"entry":  3}, {"entry":  4}]

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/resources/generic-kubernetes-resource/complex-structure-resource.json
@@ -17,7 +17,12 @@
         [{"entry":  1}, {"entry":  2}],
         [{"entry":  3}, {"entry":  4}]
       ]
-    }
+    },
+    "oh!.come-on![1337]this.is#Outrageous[0][1]": [
+      [
+        {"impossible": [313373]}
+      ]
+    ]
   },
   "status": {
     "reconciled": true


### PR DESCRIPTION
## Description
Allow the easy retrieval of field values from the additionalProperties Map.

The purpose of this method is to simplify the task when working with GenericKubernetesResources. With the proposed `GenericKubernetesResource#get` method, the following statements can be simplified:

```java
// before
int field = (Integer)gkr.getAdditionalProperties().get("field");
// after
int field = gkr.get("field");

// before
String value = ((Map)gkr.getAdditionalProperties().get("field")).get("nested").toString();
// after
String value = gkr.get("field", "nested");
// or
String value = gkr.get("field.nested");

// before
String value = ((Map)((List)((Map)gkr.getAdditionalProperties().get("field")).get("nested")).get(1)).get("inArray").toString();
// after
String value = gkr.get("field", "nested[1]", "inArray");
// or
String value = gkr.get("field.nested[1].inArray");
```

The more complicated the structure of the resource is, the more value this new method adds.

/cc @lordofthejars 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
