### PR TITLE
[chore] Use concurrency limits to reduce the queue on GH Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-build-kubernetes-client-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Java ${{ matrix.java }} Maven

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,6 +24,11 @@ on:
   schedule:
     - cron: '0 1 * * *' # Everyday at 1
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-e2e-kubernetes-client-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IT_REVISION: master
   IT_DIR: kubernetes-itests

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -22,6 +22,11 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-go-kubernetes-client-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Kubernetes Model Generator Build

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -25,6 +25,11 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-docs-kubernetes-client-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   javadoc:
     name: JavaDocs

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -25,6 +25,11 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-license-kubernetes-client-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   license-check:
     name: License Check

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -25,6 +25,11 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-sonar-kubernetes-client-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sonar:
     name: Sonar

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,6 +22,11 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-win-kubernetes-client-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Java ${{ matrix.java }} Maven


### PR DESCRIPTION
## Description

I noticed that the CI is piling up a lot of running Actions, this should reduce the pressure and overall improve the performance.
Ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
