### PR TITLE
Initialize labels and annotations on ObjectMeta

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ObjectMeta.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ObjectMeta.java
@@ -53,7 +53,7 @@ public class ObjectMeta implements KubernetesResource
 {
 
     @JsonProperty("annotations")
-    private Map<String, String> annotations;
+    private Map<String, String> annotations = new HashMap<>();
     @JsonProperty("clusterName")
     private java.lang.String clusterName;
     @JsonProperty("creationTimestamp")
@@ -70,7 +70,7 @@ public class ObjectMeta implements KubernetesResource
     @JsonProperty("generation")
     private Long generation;
     @JsonProperty("labels")
-    private Map<String, String> labels;
+    private Map<String, String> labels = new HashMap<>();
     @JsonProperty("managedFields")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ManagedFieldsEntry> managedFields = new ArrayList<ManagedFieldsEntry>();


### PR DESCRIPTION
## Description

Initialize the `labels` and `annotations` maps on ObjectMeta so they're empty Maps instead of null if there are no labels/annotations on a resource. 
The `additionalProperties` map is already initialized in ObjectMeta, as are all the List fields, so I don't see a reason to not initialize the `labels` and `annotations` too. 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

It says to open the PR as a draft if you haven't completed the checklist, but most of this doesn't seem warranted for such a simple change, and I'm afraid this won't be looked at if I don't just open for review 