### PR TITLE
fix #3697: closing the initial interceptor response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.12-SNAPSHOT
 
 #### Bugs
+* Fix #3697: addresses response that aren't closed by interceptors that issue new requests
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
@@ -49,7 +49,7 @@ class OkHttpClientBuilderImpl implements Builder {
     private final io.fabric8.kubernetes.client.http.Interceptor interceptor;
     private final String name;
 
-    private InteceptorAdapter(io.fabric8.kubernetes.client.http.Interceptor interceptor, String name) {
+    InteceptorAdapter(io.fabric8.kubernetes.client.http.Interceptor interceptor, String name) {
       this.interceptor = interceptor;
       this.name = name;
     }
@@ -63,6 +63,7 @@ class OkHttpClientBuilderImpl implements Builder {
       if (!response.isSuccessful()) {
         boolean call = interceptor.afterFailure(builderImpl, new OkHttpResponseImpl<>(response, InputStream.class));
         if (call) {
+          response.close();
           return chain.proceed(requestBuilder.build());
         }
       }


### PR DESCRIPTION
## Description
Fix #3697 
Fix #3699 

To address #3697 the previous interceptor response needs explicitly closed before issuing the next call.  This was handled by each interceptor previously, but due to the refactoring it needs to be elevated to the adapter.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
