### PR TITLE
Fix #3568: Pod upload file fails if file is directly in root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix #3588: `openshift-server-mock` is not listed in dependencyManagement in main pom
 * Fix #3679: output additionalProperties field with correct value type for map-like fields (CRD Generator)
 * Fix #3648: `Serialization.unmarshal` fails to deserialize YAML with single document in presence of document delimiter(`---`)
+* Fix #3568: Pod file upload fails if the path is `/`
 
 #### Improvements
 * Fix #3674: allows the connect and websocket timeouts to apply to watches instead of a hardcoded timeout

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -73,13 +73,8 @@ public class PodUpload {
   private static boolean uploadFile(HttpClient client, PodOperationContext context,
     OperationSupport operationSupport, Path pathToUpload)
     throws IOException, InterruptedException {
-
-    final String file = context.getFile();
-    final String directory = file.substring(0, file.lastIndexOf('/'));
-    final String command = String.format(
-      "mkdir -p %s && base64 -d - > %s", shellQuote(directory), shellQuote(file));
     final PodUploadWebSocketListener podUploadWebSocketListener = initWebSocket(
-      buildCommandUrl(command, context, operationSupport), client);
+      buildCommandUrl(createExecCommandForUpload(context), context, operationSupport), client);
     try (
       final FileInputStream fis = new FileInputStream(pathToUpload.toFile());
       final Base64.InputStream b64In = new Base64.InputStream(fis, Base64.ENCODE)
@@ -192,5 +187,13 @@ public class PodUpload {
     commandBuilder.append("&stderr=true");
     return new URL(
       URLUtils.join(operationSupport.getResourceUrl().toString(), commandBuilder.toString()));
+  }
+
+  static String createExecCommandForUpload(PodOperationContext context) {
+    final String file = context.getFile();
+    String directoryTrimmedFromFilePath = file.substring(0, file.lastIndexOf('/'));
+    final String directory = directoryTrimmedFromFilePath.isEmpty() ? "/" : directoryTrimmedFromFilePath;
+    return String.format(
+      "mkdir -p %s && base64 -d - > %s", shellQuote(directory), shellQuote(file));
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -80,7 +80,7 @@ class PodUploadTest {
   }
 
   @Test
-  void testUploadInvalidParametersShouldThrowException() throws Exception {
+  void testUploadInvalidParametersShouldThrowException() {
     final IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
       () -> PodUpload.upload(mockClient, mockContext, operationSupport, mockPathToUpload));
 
@@ -169,6 +169,30 @@ class PodUploadTest {
     };
 
     PodUpload.copy(input, consumer);
+  }
+
+  @Test
+  void createExecCommandForUpload_withFileInRootPath_shouldCreateValidExecCommandForUpload() {
+    // Given
+    when(mockContext.getFile()).thenReturn("/cp.log");
+
+    // When
+    String result = PodUpload.createExecCommandForUpload(mockContext);
+
+    // Then
+    assertThat(result, equalTo("mkdir -p '/' && base64 -d - > '/cp.log'"));
+  }
+
+  @Test
+  void createExecCommandForUpload_withNormalFile_shouldCreateValidExecCommandForUpload() {
+    // Given
+    when(mockContext.getFile()).thenReturn("/tmp/foo/cp.log");
+
+    // When
+    String result = PodUpload.createExecCommandForUpload(mockContext);
+
+    // Then
+    assertThat(result, equalTo("mkdir -p '/tmp/foo' && base64 -d - > '/tmp/foo/cp.log'"));
   }
 
 }


### PR DESCRIPTION
## Description
Fix #3568

Pod file upload seems be be creating invalid exec command for upload if
the file is directly in root path e.g. `/cp.log`. We create parent
directory of file by creating a substring based on last index of `/`.
This returns an empty string for a string like `/cp.log`.

Assume directory path to be `/` when directory is returned as empty string.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
