### PR TITLE
fix #3859: refinements to how a deserialization class is chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #3848: Supports Queue (cluster) API for Volcano extension
 * Fix #3582: SSL truststore can be loaded in FIPS enabled environments
 * Fix #3818: adding missing throws to launderThrowable
+* Fix #3859: refined how a deserialization class is chosen to not confuse types with the same kind
 
 #### Improvements
 * Fix #3811: Reintroduce `Replaceable` interface in `NonNamespaceOperation`

--- a/doc/MIGRATION-v6.md
+++ b/doc/MIGRATION-v6.md
@@ -2,6 +2,7 @@
 
 ## Contents:
 - [API/Impl split](#api-impl-split)
+- [Deserialization Resolution](#deserialization-resolution)
 - [Deprecation Removals](#deprecation-removals)
 - [IntOrString changes](#intorstring-changes)
 - [Object sorting](#object-sorting)
@@ -30,7 +31,11 @@ To use it, exclude the kubernetes-httpclient-okhttp dependency and add the kuber
 - client.utils classes including Base64, CreateOrReplaceHelper, DeleteOrCreateHelper, OptionalDendencyWrapper, etc. are not in the -api jar, they are still in the -client jar under utils.internal.
 - Some other effectively internal classes in dsl.base and other packages were moved to corresponding internal packages - it is unlikely this will affect you unless you developed a custom extension.
 
-### Deprecation Removals
+## Deserialization Resolution
+
+The group on the object being deserialized is not required to match the prospective class - even for built-in types.  This prevents the unintentional parsing of custom types without a registered class as a built-in type of the same name.  This also means that you must ensure the apiVersion values are correct on the objects you are deserializing as they will no longer resolve to built-in type of the same name when there is a mistake.
+
+## Deprecation Removals
 
 - Removed KubernetesClient.customResource / RawCustomResourceOperationsImpl, please use the generic resource api instead 
 - Removed HttpClientUtils.createHttpClient(final Config config, final Consumer<OkHttpClient.Builder> additionalConfig), please use the OkHttpClientFactory instead

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -20,6 +20,9 @@ import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
@@ -51,8 +54,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Utils {
 
@@ -63,7 +64,7 @@ public class Utils {
   public static final String PATH_WINDOWS = "Path";
   public static final String PATH_UNIX = "PATH";
   private static final Random random = new Random();
-  
+
   private static final ExecutorService SHARED_POOL = Executors.newCachedThreadPool();
   private static final CachedSingleThreadScheduler SHARED_SCHEDULER = new CachedSingleThreadScheduler();
 
@@ -166,12 +167,12 @@ public class Utils {
         t = e.getCause();
       }
       t.addSuppressed(new Throwable("waiting here"));
-      throw KubernetesClientException.launderThrowable(t);      
+      throw KubernetesClientException.launderThrowable(t);
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(e);
     }
   }
-  
+
   /**
    * Similar to {@link #waitUntilReady(Future, long, TimeUnit)}, but will always throw an exception if not ready
    */
@@ -222,15 +223,6 @@ public class Utils {
   public static String randomString(int length) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < length; i++) {
-      int index = random.nextInt(ALL_CHARS.length());
-      sb.append(ALL_CHARS.charAt(index));
-    }
-    return sb.toString();
-  }
-
-  public static String randomString(String prefix, int length) {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < length - prefix.length(); i++) {
       int index = random.nextInt(ALL_CHARS.length());
       sb.append(ALL_CHARS.charAt(index));
     }
@@ -431,7 +423,7 @@ public class Utils {
   private static String getOperatingSystemFromSystemProperty() {
     return System.getProperty(OS_NAME);
   }
-  
+
   /**
    * Create a {@link ThreadFactory} with daemon threads and a thread
    * name based upon the object passed in.
@@ -444,17 +436,17 @@ public class Utils {
   static ThreadFactory daemonThreadFactory(String name) {
     return new ThreadFactory() {
       ThreadFactory threadFactory = Executors.defaultThreadFactory();
-      
+
       @Override
       public Thread newThread(Runnable r) {
-        Thread ret = threadFactory.newThread(r); 
+        Thread ret = threadFactory.newThread(r);
         ret.setName(name + "-" + ret.getName());
         ret.setDaemon(true);
         return ret;
       }
     };
   }
-  
+
   /**
    * Schedule a task to run in the given {@link Executor} - which should run the task in a different thread as to not
    * hold the scheduling thread
@@ -471,12 +463,12 @@ public class Utils {
     // because of the hand-off to the other executor, there's no difference between rate and delay
     return SHARED_SCHEDULER.scheduleWithFixedDelay(() -> executor.execute(command), initialDelay, delay, unit);
   }
-  
+
   /**
    * Get the common executor service - callers should not shutdown this service
    */
   public static ExecutorService getCommonExecutorSerive() {
     return SHARED_POOL;
   }
-    
+
 }

--- a/kubernetes-itests/src/test/resources/test-podsecuritypolicy.yml
+++ b/kubernetes-itests/src/test/resources/test-podsecuritypolicy.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: example

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/core/TemplateOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/core/TemplateOperationsImpl.java
@@ -233,7 +233,7 @@ public class TemplateOperationsImpl
 
   @Override
   public TemplateResource<Template, KubernetesList> load(InputStream is) {
-    String generatedName = Utils.randomString("template-", 10);
+    String generatedName = "template-" + Utils.randomString(5);
     Template template = null;
     Object item = Serialization.unmarshal(is, parameters);
     if (item instanceof Template) {


### PR DESCRIPTION
## Description
This updates the search strategy used by the KubernetesDeserializer - to not use classes with conflicting apiGroups.  

~~It goes further to not use classes with conflicting versions - but that leads to several test failures.  That was a concern of @andreaTP when dealing with multiple versions - if they are custom resources which do not implement additionalProperties, then it could be a lossful conversion (if ignoring unmatched fields) or an exception when fields don't match.~~  

Sorry I wasn't thinking straight, the internal types are only going to be from what's in the PACKAGES, so any laxity made there on version matching won't affect custom types.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
