### PR TITLE
A Java Long should generate a field of type integer in the CRD

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -65,6 +65,7 @@ public abstract class AbstractJsonSchema<T, B> {
 
   private static final String INT_OR_STRING_MARKER = "int_or_string";
   private static final String STRING_MARKER = "string";
+  private static final String INTEGER_MARKER = "integer";
   private static final String NUMBER_MARKER = "number";
   private static final String BOOLEAN_MARKER = "boolean";
 
@@ -88,10 +89,10 @@ public abstract class AbstractJsonSchema<T, B> {
   static {
     COMMON_MAPPINGS.put(STRING_REF, STRING_MARKER);
     COMMON_MAPPINGS.put(DATE_REF, STRING_MARKER);
-    COMMON_MAPPINGS.put(INT_REF, "integer");
-    COMMON_MAPPINGS.put(P_INT_REF, "integer");
-    COMMON_MAPPINGS.put(LONG_REF, NUMBER_MARKER);
-    COMMON_MAPPINGS.put(P_LONG_REF, NUMBER_MARKER);
+    COMMON_MAPPINGS.put(INT_REF, INTEGER_MARKER);
+    COMMON_MAPPINGS.put(P_INT_REF, INTEGER_MARKER);
+    COMMON_MAPPINGS.put(LONG_REF, INTEGER_MARKER);
+    COMMON_MAPPINGS.put(P_LONG_REF, INTEGER_MARKER);
     COMMON_MAPPINGS.put(DOUBLE_REF, NUMBER_MARKER);
     COMMON_MAPPINGS.put(P_DOUBLE_REF, NUMBER_MARKER);
     COMMON_MAPPINGS.put(BOOLEAN_REF, BOOLEAN_MARKER);

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/basic/BasicSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/basic/BasicSpec.java
@@ -25,4 +25,14 @@ public class BasicSpec {
   public void setMyInt(int myInt) {
     this.myInt = myInt;
   }
+
+  private long myLong;
+
+  public long getMyLong() {
+    return myLong;
+  }
+
+  public void setMyLong(long myLong) {
+    this.myLong = myLong;
+  }
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -64,6 +64,7 @@ class JsonSchemaTest {
     assertEquals(2, properties.size());
     Map<String, JSONSchemaProps> spec = properties.get("spec").getProperties();
     assertEquals("integer", spec.get("myInt").getType());
+    assertEquals("integer", spec.get("myLong").getType());
     Map<String, JSONSchemaProps> status = properties.get("status").getProperties();
     assertEquals("string", status.get("message").getType());
   }


### PR DESCRIPTION
## Description

Fix for #3763 

## Type of change

 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift