### PR TITLE
fix (kubernetes-client) : reintroduce Replaceable interface in NonNamespaceOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #3811: Reintroduce `Replaceable` interface in `NonNamespaceOperation`
 
 #### Dependency Upgrade
 * Fix #3788: Point CamelK Extension model to latest released version v1.8.0

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
@@ -28,6 +28,8 @@ public interface NonNamespaceOperation<T, L, R> extends
   Createable<T>,
   CreateOrReplaceable<T>,
   DryRunable<WritableOperation<T>>,
+  Replaceable<T>,
+  StatusReplaceable<T>,
   Loadable<R> {
 }
 

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
@@ -214,7 +214,7 @@ public class TypedCustomResourceIT {
     // use the original pet, no need to pick up the resourceVersion
     pet.getSpec().setType("shouldn't change");
     pet.setStatus(petStatusToUpdate);
-    Pet updatedPet = petClient.inNamespace(currentNamespace).withName(pet.getMetadata().getName()).replaceStatus(pet);
+    Pet updatedPet = petClient.inNamespace(currentNamespace).replaceStatus(pet);
 
     // Then
     assertPet(updatedPet, "pet-replacestatus", "Pigeon", "Sleeping");

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -175,7 +175,7 @@ class CustomResourceCrudTest {
 
     cronTab.getMetadata().setLabels(labels);
 
-    result = cronTabClient.withName(cronTab.getMetadata().getName()).replace(cronTab);
+    result = cronTabClient.replace(cronTab);
 
     String originalUid = result.getMetadata().getUid();
 
@@ -187,7 +187,7 @@ class CustomResourceCrudTest {
     labels.put("other", "label");
     cronTab.setStatus(null);
 
-    result = cronTabClient.withName(cronTab.getMetadata().getName()).replace(cronTab);
+    result = cronTabClient.replace(cronTab);
 
     // should retain the existing
     assertNotNull(result.getStatus());

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
@@ -157,7 +157,7 @@ class TypedClusterScopeCustomResourceApiTest {
       server.expect().put().withPath("/apis/example.crd.com/v1alpha1/stars/sun/status").andReturn(200, "{\"apiVersion\":\"example.crd.com/v1alpha1\",\"kind\":\"Star\",\"metadata\":{\"name\":\"sun\",\"resourceVersion\":\"2\"},\"spec\":{\"type\":\"G\",\"location\":\"Galaxy\"},\"status\":{\"location\":\"M\"}}").once();
       starClient = client.customResources(Star.class);
 
-      Star replaced = starClient.inNamespace("test").withName(updatedStar.getMetadata().getName()).replaceStatus(updatedStar);
+      Star replaced = starClient.inNamespace("test").replaceStatus(updatedStar);
       assertEquals("2", replaced.getMetadata().getResourceVersion());
       RecordedRequest recordedRequest = server.getLastRequest();
       // get of the latest version, put of status


### PR DESCRIPTION
## Description

This was introduced by mistake in Dry Run implementation as part of
WritableOperation and was subsequently removed in
https://github.com/fabric8io/kubernetes-client/pull/3798

But it makes sense for replace operation to work without name. It can be
inferred from the passed object. Read this discussion for more details https://github.com/fabric8io/kubernetes-client/pull/3798#issuecomment-1029958757

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
