### PR TITLE
Move the Arquillian dep to <dependency management> section

### DIFF
--- a/kubernetes-itests/pom.xml
+++ b/kubernetes-itests/pom.xml
@@ -44,13 +44,11 @@
     <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
-      <version>${arquillian.cube.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-openshift-starter</artifactId>
-      <version>${arquillian.cube.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -663,6 +663,20 @@
       </dependency>
 
       <dependency>
+        <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-requirement</artifactId>
+        <version>${arquillian.cube.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-openshift-starter</artifactId>
+        <version>${arquillian.cube.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>javax.validation</groupId>
         <artifactId>validation-api</artifactId>
         <version>${validation-api.version}</version>
@@ -1115,28 +1129,12 @@
           </plugin>
         </plugins>
       </build>
-      <dependencies>
-        <dependency>
-          <groupId>org.arquillian.cube</groupId>
-          <artifactId>arquillian-cube-kubernetes-starter</artifactId>
-          <version>${arquillian.cube.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
     </profile>
     <profile>
       <id>itests-openshift</id>
       <modules>
         <module>kubernetes-itests</module>
       </modules>
-      <dependencies>
-        <dependency>
-          <groupId>org.arquillian.cube</groupId>
-          <artifactId>arquillian-cube-openshift-starter</artifactId>
-          <version>${arquillian.cube.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
## Description

This PR removes the redundant arquillian deps in the <profile> section of the ids `itests-kubernetes` and `itests-openshift` and move the arquillian dependency to <dependency-management> section

Fix #3759 

## Type of change

What types of changes does your code introduce? Put an `x` in all the boxes that apply

 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift


