### PR TITLE
[crd-generator] Implement SchemaSwap

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaSwap.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaSwap.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.crd.example.extraction;
+package io.fabric8.crd.generator.annotation;
 
-import io.fabric8.crd.generator.annotation.SchemaSwap;
-import io.fabric8.kubernetes.client.CustomResource;
+import java.lang.annotation.*;
 
-@SchemaSwap(originalType = ExtractionSpec.class, fieldName = "bar", targetType = FooExtractor.class)
-public class Extraction extends  CustomResource<ExtractionSpec, Void> {
-
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE_USE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SchemaSwap {
+  Class<?> originalType();
+  String fieldName();
+  Class<?> targetType() default void.class;
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/utils/Types.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/utils/Types.java
@@ -19,6 +19,8 @@ import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.sundr.adapter.api.AdapterContext;
 import io.sundr.adapter.api.Adapters;
+import io.sundr.adapter.apt.AptAdapter;
+import io.sundr.adapter.apt.AptContext;
 import io.sundr.builder.TypedVisitor;
 import io.sundr.model.*;
 import io.sundr.model.functions.GetDefinition;

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
@@ -22,4 +22,6 @@ public class ExtractionSpec {
   @SchemaFrom(type = FooExtractor.class)
   private Foo foo;
 
+  private Foo bar;
+
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/IncorrectExtraction.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/IncorrectExtraction.java
@@ -18,7 +18,7 @@ package io.fabric8.crd.example.extraction;
 import io.fabric8.crd.generator.annotation.SchemaSwap;
 import io.fabric8.kubernetes.client.CustomResource;
 
-@SchemaSwap(originalType = ExtractionSpec.class, fieldName = "bar", targetType = FooExtractor.class)
-public class Extraction extends  CustomResource<ExtractionSpec, Void> {
+@SchemaSwap(originalType = ExtractionSpec.class, fieldName = "FOO", targetType = FooExtractor.class)
+public class IncorrectExtraction extends  CustomResource<ExtractionSpec, Void> {
 
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/IncorrectExtraction2.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/IncorrectExtraction2.java
@@ -15,10 +15,11 @@
  */
 package io.fabric8.crd.example.extraction;
 
+import io.fabric8.crd.example.basic.BasicSpec;
 import io.fabric8.crd.generator.annotation.SchemaSwap;
 import io.fabric8.kubernetes.client.CustomResource;
 
-@SchemaSwap(originalType = ExtractionSpec.class, fieldName = "bar", targetType = FooExtractor.class)
-public class Extraction extends  CustomResource<ExtractionSpec, Void> {
+@SchemaSwap(originalType = BasicSpec.class, fieldName = "bar", targetType = FooExtractor.class)
+public class IncorrectExtraction2 extends  CustomResource<ExtractionSpec, Void> {
 
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/ResourcesTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/ResourcesTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.crd.generator.decorator.Decorator;
 import io.fabric8.crd.generator.v1.decorator.AddAdditionPrinterColumnDecorator;
 import io.fabric8.crd.generator.v1.decorator.SortPrinterColumnsDecorator;
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -18,6 +18,8 @@ package io.fabric8.crd.generator.v1;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.example.annotated.Annotated;
 import io.fabric8.crd.example.basic.Basic;
+import io.fabric8.crd.example.extraction.IncorrectExtraction;
+import io.fabric8.crd.example.extraction.IncorrectExtraction2;
 import io.fabric8.crd.example.json.ContainingJson;
 import io.fabric8.crd.example.extraction.Extraction;
 import io.fabric8.crd.example.person.Person;
@@ -113,7 +115,7 @@ class JsonSchemaTest {
   }
 
   @Test
-  void shouldProbuceKubernetesPreserveFields() {
+  void shouldProduceKubernetesPreserveFields() {
     TypeDef containingJson = Types.typeDefFrom(ContainingJson.class);
     JSONSchemaProps schema = JsonSchema.from(containingJson);
     assertNotNull(schema);
@@ -149,7 +151,7 @@ class JsonSchemaTest {
     assertEquals(2, properties.size());
     final JSONSchemaProps specSchema = properties.get("spec");
     Map<String, JSONSchemaProps> spec = specSchema.getProperties();
-    assertEquals(1, spec.size());
+    assertEquals(2, spec.size());
 
     // check typed SchemaFrom
     JSONSchemaProps foo = spec.get("foo");
@@ -157,11 +159,34 @@ class JsonSchemaTest {
     assertNotNull(fooProps);
 
     // you can change everything
-    assertEquals(fooProps.get("BAZ").getType(), "integer");
+    assertEquals("integer", fooProps.get("BAZ").getType());
     assertTrue(foo.getRequired().contains("BAZ"));
 
     // you can exclude fields
     assertNull(fooProps.get("baz"));
+
+    // check typed SchemaSwap
+    JSONSchemaProps bar = spec.get("bar");
+    Map<String, JSONSchemaProps> barProps = bar.getProperties();
+    assertNotNull(barProps);
+
+    // you can change everything
+    assertEquals("integer", barProps.get("BAZ").getType());
+    assertTrue(bar.getRequired().contains("BAZ"));
+
+    // you can exclude fields
+    assertNull(barProps.get("baz"));
   }
 
+  @Test
+  void shouldThrowIfSchemaSwapHasUnmatchedField() {
+    TypeDef incorrectExtraction = Types.typeDefFrom(IncorrectExtraction.class);
+    assertThrows(IllegalArgumentException.class, () -> JsonSchema.from(incorrectExtraction));
+  }
+
+  @Test
+  void shouldThrowIfSchemaSwapHasUnmatchedClass() {
+    TypeDef incorrectExtraction2 = Types.typeDefFrom(IncorrectExtraction2.class);
+    assertThrows(IllegalArgumentException.class, () -> JsonSchema.from(incorrectExtraction2));
+  }
 }

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -201,6 +201,30 @@ The CRD generator will substitute the default type inferred from the field and r
             type: object
 ```
 
+### io.fabric8.crd.generator.annotation.SchemaSwap
+
+If a class is annotated with `io.fabric8.crd.generator.annotation.SchemaSwap`
+
+```java
+@SchemaSwap(originalType = ExampleSpec.class, fieldName = "someValue", targetType = ExampleStatus.class)
+public class Example extends CustomResource<ExampleSpec, ExampleStatus> implements Namespaced {}
+```
+
+The CRD generator will perform the same substitution as a `SchemaFrom` annotation with `value` equal to `targetType` was placed on the field named `fieldName` in the `originalType` class:
+
+```yaml
+          spec:
+            properties:
+              someValue:
+                properties:
+                  error:
+                    type: boolean
+                  message:
+                    type: string
+                type: object
+            type: object
+```
+
 ### Generating `x-kubernetes-preserve-unknown-fields: true`
 
 If a field or one of its accessors is annotated with
@@ -246,5 +270,6 @@ Corresponding `x-kubernetes-preserve-unknown-fields: true` will be generated in 
 | `com.fasterxml.jackson.annotation.JsonAnySetter`          | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
 | `javax.validation.constraints.NotNull`                    | The field is marked as `required`                                                     |
 | `io.fabric8.crd.generator.annotation.SchemaFrom`          | The field type for the generation is the one coming from the annotation               |
+| `io.fabric8.crd.generator.annotation.SchemaSwap`          | Same as SchemaFrom, but can be applied at any point in the class hierarchy            |
 
 A field of type `com.fasterxml.jackson.databind.JsonNode` is encoded as an empty object with `x-kubernetes-preserve-unknown-fields: true` defined.


### PR DESCRIPTION
## Description

This is a ~~Draft~~ implementation of `SchemaSwap`.
The annotation serves to enable the use-case where you want to generate a valid CRD from a model that you don't own.

e.g.:
The model comes as a dependency on the classpath and you cannot add `SchemaFrom` annotations to it.

Issue found in (cc. @vmuzikar):
https://github.com/keycloak/keycloak/pull/9759

I'm opening this PR as Draft to start the conversation regarding pros/cons and alternatives to this approach.
PRO:
 - it enables to inject the equivalent of `SchemaFrom` annotations in a hierarchy without punctual changes
 - the type checker is mostly preventing big issues
 - ~~[not implemented yet] we can implement a~~ guard to throw an exception in case of fields/classes not found
 
~~CONS:~~
- ~~the CRD api module cannot be easily executed anymore outside an `AnnotationProcessor` (the `REFLECTION_CONTEXT` doesn't preserve Annotations at the class level cc. @iocanel )~~
- ~~Adding the APT Context subtly breaks the extraction of the Map value type~~

I'm happy to gather feedback and alternative proposals! cc. @metacosm @iocanel 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift