### PR TITLE
Fix #3662: NodeMetrics should be marked as Cluster Scoped resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.12-SNAPSHOT
 
 #### Bugs
+* Fix #3662: NodeMetrics should be marked as Cluster scoped resource
 
 #### Improvements
 

--- a/kubernetes-model-generator/kubernetes-model-metrics/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-metrics/pom.xml
@@ -41,6 +41,11 @@
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-model-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetrics.java
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetrics.java
@@ -16,7 +16,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -66,7 +65,7 @@ import lombok.experimental.Accessors;
 @TemplateTransformations({
     @TemplateTransformation(value = "/manifest.vm", outputPath = "metrics.properties", gather = true)
 })
-public class NodeMetrics implements HasMetadata, Namespaced
+public class NodeMetrics implements HasMetadata
 {
 
     /**

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/kube-schema.json
@@ -837,8 +837,7 @@
       "additionalProperties": true,
       "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata",
-        "io.fabric8.kubernetes.api.model.Namespaced"
+        "io.fabric8.kubernetes.api.model.HasMetadata"
       ]
     },
     "kubernetes_metrics_v1beta1_NodeMetricsList": {

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/validation-schema.json
@@ -837,8 +837,7 @@
       "additionalProperties": true,
       "javaType": "io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata",
-        "io.fabric8.kubernetes.api.model.Namespaced"
+        "io.fabric8.kubernetes.api.model.HasMetadata"
       ]
     },
     "kubernetes_metrics_v1beta1_NodeMetricsList": {

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/test/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetricsTest.java
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/test/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetricsTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api.model.metrics.v1beta1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.Duration;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.Quantity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.Scanner;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class NodeMetricsTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void shouldNotImplementNamespacedInterface() {
+    assertThat(Namespaced.class.isAssignableFrom(NodeMetrics.class)).isFalse();
+  }
+
+  @Test
+  void deserializationAndSerializationShouldWorkAsExpected() throws IOException {
+    // Given
+    String originalJson = new Scanner(getClass().getResourceAsStream("/valid-nodemetric.json"))
+      .useDelimiter("\\A")
+      .next();
+
+    // When
+    final NodeMetrics nodeMetrics = mapper.readValue(originalJson, NodeMetrics.class);
+    final String serializedJson = mapper.writeValueAsString(nodeMetrics);
+    final NodeMetrics nodeMetricsFromSerializedJson = mapper.readValue(serializedJson, NodeMetrics.class);
+
+    // Then
+    assertThat(nodeMetrics).isNotNull();
+    assertThat(serializedJson).isNotNull();
+    assertThat(nodeMetricsFromSerializedJson).isNotNull();
+    assertThat(nodeMetrics).isEqualTo(nodeMetricsFromSerializedJson);
+  }
+
+  @Test
+  void builderShouldCreateObject() throws ParseException {
+    // Given
+    NodeMetricsBuilder nodeMetricsBuilder = new NodeMetricsBuilder()
+      .withNewMetadata().withName("minikube").endMetadata()
+      .withTimestamp("2021-12-23T16:05:09Z")
+      .withWindow(Duration.parse("30s"))
+      .withUsage(Collections.singletonMap("cpu", new Quantity("134994244n")));
+
+    // When
+    NodeMetrics nodeMetrics = nodeMetricsBuilder.build();
+
+    // Then
+    assertThat(nodeMetrics)
+      .isNotNull()
+      .hasFieldOrPropertyWithValue("metadata.name", "minikube")
+      .hasFieldOrPropertyWithValue("timestamp", "2021-12-23T16:05:09Z")
+      .hasFieldOrPropertyWithValue("window", Duration.parse("30s"))
+      .hasFieldOrPropertyWithValue("usage", Collections.singletonMap("cpu", new Quantity("134994244n")));
+  }
+}

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/test/resources/valid-nodemetric.json
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/test/resources/valid-nodemetric.json
@@ -1,0 +1,15 @@
+{
+  "kind": "NodeMetrics",
+  "apiVersion": "metrics.k8s.io/v1beta1",
+  "metadata": {
+    "name": "minikube",
+    "selfLink": "/apis/metrics.k8s.io/v1beta1/nodes/minikube",
+    "creationTimestamp": "2021-12-23T16:05:25Z"
+  },
+  "timestamp": "2021-12-23T16:05:09Z",
+  "window": "30s",
+  "usage": {
+    "cpu": "134994244n",
+    "memory": "1275716Ki"
+  }
+}

--- a/kubernetes-model-generator/pkg/schemagen/generate.go
+++ b/kubernetes-model-generator/pkg/schemagen/generate.go
@@ -637,6 +637,7 @@ func (g *schemaGenerator) isClusterScopedResource(t reflect.Type) bool {
 		"k8s.io/api/storage/v1/CSIDriver",
 		"k8s.io/api/storage/v1/CSINode",
 		"k8s.io/api/storage/v1/VolumeAttachment",
+		"k8s.io/metrics/pkg/apis/metrics/v1beta1/NodeMetrics",
 		"k8s.io/api/node/v1beta1/RuntimeClass",
 		"k8s.io/api/node/v1/RuntimeClass",
 		"k8s.io/api/node/v1alpha1/RuntimeClass",


### PR DESCRIPTION
## Description
Fix #3662 
NodeMetrics should not implement Namespaced interface

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
