### PR TITLE
Apply minor optimization for to decrease allocations

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/BeanPropertyWriterDelegate.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/serialization/BeanPropertyWriterDelegate.java
@@ -54,11 +54,13 @@ public class BeanPropertyWriterDelegate extends BeanPropertyWriter {
 
   @Override
   public void serializeAsField(Object bean, JsonGenerator gen, SerializerProvider prov) throws Exception {
-    final Object valueInAnyGetter = Optional.ofNullable(anyGetter)
-      .map(ag -> ag.getValue(bean))
-      .map(Map.class::cast)
-      .map(m -> m.get(delegate.getName()))
-      .orElse(null);
+    Object valueInAnyGetter = null;
+    if (anyGetter != null) {
+      Object anyGetterValue = anyGetter.getValue(bean);
+      if (anyGetterValue != null) {
+        valueInAnyGetter = ((Map<?, ?>) anyGetterValue).get(delegate.getName());
+      }
+    }
     if (valueInAnyGetter == null) {
       delegate.serializeAsField(bean, gen, prov);
     } else if (Boolean.TRUE.equals(logDuplicateWarning.get())) {


### PR DESCRIPTION
## Description

When performing a small profiling of a sample Operator SDK application,
I noticed that BeanPropertyWriterDelegate was leading to a lot of
allocations due to the use of lambdas.
Lambdas are great, but can lead to performance issues when used on the
hot path of the code, which this class seems to be.
Furthermore, the change does not reduce the readability of the code