### PR TITLE
Ignore fields annotated with JsonIgnore during CRD generation

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -80,6 +80,7 @@ public abstract class AbstractJsonSchema<T, B> {
   private static final Map<TypeRef, String> COMMON_MAPPINGS = new HashMap<>();
   public static final String ANNOTATION_JSON_PROPERTY = "com.fasterxml.jackson.annotation.JsonProperty";
   public static final String ANNOTATION_JSON_PROPERTY_DESCRIPTION = "com.fasterxml.jackson.annotation.JsonPropertyDescription";
+  public static final String ANNOTATION_JSON_IGNORE = "com.fasterxml.jackson.annotation.JsonIgnore";
   public static final String ANNOTATION_NOT_NULL = "javax.validation.constraints.NotNull";
 
   static {
@@ -139,6 +140,8 @@ public abstract class AbstractJsonSchema<T, B> {
 
       if (facade.required) {
         required.add(name);
+      } else if (facade.ignored) {
+        continue;
       }
       final T schema = internalFrom(name, possiblyRenamedProperty.getTypeRef());
       // if we got a description from the field or an accessor, use it
@@ -171,6 +174,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private final String type;
     private String renamedTo;
     private boolean required;
+    private boolean ignored;
     private String description;
 
     private PropertyOrAccessor(Collection<AnnotationRef> annotations, String name, String propertyName, boolean isMethod) {
@@ -206,6 +210,9 @@ public abstract class AbstractJsonSchema<T, B> {
               description = descriptionFromAnnotation;
             }
             break;
+          case ANNOTATION_JSON_IGNORE:
+            ignored = true;
+            break;
         }
       });
     }
@@ -216,6 +223,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public boolean isRequired() {
       return required;
+    }
+
+    public boolean isIgnored() {
+      return ignored;
     }
 
     public String getDescription() {
@@ -241,6 +252,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private String renamedTo;
     private String description;
     private boolean required;
+    private boolean ignored;
     private final Property original;
     private String nameContributedBy;
     private String descriptionContributedBy;
@@ -290,6 +302,8 @@ public abstract class AbstractJsonSchema<T, B> {
 
         if (p.isRequired()) {
           required = true;
+        } else if (p.isIgnored()) {
+          ignored = true;
         }
       });
       

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.example.annotated;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
@@ -34,11 +35,18 @@ public class AnnotatedSpec {
   @Min(0) // a non-string value attribute
   private int sizedField;
 
+  @JsonIgnore
+  private int ignoredFoo;
+
   @JsonProperty("from-getter")
   @JsonPropertyDescription("from-getter-description")
   @NotNull
   public int getFoo() {
     return foo;
+  }
+
+  public int getIgnoredFoo() {
+    return ignoredFoo;
   }
 
   @JsonProperty

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -103,5 +103,8 @@ class JsonSchemaTest {
     final List<JsonNode> enumValues = anEnum.getEnum();
     assertEquals(2, enumValues.size());
     enumValues.stream().map(JsonNode::textValue).forEach(s -> assertTrue("oui".equals(s) || "non".equals(s)));
+
+    // check ignored fields
+    assertFalse(spec.containsKey("ignoredFoo"));
   }
 }


### PR DESCRIPTION
## Description
fix #3686 

`JsonIgnore` should be correctly handled by the CRD generator.

## Type of change

 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
