### PR TITLE
fix: NodeMetrics and PodMetrics can have informers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bugs
 * Fix #3672: Native image builds of Fabric8 work (commons-codec no longer required)
+* Fix #3639: Support for NodeMetrics and PodMetrics informers
 
 ### 5.11.0 (2021-12-17)
 

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -226,6 +226,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ApiVersionUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ApiVersionUtil.java
@@ -18,10 +18,11 @@ package io.fabric8.kubernetes.client.utils;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
 public class ApiVersionUtil {
-  
+
   private ApiVersionUtil() {
     throw new IllegalStateException("Utility class");
   }
+
   /**
    * Extracts apiGroupName from apiGroupVersion when in resource for apiGroupName/apiGroupVersion combination
    * @param <T>       Template argument provided
@@ -29,7 +30,6 @@ public class ApiVersionUtil {
    * @param apiGroup  apiGroupName present if any
    * @return          Just the apiGroupName part without apiGroupVersion
    */
-  
   public static <T> String apiGroup(T item, String apiGroup) {
     if (item instanceof HasMetadata && Utils.isNotNullOrEmpty(((HasMetadata) item).getApiVersion())) {
       return trimGroupOrNull(((HasMetadata) item).getApiVersion());

--- a/kubernetes-itests/src/test/java/io/fabric8/commons/ClusterEntity.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/commons/ClusterEntity.java
@@ -74,7 +74,7 @@ public class ClusterEntity {
 
   public static boolean kubernetesVersionAtLeast(String majorVersion, String minorVersion) {
     try (KubernetesClient client = new DefaultKubernetesClient()) {
-      VersionInfo versionInfo = client.getVersion();
+      VersionInfo versionInfo = client.getKubernetesVersion();
       String clusterMajorVersion = versionInfo.getMajor().replaceAll(NON_NUMERIC_CHARACTERS, EMPTY);
       String clusterMinorVersion = versionInfo.getMinor().replaceAll(NON_NUMERIC_CHARACTERS, EMPTY);
 

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PluralizeIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PluralizeIT.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import io.fabric8.commons.ClusterEntity;
+import io.fabric8.kubernetes.api.Pluralize;
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIResource;
+import io.fabric8.kubernetes.api.model.APIResourceList;
+import io.fabric8.kubernetes.api.model.GroupVersionForDiscovery;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import io.fabric8.kubernetes.client.utils.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+// Not running with Arquillian because I want to make it parameterized.
+// We should probably remove Arquillian anyway so we can update this module to JUnit 5.
+@RunWith(Parameterized.class)
+public class PluralizeIT {
+
+  @Parameterized.Parameters(name = "{index} {0}: ''{1}'' plural is ''{2}''")
+  public static Collection<Object[]> parameters() {
+    if (!ClusterEntity.kubernetesVersionAtLeast("1", "16")) {
+      return Collections.emptyList();
+    }
+    final List<APIResource> testCases;
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      // Core Resources
+      testCases = new ArrayList<>(new OperationSupport(client.getHttpClient(), client.getConfiguration())
+        .restCall(APIResourceList.class, "api/v1").getResources());
+      // Additional groups
+      for (APIGroup group : client.getApiGroups().getGroups()) {
+        for (GroupVersionForDiscovery version : group.getVersions()) {
+          testCases.addAll(client.getApiResources(version.getGroupVersion()).getResources());
+        }
+      }
+    }
+    if (testCases.isEmpty()) {
+      throw new IllegalStateException("No API resources found");
+    }
+    return testCases.stream()
+      .filter(ar -> !ar.getName().contains("/"))
+      .map(ar -> new Object[]{
+        ar.getKind(),
+        // So far singularName field is always blank, we fall back to lower-cased kind
+        Utils.isNullOrEmpty(ar.getSingularName()) ? ar.getKind().toLowerCase(Locale.ROOT) : ar.getSingularName(),
+        ar.getName()
+      })
+      .collect(Collectors.toList());
+  }
+
+  @Parameterized.Parameter
+  public String kind;
+
+  @Parameterized.Parameter(1)
+  public String singular;
+
+  @Parameterized.Parameter(2)
+  public String plural;
+
+  @Test
+  public void toPlural() {
+    assertEquals(plural, Pluralize.toPlural(singular));
+  }
+}

--- a/kubernetes-itests/src/test/resources/apiservice-it.yml
+++ b/kubernetes-itests/src/test/resources/apiservice-it.yml
@@ -15,43 +15,27 @@
 #
 
 ---
-apiVersion: apiregistration.k8s.io/v1
-kind: APIService
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
-  name: v1beta1.get.fabric8.io
+  name: apiservices.tests.example.com
 spec:
-  group: get.fabric8.io
-  groupPriorityMinimum: 1000
-  versionPriority: 5
-  version: v1beta1
----
-apiVersion: apiregistration.k8s.io/v1
-kind: APIService
-metadata:
-  name: v1beta1.list.fabric8.io
-spec:
-  group: list.fabric8.io
-  groupPriorityMinimum: 1000
-  versionPriority: 5
-  version: v1beta1
----
-apiVersion: apiregistration.k8s.io/v1
-kind: APIService
-metadata:
-  name: v1beta1.update.fabric8.io
-spec:
-  group: update.fabric8.io
-  groupPriorityMinimum: 1000
-  versionPriority: 5
-  version: v1beta1
----
-apiVersion: apiregistration.k8s.io/v1
-kind: APIService
-metadata:
-  name: v1beta1.delete.fabric8.io
-spec:
-  group: delete.fabric8.io
-  groupPriorityMinimum: 1000
-  versionPriority: 5
-  version: v1beta1
-
+  group: tests.example.com
+  scope: Namespaced
+  names:
+    kind: ApiService
+    plural: apiservices
+    singular: apiservice
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/Pluralize.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/Pluralize.java
@@ -38,6 +38,8 @@ public class Pluralize implements UnaryOperator<String> {
     EXCEPTIONS.put("child", "children");
     EXCEPTIONS.put("ox", "oxen");
     EXCEPTIONS.put("die", "dice");
+    EXCEPTIONS.put("podmetrics", "pods");
+    EXCEPTIONS.put("nodemetrics", "nodes");
   }
 
   private static final List<UnaryOperator<String>> PLURALS = Arrays.asList(

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/PluralizeTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/PluralizeTest.java
@@ -17,33 +17,47 @@ package io.fabric8.kubernetes.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class PluralizeTest {
-  @Test
-  void pluralizeShouldWork() {
-    assertNull(Pluralize.toPlural(null));
-    assertEquals("", Pluralize.toPlural(""));
-    
-    assertEquals("equipment", Pluralize.toPlural("equipment"));
-    assertEquals("news", Pluralize.toPlural("news"));
+import java.util.stream.Stream;
 
-    assertEquals("people", Pluralize.toPlural("person"));
-    assertEquals("children", Pluralize.toPlural("child"));
-    assertEquals("shoes", Pluralize.toPlural("shoe"));
-    assertEquals("loves", Pluralize.toPlural("love"));
-    assertEquals("movies", Pluralize.toPlural("movie"));
-    assertEquals("lives", Pluralize.toPlural("life"));
-    assertEquals("chives", Pluralize.toPlural("chive"));
-    assertEquals("diminutives", Pluralize.toPlural("diminutive"));
-    assertEquals("dice", Pluralize.toPlural("die"));
-    assertEquals("scarves", Pluralize.toPlural("scarf"));
-    assertEquals("humans", Pluralize.toPlural("human"));
+class PluralizeTest {
 
-    assertEquals("definitions", Pluralize.toPlural("definition"));
-    assertEquals("statuses", Pluralize.toPlural("status"));
-    assertEquals("endpoints", Pluralize.toPlural("endpoints"));
+  @DisplayName("toPlural, should return argument's plural")
+  @ParameterizedTest(name = "{index}: ''{1}'' plural is ''{0}''")
+  @MethodSource("toPluralInput")
+  void toPlural(String plural, String singular) {
+    assertEquals(plural, Pluralize.toPlural(singular));
+  }
+
+  static Stream<Arguments> toPluralInput() {
+    return Stream.of(
+      arguments("", ""),
+      arguments(null, null),
+      arguments("equipment", "equipment"),
+      arguments("news", "news"),
+      arguments("people", "person"),
+      arguments("children", "child"),
+      arguments("shoes", "shoe"),
+      arguments("loves", "love"),
+      arguments("movies", "movie"),
+      arguments("lives", "life"),
+      arguments("chives", "chive"),
+      arguments("diminutives", "diminutive"),
+      arguments("dice", "die"),
+      arguments("scarves", "scarf"),
+      arguments("humans", "human"),
+      arguments("definitions", "definition"),
+      arguments("statuses", "status"),
+      arguments("endpoints", "endpoints"),
+      arguments("pods", "podmetrics"),
+      arguments("nodes", "nodemetrics")
+    );
   }
 
 }

--- a/kubernetes-model-generator/pom.xml
+++ b/kubernetes-model-generator/pom.xml
@@ -110,6 +110,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit-fluent</artifactId>
       <version>2.7.0</version>

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.ListMeta;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsList;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetricsListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient
+class NodeMetricsTest {
+
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  void testMetrics() {
+    // Given
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes/the-node").andReturn(HTTP_OK,
+      new NodeMetricsListBuilder().addToItems(new NodeMetricsBuilder()
+          .withNewMetadata().withName("the-metric").endMetadata()
+        .build()).build()).once();
+    // When
+    final NodeMetricsList result = client.top().nodes().withName("the-node").metrics();
+    // Then
+    assertThat(result)
+      .extracting(NodeMetricsList::getItems).asList().singleElement()
+      .hasFieldOrPropertyWithValue("Kind", "NodeMetrics")
+      .hasFieldOrPropertyWithValue("metadata.name", "the-metric");
+  }
+
+  @Test
+  void testInform() {
+    // Given
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes").andReturn(HTTP_OK,
+      new NodeMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?allowWatchBookmarks=true&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .done()
+      .once();
+    // When
+    try (SharedIndexInformer<NodeMetrics> result = client.resources(NodeMetrics.class).inAnyNamespace().inform()) {
+      // Then
+      assertThat(result).isNotNull();
+    }
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.ListMeta;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetrics;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsBuilder;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsList;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.PodMetricsListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient
+class PodMetricsTest {
+
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  void testMetrics() {
+    // Given
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods/the-pod").andReturn(HTTP_OK,
+      new PodMetricsListBuilder().addToItems(new PodMetricsBuilder()
+          .withNewMetadata().withName("the-metric").endMetadata()
+        .build()).build()).once();
+    // When
+    final PodMetricsList result = client.top().pods().withName("the-pod").metrics();
+    // Then
+    assertThat(result)
+      .extracting(PodMetricsList::getItems).asList().singleElement()
+      .hasFieldOrPropertyWithValue("Kind", "PodMetrics")
+      .hasFieldOrPropertyWithValue("metadata.name", "the-metric");
+  }
+
+  @Test
+  void testMetricsInNamespace() {
+    // Given
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/namespaces/the-namespace/pods/the-pod")
+      .andReturn(HTTP_OK, new PodMetricsListBuilder().addToItems(new PodMetricsBuilder()
+        .withNewMetadata().withName("the-metric").endMetadata()
+        .build()).build()).once();
+    // When
+    final PodMetricsList result = client.top().pods().inNamespace("the-namespace").withName("the-pod").metrics();
+    // Then
+    assertThat(result)
+      .extracting(PodMetricsList::getItems).asList().singleElement()
+      .hasFieldOrPropertyWithValue("Kind", "PodMetrics")
+      .hasFieldOrPropertyWithValue("metadata.name", "the-metric");
+  }
+
+  @Test
+  void testInform() {
+    // Given
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods").andReturn(HTTP_OK,
+      new PodMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?allowWatchBookmarks=true&watch=true")
+      .andUpgradeToWebSocket()
+      .open()
+      .done()
+      .once();
+    // When
+    try (SharedIndexInformer<PodMetrics> result = client.resources(PodMetrics.class).inAnyNamespace().inform()) {
+      // Then
+      assertThat(result).isNotNull();
+    }
+  }
+}


### PR DESCRIPTION
## Description

fix #3639: NodeMetrics and PodMetrics can have informers
fix #3668: APIServiceIT doesn't manipulate the API server directly (no write operations)

- Related to: #3589
  Added E2E test to make sure that Pluralize works on all cluster resources (at least on the cluster where the test is performed)
- Added integration test for top()/inform() on PodMetrics and NodeMetrics resources


@shawkins please check the following snippet:
```java
      testCases = new ArrayList<>(new OperationSupport(client.getHttpClient(), client.getConfiguration())
        .restCall(APIResourceList.class, "api/v1").getResources());
```

I didn't find a better way to list these (core) resources.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
