### PR TITLE
[java-gen] Support storage and served in generated CR version

### DIFF
--- a/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
@@ -90,7 +90,13 @@ public class CRGeneratorRunner {
 
             AbstractJSONSchema2Pojo crGenerator =
                     new JCRObject(
-                            crName, group, version, specGenerator != null, statusGenerator != null);
+                            crName,
+                            group,
+                            version,
+                            specGenerator != null,
+                            statusGenerator != null,
+                            crdv.getStorage(),
+                            crdv.getServed());
 
             List<String> classNames =
                     validateAndAggregate(cu, crGenerator, specGenerator, statusGenerator);

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -18,6 +18,7 @@ package io.fabric8.java.generator.nodes;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -31,13 +32,24 @@ public class JCRObject extends AbstractJSONSchema2Pojo {
     private final boolean withSpec;
     private final boolean withStatus;
 
+    private final boolean storage;
+    private final boolean served;
+
     public JCRObject(
-            String type, String group, String version, boolean withSpec, boolean withStatus) {
+            String type,
+            String group,
+            String version,
+            boolean withSpec,
+            boolean withStatus,
+            boolean storage,
+            boolean served) {
         this.type = type;
         this.group = group;
         this.version = version;
         this.withSpec = withSpec;
         this.withStatus = withStatus;
+        this.storage = storage;
+        this.served = served;
     }
 
     @Override
@@ -53,7 +65,13 @@ public class JCRObject extends AbstractJSONSchema2Pojo {
         clz.addAnnotation(
                 new SingleMemberAnnotationExpr(
                         new Name("io.fabric8.kubernetes.model.annotation.Version"),
-                        new StringLiteralExpr(version)));
+                        new NameExpr(
+                                "value = \""
+                                        + version
+                                        + "\" , storage = "
+                                        + storage
+                                        + " , served = "
+                                        + served)));
         clz.addAnnotation(
                 new SingleMemberAnnotationExpr(
                         new Name("io.fabric8.kubernetes.model.annotation.Group"),

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -48,7 +48,7 @@ class GeneratorTest {
     void testCR() {
         // Arrange
         CompilationUnit cu = new CompilationUnit();
-        JCRObject cro = new JCRObject("t", "g", "v", true, true);
+        JCRObject cro = new JCRObject("t", "g", "v", true, true, true, true);
 
         // Act
         GeneratorResult res = cro.generateJava(cu);

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testCrontabCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testCrontabCrd.approved.txt
@@ -1,6 +1,6 @@
 CrontabJavaCr[0] = package org.test.v1;
 
-@io.fabric8.kubernetes.model.annotation.Version("v1")
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
 @io.fabric8.kubernetes.model.annotation.Group("stable.example.com")
 public class CronTab extends io.fabric8.kubernetes.client.CustomResource<CronTabSpec, CronTabStatus> implements io.fabric8.kubernetes.api.model.Namespaced {
 }

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testJokeCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testJokeCrd.approved.txt
@@ -1,6 +1,6 @@
 JokeRequestJavaCr[0] = package org.test.v1alpha1;
 
-@io.fabric8.kubernetes.model.annotation.Version("v1alpha1")
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1" , storage = true , served = true)
 @io.fabric8.kubernetes.model.annotation.Group("samples.javaoperatorsdk.io")
 public class JokeRequest extends io.fabric8.kubernetes.client.CustomResource<JokeRequestSpec, JokeRequestStatus> implements io.fabric8.kubernetes.api.model.Namespaced {
 }

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testKeycloakCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testKeycloakCrd.approved.txt
@@ -1,6 +1,6 @@
 KeycloakJavaCr[0] = package org.test.v1alpha1;
 
-@io.fabric8.kubernetes.model.annotation.Version("v1alpha1")
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1" , storage = true , served = true)
 @io.fabric8.kubernetes.model.annotation.Group("keycloak.org")
 public class Keycloak extends io.fabric8.kubernetes.client.CustomResource<KeycloakSpec, KeycloakStatus> implements io.fabric8.kubernetes.api.model.Namespaced {
 }


### PR DESCRIPTION
## Description

Support "served" and "storage" version of the generated Java CR.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
