### PR TITLE
fix: properly return full resource name for resources with empty group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #3683: Handle JsonNode fields by adding x-kubernetes-preserve-unknown-fields
 * Fix #3697: addresses response that aren't closed by interceptors that issue new requests
+* Fix #3712: properly return the full resource name for resources with empty group
 
 #### Improvements
 * Fix #3674: allows the connect and websocket timeouts to apply to watches instead of a hardcoded timeout

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -216,7 +216,7 @@ public abstract class CustomResource<S, T> implements HasMetadata {
    * @return the CRD name associated with the CustomResource
    */
   public static String getCRDName(Class<?> clazz) {
-    return HasMetadata.getPlural(clazz) + "." + HasMetadata.getGroup(clazz);
+    return HasMetadata.getFullResourceName(clazz);
   }
 
   @JsonIgnore

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/Pluralize.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/Pluralize.java
@@ -34,6 +34,7 @@ public class Pluralize implements UnaryOperator<String> {
 
   static {
     EXCEPTIONS.put("person", "people");
+    EXCEPTIONS.put("woman", "women");
     EXCEPTIONS.put("man", "men");
     EXCEPTIONS.put("child", "children");
     EXCEPTIONS.put("ox", "oxen");

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
@@ -164,7 +164,7 @@ public interface HasMetadata extends KubernetesResource {
   static String getFullResourceName(String plural, String group) {
     Objects.requireNonNull(plural);
     Objects.requireNonNull(group);
-    return plural + "." + group;
+    return group.isEmpty() ? plural : plural + "." + group;
   }
 
   @JsonIgnore

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/PluralizeTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/PluralizeTest.java
@@ -56,7 +56,9 @@ class PluralizeTest {
       arguments("statuses", "status"),
       arguments("endpoints", "endpoints"),
       arguments("pods", "podmetrics"),
-      arguments("nodes", "nodemetrics")
+      arguments("nodes", "nodemetrics"),
+      arguments("women", "woman"),
+      arguments("men", "man")
     );
   }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
@@ -15,6 +15,9 @@
  */
 package io.fabric8.kubernetes.api.model;
 
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Plural;
+import io.fabric8.kubernetes.model.annotation.Version;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +30,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 class HasMetadataTest {
+  @Test
+  void fullResourceNameShouldNotEndWithPeriodForHistoricResources() {
+    assertEquals("pods", HasMetadata.getFullResourceName(Pod.class));
+    assertEquals("services", HasMetadata.getFullResourceName(Service.class));
+  }
+
+  @Test
+  void fullResourceNameShouldConcatenatePluralAndGroup() {
+    assertEquals("foos.fabric8.io", HasMetadata.getFullResourceName(Foo.class));
+    assertEquals("overridden.fabric8.io", HasMetadata.getFullResourceName(Over.class));
+  }
+
   @Test
   void validFinalizersShouldBeAddedAndCanBeRemoved() {
     HasMetadata hasMetadata = new Default();
@@ -191,6 +206,43 @@ class HasMetadataTest {
     hasMetadata.addOwnerReference(owner);
     hasMetadata.addOwnerReference(owner);
     assertEquals(1, hasMetadata.getMetadata().getOwnerReferences().size());
+  }
+
+  @Group("fabric8.io")
+  @Version("v1")
+  private static class Foo implements HasMetadata {
+
+    @Override
+    public ObjectMeta getMetadata() {
+      return null;
+    }
+
+    @Override
+    public void setMetadata(ObjectMeta metadata) {
+    }
+
+    @Override
+    public void setApiVersion(String version) {
+    }
+  }
+
+  @Group("fabric8.io")
+  @Version("v1")
+  @Plural("overridden")
+  private static class Over implements HasMetadata {
+
+    @Override
+    public ObjectMeta getMetadata() {
+      return null;
+    }
+
+    @Override
+    public void setMetadata(ObjectMeta metadata) {
+    }
+
+    @Override
+    public void setApiVersion(String version) {
+    }
   }
 
   private static class Empty implements HasMetadata {

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
@@ -38,7 +38,7 @@ class HasMetadataTest {
 
   @Test
   void fullResourceNameShouldConcatenatePluralAndGroup() {
-    assertEquals("foos.fabric8.io", HasMetadata.getFullResourceName(Foo.class));
+    assertEquals("women.fabric8.io", HasMetadata.getFullResourceName(Woman.class));
     assertEquals("overridden.fabric8.io", HasMetadata.getFullResourceName(Over.class));
   }
 
@@ -210,7 +210,7 @@ class HasMetadataTest {
 
   @Group("fabric8.io")
   @Version("v1")
-  private static class Foo implements HasMetadata {
+  private static class Woman implements HasMetadata {
 
     @Override
     public ObjectMeta getMetadata() {


### PR DESCRIPTION
Fixes #3712

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
