### PR TITLE
fix(kubernetes-client) : HTTP(s) Proxy Port is not defaulted or validated (#3671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@
 * Fix #3683: Handle JsonNode fields by adding x-kubernetes-preserve-unknown-fields
 * Fix #3697: addresses response that aren't closed by interceptors that issue new requests
 * Fix #3255: adding basic crud mock resourceVersion support - the field will be set and updated, but not utilized by list/watch queries
-* Fix #3712: properly return the full resource name for resources with empty group
-* Fix #3588: `openshift-server-mock` is not listed in dependencyManagement in main pom
-* Fix #3679: output additionalProperties field with correct value type for map-like fields (CRD Generator)
-* Fix #3648: `Serialization.unmarshal` fails to deserialize YAML with single document in presence of document delimiter(`---`)
 * Fix #3568: Pod file upload fails if the path is `/`
+* Fix #3588: `openshift-server-mock` is not listed in dependencyManagement in main pom
+* Fix #3648: `Serialization.unmarshal` fails to deserialize YAML with single document in presence of document delimiter(`---`)
+* Fix #3679: output additionalProperties field with correct value type for map-like fields (CRD Generator)
+* Fix #3671: HTTP(s) Proxy port is not defaulted or validated
+* Fix #3712: properly return the full resource name for resources with empty group
+* Fix #3761: Extension Jar packages don't contain the META-INF/jandex.idx index file
 * Fix #3763: A Java Long should generate a field of type integer in the CRD
 * Fix #3769: Fix for ClassCastException from SchemaFrom
 * Fix #3756 prevent modifications by standard operations to user objects
-* Fix #3761: Extension Jar packages don't contain the META-INF/jandex.idx index file
 
 #### Improvements
 * Fix #3674: allows the connect and websocket timeouts to apply to watches instead of a hardcoded timeout

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -103,7 +103,11 @@ public class HttpClientUtils {
             proxy = config.getHttpProxy();
         }
         if (proxy != null) {
-            return new URL(proxy);
+            URL proxyUrl = new URL(proxy);
+            if (proxyUrl.getPort() < 0) {
+              throw new IllegalArgumentException("Failure in creating proxy URL. Proxy port is required!");
+            }
+            return proxyUrl;
         }
         return null;
     }


### PR DESCRIPTION
## Description

Fix #3671

Add validation for case when no port is provided in proxy URL. Now we
would throw IllegalArgumentException in case resolved port is less than
zero (It's resolved to `-1` by `java.net.URL` class when no port is
being provided)

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
