### PR TITLE
fix #3813: adding onExit to execwatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Dependency Upgrade
 * Fix #3788: Point CamelK Extension model to latest released version v1.8.0
+* Fix #3813: Handle exit code status messages with pod uploads
 
 #### New Features
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ExecListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/ExecListener.java
@@ -15,7 +15,10 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import io.fabric8.kubernetes.api.model.Status;
+
 import java.io.IOException;
+import java.util.Optional;
 
 public interface ExecListener {
   
@@ -53,4 +56,13 @@ public interface ExecListener {
      * @param reason Reason for close or an empty string.
      */
     void onClose(int code, String reason);
+  
+  /**
+   * Called after a Status message is seen on channel 3.
+   * 
+   * Use {@link ExecWatch#getErrorChannel()} if you need the raw channel 3 contents.
+   * @param code the exit code, -1 will be used if the code cannot be determined
+   * @param status may be null if no valid status was received
+   */
+  default void onExit(int code, Status status) {}
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.dsl.internal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusCause;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
@@ -27,14 +28,17 @@ import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
 import io.fabric8.kubernetes.client.utils.InputStreamPumper;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -57,6 +61,10 @@ import static io.fabric8.kubernetes.client.utils.Utils.closeQuietly;
  *
  */
 public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocket.Listener {
+
+    static final String CAUSE_REASON_EXIT_CODE = "ExitCode";
+    static final String REASON_NON_ZERO_EXIT_CODE = "NonZeroExitCode";
+    static final String STATUS_SUCCESS = "Success";
 
     private final class SimpleResponse implements Response {
     private final HttpResponse<?> response;
@@ -95,11 +103,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
 
     private final ExecListener listener;
 
-    private final AtomicBoolean explicitlyClosed = new AtomicBoolean(false);
-
-    private final AtomicBoolean failed = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private final AtomicBoolean cleaned = new AtomicBoolean(false);
 
     private final Set<Closeable> toClose = new LinkedHashSet<>();
 
@@ -125,8 +129,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
       close(1000, "Closing...");
     }
 
-    public void close(int code, String reason) {
-      explicitlyClosed.set(true);
+    private void close(int code, String reason) {
       closeWebSocketOnce(code, reason);
       onClosed(code, reason);
     }
@@ -140,12 +143,8 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
    * if the stream it uses closes before the pumper it self.
    */
   private void cleanUpOnce() {
-   if (!cleaned.compareAndSet(false, true)) {
-        return;
-   }
-
-   executorService.shutdownNow();
-   closeQuietly(toClose);
+     executorService.shutdownNow();
+     closeQuietly(toClose);
   }
 
     private void closeWebSocketOnce(int code, String reason) {
@@ -197,7 +196,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
   public void onError(WebSocket webSocket, Throwable t) {
 
       //If we already called onClosed() or onFailed() before, we need to abort.
-      if (explicitlyClosed.get() || closed.get() || !failed.compareAndSet(false, true) ) {
+      if (closed.compareAndSet(false, true) ) {
         //We are not going to notify the listener, sicne we've already called onClose(), so let's log a debug/warning.
         if (LOGGER.isWarnEnabled()) {
           LOGGER.warn("Received [{}], with message:[{}] after ExecWebSocketListener is closed, Ignoring.",t.getClass().getCanonicalName(),t.getMessage());
@@ -240,7 +239,10 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
                         writeAndFlush(err, byteString);
                         break;
                     case 3:
+                        handleExitStatus(bytes);
                         writeAndFlush(errChannel, byteString);
+                        // once the process is done, we can proactively close
+                        this.close(); 
                         break;
                     default:
                         throw new IOException("Unknown stream ID " + streamID);
@@ -251,6 +253,23 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
         }
     }
 
+
+  private void handleExitStatus(ByteBuffer bytes) {
+    Status status = null;
+    int code = -1;
+    try {
+      String stringValue = StandardCharsets.UTF_8.decode(bytes).toString();
+      status = Serialization.unmarshal(stringValue, Status.class);
+      if (status != null) {
+        code = parseExitCode(status);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Could not determine exit code", e);
+    }
+    if (this.listener != null) {
+      this.listener.onExit(code, status);
+    }
+  }
 
   private void writeAndFlush(OutputStream stream, ByteBuffer byteString) throws IOException {
     if (stream != null) {
@@ -268,14 +287,12 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
 
     private void onClosed(int code, String reason) {
        //If we already called onClosed() or onFailed() before, we need to abort.
-       if (!closed.compareAndSet(false, true) || failed.get()) {
+       if (!closed.compareAndSet(false, true)) {
          return;
        }
        LOGGER.debug("Exec Web Socket: On Close with code:[{}], due to: [{}]", code, reason);
         try {
-            if (explicitlyClosed.get()) {
-              cleanUpOnce();
-            }
+            cleanUpOnce();
         } finally {
             if (listener != null) {
               listener.onClose(code, reason);
@@ -359,4 +376,27 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
             return null;
         }
     }
+    
+    public static int parseExitCode(Status status) {
+      if (STATUS_SUCCESS.equals(status.getStatus())) {
+        return 0;
+      }
+      if (REASON_NON_ZERO_EXIT_CODE.equals(status.getReason())) {
+        if (status.getDetails() == null) {
+          return -1;
+        }
+        List<StatusCause> causes = status.getDetails().getCauses();
+        if (causes == null) {
+          return -1;
+        }
+        return causes.stream()
+            .filter(c -> CAUSE_REASON_EXIT_CODE.equals(c.getReason()))
+            .map(StatusCause::getMessage)
+            .map(Integer::valueOf)
+            .findFirst()
+            .orElse(-1);
+      }
+      return -1;
+    }
+
  }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.StatusCause;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+
+class ExecWebSocketListenerTest {
+
+  @Test
+  void testParseExitCodeSuccess() {
+    assertEquals(0, ExecWebSocketListener
+        .parseExitCode(new StatusBuilder().withStatus(ExecWebSocketListener.STATUS_SUCCESS).build()));
+  }
+
+  @Test
+  void testParseExitCodeInvalid() {
+    assertEquals(-1, ExecWebSocketListener
+        .parseExitCode(new StatusBuilder().withStatus("don't know").build()));
+  }
+
+  @Test
+  void testParseExitCodeNonZeroInvalid() {
+    assertEquals(-1, ExecWebSocketListener
+        .parseExitCode(new StatusBuilder().withStatus("Failed")
+            .withReason(ExecWebSocketListener.REASON_NON_ZERO_EXIT_CODE)
+            .build()));
+  }
+
+  @Test
+  void testParseExitCodeNonZero() {
+    assertEquals(126, ExecWebSocketListener
+        .parseExitCode(new StatusBuilder().withStatus("Failed")
+            .withReason(ExecWebSocketListener.REASON_NON_ZERO_EXIT_CODE)
+            .withNewDetails().withCauses(new StatusCause("ExitCode", "126", ExecWebSocketListener.CAUSE_REASON_EXIT_CODE)).endDetails()
+            .build()));
+  }
+
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -33,6 +33,8 @@ import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.utils.InputStreamPumper;
+import io.fabric8.kubernetes.client.utils.InputStreamPumper.Writable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -151,13 +153,13 @@ class PodUploadTest {
   @Test
   void testCopy() throws Exception {
     final ByteArrayInputStream input = new ByteArrayInputStream("I'LL BE COPIED".getBytes(Charset.defaultCharset()));
-    final ObjIntConsumer<byte[]> consumer = (bytes, length) -> {
+    final Writable consumer = (bytes, offset, length) -> {
       assertThat(length, equalTo(14));
       assertThat(new String(Arrays.copyOf(bytes, 14), Charset.defaultCharset()),
         equalTo("I'LL BE COPIED"));
     };
 
-    PodUpload.copy(input, consumer);
+    InputStreamPumper.transferTo(input, consumer);
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadWebSocketListenerTest.java
@@ -50,7 +50,7 @@ class PodUploadWebSocketListenerTest {
     podUploadWebSocketListener.onOpen(mockedWebSocket);
     final byte[] toSend = new byte[]{1, 3, 3, 7, 0};
 
-    podUploadWebSocketListener.send(toSend, 4);
+    podUploadWebSocketListener.send(toSend, 0, 4);
 
     verify(mockedWebSocket, times(1))
       .send(eq(ByteBuffer.wrap(new byte[] {(byte) 0, (byte) 1, (byte) 3, (byte) 3, (byte) 7})));


### PR DESCRIPTION
## Description
Builds on the change for upload to move the exit code handling into the base exec.

After this change if ExecWatch were to expose a way to directly send, or a way to notify when the inputstream is exhausted, it is possible to eliminate the pod upload websocket listener.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
