### PR TITLE
[#3700] Change ManagedKubernetesClient OSGi ConfigurationPolicy to REQUIRE

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -127,7 +127,7 @@ import java.util.concurrent.ExecutorService;
 
 import static io.fabric8.kubernetes.client.Config.*;
 
-@Component(immediate = true, configurationPid = "io.fabric8.kubernetes.client", policy = ConfigurationPolicy.OPTIONAL)
+@Component(immediate = true, configurationPid = "io.fabric8.kubernetes.client", policy = ConfigurationPolicy.REQUIRE)
 @Service({KubernetesClient.class,NamespacedKubernetesClient.class})
 @References({
   @Reference(referenceInterface = io.fabric8.kubernetes.client.ResourceHandler.class, cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE, policy = ReferencePolicy.DYNAMIC, bind = "bindResourceHandler", unbind = "unbindResourceHandler"),

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
@@ -53,6 +53,8 @@ public class TestBase {
         configureSecurity().disableKarafMBeanServerBuilder(),
         features,
         editConfigurationFileExtend(
+          "etc/io.fabric8.kubernetes.client.cfg", "junit", "ignored"),
+        editConfigurationFileExtend(
           "etc/org.ops4j.pax.url.mvn.cfg",
           "org.ops4j.pax.url.mvn.repositories",
           "https://repo1.maven.org/maven2/"),
@@ -62,10 +64,10 @@ public class TestBase {
           + "org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED"),
         new VMOption("--patch-module"),
         new VMOption("java.base=lib/endorsed/org.apache.karaf.specs.locator-"
-          + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
+          + System.getProperty("karaf.version", "4.3.5") + ".jar"),
         new VMOption("--patch-module"),
         new VMOption("java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-"
-          + System.getProperty("karaf.version", "4.2.2-SNAPSHOT") + ".jar"),
+          + System.getProperty("karaf.version", "4.3.5") + ".jar"),
         new VMOption("--add-opens"),
         new VMOption("java.base/java.security=ALL-UNNAMED"),
         new VMOption("--add-opens"),
@@ -90,6 +92,8 @@ public class TestBase {
         karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
         configureSecurity().disableKarafMBeanServerBuilder(),
         features,
+        editConfigurationFileExtend(
+          "etc/io.fabric8.kubernetes.client.cfg", "junit", "ignored"),
         editConfigurationFileExtend(
           "etc/org.ops4j.pax.url.mvn.cfg",
           "org.ops4j.pax.url.mvn.repositories",


### PR DESCRIPTION
## Description
 - Prevent NPE when config does not exist

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
