### PR TITLE
fix (kubernetes-client) : `edit()`, `patch()` and other mutating operations shouldn't be allowed in NonNamespaceOperation (#3772)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #3776: VerticalPodAutoscaler cannot load yaml with "controlledResources"
+* Fix #3772: `edit()` should not be allowed as a NonNamespaceOperation
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
@@ -25,7 +25,8 @@ package io.fabric8.kubernetes.client.dsl;
 public interface NonNamespaceOperation<T, L, R> extends
   Nameable<R>,
   FilterWatchListMultiDeletable<T, L>,
-  WritableOperation<T>,
+  Createable<T>,
+  CreateOrReplaceable<T>,
   DryRunable<WritableOperation<T>>,
   Loadable<R> {
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
@@ -24,6 +24,7 @@ public interface Resource<T> extends CreateOrReplaceable<T>,
   CreateFromServerGettable<T>,
   CascadingEditReplacePatchDeletable<T>,
   VersionWatchAndWaitable<T>,
+  WritableOperation<T>,
   DryRunable<WritableOperation<T>>,
   Requirable<T>, Readiable, Informable<T>,
   CreateOrDeleteable<T> {

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PatchIT.java
@@ -128,7 +128,7 @@ public class PatchIT {
     // When
     ConfigMap configMapFromServer = client.configMaps().inNamespace(currentNamespace).withName(name).get();
     configMapFromServer.setData(Collections.singletonMap("foo", "bar"));
-    ConfigMap patchedConfigMap = client.configMaps().patch(configMapFromServer);
+    ConfigMap patchedConfigMap = client.configMaps().inNamespace(currentNamespace).withName(name).patch(configMapFromServer);
 
     // Then
     assertThat(patchedConfigMap).isNotNull();
@@ -148,7 +148,7 @@ public class PatchIT {
     // concurrent change to empty
     ConfigMap baseCopy = new ConfigMapBuilder(base).build();
     baseCopy.setData(Collections.emptyMap());
-    client.configMaps().patch(baseCopy);
+    client.configMaps().inNamespace(currentNamespace).withName(name).patch(baseCopy);
 
     // concurrent change to empty
     ConfigMap baseCopy2 = new ConfigMapBuilder(base).build();

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
@@ -214,7 +214,7 @@ public class TypedCustomResourceIT {
     // use the original pet, no need to pick up the resourceVersion
     pet.getSpec().setType("shouldn't change");
     pet.setStatus(petStatusToUpdate);
-    Pet updatedPet = petClient.inNamespace(currentNamespace).replaceStatus(pet);
+    Pet updatedPet = petClient.inNamespace(currentNamespace).withName(pet.getMetadata().getName()).replaceStatus(pet);
 
     // Then
     assertPet(updatedPet, "pet-replacestatus", "Pigeon", "Sleeping");
@@ -234,7 +234,7 @@ public class TypedCustomResourceIT {
     // use the original pet, no need to pick up the resourceVersion
     pet.getSpec().setType("shouldn't change");
     pet.setStatus(petStatusToUpdate);
-    Pet updatedPet = petClient.inNamespace(currentNamespace).patchStatus(pet);
+    Pet updatedPet = petClient.inNamespace(currentNamespace).withName(pet.getMetadata().getName()).patchStatus(pet);
 
     // Then
     assertPet(updatedPet, "pet-applystatus", "Pigeon", "Sleeping");

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -175,7 +175,7 @@ class CustomResourceCrudTest {
 
     cronTab.getMetadata().setLabels(labels);
 
-    result = cronTabClient.replace(cronTab);
+    result = cronTabClient.withName(cronTab.getMetadata().getName()).replace(cronTab);
 
     String originalUid = result.getMetadata().getUid();
 
@@ -187,13 +187,13 @@ class CustomResourceCrudTest {
     labels.put("other", "label");
     cronTab.setStatus(null);
 
-    result = cronTabClient.replace(cronTab);
+    result = cronTabClient.withName(cronTab.getMetadata().getName()).replace(cronTab);
 
     // should retain the existing
     assertNotNull(result.getStatus());
 
     labels.put("another", "label");
-    result = cronTabClient.patch(cronTab);
+    result = cronTabClient.withName(cronTab.getMetadata().getName()).patch(cronTab);
 
     // should retain the existing
     assertNotNull(result.getStatus());
@@ -220,7 +220,7 @@ class CustomResourceCrudTest {
 
     result.setStatus(status);
 
-    result = cronTabClient.patchStatus(result);
+    result = cronTabClient.withName(cronTab.getMetadata().getName()).patchStatus(result);
     assertNotNull(result.getStatus());
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
@@ -157,7 +157,7 @@ class TypedClusterScopeCustomResourceApiTest {
       server.expect().put().withPath("/apis/example.crd.com/v1alpha1/stars/sun/status").andReturn(200, "{\"apiVersion\":\"example.crd.com/v1alpha1\",\"kind\":\"Star\",\"metadata\":{\"name\":\"sun\",\"resourceVersion\":\"2\"},\"spec\":{\"type\":\"G\",\"location\":\"Galaxy\"},\"status\":{\"location\":\"M\"}}").once();
       starClient = client.customResources(Star.class);
 
-      Star replaced = starClient.inNamespace("test").replaceStatus(updatedStar);
+      Star replaced = starClient.inNamespace("test").withName(updatedStar.getMetadata().getName()).replaceStatus(updatedStar);
       assertEquals("2", replaced.getMetadata().getResourceVersion());
       RecordedRequest recordedRequest = server.getLastRequest();
       // get of the latest version, put of status


### PR DESCRIPTION
## Description
Fix #3772

Remove reference to `WritableOperation<T>` interface from
NonNamespaceOperation as it exposes `edit()`, `patch()` and other
mutating operations.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
