### PR TITLE
[java-gen] Support JsonPropertyDescription

### DIFF
--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -229,6 +229,13 @@ public class JObject extends AbstractJSONSchema2Pojo {
 
         if (Utils.isNotNullOrEmpty(prop.getDescription())) {
           objField.setJavadocComment(prop.getDescription());
+
+          objField.addAnnotation(
+              new SingleMemberAnnotationExpr(
+                  new Name(
+                      "com.fasterxml.jackson.annotation.JsonPropertyDescription"),
+                  new StringLiteralExpr(
+                      prop.getDescription().replace("\"", "\\\""))));
         }
       } catch (Exception cause) {
         throw new JavaGeneratorException(

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testKeycloakCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.testKeycloakCrd.approved.txt
@@ -16,6 +16,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("extensions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.")
     private java.util.List<String> extensions;
 
     public java.util.List<String> getExtensions() {
@@ -30,6 +31,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("external")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.")
     private org.test.v1alpha1.keycloakspec.External external;
 
     public org.test.v1alpha1.keycloakspec.External getExternal() {
@@ -44,6 +46,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Controls external Ingress/Route settings.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("externalAccess")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Controls external Ingress/Route settings.")
     private org.test.v1alpha1.keycloakspec.ExternalAccess externalAccess;
 
     public org.test.v1alpha1.keycloakspec.ExternalAccess getExternalAccess() {
@@ -61,6 +64,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      *  For more information, please refer to the Operator documentation.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("externalDatabase")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation.")
     private org.test.v1alpha1.keycloakspec.ExternalDatabase externalDatabase;
 
     public org.test.v1alpha1.keycloakspec.ExternalDatabase getExternalDatabase() {
@@ -75,6 +79,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Number of Keycloak instances in HA mode. Default is 1.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("instances")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Number of Keycloak instances in HA mode. Default is 1.")
     private Long instances;
 
     public Long getInstances() {
@@ -89,6 +94,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Resources (Requests and Limits) for KeycloakDeployment.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("keycloakDeploymentSpec")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources (Requests and Limits) for KeycloakDeployment.")
     private org.test.v1alpha1.keycloakspec.KeycloakDeploymentSpec keycloakDeploymentSpec;
 
     public org.test.v1alpha1.keycloakspec.KeycloakDeploymentSpec getKeycloakDeploymentSpec() {
@@ -103,6 +109,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Specify Migration configuration
      */
     @com.fasterxml.jackson.annotation.JsonProperty("migration")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify Migration configuration")
     private org.test.v1alpha1.keycloakspec.Migration migration;
 
     public org.test.v1alpha1.keycloakspec.Migration getMigration() {
@@ -117,6 +124,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
      */
     @com.fasterxml.jackson.annotation.JsonProperty("multiAvailablityZones")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ")
     private org.test.v1alpha1.keycloakspec.MultiAvailablityZones multiAvailablityZones;
 
     public org.test.v1alpha1.keycloakspec.MultiAvailablityZones getMultiAvailablityZones() {
@@ -131,6 +139,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Specify PodDisruptionBudget configuration.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("podDisruptionBudget")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify PodDisruptionBudget configuration.")
     private org.test.v1alpha1.keycloakspec.PodDisruptionBudget podDisruptionBudget;
 
     public org.test.v1alpha1.keycloakspec.PodDisruptionBudget getPodDisruptionBudget() {
@@ -145,6 +154,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Resources (Requests and Limits) for PostgresDeployment.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("postgresDeploymentSpec")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources (Requests and Limits) for PostgresDeployment.")
     private org.test.v1alpha1.keycloakspec.PostgresDeploymentSpec postgresDeploymentSpec;
 
     public org.test.v1alpha1.keycloakspec.PostgresDeploymentSpec getPostgresDeploymentSpec() {
@@ -159,6 +169,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Profile used for controlling Operator behavior. Default is empty.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("profile")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Profile used for controlling Operator behavior. Default is empty.")
     private String profile;
 
     public String getProfile() {
@@ -173,6 +184,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * Name of the StorageClass for Postgresql Persistent Volume Claim
      */
     @com.fasterxml.jackson.annotation.JsonProperty("storageClassName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name of the StorageClass for Postgresql Persistent Volume Claim")
     private String storageClassName;
 
     public String getStorageClassName() {
@@ -187,6 +199,7 @@ public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesR
      * When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("unmanaged")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.")
     private Boolean unmanaged;
 
     public Boolean getUnmanaged() {
@@ -210,6 +223,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      */
     @com.fasterxml.jackson.annotation.JsonProperty("credentialSecret")
     @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The secret where the admin credentials are to be found.")
     private String credentialSecret;
 
     public String getCredentialSecret() {
@@ -224,6 +238,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
      */
     @com.fasterxml.jackson.annotation.JsonProperty("externalURL")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).")
     private String externalURL;
 
     public String getExternalURL() {
@@ -239,6 +254,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      */
     @com.fasterxml.jackson.annotation.JsonProperty("internalURL")
     @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An internal URL (service name) to be used by the admin client.")
     private String internalURL;
 
     public String getInternalURL() {
@@ -254,6 +270,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      */
     @com.fasterxml.jackson.annotation.JsonProperty("message")
     @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Human-readable message indicating details about current operator phase or error.")
     private String message;
 
     public String getMessage() {
@@ -269,6 +286,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      */
     @com.fasterxml.jackson.annotation.JsonProperty("phase")
     @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Current phase of the operator.")
     private String phase;
 
     public String getPhase() {
@@ -284,6 +302,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      */
     @com.fasterxml.jackson.annotation.JsonProperty("ready")
     @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if all resources are in a ready state and all work is done.")
     private Boolean ready;
 
     public Boolean getReady() {
@@ -298,6 +317,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ].
      */
     @com.fasterxml.jackson.annotation.JsonProperty("secondaryResources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ].")
     private java.util.Map<java.lang.String, java.util.List<String>> secondaryResources;
 
     public java.util.Map<java.lang.String, java.util.List<String>> getSecondaryResources() {
@@ -313,6 +333,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      */
     @com.fasterxml.jackson.annotation.JsonProperty("version")
     @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Version of Keycloak or RHSSO running on the cluster.")
     private String version;
 
     public String getVersion() {

--- a/java-generator/it/src/it/cert-manager/expected/Auth.expected
+++ b/java-generator/it/src/it/cert-manager/expected/Auth.expected
@@ -26,6 +26,7 @@ public class Auth implements io.fabric8.kubernetes.api.model.KubernetesResource 
      * AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("appRole")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.")
     private io.cert_manager.v1.AppRole appRole;
 
     public io.cert_manager.v1.AppRole getAppRole() {
@@ -40,6 +41,7 @@ public class Auth implements io.fabric8.kubernetes.api.model.KubernetesResource 
      * Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.")
     private io.cert_manager.v1.Kubernetes kubernetes;
 
     public io.cert_manager.v1.Kubernetes getKubernetes() {
@@ -54,6 +56,7 @@ public class Auth implements io.fabric8.kubernetes.api.model.KubernetesResource 
      * TokenSecretRef authenticates with Vault by presenting a token.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("tokenSecretRef")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("TokenSecretRef authenticates with Vault by presenting a token.")
     private io.cert_manager.v1.TokenSecretRef tokenSecretRef;
 
     public io.cert_manager.v1.TokenSecretRef getTokenSecretRef() {


### PR DESCRIPTION
## Description

Support for `JsonPropertyDescription` (to mirror the CRD generator).

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
