### PR TITLE
fix #3636: updating how streams are closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #3598: applying cancel to the correct future for waitUntilCondition and waitUntilReady
 * Fix #3609: adding locking to prevent long running Watcher methods from causing reconnects with concurrent processing
 * Fix #3620: throw a meaningful exception if no kind/plural is on a ResourceDefinitionContext, default plural if possible
+* Fix #3636: ensure proper handling of LogWatch closure wrt its streams
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/LogWatch.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/LogWatch.java
@@ -17,13 +17,20 @@ package io.fabric8.kubernetes.client.dsl;
 
 import java.io.Closeable;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 public interface LogWatch extends Closeable {
 
+    /**
+     * Returns the {@link InputStream} for the log watch.
+     * If an {@link OutputStream} was passed in, will be null
+     * @return the {@link InputStream}
+     */
     InputStream getOutput();
 
     /**
      * Close the Watch.
      */
+    @Override
     void close();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
@@ -57,6 +57,7 @@ public interface Loggable<W> {
 
   /**
    * Watch logs of resource and put them inside OutputStream inside
+   * <br>if the OutputStream is a PipedOutputStream, it will be closed when the Watch terminates
    *
    * @param out {@link OutputStream} for storing logs
    * @return returns a Closeable interface for log watch

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallback.java
@@ -65,22 +65,18 @@ public class LogWatchCallback implements LogWatch, Callback, AutoCloseable {
     if (out == null) {
       this.out = new PipedOutputStream();
       this.output = new PipedInputStream();
-      toClose.add(this.out);
-      toClose.add(this.output);
-    } else {
-      this.out = out;
-      this.output = null;
-    }
-
-    //We need to connect the pipe here, because onResponse might not be called in time (if log is empty)
-    //This will cause a `Pipe not connected` exception for everyone that tries to read. By always opening
-    //the pipe the user will get a ready to use inputstream, which will block until there is actually something to read.
-    if (this.out instanceof PipedOutputStream && this.output != null) {
       try {
+        // connect so the user will get a ready to use inputstream, which will block until there is actually something to read.
         this.output.connect((PipedOutputStream) this.out);
       } catch (IOException e) {
         throw KubernetesClientException.launderThrowable(e);
       }
+    } else {
+      this.out = out;
+      this.output = null;
+    }
+    if (this.out instanceof PipedOutputStream) {
+      toClose.add(this.out);
     }
   }
 


### PR DESCRIPTION


## Description
fix for #3636 - the inputstream is not directly closed, as that leads to data loss.  The outputstream is closed when it's piped so that the connected stream sees eof

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
