### PR TITLE
[java-gen] Create classes with unique names

### DIFF
--- a/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
@@ -62,6 +62,7 @@ public class CRGeneratorRunner {
         List<WritableCRCompilationUnit> writableCUs = new ArrayList<>(crSpec.getVersions().size());
         for (CustomResourceDefinitionVersion crdv : crSpec.getVersions()) {
             CompilationUnit cu = new CompilationUnit();
+            AbstractJSONSchema2Pojo.resetClassNames();
 
             String version = crdv.getName();
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -20,6 +20,8 @@ import static io.fabric8.java.generator.nodes.Keywords.JAVA_KEYWORDS;
 import com.github.javaparser.ast.CompilationUnit;
 import io.fabric8.java.generator.exceptions.JavaGeneratorException;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 public abstract class AbstractJSONSchema2Pojo {
@@ -64,6 +66,26 @@ public abstract class AbstractJSONSchema2Pojo {
         }
 
         return sanitized;
+    }
+
+    private static Set<String> classNames = new TreeSet<>();
+
+    public static void resetClassNames() {
+        classNames.clear();
+    }
+
+    public static String uniqueClassName(String name) {
+        String finalTypeName = uniqueClassName(name, name, 0);
+        classNames.add(finalTypeName);
+        return finalTypeName;
+    }
+
+    private static String uniqueClassName(String base, String name, int num) {
+        if (classNames.contains(name)) {
+            return uniqueClassName(base, base + num, num + 1);
+        } else {
+            return name;
+        }
     }
 
     public static AbstractJSONSchema2Pojo fromJsonSchema(

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/Keywords.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/Keywords.java
@@ -82,4 +82,5 @@ public class Keywords {
     static final String JAVA_UTIL_LIST = "java.util.List";
     static final String JAVA_LANG_STRING = "java.lang.String";
     static final String ADDITIONAL_PROPERTIES = "additionalProperties";
+    static final String GENERATED_ADDITIONAL_PROPERTIES = "generatedAdditionalProperties";
 }

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -91,7 +91,7 @@ class CompilationTest {
 
         // Assert
         assertTrue(compilation.errors().isEmpty());
-        assertEquals(32, compilation.sourceFiles().size());
+        assertEquals(50, compilation.sourceFiles().size());
         assertEquals(Compilation.Status.SUCCESS, compilation.status());
     }
 
@@ -107,7 +107,7 @@ class CompilationTest {
 
         // Assert
         assertTrue(compilation.errors().isEmpty());
-        assertEquals(27, compilation.sourceFiles().size());
+        assertEquals(28, compilation.sourceFiles().size());
         assertEquals(Compilation.Status.SUCCESS, compilation.status());
     }
 
@@ -123,7 +123,7 @@ class CompilationTest {
 
         // Assert
         assertTrue(compilation.errors().isEmpty());
-        assertEquals(72, compilation.sourceFiles().size());
+        assertEquals(704, compilation.sourceFiles().size());
         assertEquals(Compilation.Status.SUCCESS, compilation.status());
     }
 
@@ -139,7 +139,7 @@ class CompilationTest {
 
         // Assert
         assertTrue(compilation.errors().isEmpty());
-        assertEquals(97, compilation.sourceFiles().size());
+        assertEquals(358, compilation.sourceFiles().size());
         assertEquals(Compilation.Status.SUCCESS, compilation.status());
     }
 
@@ -155,7 +155,7 @@ class CompilationTest {
 
         // Assert
         assertTrue(compilation.errors().isEmpty());
-        assertEquals(73, compilation.sourceFiles().size());
+        assertEquals(267, compilation.sourceFiles().size());
         assertEquals(Compilation.Status.SUCCESS, compilation.status());
     }
 


### PR DESCRIPTION
## Description

The generated class names are, sometimes, colliding.
Since we are generating everything in a single package we have been emitting a warning in case of name clash, but this is not good enough.

This is a somewhat simplistic, but effective, approach to the problem, adding trailing numbers to the class names.
The names are going to be uglier but the output is going to be correctly typed and checked.

I'm open to alternative ways to mangle the class names! 🙏 
One "obvious" possibility is to generate nested packages(names needs to be mangled anyhow), but, at the moment, I still enjoy the simplicity of a single package and a flat structure. ( :change_my_mind: 😃  )

_side note:_
I took the opportunity to go ahead with a few small refactoring here and there.

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
