### PR TITLE
[java-gen] Adding support for basic Javadoc comments generation

### DIFF
--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -35,9 +35,23 @@ public abstract class AbstractJSONSchema2Pojo {
     static final String OBJECT_CRD_TYPE = "object";
     static final String ARRAY_CRD_TYPE = "array";
 
+    private final String description;
+
     public abstract String getType();
 
     public abstract GeneratorResult generateJava(CompilationUnit cu);
+
+    public String getDescription() {
+      return description;
+    }
+
+    protected AbstractJSONSchema2Pojo() {
+        this(null);
+    }
+
+    protected AbstractJSONSchema2Pojo(String description) {
+        this.description = description;
+    }
 
     /** Takes a random string and manipulate it to be a valid Java identifier */
     public static String sanitizeString(String str) {
@@ -129,13 +143,13 @@ public abstract class AbstractJSONSchema2Pojo {
             String key, JavaNameAndType nt, JSONSchemaProps prop, String prefix, String suffix) {
         switch (nt.getType()) {
             case PRIMITIVE:
-                return new JPrimitive(nt.getName());
+                return new JPrimitive(nt.getName(), prop.getDescription());
             case ARRAY:
-                return new JArray(fromJsonSchema(key, prop.getItems().getSchema(), prefix, suffix));
+                return new JArray(fromJsonSchema(key, prop.getItems().getSchema(), prefix, suffix), prop.getDescription());
             case MAP:
                 return new JMap(
                         fromJsonSchema(
-                                key, prop.getAdditionalProperties().getSchema(), prefix, suffix));
+                                key, prop.getAdditionalProperties().getSchema(), prefix, suffix), prop.getDescription());
             case OBJECT:
                 boolean preserveUnknownFields =
                         Boolean.TRUE.equals(prop.getXKubernetesPreserveUnknownFields());
@@ -143,9 +157,10 @@ public abstract class AbstractJSONSchema2Pojo {
                         key,
                         prop.getProperties(),
                         prop.getRequired(),
-                        new JObjectOptions(preserveUnknownFields, prefix, suffix));
+                        new JObjectOptions(preserveUnknownFields, prefix, suffix),
+                        prop.getDescription());
             case ENUM:
-                return new JEnum(key, prop.getEnum());
+                return new JEnum(key, prop.getEnum(), prop.getDescription());
             default:
                 throw new JavaGeneratorException("Unreachable " + nt.getType());
         }

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JArray.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JArray.java
@@ -26,6 +26,11 @@ public class JArray extends AbstractJSONSchema2Pojo {
     private final AbstractJSONSchema2Pojo nested;
 
     public JArray(AbstractJSONSchema2Pojo nested) {
+        this(nested, null);
+    }
+
+    public JArray(AbstractJSONSchema2Pojo nested, String description) {
+        super(description);
         this.type =
                 new ClassOrInterfaceType()
                         .setName(JAVA_UTIL_LIST)

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JEnum.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JEnum.java
@@ -37,6 +37,11 @@ public class JEnum extends AbstractJSONSchema2Pojo {
     private final List<String> values;
 
     public JEnum(String type, List<JsonNode> values) {
+        this(type, values, null);
+    }
+
+    public JEnum(String type, List<JsonNode> values, String description) {
+        super(description);
         this.type =
                 AbstractJSONSchema2Pojo.sanitizeString(
                         type.substring(0, 1).toUpperCase() + type.substring(1));

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JMap.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JMap.java
@@ -28,6 +28,11 @@ public class JMap extends AbstractJSONSchema2Pojo {
     private final AbstractJSONSchema2Pojo nested;
 
     public JMap(AbstractJSONSchema2Pojo nested) {
+        this(nested, null);
+    }
+
+    public JMap(AbstractJSONSchema2Pojo nested, String description) {
+        super(description);
         this.type =
                 new ClassOrInterfaceType()
                         .setName(JAVA_UTIL_MAP)

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import io.fabric8.java.generator.exceptions.JavaGeneratorException;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
+import io.fabric8.kubernetes.client.utils.Utils;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -52,10 +53,22 @@ public class JObject extends AbstractJSONSchema2Pojo {
     private JObjectOptions options;
 
     public JObject(
+        String type,
+        Map<String, JSONSchemaProps> fields,
+        List<String> required,
+        JObjectOptions options) {
+        this(type, fields, required, options, null);
+    }
+    
+    public JObject(
             String type,
             Map<String, JSONSchemaProps> fields,
             List<String> required,
-            JObjectOptions options) {
+            JObjectOptions options,
+            String description) {
+
+        super(description);
+
         this.options = options;
         this.required =
                 new HashSet<>(Optional.ofNullable(required).orElse(Collections.emptyList()));
@@ -101,7 +114,7 @@ public class JObject extends AbstractJSONSchema2Pojo {
         if (clz != null) {
             // TODO: investigate a more nested structure for the generated code
             LOGGER.warn(
-                    "A class named {} has been already processed, if this class have multiple implementations the resulting code might be incorrect",
+                    "A class named {} has been already processed, if this class has multiple implementations the resulting code might be incorrect",
                     this.type);
             return new GeneratorResult();
         }
@@ -236,6 +249,10 @@ public class JObject extends AbstractJSONSchema2Pojo {
 
                     objField.createGetter();
                     objField.createSetter();
+
+                    if (Utils.isNotNullOrEmpty(prop.getDescription())) {
+                      objField.setJavadocComment(prop.getDescription());
+                    }
                 } catch (Exception cause) {
                     throw new JavaGeneratorException(
                             "Error generating field " + fieldName + " with type " + prop.getType(),

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitive.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitive.java
@@ -25,6 +25,10 @@ public class JPrimitive extends AbstractJSONSchema2Pojo {
             new GeneratorResult(new ArrayList<>(), new ArrayList<>());
 
     public JPrimitive(String type) {
+        this(type, null);
+    }
+    public JPrimitive(String type, String description) {
+        super(description);
         this.type = type;
     }
 

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testKeycloakCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testKeycloakCrd.approved.txt
@@ -28,6 +28,9 @@ KeycloakJavaCr[1] = package org.test.v1alpha1;
 })
 public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
 
+    /**
+     * A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("extensions")
     private java.util.List<String> extensions;
 
@@ -39,6 +42,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.extensions = extensions;
     }
 
+    /**
+     * Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("external")
     private ExternalSpec external;
 
@@ -50,6 +56,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.external = external;
     }
 
+    /**
+     * Controls external Ingress/Route settings.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("externalAccess")
     private ExternalAccessSpec externalAccess;
 
@@ -61,6 +70,12 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.externalAccess = externalAccess;
     }
 
+    /**
+     * Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret:
+     *      apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque
+     *  Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret
+     *  For more information, please refer to the Operator documentation.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("externalDatabase")
     private ExternalDatabaseSpec externalDatabase;
 
@@ -72,6 +87,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.externalDatabase = externalDatabase;
     }
 
+    /**
+     * Number of Keycloak instances in HA mode. Default is 1.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("instances")
     private Long instances;
 
@@ -83,6 +101,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.instances = instances;
     }
 
+    /**
+     * Resources (Requests and Limits) for KeycloakDeployment.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("keycloakDeploymentSpec")
     private KeycloakDeploymentSpecSpec keycloakDeploymentSpec;
 
@@ -94,6 +115,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.keycloakDeploymentSpec = keycloakDeploymentSpec;
     }
 
+    /**
+     * Specify Migration configuration
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("migration")
     private MigrationSpec migration;
 
@@ -105,6 +129,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.migration = migration;
     }
 
+    /**
+     * Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("multiAvailablityZones")
     private MultiAvailablityZonesSpec multiAvailablityZones;
 
@@ -116,6 +143,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.multiAvailablityZones = multiAvailablityZones;
     }
 
+    /**
+     * Specify PodDisruptionBudget configuration.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("podDisruptionBudget")
     private PodDisruptionBudgetSpec podDisruptionBudget;
 
@@ -127,6 +157,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.podDisruptionBudget = podDisruptionBudget;
     }
 
+    /**
+     * Resources (Requests and Limits) for PostgresDeployment.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("postgresDeploymentSpec")
     private PostgresDeploymentSpecSpec postgresDeploymentSpec;
 
@@ -138,6 +171,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.postgresDeploymentSpec = postgresDeploymentSpec;
     }
 
+    /**
+     * Profile used for controlling Operator behavior. Default is empty.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("profile")
     private String profile;
 
@@ -149,6 +185,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.profile = profile;
     }
 
+    /**
+     * Name of the StorageClass for Postgresql Persistent Volume Claim
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("storageClassName")
     private String storageClassName;
 
@@ -160,6 +199,9 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
         this.storageClassName = storageClassName;
     }
 
+    /**
+     * When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("unmanaged")
     private Boolean unmanaged;
 
@@ -195,6 +237,9 @@ KeycloakJavaCr[2] = package org.test.v1alpha1;
 })
 public class KeycloakStatus implements io.fabric8.kubernetes.api.model.KubernetesResource {
 
+    /**
+     * The secret where the admin credentials are to be found.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("credentialSecret")
     @javax.validation.constraints.NotNull()
     private String credentialSecret;
@@ -207,6 +252,9 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
         this.credentialSecret = credentialSecret;
     }
 
+    /**
+     * External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("externalURL")
     private String externalURL;
 
@@ -218,6 +266,9 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
         this.externalURL = externalURL;
     }
 
+    /**
+     * An internal URL (service name) to be used by the admin client.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("internalURL")
     @javax.validation.constraints.NotNull()
     private String internalURL;
@@ -230,6 +281,9 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
         this.internalURL = internalURL;
     }
 
+    /**
+     * Human-readable message indicating details about current operator phase or error.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("message")
     @javax.validation.constraints.NotNull()
     private String message;
@@ -242,6 +296,9 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
         this.message = message;
     }
 
+    /**
+     * Current phase of the operator.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("phase")
     @javax.validation.constraints.NotNull()
     private String phase;
@@ -254,6 +311,9 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
         this.phase = phase;
     }
 
+    /**
+     * True if all resources are in a ready state and all work is done.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("ready")
     @javax.validation.constraints.NotNull()
     private Boolean ready;
@@ -266,6 +326,9 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
         this.ready = ready;
     }
 
+    /**
+     * A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ].
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("secondaryResources")
     private java.util.Map<java.lang.String, java.util.List<String>> secondaryResources;
 
@@ -277,6 +340,9 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
         this.secondaryResources = secondaryResources;
     }
 
+    /**
+     * Version of Keycloak or RHSSO running on the cluster.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("version")
     @javax.validation.constraints.NotNull()
     private String version;

--- a/java-generator/it/src/it/cert-manager/expected/AuthSpec.java
+++ b/java-generator/it/src/it/cert-manager/expected/AuthSpec.java
@@ -22,6 +22,9 @@ package io.cert_manager.v1;
 })
 public class AuthSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
 
+    /**
+     * AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("appRole")
     private AppRoleSpec appRole;
 
@@ -33,6 +36,9 @@ public class AuthSpec implements io.fabric8.kubernetes.api.model.KubernetesResou
         this.appRole = appRole;
     }
 
+    /**
+     * Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetes")
     private KubernetesSpec kubernetes;
 
@@ -44,6 +50,9 @@ public class AuthSpec implements io.fabric8.kubernetes.api.model.KubernetesResou
         this.kubernetes = kubernetes;
     }
 
+    /**
+     * TokenSecretRef authenticates with Vault by presenting a token.
+     */
     @com.fasterxml.jackson.annotation.JsonProperty("tokenSecretRef")
     private TokenSecretRefSpec tokenSecretRef;
 


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
This PR aims at improving the Java (from CRD) generator feature in its baseline implementation, by adding support for generating basic Javadoc comments for a POJO fields as part of the model, by using an YAML element `description` as the source of information.

As discussed in the [issue for the baseline implementation](https://github.com/fabric8io/kubernetes-client/issues/3642), it seems reasonable to track this enhancement separately, hence this is a draft and a review by @andreaTP as the original contributor of the baseline implementation would help in evaluating whether it could be accepted.

Fixes #3762

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
