### PR TITLE
Fix #3648: `Serialization.unmarshal` fails to deserialize YAML with single document in presence of document delimiter(`---`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Fix #3712: properly return the full resource name for resources with empty group
 * Fix #3588: `openshift-server-mock` is not listed in dependencyManagement in main pom
 * Fix #3679: output additionalProperties field with correct value type for map-like fields (CRD Generator)
+* Fix #3648: `Serialization.unmarshal` fails to deserialize YAML with single document in presence of document delimiter(`---`)
+
 #### Improvements
 * Fix #3674: allows the connect and websocket timeouts to apply to watches instead of a hardcoded timeout
 * Fix #3651: Introduce SchemaFrom annotation as escape hatch (CRD Generator)

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -153,6 +153,9 @@ public class Serialization {
     String specFile = readSpecFileFromInputStream(is);
     if (containsMultipleDocuments(specFile)) {
       return (T) getKubernetesResourceList(parameters, specFile);
+    } else if (specFile.contains(DOCUMENT_DELIMITER)) {
+      specFile = specFile.replaceAll("^---([ \\t].*?)?\\r?\\n","");
+      specFile = specFile.replaceAll("\\n---([ \\t].*?)?\\r?\\n?$","\n");
     }
     return unmarshal(new ByteArrayInputStream(specFile.getBytes()), JSON_MAPPER, parameters);
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/SerializationSingleDocumentUnmarshalTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/SerializationSingleDocumentUnmarshalTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.Service;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SerializationSingleDocumentUnmarshalTest {
+  @ParameterizedTest(name = "#{index} - unmarshal {0}")
+  @ValueSource(strings = {"document-with-trailing-document-delimiter.yml", "document-with-leading-document-delimiter.yml", "document-with-leading-and-trailing-document-delimiter.yml", "document-with-no-document-delimiter.yml"})
+  void unmarshalWithSingleDocumentWithDocumentDelimiterShouldReturnKubernetesResource(String arg) {
+    // When
+    final KubernetesResource result = Serialization.unmarshal(
+      SerializationTest.class.getResourceAsStream(String.format("/serialization/%s", arg)),
+      Collections.emptyMap()
+    );
+    // Then
+    assertThat(result)
+      .asInstanceOf(InstanceOfAssertFactories.type(Service.class))
+      .hasFieldOrPropertyWithValue("apiVersion", "v1")
+      .hasFieldOrPropertyWithValue("kind", "Service")
+      .hasFieldOrPropertyWithValue("metadata.name", "redis-master")
+      .hasFieldOrPropertyWithValue("metadata.labels.app", "redis")
+      .hasFieldOrPropertyWithValue("metadata.labels.tier", "backend")
+      .hasFieldOrPropertyWithValue("metadata.labels.role", "master")
+      .hasFieldOrPropertyWithValue("spec.selector.app", "redis")
+      .hasFieldOrPropertyWithValue("spec.selector.tier", "backend")
+      .hasFieldOrPropertyWithValue("spec.selector.role", "master");
+  }
+}

--- a/kubernetes-client/src/test/resources/serialization/document-with-leading-and-trailing-document-delimiter.yml
+++ b/kubernetes-client/src/test/resources/serialization/document-with-leading-and-trailing-document-delimiter.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---

--- a/kubernetes-client/src/test/resources/serialization/document-with-leading-document-delimiter.yml
+++ b/kubernetes-client/src/test/resources/serialization/document-with-leading-document-delimiter.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master

--- a/kubernetes-client/src/test/resources/serialization/document-with-no-document-delimiter.yml
+++ b/kubernetes-client/src/test/resources/serialization/document-with-no-document-delimiter.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master

--- a/kubernetes-client/src/test/resources/serialization/document-with-trailing-document-delimiter.yml
+++ b/kubernetes-client/src/test/resources/serialization/document-with-trailing-document-delimiter.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---


### PR DESCRIPTION
## Description
Fix #3648 

Serialization.unmarshal doesn't handle the case when YAML contains only
single document but yet contains a leading or trailing document
delimiter(`---`).

Trim YAML document delimiters in case of single documents

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
