### PR TITLE
fix #3587: adding inform support for limit/batch fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### Improvements
 * Fix #3674: allows the connect and websocket timeouts to apply to watches instead of a hardcoded timeout
 * Fix #3651: Introduce SchemaFrom annotation as escape hatch (CRD Generator)
+* Fix #3587: adding inform support for limit/batch fetching
 * Fix #3734: extract static finalizer validation method
 
 #### Dependency Upgrade

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
@@ -38,6 +38,21 @@ public interface Informable<T> {
   Informable<T> withIndexers(Map<String, Function<T, List<String>>> indexers);
   
   /**
+   * Set the limit to the number of resources to list at one time.  This means that longer
+   * lists will take multiple requests to fetch.
+   * <p>If the list fails to complete it will be re-attempted with this limit, rather than
+   * falling back to the full list.  You should ensure that your handlers are either async or 
+   * fast acting to prevent long delays in list processing that may cause results to expire
+   * before reaching the end of the list.
+   * <p>WARNING As noted in the go client: "paginated lists are always served directly from
+   * etcd, which is significantly less efficient and may lead to serious performance and
+   * scalability problems."
+   * @param limit of a items in a list fetch
+   * @return the current {@link Informable}
+   */
+  Informable<T> withLimit(Long limit);
+  
+  /**
    * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
    * and provides a store of all the current resources.
    * <p>This returned informer will not support resync.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ListerWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/ListerWatcher.java
@@ -29,7 +29,9 @@ import io.fabric8.kubernetes.client.Watcher;
 public interface ListerWatcher<T, L> {
   Watch watch(ListOptions params, Watcher<T> watcher);
 
-  L list();
+  L list(ListOptions listOptions);
+  
+  Long getLimit();
 
   String getNamespace();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/SyncableStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/SyncableStore.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.informers.cache;
 
-import java.util.List;
+import java.util.Set;
 
 public interface SyncableStore<T> extends Store<T> {
 
@@ -41,17 +41,21 @@ public interface SyncableStore<T> extends Store<T> {
   void delete(T obj);
   
   /**
-   * Deletes the contents of the store, using instead the given list.
-   * Store takes ownership of the list, you should not reference it
-   * after calling this function
-   *
-   * @param list list of objects
-   */
-  void replace(List<T> list);
-
-  /**
    * Sends a resync event for each item.
    */
   void resync();
+  
+  /**
+   * Get the key for the given object
+   * @param obj object
+   * @return the key
+   */
+  String getKey(T obj);
+
+  /**
+   * Retain only the values with keys in the given set
+   * @param nextKeys to retain
+   */
+  void retainAll(Set<String> nextKeys);
 
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReflectorTest.java
@@ -36,7 +36,7 @@ class ReflectorTest {
   void testStateFlags() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
-    Mockito.when(mock.list()).thenReturn(list);
+    Mockito.when(mock.list(Mockito.any())).thenReturn(list);
 
     Reflector<Pod, PodList> reflector =
         new Reflector<>(Pod.class, mock, Mockito.mock(SyncableStore.class));
@@ -70,7 +70,7 @@ class ReflectorTest {
   void testNonHttpGone() {
     ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
     PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
-    Mockito.when(mock.list()).thenReturn(list);
+    Mockito.when(mock.list(Mockito.any())).thenReturn(list);
 
     Reflector<Pod, PodList> reflector =
         new Reflector<>(Pod.class, mock, Mockito.mock(SyncableStore.class));

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
@@ -17,7 +17,6 @@ package io.fabric8.kubernetes.client.informers.impl;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.informers.ListerWatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## Description
Related to #3587 #3616 - adds limit / batch fetching support to informers.  This can cut down on the size of the responses from the server and eventually the memory footprint of an informer.  To support the latter this will not fall back to fetching the entire list like the go client - this may need some refinement as currently it will just keep retrying.

If the limit is not specified, the default is to fetch everything in a single list.

A behavioral difference introduced here is that the affect of a relist is no longer atomic on the cache - rather each item in the relist will perform a cache update and create an event as it is seen.  Since the cache is still eventually consistent either way, I think this change is not a concern.

The javadocs call out a performance warning - it seems that pagination hits etc.d directly and so there's a concern about performance and scaling.

These changes to conflict of course with the api module creation, but that will be easy to resolve.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
