### PR TITLE
fix #3848: Add queue support (cluster level) for Volcano extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 5.12-SNAPSHOT
 
 #### Bugs
+* Fix #3848: Supports Queue (cluster) API for Volcano extension
 
 #### Improvements
 

--- a/extensions/volcano/examples/src/main/java/io/fabric8/volcano/examples/QueueCreate.java
+++ b/extensions/volcano/examples/src/main/java/io/fabric8/volcano/examples/QueueCreate.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.volcano.examples;
+
+import io.fabric8.volcano.client.DefaultVolcanoClient;
+import io.fabric8.volcano.client.NamespacedVolcanoClient;
+import io.fabric8.volcano.scheduling.v1beta1.Queue;
+import io.fabric8.volcano.scheduling.v1beta1.QueueList;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class QueueCreate {
+  public static void main(String[] args) {
+    try (NamespacedVolcanoClient volcanoClient = new DefaultVolcanoClient()) {
+
+      String queueName = "queue1";
+      Queue queue = Utils.buildDefaultQueues(queueName);
+
+      volcanoClient.queues().createOrReplace(queue);
+
+      // Wait for status or 5s timeout
+      volcanoClient.queues().withName(queueName).waitUntilCondition(
+        q -> Objects.nonNull(q.getStatus()) && q.getStatus().getState().equals("Open"),
+        5,
+        TimeUnit.SECONDS
+      );
+      System.out.println("Created: " + queue.getMetadata().getName());
+
+      // List queue
+      QueueList queueList = volcanoClient.queues().list();
+      System.out.println("There are " + queueList.getItems().size() + " queue objects");
+
+      // Delete queue
+      volcanoClient.queues().withName(queueName).delete();
+    }
+  }
+}

--- a/extensions/volcano/examples/src/main/java/io/fabric8/volcano/examples/Utils.java
+++ b/extensions/volcano/examples/src/main/java/io/fabric8/volcano/examples/Utils.java
@@ -19,6 +19,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.QuantityBuilder;
 import io.fabric8.volcano.scheduling.v1beta1.PodGroup;
 import io.fabric8.volcano.scheduling.v1beta1.PodGroupBuilder;
+import io.fabric8.volcano.scheduling.v1beta1.Queue;
+import io.fabric8.volcano.scheduling.v1beta1.QueueBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +30,7 @@ public class Utils {
   private Utils() {
   }
 
-  public static PodGroup buildDefaultPodGroups(String namespace, String groupName) {
+  public static Map<String, Quantity> buildDefaultResourceMap() {
     Quantity cpu = new QuantityBuilder(false)
       .withAmount("1")
       .build();
@@ -38,7 +40,10 @@ public class Utils {
     Map<String, Quantity> resourceMap = new HashMap<>();
     resourceMap.put("cpu", cpu);
     resourceMap.put("memory", memory);
+    return resourceMap;
+  }
 
+  public static PodGroup buildDefaultPodGroups(String namespace, String groupName) {
     // Build PodGroup with metadata and spec
     return new PodGroupBuilder()
       .editOrNewMetadata()
@@ -46,7 +51,20 @@ public class Utils {
       .withNamespace(namespace)
       .endMetadata()
       .editOrNewSpec()
-      .withMinResources(resourceMap)
+      .withMinResources(buildDefaultResourceMap())
+      .endSpec()
+      .build();
+  }
+
+  public static Queue buildDefaultQueues(String queueName) {
+    // Build Queue with metadata and spec
+    return new QueueBuilder()
+      .editOrNewMetadata()
+      .withName(queueName)
+      .endMetadata()
+      .editOrNewSpec()
+      .withCapability(buildDefaultResourceMap())
+      .withWeight(1)
       .endSpec()
       .build();
   }

--- a/extensions/volcano/examples/src/main/java/io/fabric8/volcano/examples/v1beta1/QueueCreate.java
+++ b/extensions/volcano/examples/src/main/java/io/fabric8/volcano/examples/v1beta1/QueueCreate.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.volcano.examples.v1beta1;
+
+import io.fabric8.volcano.client.DefaultVolcanoClient;
+import io.fabric8.volcano.client.NamespacedVolcanoClient;
+import io.fabric8.volcano.examples.Utils;
+import io.fabric8.volcano.scheduling.v1beta1.Queue;
+import io.fabric8.volcano.scheduling.v1beta1.QueueList;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class QueueCreate {
+  public static void main(String[] args) {
+    try (NamespacedVolcanoClient volcanoClient = new DefaultVolcanoClient()) {
+
+      String queueName = "queue1";
+      Queue queue = Utils.buildDefaultQueues(queueName);
+
+      volcanoClient.v1beta1().queues().createOrReplace(queue);
+
+      // Wait for status or 5s timeout
+      volcanoClient.v1beta1().queues().withName(queueName).waitUntilCondition(
+        q -> Objects.nonNull(q.getStatus()) && q.getStatus().getState().equals("Open"),
+        5,
+        TimeUnit.SECONDS
+      );
+      System.out.println("Created: " + queue.getMetadata().getName());
+
+      // List queue
+      QueueList queueList = volcanoClient.v1beta1().queues().list();
+      System.out.println("There are " + queueList.getItems().size() + " queue objects");
+
+      // Delete queue
+      volcanoClient.v1beta1().queues().withName(queueName).delete();
+    }
+  }
+}

--- a/extensions/volcano/generator-v1beta1/cmd/generate/generate.go
+++ b/extensions/volcano/generator-v1beta1/cmd/generate/generate.go
@@ -30,7 +30,7 @@ func main() {
 	// no other types need to be defined as they are auto discovered
 	crdLists := map[reflect.Type]schemagen.CrdScope{
 		reflect.TypeOf(volcanov1beta1.PodGroupList{}): schemagen.Namespaced,
-		reflect.TypeOf(volcanov1beta1.QueueList{}):    schemagen.Namespaced,
+		reflect.TypeOf(volcanov1beta1.QueueList{}):    schemagen.Cluster,
 	}
 
 	// constraints and patterns for fields

--- a/extensions/volcano/generator-v1beta1/go.mod
+++ b/extensions/volcano/generator-v1beta1/go.mod
@@ -1,10 +1,9 @@
 module cmd/generate/generate.go
 
 require (
-	github.com/fabric8io/kubernetes-client/generator v0.0.0
+	github.com/fabric8io/kubernetes-client/generator v0.0.0 // indirect
 	k8s.io/apiextensions-apiserver v0.19.0 // indirect
-	k8s.io/apimachinery v0.19.0
-	volcano.sh/apis v1.3.0-k8s1.18.3
+	volcano.sh/apis v1.3.0-k8s1.18.3 // indirect
 )
 
 replace github.com/fabric8io/kubernetes-client/generator v0.0.0 => ./../../../generator

--- a/extensions/volcano/model-v1beta1/src/main/resources/schema/volcano-schema.json
+++ b/extensions/volcano/model-v1beta1/src/main/resources/schema/volcano-schema.json
@@ -168,8 +168,7 @@
       },
       "javaType": "io.fabric8.volcano.scheduling.v1beta1.Queue",
       "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.HasMetadata",
-        "io.fabric8.kubernetes.api.model.Namespaced"
+        "io.fabric8.kubernetes.api.model.HasMetadata"
       ]
     },
     "volcano_sh_apis_pkg_apis_scheduling_v1beta1_QueueList": {

--- a/extensions/volcano/tests/src/test/java/io/fabric8/volcano/test/crud/V1Beta1VolcanoTest.java
+++ b/extensions/volcano/tests/src/test/java/io/fabric8/volcano/test/crud/V1Beta1VolcanoTest.java
@@ -49,9 +49,9 @@ class V1Beta1VolcanoTest {
         .withName("queue1")
       .endMetadata()
       .build();
-    client.v1beta1().queues().inNamespace("ns1").create(queue);
+    client.v1beta1().queues().create(queue);
 
-    QueueList queueList = client.v1beta1().queues().inNamespace("ns1").list();
+    QueueList queueList = client.v1beta1().queues().list();
     assertNotNull(queueList);
     assertEquals(1, queueList.getItems().size());
   }

--- a/extensions/volcano/tests/src/test/java/io/fabric8/volcano/test/crud/VolcanoTest.java
+++ b/extensions/volcano/tests/src/test/java/io/fabric8/volcano/test/crud/VolcanoTest.java
@@ -84,8 +84,8 @@ class VolcanoTest {
         .withName("queue1")
       .endMetadata()
       .build();
-    client.queues().inNamespace("ns1").create(queue);
-    QueueList queueList = client.queues().inNamespace("ns1").list();
+    client.queues().create(queue);
+    QueueList queueList = client.queues().list();
     assertNotNull(queueList);
     assertEquals(1, queueList.getItems().size());
   }

--- a/extensions/volcano/tests/src/test/java/io/fabric8/volcano/test/request/QueueTest.java
+++ b/extensions/volcano/tests/src/test/java/io/fabric8/volcano/test/request/QueueTest.java
@@ -38,10 +38,10 @@ class QueueTest {
   @Test
   @DisplayName("Should get a queue")
   void testGet() {
-    server.expect().get().withPath("/apis/scheduling.volcano.sh/v1beta1/namespaces/ns1/queues/q1")
+    server.expect().get().withPath("/apis/scheduling.volcano.sh/v1beta1/queues/q1")
       .andReturn(HttpURLConnection.HTTP_OK, createQueue()).once();
 
-    Queue queue = client.v1beta1().queues().inNamespace("ns1").withName("q1").get();
+    Queue queue = client.v1beta1().queues().withName("q1").get();
     assertNotNull(queue);
   }
 
@@ -49,9 +49,9 @@ class QueueTest {
   @DisplayName("Should create a queue")
   void testCreate() {
     Queue queue = createQueue();
-    server.expect().post().withPath("/apis/scheduling.volcano.sh/v1beta1/namespaces/ns1/queues")
+    server.expect().post().withPath("/apis/scheduling.volcano.sh/v1beta1/queues")
       .andReturn(HttpURLConnection.HTTP_CREATED, queue).once();
-    queue = client.v1beta1().queues().inNamespace("ns1").create(queue);
+    queue = client.v1beta1().queues().create(queue);
     assertNotNull(queue);
     assertEquals("q1", queue.getMetadata().getName());
   }


### PR DESCRIPTION
## Description

This patch fix the volcano queue type, it should be `Cluster`.
- Fix Queue type: change `schemagen.Namespaced` to `schemagen.Cluster`
- Add example for queue create, and it works as integrations test in real K8S.
- Adapt volcano queue test

Closes: https://github.com/fabric8io/kubernetes-client/issues/3848

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
