### PR TITLE
fix #3620: throw a meaningful exception if no kind/plural, default plural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #3535: ensure clientKeyAlgo is set properly when loading config YAML from `fromKubeconfig`
 * Fix #3598: applying cancel to the correct future for waitUntilCondition and waitUntilReady
 * Fix #3609: adding locking to prevent long running Watcher methods from causing reconnects with concurrent processing
+* Fix #3620: throw a meaningful exception if no kind/plural is on a ResourceDefinitionContext, default plural if possible
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContext.java
@@ -223,6 +223,7 @@ public class CustomResourceDefinitionContext extends ResourceDefinitionContext {
     }
 
     public CustomResourceDefinitionContext build() {
+      this.customResourceDefinitionContext.validate();
       return this.customResourceDefinitionContext;
     }
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/ResourceDefinitionContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/ResourceDefinitionContext.java
@@ -45,6 +45,15 @@ public class ResourceDefinitionContext {
   public boolean isNamespaceScoped() {
     return namespaced;
   }
+  
+  protected void validate() {
+    if (plural == null) {
+      if (kind == null) {
+        throw new IllegalArgumentException("Neither kind nor plural was set, at least one is required");
+      }
+      plural = Utils.getPluralFromKind(kind);
+    }
+  }
 
   public static ResourceDefinitionContext fromResourceType(Class<? extends KubernetesResource> resource) {
     return new Builder()
@@ -89,6 +98,7 @@ public class ResourceDefinitionContext {
     }
     
     public ResourceDefinitionContext build() {
+      this.resourceDefinitionContext.validate();
       return this.resourceDefinitionContext;
     }
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/CustomResourceDefinitionContextTest.java
@@ -142,8 +142,8 @@ class CustomResourceDefinitionContextTest {
   @Test
   void isNamespaceScoped() {
     // Given
-    CustomResourceDefinitionContext crdc1 = new CustomResourceDefinitionContext.Builder().withScope("Namespaced").build();
-    CustomResourceDefinitionContext crdc2 = new CustomResourceDefinitionContext.Builder().withScope("Cluster").build();
+    CustomResourceDefinitionContext crdc1 = new CustomResourceDefinitionContext.Builder().withPlural("values").withScope("Namespaced").build();
+    CustomResourceDefinitionContext crdc2 = new CustomResourceDefinitionContext.Builder().withPlural("values").withScope("Cluster").build();
 
     // When + Then
     assertThat(crdc1.isNamespaceScoped()).isTrue();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/ResourceDefinitionContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/ResourceDefinitionContextTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ResourceDefinitionContextTest {
 
   @Test
-  void testMissing() {
+  void missingRequiredKindShouldFail() {
     ResourceDefinitionContext.Builder builder = new ResourceDefinitionContext.Builder();
     assertThrows(IllegalArgumentException.class, () -> builder.build());
     builder.withKind("Kind");

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/ResourceDefinitionContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/base/ResourceDefinitionContextTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.dsl.base;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ResourceDefinitionContextTest {
+
+  @Test
+  void testMissing() {
+    ResourceDefinitionContext.Builder builder = new ResourceDefinitionContext.Builder();
+    assertThrows(IllegalArgumentException.class, () -> builder.build());
+    builder.withKind("Kind");
+    ResourceDefinitionContext context = builder.build();
+    assertEquals("kinds", context.getPlural());
+  }
+  
+}


### PR DESCRIPTION
## Description
fix #3620: throw a meaningful exception if no kind/plural, and default plural based upon kind.

It looks like the code is tolerant to the other fields being missing - including group.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
