### PR TITLE
Fix #3721: Add support for uploading file via InputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix #3637: Update Fabric8 Kubernetes Model to v1.23.0
 
 #### New Features
+* Fix #3721: Add support for uploading file via InputStream
 
 #### _**Note**_: Breaking changes in the API
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Uploadable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Uploadable.java
@@ -15,9 +15,24 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 
 public interface Uploadable<T> {
 
+  /**
+   * Upload file located at specified {@link Path} to Pod
+   *
+   * @param path path of the file which needs to be uploaded
+   * @return boolean value regarding upload was successful or not.
+   */
   T upload(Path path);
+
+  /**
+   * Upload file extracted from provided InputStream to Pod
+   *
+   * @param inputStream {@link InputStream} which will be uploaded
+   * @return boolean value regarding upload was successful or not.
+   */
+  T upload(InputStream inputStream);
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -380,6 +380,18 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
    }
 
   @Override
+  public Boolean upload(InputStream inputStream) {
+    return wrapRunWithOptionalDependency(() -> {
+      try {
+        return PodUpload.uploadFileData(httpClient, getContext(), this, inputStream);
+      } catch (Exception ex) {
+        Thread.currentThread().interrupt();
+        throw KubernetesClientException.launderThrowable(ex);
+      }
+    }, "TarArchiveOutputStream is provided by commons-compress");
+  }
+
+  @Override
   public Boolean upload(Path path) {
     return wrapRunWithOptionalDependency(() -> {
       try {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -70,19 +70,26 @@ public class PodUpload {
     throw new IllegalArgumentException("Provided arguments are not valid (file, directory, path)");
   }
 
-  private static boolean uploadFile(HttpClient client, PodOperationContext context,
-    OperationSupport operationSupport, Path pathToUpload)
+  public static boolean uploadFileData(HttpClient client, PodOperationContext context,
+    OperationSupport operationSupport, InputStream inputStream)
     throws IOException, InterruptedException {
     final PodUploadWebSocketListener podUploadWebSocketListener = initWebSocket(
       buildCommandUrl(createExecCommandForUpload(context), context, operationSupport), client);
     try (
-      final FileInputStream fis = new FileInputStream(pathToUpload.toFile());
-      final Base64.InputStream b64In = new Base64.InputStream(fis, Base64.ENCODE)
+      final Base64.InputStream b64In = new Base64.InputStream(inputStream, Base64.ENCODE)
     ) {
       podUploadWebSocketListener.waitUntilReady(operationSupport.getConfig().getRequestConfig().getUploadConnectionTimeout());
       copy(b64In, podUploadWebSocketListener::send);
       podUploadWebSocketListener.waitUntilComplete(operationSupport.getConfig().getRequestConfig().getUploadRequestTimeout());
       return true;
+    }
+  }
+
+  private static boolean uploadFile(HttpClient client, PodOperationContext context,
+    OperationSupport operationSupport, Path pathToUpload)
+    throws IOException, InterruptedException {
+    try (final FileInputStream fis = new FileInputStream(pathToUpload.toFile())) {
+      return uploadFileData(client, context, operationSupport, fis);
     }
   }
 


### PR DESCRIPTION
## Description

Fix #3721
Refactor PodUpload.upload implementation to expose a method which will
receive InputStream which can be reused by newly added
upload(InputStream) method

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
