### PR TITLE
fix #3255 adding basic resourceVersion handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #3683: Handle JsonNode fields by adding x-kubernetes-preserve-unknown-fields
 * Fix #3697: addresses response that aren't closed by interceptors that issue new requests
+* Fix #3255: adding basic crud mock resourceVersion support - the field will be set and updated, but not utilized by list/watch queries
 * Fix #3712: properly return the full resource name for resources with empty group
 
 #### Improvements

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposer.java
@@ -21,26 +21,15 @@ import java.util.Collection;
 
 public class KubernetesResponseComposer implements ResponseComposer {
 
-  // This is a reimplementation of Java 8's String.join.
-  private static String join(String sep, Collection<String> collection) {
-    StringBuilder builder = new StringBuilder();
-    boolean first = true;
-    for (String element : collection) {
-      if (first) {
-        first = false;
-      } else {
-        builder.append(sep);
-      }
-      builder.append(element);
-    }
-    return builder.toString();
-  }
-
   @Override
   public String compose(Collection<String> collection) {
+    return compose(collection, "");
+  }
+
+  public String compose(Collection<String> collection, String resourceVersion) {
     return String.format(
         "{\"apiVersion\":\"v1\",\"kind\":\"List\", \"items\": [%s], " +
-         "\"metadata\": {\"resourceVersion\": \"\", \"selfLink\": \"\"}}",
-        join(",", collection));
+         "\"metadata\": {\"resourceVersion\": \"%s\", \"selfLink\": \"\"}}",
+        String.join(",", collection), resourceVersion);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetadataCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetadataCrudTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnableKubernetesMockClient(crud = true)
+class MetadataCrudTest {
+
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  void testResourceVersion() {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
+    Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").addToLabels("testKey", "testValue").endMetadata().build();
+
+    NonNamespaceOperation<Pod, PodList, PodResource<Pod>> podClient = client.pods().inNamespace("ns1");
+    pod1 = podClient.create(pod1);
+    pod2 = podClient.create(pod2);
+
+    assertEquals("1", pod1.getMetadata().getResourceVersion());
+    assertEquals("2", pod2.getMetadata().getResourceVersion());
+
+    PodList podList = client.pods().list();
+    assertEquals("2", podList.getMetadata().getResourceVersion());
+
+    // should do nothing
+    pod1 = podClient.createOrReplace(pod1);
+    assertEquals("1", pod1.getMetadata().getResourceVersion());
+
+    // should increment
+    pod1 = podClient.withName("pod1").editStatus(p->new PodBuilder(p).withStatus(new PodStatus()).build());
+    assertEquals("3", pod1.getMetadata().getResourceVersion());
+  }
+
+}


### PR DESCRIPTION
## Description
Adding basic resourceVersion handling for #3255 - does not add list/watch querying based upon resourceVersion..

fix #3255

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
