### PR TITLE
fix #3756 prevent modifications by standard operations to user objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #3679: output additionalProperties field with correct value type for map-like fields (CRD Generator)
 * Fix #3648: `Serialization.unmarshal` fails to deserialize YAML with single document in presence of document delimiter(`---`)
 * Fix #3568: Pod file upload fails if the path is `/`
+* Fix #3756 prevent modifications by standard operations to user objects
 
 #### Improvements
 * Fix #3674: allows the connect and websocket timeouts to apply to watches instead of a hardcoded timeout

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -20,7 +20,6 @@ public interface CreateOrReplaceable<T> {
   /**
    * Creates a provided resource in a Kubernetes Cluster. If creation
    * fails with a HTTP_CONFLICT, it tries to replace resource.
-   * <br>The resourceVersion and other fields of the item may be modified by this call.
    *
    * @param item to create or replace
    * @return created item returned in kubernetes api response

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Patchable.java
@@ -41,7 +41,7 @@ public interface Patchable<T> {
    * <ul>
    * <li>{@link PatchType#JSON} - will create a JSON patch against the current item.
    * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected way.
-   * Consider using edit instead.  The resourceVersion and other fields of the item may be modified by this call.
+   * Consider using edit instead.
    * <li>{@link PatchType#JSON_MERGE} - will send the serialization of the item as a JSON MERGE patch.
    * Set the resourceVersion to null to prevent optimistic locking.
    * <li>{@link PatchType#STRATEGIC_MERGE} - will send the serialization of the item as a STRATEGIC MERGE patch.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.dsl;
 public interface Replaceable<T> {
 
   /**
-   * Replace the server's state with the given item. The resourceVersion and other fields of the item may be modified by this call.
+   * Replace the server's state with the given item.
    * 
    * <p>If {@link Lockable#lockResourceVersion(String)} has been used to lock the resourceVersion, 
    * this operation is effectively a single update attempt against that version.

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.dsl.base;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.client.dsl.WritableOperation;
 import io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper;
-
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
@@ -175,7 +175,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   public T getMandatory() {
     if (item != null && !reloadingFromServer) {
-      return item;
+      return Serialization.clone(item);
     }
     try {
       URL requestUrl = getCompleteResourceUrl();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/HasMetadataOperation.java
@@ -163,6 +163,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
     String fixedResourceVersion = getResourceVersion();
     Exception caught = null;
     int maxTries = 10;
+    item = clone(item);
     if (item.getMetadata() == null) {
       item.setMetadata(new ObjectMeta());
     }
@@ -249,12 +250,12 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
   
   @Override
   public T patchStatus(T item) {
-    return patch(PatchContext.of(PatchType.JSON_MERGE), null, item, true);
+    return patch(PatchContext.of(PatchType.JSON_MERGE), null, clone(item), true);
   }
   
   @Override
   public T patch(PatchContext patchContext, T item) {
-    return patch(patchContext, null, item, false);
+    return patch(patchContext, null, clone(item), false);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.fabric8.kubernetes.client.dsl.internal.RollingOperationContext;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,7 +140,7 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
     }
     try {
         T oldObj = getMandatory();
-        T newObj = function.apply(oldObj);
+        T newObj = function.apply(Serialization.clone(oldObj));
         return getRollingUpdater(rollingTimeout, rollingTimeUnit).rollUpdate(oldObj, newObj);
     } catch (Exception e) {
         throw KubernetesClientException.launderThrowable(e);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/CreateOrReplaceHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/CreateOrReplaceHelper.java
@@ -40,6 +40,7 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
     String resourceVersion = KubernetesResourceUtil.getResourceVersion(item);
     final CompletableFuture<T> future = new CompletableFuture<>();
     int nTries = 0;
+    item = Serialization.clone(item);
     while (!future.isDone() && nTries < CREATE_OR_REPLACE_RETRIES) {
       try {
         // Create

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/CreateOrReplaceHelperTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/CreateOrReplaceHelperTest.java
@@ -24,9 +24,9 @@ import org.mockito.Mockito;
 
 import java.net.HttpURLConnection;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,13 +49,17 @@ class CreateOrReplaceHelperTest {
       p -> getPod(),
       p -> getPod()
     );
+    
+    Pod p = getPod();
+    p.getMetadata().setResourceVersion("1");
 
     // When
-    Pod podCreated = podCreateOrReplaceHelper.createOrReplace(getPod());
+    Pod podCreated = podCreateOrReplaceHelper.createOrReplace(p);
 
     // Then
     assertNotNull(podCreated);
     assertTrue(wasPodCreated.get());
+    assertEquals("1", p.getMetadata().getResourceVersion());
   }
 
   @Test

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/ServiceToURLIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/ServiceToURLIT.java
@@ -94,7 +94,7 @@ public class ServiceToURLIT {
     assertNotNull(url);
 
     // Testing Ingress Impl
-    Ingress ingress = client.extensions().ingresses().load(getClass().getResourceAsStream("/test-ingress.yml")).get();
+    Ingress ingress = client.extensions().ingresses().load(getClass().getResourceAsStream("/test-ingress-extensions.yml")).get();
     client.extensions().ingresses().inNamespace(currentNamespace).create(ingress);
 
     url = client.services().inNamespace(currentNamespace).withName("svc2").getURL("80");

--- a/kubernetes-itests/src/test/resources/test-crd.yml
+++ b/kubernetes-itests/src/test/resources/test-crd.yml
@@ -14,25 +14,27 @@
 # limitations under the License.
 #
 
-apiVersion: "apiextensions.k8s.io/v1beta1"
+apiVersion: "apiextensions.k8s.io/v1"
 kind: "CustomResourceDefinition"
 metadata:
   name: "projects.example.fabric8.io"
 spec:
-  group: "example.fabric8.io"
-  version: "v1alpha1"
-  scope: "Namespaced"
+  group: "examples.fabric8.io"
   names:
     plural: "projects"
     singular: "project"
     kind: "Project"
-  validation:
-    openAPIV3Schema:
-      required: ["spec"]
-      properties:
-        spec:
-          required: ["replicas"]
-          properties:
-            replicas:
-              type: "integer"
-              minimum: 1
+  scope: "Namespaced"
+  versions:
+  - name: "v1"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              field:
+                type: "string"
+            type: "object"
+        type: "object"
+    served: true
+    storage: true

--- a/kubernetes-itests/src/test/resources/test-ingress-extensions.yml
+++ b/kubernetes-itests/src/test/resources/test-ingress-extensions.yml
@@ -14,20 +14,22 @@
 # limitations under the License.
 #
 
-apiVersion: batch/v1beta1
-kind: CronJob
+apiVersion: extensions/v1beta1
+kind: Ingress
 metadata:
-  name: hello
+  name: test-multiple-paths
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
-  schedule: "*/1 * * * *"
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-          - name: hello
-            image: busybox
-            args:
-            - /bin/sh
-            - -c
-            - date; echo Hello from the Kubernetes cluster
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /foo
+        backend:
+          serviceName: svc2
+          servicePort: 80
+      - path: /bar
+        backend:
+          serviceName: s2
+          servicePort: 80

--- a/kubernetes-itests/src/test/resources/test-ingress.yml
+++ b/kubernetes-itests/src/test/resources/test-ingress.yml
@@ -14,22 +14,25 @@
 # limitations under the License.
 #
 
-apiVersion: extensions/v1beta1
-kind: Ingress
+apiVersion: "networking.k8s.io/v1"
+kind: "Ingress"
 metadata:
   name: test-multiple-paths
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - host: foo.bar.com
-    http:
+  - http:
       paths:
-      - path: /foo
-        backend:
-          serviceName: svc2
-          servicePort: 80
-      - path: /bar
-        backend:
-          serviceName: s2
-          servicePort: 80
+      - backend:
+          service:
+            name: "web"
+            port:
+              number: 8080
+        path: "/*"
+        pathType: "Prefix"
+      - backend:
+          service:
+            name: "web2"
+            port:
+              number: 8080
+        path: "/v2/*"
+        pathType: "Prefix"

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
@@ -102,7 +102,7 @@ class ConfigMapCrudTest {
       .build();
     client.configMaps().create(cm);
     // When
-    client.configMaps().edit(c -> new ConfigMapBuilder(c).removeFromData("one").addToData("two", "2").build());
+    client.configMaps().withName("config-map").edit(c -> new ConfigMapBuilder(c).removeFromData("one").addToData("two", "2").build());
     // Then
     assertThat(client.configMaps().withName("config-map").get().getData())
       .hasSize(1)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
@@ -37,9 +37,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
-import java.nio.charset.Charset;
 import java.util.List;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -249,10 +249,12 @@ class CreateOrReplaceResourceTest {
     server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1").andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
       .withNewMetadata().withResourceVersion("1001").and().build()).once();
 
-    ConfigMap map = client.configMaps().withName("map1").replace(new ConfigMapBuilder()
-      .withNewMetadata().withName("map1").and().build());
+    ConfigMap original = new ConfigMapBuilder()
+      .withNewMetadata().withName("map1").and().build();
+    ConfigMap map = client.configMaps().withName("map1").replace(original);
     assertNotNull(map);
     assertEquals("1001", map.getMetadata().getResourceVersion());
+    assertNull(original.getMetadata().getResourceVersion());
 
     ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class).readValue(server.getLastRequest().getBody().inputStream());
     assertEquals("1000", replacedMap.getMetadata().getResourceVersion());

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -17,7 +17,7 @@ package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -56,11 +56,11 @@ class CustomResourceCrudTest {
   void setUp() {
     KubernetesDeserializer.registerCustomKind("stable.example.com/v1", "CronTab", CronTab.class);
     cronTabCrd = client
-      .apiextensions().v1beta1()
+      .apiextensions().v1()
       .customResourceDefinitions()
       .load(getClass().getResourceAsStream("/crontab-crd.yml"))
       .get();
-    client.apiextensions().v1beta1().customResourceDefinitions().create(cronTabCrd);
+    client.apiextensions().v1().customResourceDefinitions().create(cronTabCrd);
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta1HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta1HorizontalPodAutoscalerTest.java
@@ -148,7 +148,7 @@ public class V2beta1HorizontalPodAutoscalerTest {
 
   @Test
   public void testLoadFromFile() {
-    HorizontalPodAutoscaler horizontalPodAutoscaler = client.autoscaling().v2beta1().horizontalPodAutoscalers().load(getClass().getResourceAsStream("/test-horizontalpodautoscaler.yml")).get();
+    HorizontalPodAutoscaler horizontalPodAutoscaler = client.autoscaling().v2beta1().horizontalPodAutoscalers().load(getClass().getResourceAsStream("/test-v2beta1-horizontalpodautoscaler.yml")).get();
     assertEquals("php-apache", horizontalPodAutoscaler.getMetadata().getName());
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta2HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta2HorizontalPodAutoscalerTest.java
@@ -162,7 +162,7 @@ public class V2beta2HorizontalPodAutoscalerTest {
 
   @Test
   public void testLoadFromFile() {
-    HorizontalPodAutoscaler horizontalPodAutoscaler = client.autoscaling().v2beta2().horizontalPodAutoscalers().load(getClass().getResourceAsStream("/test-horizontalpodautoscaler.yml")).get();
+    HorizontalPodAutoscaler horizontalPodAutoscaler = client.autoscaling().v2beta2().horizontalPodAutoscalers().load(getClass().getResourceAsStream("/test-v2beta2-horizontalpodautoscaler.yml")).get();
     assertEquals("php-apache", horizontalPodAutoscaler.getMetadata().getName());
   }
 

--- a/kubernetes-tests/src/test/resources/test-resourcequota-deployment.yml
+++ b/kubernetes-tests/src/test/resources/test-resourcequota-deployment.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deployment

--- a/kubernetes-tests/src/test/resources/test-v2beta1-horizontalpodautoscaler.yml
+++ b/kubernetes-tests/src/test/resources/test-v2beta1-horizontalpodautoscaler.yml
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: <some-time>
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+    - type: Resource
+      resource:
+        name: cpu
+        current:
+          averageUtilization: 0
+          averageValue: 0

--- a/kubernetes-tests/src/test/resources/test-v2beta2-horizontalpodautoscaler.yml
+++ b/kubernetes-tests/src/test/resources/test-v2beta2-horizontalpodautoscaler.yml
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+status:
+  observedGeneration: 1
+  lastScaleTime: <some-time>
+  currentReplicas: 1
+  desiredReplicas: 1
+  currentMetrics:
+    - type: Resource
+      resource:
+        name: cpu
+        current:
+          averageUtilization: 0
+          averageValue: 0

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/core/NetworkAttachmentDefinitionOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/core/NetworkAttachmentDefinitionOperationsImpl.java
@@ -15,12 +15,10 @@
  */
 package io.fabric8.openshift.client.dsl.internal.core;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
 import io.fabric8.openshift.api.model.miscellaneous.cncf.cni.v1.NetworkAttachmentDefinition;
-import io.fabric8.openshift.api.model.miscellaneous.cncf.cni.v1.NetworkAttachmentDefinitionBuilder;
 import io.fabric8.openshift.api.model.miscellaneous.cncf.cni.v1.NetworkAttachmentDefinitionList;
 import io.fabric8.openshift.client.OpenshiftClientContext;
 import io.fabric8.openshift.client.dsl.internal.OpenShiftOperation;
@@ -40,11 +38,6 @@ public class NetworkAttachmentDefinitionOperationsImpl extends OpenShiftOperatio
   @Override
   public NetworkAttachmentDefinitionOperationsImpl newInstance(OperationContext context) {
     return new NetworkAttachmentDefinitionOperationsImpl(context);
-  }
-
-  @Override
-  public NetworkAttachmentDefinition edit(Visitor... visitors) {
-    return patch(new NetworkAttachmentDefinitionBuilder(getMandatory()).accept(visitors).build());
   }
 
   @Override


### PR DESCRIPTION
## Description
Guards against the basic operations from modifying passed in resources.

I couldn't see any other places besides the JobOperationsImpl where we making similar modifications.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
