### PR TITLE
refining #3559 - allows the connect and websocket timeouts to apply to watches instead of hardcoded timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #3674: allows the connect and websocket timeouts to apply to watches instead of a hardcoded timeout
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
@@ -60,12 +60,16 @@ class OkHttpWebSocketImpl implements WebSocket {
           if (response != null) {
             response.close();
           }
-          if (!opened && response != null) {
-            try {
-              future.completeExceptionally(new WebSocketHandshakeException(new OkHttpResponseImpl<>(response, null)).initCause(t));
-            } catch (IOException e) {
-              // can't happen
-            } 
+          if (!opened) {
+            if (response != null) {
+              try {
+                future.completeExceptionally(new WebSocketHandshakeException(new OkHttpResponseImpl<>(response, null)).initCause(t));
+              } catch (IOException e) {
+                // can't happen
+              } 
+            } else {
+              future.completeExceptionally(t);
+            }
           } else {
             listener.onError(new OkHttpWebSocketImpl(webSocket), t);
           }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -145,14 +145,18 @@ public class Utils {
    * Wait until an other thread signals the completion of a task.
    * If an exception is passed, it will be propagated to the caller.
    * @param future    The communication channel.
-   * @param amount    The amount of time to wait.
+   * @param amount    The amount of time to wait.  If less than 0, wait indefinitely
    * @param timeUnit  The time unit.
    *
    * @return a boolean value indicating resource is ready or not.
    */
   public static boolean waitUntilReady(Future<?> future, long amount, TimeUnit timeUnit) {
     try {
-      future.get(amount, timeUnit);
+      if (amount < 0) {
+        future.get();
+      } else {
+        future.get(amount, timeUnit);
+      }
       return true;
     } catch (TimeoutException e) {
       return false;


### PR DESCRIPTION
## Description
Supersedes closes #3559

A replacement for #3559 post okhttp refactoring.  There were a couple of refinements to make sure that timeout exceptions bubble up as expected.  With this change the connect and websocket (which defaults to the smallest amount of time) timeouts are enforced during waitUntilReady.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
