### PR TITLE
Limit usage of YAML Serializer

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -269,7 +269,7 @@ public class Config {
    * @return Config object
    */
   public static Config autoConfigure(String context) {
-    Config config = new Config();
+    Config config = new Config(false);
     return autoConfigure(config, context);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -61,7 +61,6 @@ public class OperationSupport {
   public static final String JSON_MERGE_PATCH = "application/merge-patch+json";
   
   protected static final ObjectMapper JSON_MAPPER = Serialization.jsonMapper();
-  protected static final ObjectMapper YAML_MAPPER = Serialization.yamlMapper();
   private static final Logger LOG = LoggerFactory.getLogger(OperationSupport.class);
   private static final String CLIENT_STATUS_FLAG = "CLIENT_STATUS_FLAG";
   private static final int maxRetryIntervalExponent = 5;


### PR DESCRIPTION
## Description

The YAML serializer is mainly used in order to parse the kubernetes config. 
This change should not have any functional effect whatsoever, but it paves the way for what I have in mind as a follow-up, which is to provide a public method that allows for clearing out the YAMLMapper (the reasoning being that this is a very heavy object that most likely is only used when the client is first booted). 