### PR TITLE
Introduce SchemaFrom annotation as escape hatch

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -79,6 +79,7 @@ public abstract class AbstractJsonSchema<T, B> {
   public static final String ANNOTATION_JSON_ANY_GETTER = "com.fasterxml.jackson.annotation.JsonAnyGetter";
   public static final String ANNOTATION_JSON_ANY_SETTER = "com.fasterxml.jackson.annotation.JsonAnySetter";
   public static final String ANNOTATION_NOT_NULL = "javax.validation.constraints.NotNull";
+  public static final String ANNOTATION_SCHEMA_FROM = "io.fabric8.crd.generator.annotation.SchemaFrom";
 
   public static final String JSON_NODE_TYPE = "com.fasterxml.jackson.databind.JsonNode";
 
@@ -188,6 +189,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean ignored;
     private boolean preserveUnknownFields;
     private String description;
+    private Class schemaFrom;
 
     private PropertyOrAccessor(Collection<AnnotationRef> annotations, String name, String propertyName, boolean isMethod) {
       this.annotations = annotations;
@@ -228,6 +230,12 @@ public abstract class AbstractJsonSchema<T, B> {
           case ANNOTATION_JSON_ANY_SETTER:
             preserveUnknownFields = true;
             break;
+          case ANNOTATION_SCHEMA_FROM:
+            final Class extractedType = (Class) a.getParameters().get("type");
+            if (extractedType != null) {
+              schemaFrom = extractedType;
+            }
+            break;
         }
       });
     }
@@ -260,6 +268,14 @@ public abstract class AbstractJsonSchema<T, B> {
       return description != null;
     }
 
+    public Class getSchemaFrom() {
+      return schemaFrom;
+    }
+
+    public boolean contributeSchemaFrom() {
+      return schemaFrom != null;
+    }
+
     @Override
     public String toString() {
       return "'" + name + "' " + type;
@@ -276,6 +292,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private final Property original;
     private String nameContributedBy;
     private String descriptionContributedBy;
+    private TypeRef schemaFrom;
 
     public PropertyFacade(Property property, Map<String, Method> potentialAccessors) {
       original = property;
@@ -329,10 +346,17 @@ public abstract class AbstractJsonSchema<T, B> {
         if (p.isPreserveUnknownFields()) {
           preserveUnknownFields = true;
         }
+
+        if (p.contributeSchemaFrom()) {
+          schemaFrom = Types.typeDefFrom(p.getSchemaFrom()).toReference();
+        }
       });
-      
-      return renamedTo != null ? new Property(original.getAnnotations(), original.getTypeRef(), renamedTo,
-        original.getComments(), original.getModifiers(), original.getAttributes()) : original;
+
+      TypeRef typeRef = schemaFrom != null ? schemaFrom : original.getTypeRef();
+      String finalName = renamedTo != null ? renamedTo : original.getName();
+
+      return new Property(original.getAnnotations(), typeRef, finalName,
+        original.getComments(), original.getModifiers(), original.getAttributes());
     }
   }
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaFrom.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaFrom.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SchemaFrom {
+  Class<?> type() default void.class;
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -63,5 +63,5 @@ public class AnnotatedSpec {
 
   public enum AnnotatedEnum {
     non, @JsonProperty("oui") Yes
-  } 
+  }
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Extraction.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Extraction.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class Extraction extends  CustomResource<ExtractionSpec, Void> {
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.SchemaFrom;
+
+public class ExtractionSpec {
+
+  @SchemaFrom(type = FooExtractor.class)
+  private Foo foo;
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Foo.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Foo.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+
+import java.util.Optional;
+
+public class Foo {
+
+  @JsonAlias({ "BAZ" })
+  public Optional<Integer> bar;
+
+  public String baz;
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/FooExtractor.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/FooExtractor.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+
+public class FooExtractor {
+
+  @JsonProperty("BAZ")
+  @NotNull
+  public int bar;
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.example.annotated.Annotated;
 import io.fabric8.crd.example.basic.Basic;
 import io.fabric8.crd.example.json.ContainingJson;
+import io.fabric8.crd.example.extraction.Extraction;
 import io.fabric8.crd.example.person.Person;
 import io.fabric8.crd.generator.utils.Types;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
@@ -137,4 +138,29 @@ class JsonSchemaTest {
 
     assertTrue(fooField.getXKubernetesPreserveUnknownFields());
   }
+
+  @Test
+  void shouldExtractPropertiesSchemaFromExtractValueAnnotation() {
+    TypeDef extraction = Types.typeDefFrom(Extraction.class);
+    JSONSchemaProps schema = JsonSchema.from(extraction);
+    assertNotNull(schema);
+    Map<String, JSONSchemaProps> properties = schema.getProperties();
+    assertEquals(2, properties.size());
+    final JSONSchemaProps specSchema = properties.get("spec");
+    Map<String, JSONSchemaProps> spec = specSchema.getProperties();
+    assertEquals(1, spec.size());
+
+    // check typed SchemaFrom
+    JSONSchemaProps foo = spec.get("foo");
+    Map<String, JSONSchemaProps> fooProps = foo.getProperties();
+    assertNotNull(fooProps);
+
+    // you can change everything
+    assertEquals(fooProps.get("BAZ").getType(), "integer");
+    assertTrue(foo.getRequired().contains("BAZ"));
+
+    // you can exclude fields
+    assertNull(fooProps.get("baz"));
+  }
+
 }


### PR DESCRIPTION
## Description
Kind of fix: #3651 

This is a big hammer to let people "swap" a class instantiation for CRD generation purposes only.
Using this trick should be possible to workaround missing features and possible issues with the generator.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

cc. @metacosm this is a possible technical implementation for your proposal.
