### PR TITLE
Handle JsonNode fields by adding x-kubernetes-preserve-unknown-fields

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -78,6 +78,8 @@ public abstract class AbstractJsonSchema<T, B> {
   public static final String ANNOTATION_JSON_IGNORE = "com.fasterxml.jackson.annotation.JsonIgnore";
   public static final String ANNOTATION_NOT_NULL = "javax.validation.constraints.NotNull";
 
+  public static final String JSON_NODE_TYPE = "com.fasterxml.jackson.databind.JsonNode";
+
   static {
     COMMON_MAPPINGS.put(STRING_REF, STRING_MARKER);
     COMMON_MAPPINGS.put(DATE_REF, STRING_MARKER);
@@ -123,6 +125,10 @@ public abstract class AbstractJsonSchema<T, B> {
         .emptySet();
     List<String> required = new ArrayList<>();
 
+    final boolean preserveUnknownFields = (
+      definition.getFullyQualifiedName() != null &&
+        definition.getFullyQualifiedName().equals(JSON_NODE_TYPE));
+
     // index potential accessors by name for faster lookup
     final Map<String, Method> accessors = indexPotentialAccessors(definition);
 
@@ -153,7 +159,7 @@ public abstract class AbstractJsonSchema<T, B> {
       }
       addProperty(possiblyRenamedProperty, builder, possiblyUpdatedSchema);
     }
-    return build(builder, required);
+    return build(builder, required, preserveUnknownFields);
   }
 
   private Map<String, Method> indexPotentialAccessors(TypeDef definition) {
@@ -364,7 +370,7 @@ public abstract class AbstractJsonSchema<T, B> {
    * @param required the list of names of required fields
    * @return the built JSON schema
    */
-  public abstract T build(B builder, List<String> required);
+  public abstract T build(B builder, List<String> required, boolean preserveUnknownFields);
 
   /**
    * Builds the specific JSON schema representing the structural schema for the specified property

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -62,8 +62,12 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   }
 
   @Override
-  public JSONSchemaProps build(JSONSchemaPropsBuilder builder, List<String> required) {
-    return builder.withRequired(required).build();
+  public JSONSchemaProps build(JSONSchemaPropsBuilder builder, List<String> required, boolean preserveUnknownFields) {
+    builder = builder.withRequired(required);
+    if (preserveUnknownFields) {
+      builder.withXKubernetesPreserveUnknownFields(preserveUnknownFields);
+    }
+    return builder.build();
   }
 
   @Override

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -63,8 +63,12 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   }
 
   @Override
-  public JSONSchemaProps build(JSONSchemaPropsBuilder builder, List<String> required) {
-    return builder.withRequired(required).build();
+  public JSONSchemaProps build(JSONSchemaPropsBuilder builder, List<String> required, boolean preserveUnknownFields) {
+    builder = builder.withRequired(required);
+    if (preserveUnknownFields) {
+      builder.withXKubernetesPreserveUnknownFields(preserveUnknownFields);
+    }
+    return builder.build();
   }
 
   @Override

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/json/ContainingJson.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/json/ContainingJson.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.json;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("containingjson.fabric8.io")
+@Version("v1alpha1")
+public class ContainingJson extends CustomResource<ContainingJsonSpec, Void> {
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/json/ContainingJsonSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/json/ContainingJsonSpec.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ContainingJsonSpec {
+
+  private int field;
+
+  public int getField() { return field; }
+
+  private JsonNode free;
+
+  public JsonNode getFree() {
+    return free;
+  }
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -18,6 +18,7 @@ package io.fabric8.crd.generator.v1;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.example.annotated.Annotated;
 import io.fabric8.crd.example.basic.Basic;
+import io.fabric8.crd.example.json.ContainingJson;
 import io.fabric8.crd.example.person.Person;
 import io.fabric8.crd.generator.utils.Types;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
@@ -106,5 +107,28 @@ class JsonSchemaTest {
 
     // check ignored fields
     assertFalse(spec.containsKey("ignoredFoo"));
+  }
+
+  @Test
+  void shouldProbuceKubernetesPreserveFields() {
+    TypeDef containingJson = Types.typeDefFrom(ContainingJson.class);
+    JSONSchemaProps schema = JsonSchema.from(containingJson);
+    assertNotNull(schema);
+    Map<String, JSONSchemaProps> properties = schema.getProperties();
+    assertEquals(2, properties.size());
+    final JSONSchemaProps specSchema = properties.get("spec");
+    Map<String, JSONSchemaProps> spec = specSchema.getProperties();
+    assertEquals(2, spec.size());
+
+    // check descriptions are present
+    assertTrue(spec.containsKey("free"));
+    JSONSchemaProps freeField = spec.get("free");
+
+    assertTrue(freeField.getXKubernetesPreserveUnknownFields());
+
+    assertTrue(spec.containsKey("field"));
+    JSONSchemaProps field = spec.get("field");
+
+    assertNull(field.getXKubernetesPreserveUnknownFields());
   }
 }


### PR DESCRIPTION
## Description
Fix #3683 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change ( the public API of `AbstractJsonSchema` changed, although I guess it's ok since is still in preview)
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

