### PR TITLE
Deserialize WatchEvents using the specific object type

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -244,7 +244,12 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
       }
 
       WatchEvent watchEvent = Serialization.jsonMapper().treeToValue(json, WatchEvent.class);
-      T object = Serialization.jsonMapper().treeToValue(objectJson, baseOperation.getType());
+      KubernetesResource object = null;
+      try {
+        object = Serialization.jsonMapper().treeToValue(objectJson, baseOperation.getType());
+      } catch (JsonProcessingException e) {
+        object = Serialization.jsonMapper().treeToValue(objectJson, KubernetesResource.class);
+      }
       watchEvent.setObject(object);
       return watchEvent;
     } catch (JsonProcessingException e) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -240,10 +240,8 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
       try {
         JsonNode json = Serialization.jsonMapper().readTree(messageSource);
         JsonNode objectJson = null;
-        if (json instanceof ObjectNode) {
-          if (json.has("object")) {
-            objectJson = ((ObjectNode) json).remove("object");
-          }
+        if (json instanceof ObjectNode && json.has("object")) {
+          objectJson = ((ObjectNode) json).remove("object");
         }
 
         WatchEvent watchEvent = Serialization.jsonMapper().treeToValue(json, WatchEvent.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -54,6 +54,7 @@ import io.fabric8.kubernetes.client.mock.crd.StarSpec;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.Utils;
+import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -917,6 +918,23 @@ class DefaultSharedIndexInformerTest {
     setupMockServerExpectations(Animal.class, "ns1", this::getList, r -> new WatchEvent(getAnimal("red-panda", "Carnivora", r), "ADDED"), null, null);
 
     // When
+    SharedIndexInformer<GenericKubernetesResource> animalSharedIndexInformer = factory.inNamespace("ns1").sharedIndexInformerForCustomResource(animalContext, 60 * WATCH_EVENT_EMIT_TIME);
+    CountDownLatch foundExistingAnimal = new CountDownLatch(1);
+    animalSharedIndexInformer.addEventHandler(new TestResourceHandler<>(foundExistingAnimal, "red-panda"));
+    factory.startAllRegisteredInformers();
+    foundExistingAnimal.await(LATCH_AWAIT_PERIOD_IN_SECONDS, TimeUnit.SECONDS);
+
+    // Then
+    assertEquals(0, foundExistingAnimal.getCount());
+  }
+
+  @Test
+  void testGenericKubernetesResourceSharedIndexInformerWithAdditionalDeserializers() throws InterruptedException {
+    // Given
+    setupMockServerExpectations(Animal.class, "ns1", this::getList, r -> new WatchEvent(getAnimal("red-panda", "Carnivora", r), "ADDED"), null, null);
+
+    // When
+    KubernetesDeserializer.registerCustomKind("jungle.example.com/v1","Animal", CronTab.class);
     SharedIndexInformer<GenericKubernetesResource> animalSharedIndexInformer = factory.inNamespace("ns1").sharedIndexInformerForCustomResource(animalContext, 60 * WATCH_EVENT_EMIT_TIME);
     CountDownLatch foundExistingAnimal = new CountDownLatch(1);
     animalSharedIndexInformer.addEventHandler(new TestResourceHandler<>(foundExistingAnimal, "red-panda"));


### PR DESCRIPTION
## Description

This is a proposal to fix the specific issue reproduced in #3785 

Instead of relying on the `KubernetesDeserializer` fallback mechanism here we are trying to deserialize the `WatchEvent`s using the specific deserializer for the type.

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

cc. @shawkins 
