### PR TITLE
Preserve unknown fields in presence of JsonAnyGetter or JsonAnySetter

### DIFF
--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/json/Foo.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/json/Foo.java
@@ -15,22 +15,24 @@
  */
 package io.fabric8.crd.example.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 
-public class ContainingJsonSpec {
+import java.util.HashMap;
+import java.util.Map;
 
-  private int field;
+public class Foo {
 
-  public int getField() { return field; }
+  private Map<String, Object> configAsMap = new HashMap<>();
 
-  private JsonNode free;
-
-  public JsonNode getFree() {
-    return free;
+  @JsonAnyGetter
+  public Map<String, Object> getConfigAsMap() {
+    return configAsMap;
   }
 
-  private Foo foo;
-
-  public Foo getFoo() { return foo; }
+  @JsonAnySetter
+  public void setConfigAsMap(String name, Object value) {
+    this.configAsMap.put(name, value);
+  }
 
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -118,9 +118,9 @@ class JsonSchemaTest {
     assertEquals(2, properties.size());
     final JSONSchemaProps specSchema = properties.get("spec");
     Map<String, JSONSchemaProps> spec = specSchema.getProperties();
-    assertEquals(2, spec.size());
+    assertEquals(3, spec.size());
 
-    // check descriptions are present
+    // check preserve unknown fields is present
     assertTrue(spec.containsKey("free"));
     JSONSchemaProps freeField = spec.get("free");
 
@@ -130,5 +130,10 @@ class JsonSchemaTest {
     JSONSchemaProps field = spec.get("field");
 
     assertNull(field.getXKubernetesPreserveUnknownFields());
+
+    assertTrue(spec.containsKey("foo"));
+    JSONSchemaProps fooField = spec.get("foo");
+
+    assertTrue(fooField.getXKubernetesPreserveUnknownFields());
   }
 }


### PR DESCRIPTION
## Description
This builds on top of #3684 I'll rebase on master as soon as the other gets merged.
Fix #3683

In presence of a class containing a "catch everything" field annotated with `JsonAnyGetter` or `JsonAnySetter`, we should produce `x-kubernetes-preserve-unknown-fields` as well.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
