### PR TITLE
fix #3876: moving the rest of the extensions to just the api

### DIFF
--- a/doc/MIGRATION-v6.md
+++ b/doc/MIGRATION-v6.md
@@ -143,9 +143,11 @@ We've removed setter methods `setIntVal`, `setKind`, `setStrVal` from the class.
   String strValue = i2.getStrVal();
   ```
 
-## Service Catalog Changes
+## Extension Changes
 
-io.fabric8.servicecatalog.client.internal.XXXResource interfaces moved to io.fabric8.servicecatalog.client.dsl.XXXResource to no longer be in an internal package.
+- io.fabric8.servicecatalog.client.internal.XXXResource interfaces moved to io.fabric8.servicecatalog.client.dsl.XXXResource to no longer be in an internal package.
+
+- io.fabric8.volumesnapshot.client.internal.XXXResource interfaces moved to io.fabric8.volumesnapshot.client.XXXResource to no longer be in an internal package.
 
 ## Adapt Changes
 

--- a/extensions/certmanager/client/pom.xml
+++ b/extensions/certmanager/client/pom.xml
@@ -60,26 +60,27 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>certmanager-model-v1alpha2</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>certmanager-model-v1alpha3</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>certmanager-model-v1beta1</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>certmanager-model-v1</artifactId>
-      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/DefaultCertManagerClient.java
+++ b/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/DefaultCertManagerClient.java
@@ -19,15 +19,14 @@ import io.fabric8.certmanager.client.dsl.V1APIGroupDSL;
 import io.fabric8.certmanager.client.dsl.V1alpha2APIGroupDSL;
 import io.fabric8.certmanager.client.dsl.V1alpha3APIGroupDSL;
 import io.fabric8.certmanager.client.dsl.V1beta1APIGroupDSL;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class DefaultCertManagerClient extends BaseClient implements NamespacedCertManagerClient {
+public class DefaultCertManagerClient extends ClientAdapter<NamespacedCertManagerClient> implements NamespacedCertManagerClient {
 
   public DefaultCertManagerClient() {
     super();
@@ -37,22 +36,13 @@ public class DefaultCertManagerClient extends BaseClient implements NamespacedCe
     super(configuration);
   }
 
-  public DefaultCertManagerClient(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultCertManagerClient(Client client) {
+    super(client);
   }
 
   @Override
-  public NamespacedCertManagerClient inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedCertManagerClient inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration())
-      .withNamespace(namespace)
-      .build();
-
-    return new DefaultCertManagerClient(newState(updated));
+  protected NamespacedCertManagerClient newInstance(Client client) {
+    return new DefaultCertManagerClient(client);
   }
 
   @Override

--- a/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1APIGroupClient.java
+++ b/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1APIGroupClient.java
@@ -28,47 +28,51 @@ import io.fabric8.certmanager.api.model.v1.ClusterIssuerList;
 import io.fabric8.certmanager.api.model.v1.Issuer;
 import io.fabric8.certmanager.api.model.v1.IssuerList;
 import io.fabric8.certmanager.client.dsl.V1APIGroupDSL;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class V1APIGroupClient extends BaseClient implements V1APIGroupDSL {
+public class V1APIGroupClient extends ClientAdapter<V1APIGroupDSL> implements V1APIGroupDSL {
   public V1APIGroupClient() {super();}
 
-  public V1APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1APIGroupDSL newInstance(Client client) {
+    return new V1APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Certificate, CertificateList, Resource<Certificate>> certificates() {
-    return Handlers.getOperation(Certificate.class, CertificateList.class, this);
+    return resources(Certificate.class, CertificateList.class);
   }
 
   @Override
   public MixedOperation<CertificateRequest, CertificateRequestList, Resource<CertificateRequest>> certificateRequests() {
-    return Handlers.getOperation(CertificateRequest.class, CertificateRequestList.class, this);
+    return resources(CertificateRequest.class, CertificateRequestList.class);
   }
 
   @Override
   public MixedOperation<Issuer, IssuerList, Resource<Issuer>> issuers() {
-    return Handlers.getOperation(Issuer.class, IssuerList.class, this);
+    return resources(Issuer.class, IssuerList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterIssuer, ClusterIssuerList, Resource<ClusterIssuer>> clusterIssuers() {
-    return Handlers.getOperation(ClusterIssuer.class, ClusterIssuerList.class, this);
+    return resources(ClusterIssuer.class, ClusterIssuerList.class);
   }
 
   @Override
   public MixedOperation<Challenge, ChallengeList, Resource<Challenge>> challenges() {
-    return Handlers.getOperation(Challenge.class, ChallengeList.class, this);
+    return resources(Challenge.class, ChallengeList.class);
   }
 
   @Override
   public MixedOperation<Order, OrderList, Resource<Order>> orders() {
-    return Handlers.getOperation(Order.class, OrderList.class, this);
+    return resources(Order.class, OrderList.class);
   }
 }

--- a/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1alpha2APIGroupClient.java
+++ b/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1alpha2APIGroupClient.java
@@ -28,49 +28,53 @@ import io.fabric8.certmanager.api.model.v1alpha2.ClusterIssuerList;
 import io.fabric8.certmanager.api.model.v1alpha2.Issuer;
 import io.fabric8.certmanager.api.model.v1alpha2.IssuerList;
 import io.fabric8.certmanager.client.dsl.V1alpha2APIGroupDSL;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class V1alpha2APIGroupClient extends BaseClient implements V1alpha2APIGroupDSL {
+public class V1alpha2APIGroupClient extends ClientAdapter<V1alpha2APIGroupDSL> implements V1alpha2APIGroupDSL {
   public V1alpha2APIGroupClient() {
     super();
   }
 
-  public V1alpha2APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1alpha2APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1alpha2APIGroupDSL newInstance(Client client) {
+    return new V1alpha2APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Certificate, CertificateList, Resource<Certificate>> certificates() {
-    return Handlers.getOperation(Certificate.class, CertificateList.class, this);
+    return resources(Certificate.class, CertificateList.class);
   }
 
   @Override
   public MixedOperation<CertificateRequest, CertificateRequestList, Resource<CertificateRequest>> certificateRequests() {
-    return Handlers.getOperation(CertificateRequest.class, CertificateRequestList.class, this);
+    return resources(CertificateRequest.class, CertificateRequestList.class);
   }
 
   @Override
   public MixedOperation<Issuer, IssuerList, Resource<Issuer>> issuers() {
-    return Handlers.getOperation(Issuer.class, IssuerList.class, this);
+    return resources(Issuer.class, IssuerList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterIssuer, ClusterIssuerList, Resource<ClusterIssuer>> clusterIssuers() {
-    return Handlers.getOperation(ClusterIssuer.class, ClusterIssuerList.class, this);
+    return resources(ClusterIssuer.class, ClusterIssuerList.class);
   }
 
   @Override
   public MixedOperation<Challenge, ChallengeList, Resource<Challenge>> challenges() {
-    return Handlers.getOperation(Challenge.class, ChallengeList.class, this);
+    return resources(Challenge.class, ChallengeList.class);
   }
 
   @Override
   public MixedOperation<Order, OrderList, Resource<Order>> orders() {
-    return Handlers.getOperation(Order.class, OrderList.class, this);
+    return resources(Order.class, OrderList.class);
   }
 }

--- a/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1alpha3APIGroupClient.java
+++ b/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1alpha3APIGroupClient.java
@@ -28,49 +28,53 @@ import io.fabric8.certmanager.api.model.v1alpha3.ClusterIssuerList;
 import io.fabric8.certmanager.api.model.v1alpha3.Issuer;
 import io.fabric8.certmanager.api.model.v1alpha3.IssuerList;
 import io.fabric8.certmanager.client.dsl.V1alpha3APIGroupDSL;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class V1alpha3APIGroupClient extends BaseClient implements V1alpha3APIGroupDSL {
+public class V1alpha3APIGroupClient extends ClientAdapter<V1alpha3APIGroupDSL> implements V1alpha3APIGroupDSL {
   public V1alpha3APIGroupClient() {
     super();
   }
 
-  public V1alpha3APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1alpha3APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1alpha3APIGroupDSL newInstance(Client client) {
+    return new V1alpha3APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Certificate, CertificateList, Resource<Certificate>> certificates() {
-    return Handlers.getOperation(Certificate.class, CertificateList.class, this);
+    return resources(Certificate.class, CertificateList.class);
   }
 
   @Override
   public MixedOperation<CertificateRequest, CertificateRequestList, Resource<CertificateRequest>> certificateRequests() {
-    return Handlers.getOperation(CertificateRequest.class, CertificateRequestList.class, this);
+    return resources(CertificateRequest.class, CertificateRequestList.class);
   }
 
   @Override
   public MixedOperation<Issuer, IssuerList, Resource<Issuer>> issuers() {
-    return Handlers.getOperation(Issuer.class, IssuerList.class, this);
+    return resources(Issuer.class, IssuerList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterIssuer, ClusterIssuerList, Resource<ClusterIssuer>> clusterIssuers() {
-    return Handlers.getOperation(ClusterIssuer.class, ClusterIssuerList.class, this);
+    return resources(ClusterIssuer.class, ClusterIssuerList.class);
   }
 
   @Override
   public MixedOperation<Challenge, ChallengeList, Resource<Challenge>> challenges() {
-    return Handlers.getOperation(Challenge.class, ChallengeList.class, this);
+    return resources(Challenge.class, ChallengeList.class);
   }
 
   @Override
   public MixedOperation<Order, OrderList, Resource<Order>> orders() {
-    return Handlers.getOperation(Order.class, OrderList.class, this);
+    return resources(Order.class, OrderList.class);
   }
 }

--- a/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1beta1APIGroupClient.java
+++ b/extensions/certmanager/client/src/main/java/io/fabric8/certmanager/client/V1beta1APIGroupClient.java
@@ -28,49 +28,53 @@ import io.fabric8.certmanager.api.model.v1beta1.ClusterIssuerList;
 import io.fabric8.certmanager.api.model.v1beta1.Issuer;
 import io.fabric8.certmanager.api.model.v1beta1.IssuerList;
 import io.fabric8.certmanager.client.dsl.V1beta1APIGroupDSL;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class V1beta1APIGroupClient extends BaseClient implements V1beta1APIGroupDSL {
+public class V1beta1APIGroupClient extends ClientAdapter<V1beta1APIGroupDSL> implements V1beta1APIGroupDSL {
   public V1beta1APIGroupClient() {
     super();
   }
 
-  public V1beta1APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1beta1APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1beta1APIGroupDSL newInstance(Client client) {
+    return new V1beta1APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Certificate, CertificateList, Resource<Certificate>> certificates() {
-    return Handlers.getOperation(Certificate.class, CertificateList.class, this);
+    return resources(Certificate.class, CertificateList.class);
   }
 
   @Override
   public MixedOperation<CertificateRequest, CertificateRequestList, Resource<CertificateRequest>> certificateRequests() {
-    return Handlers.getOperation(CertificateRequest.class, CertificateRequestList.class, this);
+    return resources(CertificateRequest.class, CertificateRequestList.class);
   }
 
   @Override
   public MixedOperation<Issuer, IssuerList, Resource<Issuer>> issuers() {
-    return Handlers.getOperation(Issuer.class, IssuerList.class, this);
+    return resources(Issuer.class, IssuerList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterIssuer, ClusterIssuerList, Resource<ClusterIssuer>> clusterIssuers() {
-    return Handlers.getOperation(ClusterIssuer.class, ClusterIssuerList.class, this);
+    return resources(ClusterIssuer.class, ClusterIssuerList.class);
   }
 
   @Override
   public MixedOperation<Challenge, ChallengeList, Resource<Challenge>> challenges() {
-    return Handlers.getOperation(Challenge.class, ChallengeList.class, this);
+    return resources(Challenge.class, ChallengeList.class);
   }
 
   @Override
   public MixedOperation<Order, OrderList, Resource<Order>> orders() {
-    return Handlers.getOperation(Order.class, OrderList.class, this);
+    return resources(Order.class, OrderList.class);
   }
 }

--- a/extensions/certmanager/examples/pom.xml
+++ b/extensions/certmanager/examples/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>certmanager-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/extensions/chaosmesh/client/pom.xml
+++ b/extensions/chaosmesh/client/pom.xml
@@ -53,18 +53,23 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>chaosmesh-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
+      <artifactId>kubernetes-client-api</artifactId>
       <exclusions>
         <exclusion>
           <groupId>io.sundr</groupId>
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/extensions/chaosmesh/client/src/main/java/io/fabric8/chaosmesh/client/DefaultChaosMeshClient.java
+++ b/extensions/chaosmesh/client/src/main/java/io/fabric8/chaosmesh/client/DefaultChaosMeshClient.java
@@ -39,18 +39,16 @@ import io.fabric8.chaosmesh.v1alpha1.StressChaos;
 import io.fabric8.chaosmesh.v1alpha1.StressChaosList;
 import io.fabric8.chaosmesh.v1alpha1.TimeChaos;
 import io.fabric8.chaosmesh.v1alpha1.TimeChaosList;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class DefaultChaosMeshClient extends BaseClient implements NamespacedChaosMeshClient {
+public class DefaultChaosMeshClient extends ClientAdapter<NamespacedChaosMeshClient> implements NamespacedChaosMeshClient {
 
     public DefaultChaosMeshClient() {
         super();
@@ -60,20 +58,13 @@ public class DefaultChaosMeshClient extends BaseClient implements NamespacedChao
         super(configuration);
     }
 
-    public DefaultChaosMeshClient(ClientContext clientContext) {
-        super(clientContext);
+    public DefaultChaosMeshClient(Client client) {
+        super(client);
     }
 
     @Override
-    public NamespacedChaosMeshClient inAnyNamespace() {
-        return inNamespace(null);
-    }
-
-    @Override
-    public NamespacedChaosMeshClient inNamespace(String namespace) {
-        Config updated = new ConfigBuilder(getConfiguration()).withNamespace(namespace).build();
-
-        return new DefaultChaosMeshClient(newState(updated));
+    protected NamespacedChaosMeshClient newInstance(Client client) {
+        return new DefaultChaosMeshClient(client);
     }
 
     @Override
@@ -84,63 +75,63 @@ public class DefaultChaosMeshClient extends BaseClient implements NamespacedChao
 
   @Override
   public MixedOperation<IoChaos, IoChaosList, Resource<IoChaos>> ioChaos() {
-    return Handlers.getOperation(IoChaos.class, IoChaosList.class, this);
+    return resources(IoChaos.class, IoChaosList.class);
   }
 
   @Override
   public MixedOperation<KernelChaos, KernelChaosList,
     Resource<KernelChaos>> kernelChaos() {
-    return Handlers.getOperation(KernelChaos.class, KernelChaosList.class, this);
+    return resources(KernelChaos.class, KernelChaosList.class);
   }
 
   @Override
   public MixedOperation<NetworkChaos, NetworkChaosList, Resource<NetworkChaos>> networkChaos() {
-    return Handlers.getOperation(NetworkChaos.class, NetworkChaosList.class, this);
+    return resources(NetworkChaos.class, NetworkChaosList.class);
   }
 
   @Override
   public MixedOperation<PodChaos, PodChaosList, Resource<PodChaos>> podChaos() {
-    return Handlers.getOperation(PodChaos.class, PodChaosList.class, this);
+    return resources(PodChaos.class, PodChaosList.class);
   }
 
   @Override
   public MixedOperation<PodIoChaos, PodIoChaosList, Resource<PodIoChaos>> podIoChaos() {
-    return Handlers.getOperation(PodIoChaos.class, PodIoChaosList.class, this);
+    return resources(PodIoChaos.class, PodIoChaosList.class);
   }
 
   @Override
   public MixedOperation<PodNetworkChaos, PodNetworkChaosList, Resource<PodNetworkChaos>> podNetworkChaos() {
-    return Handlers.getOperation(PodNetworkChaos.class, PodNetworkChaosList.class, this);
+    return resources(PodNetworkChaos.class, PodNetworkChaosList.class);
   }
 
   @Override
   public MixedOperation<StressChaos, StressChaosList,
     Resource<StressChaos>> stressChaos() {
-    return Handlers.getOperation(StressChaos.class, StressChaosList.class, this);
+    return resources(StressChaos.class, StressChaosList.class);
   }
 
   @Override
   public MixedOperation<TimeChaos, TimeChaosList, Resource<TimeChaos>> timeChaos() {
-    return Handlers.getOperation(TimeChaos.class, TimeChaosList.class, this);
+    return resources(TimeChaos.class, TimeChaosList.class);
   }
 
   @Override
   public MixedOperation<JVMChaos, JVMChaosList, Resource<JVMChaos>> jvmChaos() {
-    return Handlers.getOperation(JVMChaos.class, JVMChaosList.class, this);
+    return resources(JVMChaos.class, JVMChaosList.class);
   }
 
   @Override
   public MixedOperation<HTTPChaos, HTTPChaosList, Resource<HTTPChaos>> httpChaos() {
-    return Handlers.getOperation(HTTPChaos.class, HTTPChaosList.class, this);
+    return resources(HTTPChaos.class, HTTPChaosList.class);
   }
 
   @Override
   public MixedOperation<DNSChaos, DNSChaosList, Resource<DNSChaos>> dnsChaos() {
-    return Handlers.getOperation(DNSChaos.class, DNSChaosList.class, this);
+    return resources(DNSChaos.class, DNSChaosList.class);
   }
 
   @Override
   public MixedOperation<AwsChaos, AwsChaosList, Resource<AwsChaos>> awsChaos() {
-    return Handlers.getOperation(AwsChaos.class, AwsChaosList.class, this);
+    return resources(AwsChaos.class, AwsChaosList.class);
   }
 }

--- a/extensions/istio/client/pom.xml
+++ b/extensions/istio/client/pom.xml
@@ -63,6 +63,11 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/extensions/istio/client/src/main/java/io/fabric8/istio/client/DefaultIstioClient.java
+++ b/extensions/istio/client/src/main/java/io/fabric8/istio/client/DefaultIstioClient.java
@@ -15,15 +15,14 @@
  */
 package io.fabric8.istio.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class DefaultIstioClient extends BaseClient implements NamespacedIstioClient {
+public class DefaultIstioClient extends ClientAdapter<NamespacedIstioClient> implements NamespacedIstioClient {
 
   public DefaultIstioClient() {
     super();
@@ -33,22 +32,13 @@ public class DefaultIstioClient extends BaseClient implements NamespacedIstioCli
     super(configuration);
   }
 
-  public DefaultIstioClient(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultIstioClient(Client client) {
+    super(client);
   }
 
   @Override
-  public NamespacedIstioClient inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedIstioClient inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration())
-      .withNamespace(namespace)
-      .build();
-
-    return new DefaultIstioClient(newState(updated));
+  protected NamespacedIstioClient newInstance(Client client) {
+    return new DefaultIstioClient(client);
   }
 
   @Override

--- a/extensions/istio/client/src/main/java/io/fabric8/istio/client/V1alpha3APIGroupClient.java
+++ b/extensions/istio/client/src/main/java/io/fabric8/istio/client/V1alpha3APIGroupClient.java
@@ -29,14 +29,13 @@ import io.fabric8.istio.api.networking.v1alpha3.VirtualService;
 import io.fabric8.istio.api.networking.v1alpha3.VirtualServiceList;
 import io.fabric8.istio.api.networking.v1alpha3.WorkloadEntry;
 import io.fabric8.istio.api.networking.v1alpha3.WorkloadEntryList;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class V1alpha3APIGroupClient extends BaseClient implements V1alpha3APIGroupDSL {
+public class V1alpha3APIGroupClient extends ClientAdapter<V1alpha3APIGroupDSL> implements V1alpha3APIGroupDSL {
 
   public V1alpha3APIGroupClient() {
     super();
@@ -46,44 +45,49 @@ public class V1alpha3APIGroupClient extends BaseClient implements V1alpha3APIGro
     super(configuration);
   }
 
-  public V1alpha3APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1alpha3APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1alpha3APIGroupDSL newInstance(Client client) {
+    return new V1alpha3APIGroupClient(client);
   }
 
   // networking
 
   @Override
   public MixedOperation<DestinationRule, DestinationRuleList, Resource<DestinationRule>> destinationRules() {
-    return Handlers.getOperation(DestinationRule.class, DestinationRuleList.class, this);
+    return resources(DestinationRule.class, DestinationRuleList.class);
   }
 
   @Override
   public MixedOperation<EnvoyFilter, EnvoyFilterList, Resource<EnvoyFilter>> envoyFilters() {
-    return Handlers.getOperation(EnvoyFilter.class, EnvoyFilterList.class, this);
+    return resources(EnvoyFilter.class, EnvoyFilterList.class);
   }
 
   @Override
   public MixedOperation<Gateway, GatewayList, Resource<Gateway>> gateways() {
-    return Handlers.getOperation(Gateway.class, GatewayList.class, this);
+    return resources(Gateway.class, GatewayList.class);
   }
 
   @Override
   public MixedOperation<ServiceEntry, ServiceEntryList, Resource<ServiceEntry>> serviceEntries() {
-    return Handlers.getOperation(ServiceEntry.class, ServiceEntryList.class, this);
+    return resources(ServiceEntry.class, ServiceEntryList.class);
   }
 
   @Override
   public MixedOperation<Sidecar, SidecarList, Resource<Sidecar>> sidecars() {
-    return Handlers.getOperation(Sidecar.class, SidecarList.class, this);
+    return resources(Sidecar.class, SidecarList.class);
   }
 
   @Override
   public MixedOperation<VirtualService, VirtualServiceList, Resource<VirtualService>> virtualServices() {
-    return Handlers.getOperation(VirtualService.class, VirtualServiceList.class, this);
+    return resources(VirtualService.class, VirtualServiceList.class);
   }
 
   @Override
   public MixedOperation<WorkloadEntry, WorkloadEntryList, Resource<WorkloadEntry>> workloadEntries() {
-    return Handlers.getOperation(WorkloadEntry.class, WorkloadEntryList.class, this);
+    return resources(WorkloadEntry.class, WorkloadEntryList.class);
   }
 }

--- a/extensions/istio/client/src/main/java/io/fabric8/istio/client/V1beta1APIGroupClient.java
+++ b/extensions/istio/client/src/main/java/io/fabric8/istio/client/V1beta1APIGroupClient.java
@@ -33,14 +33,13 @@ import io.fabric8.istio.api.security.v1beta1.PeerAuthentication;
 import io.fabric8.istio.api.security.v1beta1.PeerAuthenticationList;
 import io.fabric8.istio.api.security.v1beta1.RequestAuthentication;
 import io.fabric8.istio.api.security.v1beta1.RequestAuthenticationList;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class V1beta1APIGroupClient extends BaseClient implements V1beta1APIGroupDSL {
+public class V1beta1APIGroupClient extends ClientAdapter<V1beta1APIGroupDSL> implements V1beta1APIGroupDSL {
 
   public V1beta1APIGroupClient() {
     super();
@@ -50,55 +49,60 @@ public class V1beta1APIGroupClient extends BaseClient implements V1beta1APIGroup
     super(configuration);
   }
 
-  public V1beta1APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1beta1APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1beta1APIGroupDSL newInstance(Client client) {
+    return new V1beta1APIGroupClient(client);
   }
 
   // networking
 
   @Override
   public MixedOperation<DestinationRule, DestinationRuleList, Resource<DestinationRule>> destinationRules() {
-    return Handlers.getOperation(DestinationRule.class, DestinationRuleList.class, this);
+    return resources(DestinationRule.class, DestinationRuleList.class);
   }
 
   @Override
   public MixedOperation<Gateway, GatewayList, Resource<Gateway>> gateways() {
-    return Handlers.getOperation(Gateway.class, GatewayList.class, this);
+    return resources(Gateway.class, GatewayList.class);
   }
 
   @Override
   public MixedOperation<ServiceEntry, ServiceEntryList, Resource<ServiceEntry>> serviceEntries() {
-    return Handlers.getOperation(ServiceEntry.class, ServiceEntryList.class, this);
+    return resources(ServiceEntry.class, ServiceEntryList.class);
   }
 
   @Override
   public MixedOperation<Sidecar, SidecarList, Resource<Sidecar>> sidecars() {
-    return Handlers.getOperation(Sidecar.class, SidecarList.class, this);
+    return resources(Sidecar.class, SidecarList.class);
   }
 
   @Override
   public MixedOperation<VirtualService, VirtualServiceList, Resource<VirtualService>> virtualServices() {
-    return Handlers.getOperation(VirtualService.class, VirtualServiceList.class, this);
+    return resources(VirtualService.class, VirtualServiceList.class);
   }
 
   @Override
   public MixedOperation<WorkloadEntry, WorkloadEntryList, Resource<WorkloadEntry>> workloadEntries() {
-    return Handlers.getOperation(WorkloadEntry.class, WorkloadEntryList.class, this);
+    return resources(WorkloadEntry.class, WorkloadEntryList.class);
   }
 
   // security
   @Override
   public MixedOperation<PeerAuthentication, PeerAuthenticationList, Resource<PeerAuthentication>> peerAuthentications() {
-    return Handlers.getOperation(PeerAuthentication.class, PeerAuthenticationList.class, this);
+    return resources(PeerAuthentication.class, PeerAuthenticationList.class);
   }
 
   @Override
   public MixedOperation<RequestAuthentication, RequestAuthenticationList, Resource<RequestAuthentication>> requestAuthentications() {
-    return Handlers.getOperation(RequestAuthentication.class, RequestAuthenticationList.class, this);
+    return resources(RequestAuthentication.class, RequestAuthenticationList.class);
   }
 
   @Override
   public MixedOperation<AuthorizationPolicy, AuthorizationPolicyList, Resource<AuthorizationPolicy>> authorizationPolicies() {
-    return Handlers.getOperation(AuthorizationPolicy.class, AuthorizationPolicyList.class, this);
+    return resources(AuthorizationPolicy.class, AuthorizationPolicyList.class);
   }
 }

--- a/extensions/knative/client/pom.xml
+++ b/extensions/knative/client/pom.xml
@@ -58,7 +58,12 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/extensions/knative/client/src/main/java/io/fabric8/knative/client/DefaultKnativeClient.java
+++ b/extensions/knative/client/src/main/java/io/fabric8/knative/client/DefaultKnativeClient.java
@@ -67,18 +67,16 @@ import io.fabric8.knative.sources.v1.PingSource;
 import io.fabric8.knative.sources.v1.PingSourceList;
 import io.fabric8.knative.sources.v1.SinkBinding;
 import io.fabric8.knative.sources.v1.SinkBindingList;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class DefaultKnativeClient extends BaseClient implements NamespacedKnativeClient {
+public class DefaultKnativeClient extends ClientAdapter<NamespacedKnativeClient> implements NamespacedKnativeClient {
 
     public DefaultKnativeClient() {
         super();
@@ -88,20 +86,13 @@ public class DefaultKnativeClient extends BaseClient implements NamespacedKnativ
         super(configuration);
     }
 
-    public DefaultKnativeClient(ClientContext clientContext) {
-        super(clientContext);
+    public DefaultKnativeClient(Client client) {
+        super(client);
     }
 
     @Override
-    public NamespacedKnativeClient inAnyNamespace() {
-        return inNamespace(null);
-    }
-
-    @Override
-    public NamespacedKnativeClient inNamespace(String namespace) {
-        Config updated = new ConfigBuilder(getConfiguration()).withNamespace(namespace).build();
-
-        return new DefaultKnativeClient(newState(updated));
+    protected NamespacedKnativeClient newInstance(Client client) {
+        return new DefaultKnativeClient(client);
     }
 
     @Override
@@ -111,131 +102,131 @@ public class DefaultKnativeClient extends BaseClient implements NamespacedKnativ
 
     @Override
     public MixedOperation<Service, ServiceList, Resource<Service>> services() {
-        return Handlers.getOperation(Service.class, ServiceList.class, this);
+        return resources(Service.class, ServiceList.class);
     }
 
     @Override
     public MixedOperation<Route, RouteList, Resource<Route>> routes() {
-        return Handlers.getOperation(Route.class, RouteList.class, this);
+        return resources(Route.class, RouteList.class);
     }
 
     @Override
     public MixedOperation<Revision, RevisionList, Resource<Revision>> revisions() {
-        return Handlers.getOperation(Revision.class, RevisionList.class, this);
+        return resources(Revision.class, RevisionList.class);
     }
 
     @Override
     public MixedOperation<Configuration, ConfigurationList, Resource<Configuration>> configurations() {
-        return Handlers.getOperation(Configuration.class, ConfigurationList.class, this);
+        return resources(Configuration.class, ConfigurationList.class);
     }
 
     @Override
     public MixedOperation<Broker, BrokerList, Resource<Broker>> brokers() {
-        return Handlers.getOperation(Broker.class, BrokerList.class, this);
+        return resources(Broker.class, BrokerList.class);
     }
 
     @Override
     public MixedOperation<Trigger, TriggerList, Resource<Trigger>> triggers() {
-        return Handlers.getOperation(Trigger.class, TriggerList.class, this);
+        return resources(Trigger.class, TriggerList.class);
     }
 
     @Override
     public MixedOperation<Channel, ChannelList, Resource<Channel>> channels() {
-        return Handlers.getOperation(Channel.class, ChannelList.class, this);
+        return resources(Channel.class, ChannelList.class);
     }
 
     @Override
     public MixedOperation<Subscription, SubscriptionList, Resource<Subscription>> subscriptions() {
-        return Handlers.getOperation(Subscription.class, SubscriptionList.class, this);
+        return resources(Subscription.class, SubscriptionList.class);
     }
 
     @Override
     public MixedOperation<EventType, EventTypeList, Resource<EventType>> eventTypes() {
-        return Handlers.getOperation(EventType.class, EventTypeList.class, this);
+        return resources(EventType.class, EventTypeList.class);
     }
 
     @Override
     public MixedOperation<Sequence, SequenceList, Resource<Sequence>> sequences() {
-        return Handlers.getOperation(Sequence.class, SequenceList.class, this);
+        return resources(Sequence.class, SequenceList.class);
     }
 
   @Override
   public MixedOperation<Parallel, ParallelList, Resource<Parallel>> parallels() {
-    return Handlers.getOperation(Parallel.class, ParallelList.class, this);
+    return resources(Parallel.class, ParallelList.class);
   }
 
   @Override
     public MixedOperation<InMemoryChannel, InMemoryChannelList, Resource<InMemoryChannel>> inMemoryChannels() {
-        return Handlers.getOperation(InMemoryChannel.class, InMemoryChannelList.class, this);
+        return resources(InMemoryChannel.class, InMemoryChannelList.class);
     }
 
   @Override
   public MixedOperation<PingSource, PingSourceList, Resource<PingSource>> pingSources() {
-    return Handlers.getOperation(PingSource.class, PingSourceList.class, this);
+    return resources(PingSource.class, PingSourceList.class);
   }
 
   @Override
   public MixedOperation<SinkBinding, SinkBindingList, Resource<SinkBinding>> sinkBindings() {
-    return Handlers.getOperation(SinkBinding.class, SinkBindingList.class, this);
+    return resources(SinkBinding.class, SinkBindingList.class);
   }
 
   @Override
   public MixedOperation<ContainerSource, ContainerSourceList, Resource<ContainerSource>> containerSources() {
-    return Handlers.getOperation(ContainerSource.class, ContainerSourceList.class, this);
+    return resources(ContainerSource.class, ContainerSourceList.class);
   }
 
   @Override
   public MixedOperation<ApiServerSource, ApiServerSourceList, Resource<ApiServerSource>> apiServerSources() {
-    return Handlers.getOperation(ApiServerSource.class, ApiServerSourceList.class, this);
+    return resources(ApiServerSource.class, ApiServerSourceList.class);
   }
 
   @Override
   public MixedOperation<AwsSqsSource, AwsSqsSourceList, Resource<AwsSqsSource>> awsSqsSources() {
-    return Handlers.getOperation(AwsSqsSource.class, AwsSqsSourceList.class, this);
+    return resources(AwsSqsSource.class, AwsSqsSourceList.class);
   }
 
   @Override
   public MixedOperation<CouchDbSource, CouchDbSourceList, Resource<CouchDbSource>> couchDbSources() {
-    return Handlers.getOperation(CouchDbSource.class, CouchDbSourceList.class, this);
+    return resources(CouchDbSource.class, CouchDbSourceList.class);
   }
 
   @Override
   public MixedOperation<GitHubSource, GitHubSourceList, Resource<GitHubSource>> gitHubSources() {
-    return Handlers.getOperation(GitHubSource.class, GitHubSourceList.class, this);
+    return resources(GitHubSource.class, GitHubSourceList.class);
   }
 
   @Override
   public MixedOperation<GitHubBinding, GitHubBindingList, Resource<GitHubBinding>> gitHubBindings() {
-    return Handlers.getOperation(GitHubBinding.class, GitHubBindingList.class, this);
+    return resources(GitHubBinding.class, GitHubBindingList.class);
   }
 
   @Override
   public MixedOperation<GitLabSource, GitLabSourceList, Resource<GitLabSource>> gitLabSources() {
-    return Handlers.getOperation(GitLabSource.class, GitLabSourceList.class, this);
+    return resources(GitLabSource.class, GitLabSourceList.class);
   }
 
   @Override
   public MixedOperation<GitLabBinding, GitLabBindingList, Resource<GitLabBinding>> gitLabBindings() {
-    return Handlers.getOperation(GitLabBinding.class, GitLabBindingList.class, this);
+    return resources(GitLabBinding.class, GitLabBindingList.class);
   }
 
   @Override
   public MixedOperation<PrometheusSource, PrometheusSourceList, Resource<PrometheusSource>> prometheusSources() {
-    return Handlers.getOperation(PrometheusSource.class, PrometheusSourceList.class, this);
+    return resources(PrometheusSource.class, PrometheusSourceList.class);
   }
 
   @Override
   public MixedOperation<KafkaChannel, KafkaChannelList, Resource<KafkaChannel>> kafkaChannels() {
-    return Handlers.getOperation(KafkaChannel.class, KafkaChannelList.class, this);
+    return resources(KafkaChannel.class, KafkaChannelList.class);
   }
 
   @Override
   public MixedOperation<KafkaSource, KafkaSourceList, Resource<KafkaSource>> kafkasSources() {
-    return Handlers.getOperation(KafkaSource.class, KafkaSourceList.class, this);
+    return resources(KafkaSource.class, KafkaSourceList.class);
   }
 
   @Override
   public MixedOperation<KafkaBinding, KafkaBindingList, Resource<KafkaBinding>> kafkaBindings() {
-    return Handlers.getOperation(KafkaBinding.class, KafkaBindingList.class, this);
+    return resources(KafkaBinding.class, KafkaBindingList.class);
   }
 }

--- a/extensions/knative/client/src/main/java/io/fabric8/knative/client/serving/v1/DefaultServingV1Client.java
+++ b/extensions/knative/client/src/main/java/io/fabric8/knative/client/serving/v1/DefaultServingV1Client.java
@@ -23,18 +23,16 @@ import io.fabric8.knative.serving.v1.Route;
 import io.fabric8.knative.serving.v1.RouteList;
 import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.knative.serving.v1.ServiceList;
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
-public class DefaultServingV1Client extends BaseClient implements NamespacedServingV1Client {
+public class DefaultServingV1Client extends ClientAdapter<NamespacedServingV1Client> implements NamespacedServingV1Client {
 
   public DefaultServingV1Client() {
     super();
@@ -44,20 +42,13 @@ public class DefaultServingV1Client extends BaseClient implements NamespacedServ
     super(configuration);
   }
 
-  public DefaultServingV1Client(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultServingV1Client(Client client) {
+    super(client);
   }
 
   @Override
-  public NamespacedServingV1Client inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedServingV1Client inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration()).withNamespace(namespace).build();
-
-    return new DefaultServingV1Client(newState(updated));
+  protected NamespacedServingV1Client newInstance(Client client) {
+    return new DefaultServingV1Client(client);
   }
 
   @Override
@@ -67,22 +58,22 @@ public class DefaultServingV1Client extends BaseClient implements NamespacedServ
 
   @Override
   public MixedOperation<Service, ServiceList, Resource<Service>> services() {
-    return Handlers.getOperation(Service.class, ServiceList.class, this);
+    return resources(Service.class, ServiceList.class);
   }
 
   @Override
   public MixedOperation<Route, RouteList, Resource<Route>> routes() {
-    return Handlers.getOperation(Route.class, RouteList.class, this);
+    return resources(Route.class, RouteList.class);
   }
 
   @Override
   public MixedOperation<Revision, RevisionList, Resource<Revision>> revisions() {
-    return Handlers.getOperation(Revision.class, RevisionList.class, this);
+    return resources(Revision.class, RevisionList.class);
   }
 
   @Override
   public MixedOperation<Configuration, ConfigurationList, Resource<Configuration>> configurations() {
-    return Handlers.getOperation(Configuration.class, ConfigurationList.class, this);
+    return resources(Configuration.class, ConfigurationList.class);
   }
 
 }

--- a/extensions/open-cluster-management/client/pom.xml
+++ b/extensions/open-cluster-management/client/pom.xml
@@ -53,58 +53,55 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-apps-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-cluster-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-discovery-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-observability-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-operator-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-placementruleapps-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-policy-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-search-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>open-cluster-management-agent-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
+      <artifactId>kubernetes-client-api</artifactId>
       <exclusions>
         <exclusion>
           <groupId>io.sundr</groupId>
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/DefaultOpenClusterManagementClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/DefaultOpenClusterManagementClient.java
@@ -15,13 +15,12 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementAgentAPIGroupDSL;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementAppsAPIGroupDSL;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementClustersAPIGroupDSL;
@@ -30,7 +29,7 @@ import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementOperator
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementPolicyAPIGroupDSL;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementSearchAPIGroupDSL;
 
-public class DefaultOpenClusterManagementClient extends BaseClient implements NamespacedOpenClusterManagementClient {
+public class DefaultOpenClusterManagementClient extends ClientAdapter<NamespacedOpenClusterManagementClient> implements NamespacedOpenClusterManagementClient {
   public DefaultOpenClusterManagementClient() {
     super();
   }
@@ -39,22 +38,13 @@ public class DefaultOpenClusterManagementClient extends BaseClient implements Na
     super(configuration);
   }
 
-  public DefaultOpenClusterManagementClient(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultOpenClusterManagementClient(Client client) {
+    super(client);
   }
 
   @Override
-  public NamespacedOpenClusterManagementClient inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedOpenClusterManagementClient inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration())
-      .withNamespace(namespace)
-      .build();
-
-    return new DefaultOpenClusterManagementClient(newState(updated));
+  protected NamespacedOpenClusterManagementClient newInstance(Client client) {
+    return new DefaultOpenClusterManagementClient(client);
   }
 
   @Override

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementAgentAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementAgentAPIGroupClient.java
@@ -15,17 +15,16 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.agent.v1.KlusterletAddonConfig;
 import io.fabric8.openclustermanagement.api.model.agent.v1.KlusterletAddonConfigList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementAgentAPIGroupDSL;
 
-public class OpenClusterManagementAgentAPIGroupClient  extends BaseClient implements OpenClusterManagementAgentAPIGroupDSL {
+public class OpenClusterManagementAgentAPIGroupClient extends ClientAdapter<OpenClusterManagementAgentAPIGroupDSL> implements OpenClusterManagementAgentAPIGroupDSL {
   public OpenClusterManagementAgentAPIGroupClient() {
     super();
   }
@@ -34,12 +33,17 @@ public class OpenClusterManagementAgentAPIGroupClient  extends BaseClient implem
     super(configuration);
   }
 
-  public OpenClusterManagementAgentAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementAgentAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementAgentAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementAgentAPIGroupClient(client);
   }
 
   @Override
   public MixedOperation<KlusterletAddonConfig, KlusterletAddonConfigList, Resource<KlusterletAddonConfig>> klusterletAddonConfigs() {
-    return Handlers.getOperation(KlusterletAddonConfig.class, KlusterletAddonConfigList.class, this);
+    return resources(KlusterletAddonConfig.class, KlusterletAddonConfigList.class);
   }
 }

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementAppsAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementAppsAPIGroupClient.java
@@ -15,11 +15,10 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.app.k8s.v1beta1.Application;
 import io.fabric8.openclustermanagement.api.model.app.k8s.v1beta1.ApplicationList;
 import io.fabric8.openclustermanagement.api.model.multicloudintegration.apps.v1beta1.GitOpsCluster;
@@ -34,43 +33,48 @@ import io.fabric8.openclustermanagement.api.model.multicloudoperatorssubscriptio
 import io.fabric8.openclustermanagement.api.model.multicloudoperatorssubscription.apps.v1.SubscriptionList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementAppsAPIGroupDSL;
 
-public class OpenClusterManagementAppsAPIGroupClient extends BaseClient implements OpenClusterManagementAppsAPIGroupDSL {
+public class OpenClusterManagementAppsAPIGroupClient extends ClientAdapter<OpenClusterManagementAppsAPIGroupDSL> implements OpenClusterManagementAppsAPIGroupDSL {
 
   public OpenClusterManagementAppsAPIGroupClient() {
     super();
   }
 
-  public OpenClusterManagementAppsAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementAppsAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementAppsAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementAppsAPIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Channel, ChannelList, Resource<Channel>> channels() {
-    return Handlers.getOperation(Channel.class, ChannelList.class, this);
+    return resources(Channel.class, ChannelList.class);
   }
 
   @Override
   public MixedOperation<Subscription, SubscriptionList, Resource<Subscription>> subscriptions() {
-    return Handlers.getOperation(Subscription.class, SubscriptionList.class, this);
+    return resources(Subscription.class, SubscriptionList.class);
   }
 
   @Override
   public MixedOperation<HelmRelease, HelmReleaseList, Resource<HelmRelease>> helmReleases() {
-    return Handlers.getOperation(HelmRelease.class, HelmReleaseList.class, this);
+    return resources(HelmRelease.class, HelmReleaseList.class);
   }
 
   @Override
   public MixedOperation<Application, ApplicationList, Resource<Application>> applications() {
-    return Handlers.getOperation(Application.class, ApplicationList.class, this);
+    return resources(Application.class, ApplicationList.class);
   }
 
   @Override
   public MixedOperation<PlacementRule, PlacementRuleList, Resource<PlacementRule>> placementRules() {
-    return Handlers.getOperation(PlacementRule.class, PlacementRuleList.class, this);
+    return resources(PlacementRule.class, PlacementRuleList.class);
   }
 
   @Override
   public MixedOperation<GitOpsCluster, GitOpsClusterList, Resource<GitOpsCluster>> gitOpsClusters() {
-    return Handlers.getOperation(GitOpsCluster.class, GitOpsClusterList.class, this);
+    return resources(GitOpsCluster.class, GitOpsClusterList.class);
   }
 }

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementClustersAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementClustersAPIGroupClient.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.cluster.v1.ManagedCluster;
 import io.fabric8.openclustermanagement.api.model.cluster.v1.ManagedClusterList;
 import io.fabric8.openclustermanagement.api.model.cluster.v1alpha1.Placement;
@@ -33,38 +32,43 @@ import io.fabric8.openclustermanagement.api.model.cluster.v1beta1.ManagedCluster
 import io.fabric8.openclustermanagement.api.model.cluster.v1beta1.ManagedClusterSetList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementClustersAPIGroupDSL;
 
-public class OpenClusterManagementClustersAPIGroupClient extends BaseClient implements OpenClusterManagementClustersAPIGroupDSL {
+public class OpenClusterManagementClustersAPIGroupClient extends ClientAdapter<OpenClusterManagementClustersAPIGroupDSL> implements OpenClusterManagementClustersAPIGroupDSL {
 
   public OpenClusterManagementClustersAPIGroupClient() {
     super();
   }
 
-  public OpenClusterManagementClustersAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementClustersAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementClustersAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementClustersAPIGroupClient(client);
   }
 
   @Override
   public NonNamespaceOperation<ManagedCluster, ManagedClusterList, Resource<ManagedCluster>> managedClusters() {
-    return Handlers.getOperation(ManagedCluster.class, ManagedClusterList.class, this);
+    return resources(ManagedCluster.class, ManagedClusterList.class);
   }
 
   @Override
   public NonNamespaceOperation<ManagedClusterSet, ManagedClusterSetList, Resource<ManagedClusterSet>> managedClusterSets() {
-    return Handlers.getOperation(ManagedClusterSet.class, ManagedClusterSetList.class, this);
+    return resources(ManagedClusterSet.class, ManagedClusterSetList.class);
   }
 
   @Override
   public MixedOperation<ManagedClusterSetBinding, ManagedClusterSetBindingList, Resource<ManagedClusterSetBinding>> managedClusterSetBindings() {
-    return Handlers.getOperation(ManagedClusterSetBinding.class, ManagedClusterSetBindingList.class, this);
+    return resources(ManagedClusterSetBinding.class, ManagedClusterSetBindingList.class);
   }
 
   @Override
   public MixedOperation<Placement, PlacementList, Resource<Placement>> placements() {
-    return Handlers.getOperation(Placement.class, PlacementList.class, this);
+    return resources(Placement.class, PlacementList.class);
   }
 
   @Override
   public MixedOperation<PlacementDecision, PlacementDecisionList, Resource<PlacementDecision>> placementDecisions() {
-    return Handlers.getOperation(PlacementDecision.class, PlacementDecisionList.class, this);
+    return resources(PlacementDecision.class, PlacementDecisionList.class);
   }
 }

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementDiscoveryAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementDiscoveryAPIGroupClient.java
@@ -15,34 +15,38 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.discovery.v1alpha1.DiscoveredCluster;
 import io.fabric8.openclustermanagement.api.model.discovery.v1alpha1.DiscoveredClusterList;
 import io.fabric8.openclustermanagement.api.model.discovery.v1alpha1.DiscoveryConfig;
 import io.fabric8.openclustermanagement.api.model.discovery.v1alpha1.DiscoveryConfigList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementDiscoveryAPIGroupDSL;
 
-public class OpenClusterManagementDiscoveryAPIGroupClient extends BaseClient implements OpenClusterManagementDiscoveryAPIGroupDSL {
+public class OpenClusterManagementDiscoveryAPIGroupClient extends ClientAdapter<OpenClusterManagementDiscoveryAPIGroupDSL> implements OpenClusterManagementDiscoveryAPIGroupDSL {
 
   public OpenClusterManagementDiscoveryAPIGroupClient() {
     super();
   }
 
-  public OpenClusterManagementDiscoveryAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementDiscoveryAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementDiscoveryAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementDiscoveryAPIGroupClient(client);
   }
 
   @Override
   public MixedOperation<DiscoveredCluster, DiscoveredClusterList, Resource<DiscoveredCluster>> discoveredClusters() {
-    return Handlers.getOperation(DiscoveredCluster.class, DiscoveredClusterList.class, this);
+    return resources(DiscoveredCluster.class, DiscoveredClusterList.class);
   }
 
   @Override
   public MixedOperation<DiscoveryConfig, DiscoveryConfigList, Resource<DiscoveryConfig>> discoveryConfigs() {
-    return Handlers.getOperation(DiscoveryConfig.class, DiscoveryConfigList.class, this);
+    return resources(DiscoveryConfig.class, DiscoveryConfigList.class);
   }
 }

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementObservabilityAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementObservabilityAPIGroupClient.java
@@ -15,35 +15,39 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.multiclusterobservabilityoperator.apps.v1beta1.ObservabilityAddon;
 import io.fabric8.openclustermanagement.api.model.multiclusterobservabilityoperator.apps.v1beta1.ObservabilityAddonList;
 import io.fabric8.openclustermanagement.api.model.multiclusterobservabilityoperator.apps.v1beta2.MultiClusterObservability;
 import io.fabric8.openclustermanagement.api.model.multiclusterobservabilityoperator.apps.v1beta2.MultiClusterObservabilityList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementObservabilityAPIGroupDSL;
 
-public class OpenClusterManagementObservabilityAPIGroupClient extends BaseClient implements OpenClusterManagementObservabilityAPIGroupDSL {
+public class OpenClusterManagementObservabilityAPIGroupClient extends ClientAdapter<OpenClusterManagementObservabilityAPIGroupDSL> implements OpenClusterManagementObservabilityAPIGroupDSL {
 
   public OpenClusterManagementObservabilityAPIGroupClient() {
     super();
   }
 
-  public OpenClusterManagementObservabilityAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementObservabilityAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementObservabilityAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementObservabilityAPIGroupClient(client);
   }
 
   @Override
   public NonNamespaceOperation<MultiClusterObservability, MultiClusterObservabilityList, Resource<MultiClusterObservability>> multiClusterObservailities() {
-    return Handlers.getOperation(MultiClusterObservability.class, MultiClusterObservabilityList.class, this);
+    return resources(MultiClusterObservability.class, MultiClusterObservabilityList.class);
   }
 
   @Override
   public MixedOperation<ObservabilityAddon, ObservabilityAddonList, Resource<ObservabilityAddon>> observabilityAddons() {
-    return Handlers.getOperation(ObservabilityAddon.class, ObservabilityAddonList.class, this);
+    return resources(ObservabilityAddon.class, ObservabilityAddonList.class);
   }
 }

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementOperatorAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementOperatorAPIGroupClient.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.multiclusterhub.operator.v1.MultiClusterHub;
 import io.fabric8.openclustermanagement.api.model.multiclusterhub.operator.v1.MultiClusterHubList;
 import io.fabric8.openclustermanagement.api.model.operator.v1.ClusterManager;
@@ -29,29 +28,34 @@ import io.fabric8.openclustermanagement.api.model.operator.v1.Klusterlet;
 import io.fabric8.openclustermanagement.api.model.operator.v1.KlusterletList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementOperatorAPIGroupDSL;
 
-public class OpenClusterManagementOperatorAPIGroupClient extends BaseClient implements OpenClusterManagementOperatorAPIGroupDSL {
+public class OpenClusterManagementOperatorAPIGroupClient extends ClientAdapter<OpenClusterManagementOperatorAPIGroupDSL> implements OpenClusterManagementOperatorAPIGroupDSL {
 
   public OpenClusterManagementOperatorAPIGroupClient() {
     super();
   }
 
-  public OpenClusterManagementOperatorAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementOperatorAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementOperatorAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementOperatorAPIGroupClient(client);
   }
 
   @Override
   public MixedOperation<MultiClusterHub, MultiClusterHubList, Resource<MultiClusterHub>> multiClusterHubs() {
-    return Handlers.getOperation(MultiClusterHub.class, MultiClusterHubList.class, this);
+    return resources(MultiClusterHub.class, MultiClusterHubList.class);
   }
 
   @Override
   public NonNamespaceOperation<Klusterlet, KlusterletList, Resource<Klusterlet>> klusterlets() {
-    return Handlers.getOperation(Klusterlet.class, KlusterletList.class, this);
+    return resources(Klusterlet.class, KlusterletList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterManager, ClusterManagerList, Resource<ClusterManager>> clusterManagers() {
-    return Handlers.getOperation(ClusterManager.class, ClusterManagerList.class, this);
+    return resources(ClusterManager.class, ClusterManagerList.class);
   }
 }
 

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementPolicyAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementPolicyAPIGroupClient.java
@@ -15,11 +15,10 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.governancepolicypropagator.policy.v1.PlacementBinding;
 import io.fabric8.openclustermanagement.api.model.governancepolicypropagator.policy.v1.PlacementBindingList;
 import io.fabric8.openclustermanagement.api.model.governancepolicypropagator.policy.v1.Policy;
@@ -28,28 +27,33 @@ import io.fabric8.openclustermanagement.api.model.governancepolicypropagator.pol
 import io.fabric8.openclustermanagement.api.model.governancepolicypropagator.policy.v1beta1.PolicyAutomationList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementPolicyAPIGroupDSL;
 
-public class OpenClusterManagementPolicyAPIGroupClient extends BaseClient implements OpenClusterManagementPolicyAPIGroupDSL {
+public class OpenClusterManagementPolicyAPIGroupClient extends ClientAdapter<OpenClusterManagementPolicyAPIGroupDSL> implements OpenClusterManagementPolicyAPIGroupDSL {
 
   public OpenClusterManagementPolicyAPIGroupClient() {
     super();
   }
 
-  public OpenClusterManagementPolicyAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementPolicyAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementPolicyAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementPolicyAPIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Policy, PolicyList, Resource<Policy>> policies() {
-    return Handlers.getOperation(Policy.class, PolicyList.class, this);
+    return resources(Policy.class, PolicyList.class);
   }
 
   @Override
   public MixedOperation<PlacementBinding, PlacementBindingList, Resource<PlacementBinding>> placementBindings() {
-    return Handlers.getOperation(PlacementBinding.class, PlacementBindingList.class, this);
+    return resources(PlacementBinding.class, PlacementBindingList.class);
   }
 
   @Override
   public MixedOperation<PolicyAutomation, PolicyAutomationList, Resource<PolicyAutomation>> policyAutomations() {
-    return Handlers.getOperation(PolicyAutomation.class, PolicyAutomationList.class, this);
+    return resources(PolicyAutomation.class, PolicyAutomationList.class);
   }
 }

--- a/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementSearchAPIGroupClient.java
+++ b/extensions/open-cluster-management/client/src/main/java/io/fabric8/openclustermanagement/client/OpenClusterManagementSearchAPIGroupClient.java
@@ -15,34 +15,38 @@
  */
 package io.fabric8.openclustermanagement.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.openclustermanagement.api.model.searchoperator.v1alpha1.SearchCustomization;
 import io.fabric8.openclustermanagement.api.model.searchoperator.v1alpha1.SearchCustomizationList;
 import io.fabric8.openclustermanagement.api.model.searchoperator.v1alpha1.SearchOperator;
 import io.fabric8.openclustermanagement.api.model.searchoperator.v1alpha1.SearchOperatorList;
 import io.fabric8.openclustermanagement.client.dsl.OpenClusterManagementSearchAPIGroupDSL;
 
-public class OpenClusterManagementSearchAPIGroupClient extends BaseClient implements OpenClusterManagementSearchAPIGroupDSL {
+public class OpenClusterManagementSearchAPIGroupClient extends ClientAdapter<OpenClusterManagementSearchAPIGroupDSL> implements OpenClusterManagementSearchAPIGroupDSL {
 
   public OpenClusterManagementSearchAPIGroupClient() {
     super();
   }
 
-  public OpenClusterManagementSearchAPIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public OpenClusterManagementSearchAPIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected OpenClusterManagementSearchAPIGroupDSL newInstance(Client client) {
+    return new OpenClusterManagementSearchAPIGroupClient(client);
   }
 
   @Override
   public MixedOperation<SearchCustomization, SearchCustomizationList, Resource<SearchCustomization>> searchCustomizations() {
-    return Handlers.getOperation(SearchCustomization.class, SearchCustomizationList.class, this);
+    return resources(SearchCustomization.class, SearchCustomizationList.class);
   }
 
   @Override
   public MixedOperation<SearchOperator, SearchOperatorList, Resource<SearchOperator>> searchOperators() {
-    return Handlers.getOperation(SearchOperator.class, SearchOperatorList.class, this);
+    return resources(SearchOperator.class, SearchOperatorList.class);
   }
 }

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceBrokerOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceBrokerOperationsImpl.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.servicecatalog.client.internal;
 
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.extension.ExtensibleResource;
 import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.servicecatalog.api.model.ClusterServiceBroker;
 import io.fabric8.servicecatalog.api.model.ClusterServiceClass;
@@ -32,10 +30,6 @@ import java.util.Map;
 
 
 public class ClusterServiceBrokerOperationsImpl extends ExtensibleResourceAdapter<ClusterServiceBroker> implements ClusterServiceBrokerResource {
-
-    public ClusterServiceBrokerOperationsImpl(ExtensibleResource<ClusterServiceBroker> resource, Client client) {
-        super(resource, client);
-    }
 
     @Override
     public ClusterServicePlanList listPlans() {

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceClassOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceClassOperationsImpl.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.servicecatalog.client.internal;
 
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.extension.ExtensibleResource;
 import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.servicecatalog.api.model.ClusterServiceClass;
 import io.fabric8.servicecatalog.api.model.ClusterServicePlan;
@@ -33,10 +31,6 @@ import java.util.Map;
 
 public class ClusterServiceClassOperationsImpl extends ExtensibleResourceAdapter<ClusterServiceClass>
         implements ClusterServiceClassResource {
-
-    public ClusterServiceClassOperationsImpl(ExtensibleResource<ClusterServiceClass> resource, Client client) {
-        super(resource, client);
-    }
 
     @Override
     public ClusterServicePlanList listPlans() {

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServicePlanOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServicePlanOperationsImpl.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.servicecatalog.client.internal;
 
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.extension.ExtensibleResource;
 import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.servicecatalog.api.model.ClusterServicePlan;
 import io.fabric8.servicecatalog.api.model.ServiceInstance;
@@ -27,10 +25,6 @@ import io.fabric8.servicecatalog.client.dsl.ServiceInstanceResource;
 
 
 public class ClusterServicePlanOperationsImpl extends ExtensibleResourceAdapter<ClusterServicePlan> implements ClusterServicePlanResource {
-
-    public ClusterServicePlanOperationsImpl(ExtensibleResource<ClusterServicePlan> resource, Client client) {
-        super(resource, client);
-    }
 
     @Override
     public ServiceInstance instantiate(String... args) {

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ServiceBindingOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ServiceBindingOperationsImpl.java
@@ -16,18 +16,12 @@
 package io.fabric8.servicecatalog.client.internal;
 
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.extension.ExtensibleResource;
 import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.servicecatalog.api.model.ServiceBinding;
 import io.fabric8.servicecatalog.client.dsl.ServiceBindingResource;
 
 public class ServiceBindingOperationsImpl extends ExtensibleResourceAdapter<ServiceBinding> implements ServiceBindingResource {
-
-    public ServiceBindingOperationsImpl(ExtensibleResource<ServiceBinding> resource, Client client) {
-        super(resource, client);
-    }
 
     @Override
     public Secret getSecret() {

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ServiceInstanceOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ServiceInstanceOperationsImpl.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.servicecatalog.client.internal;
 
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.extension.ExtensibleResource;
 import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.servicecatalog.api.model.ServiceBinding;
 import io.fabric8.servicecatalog.api.model.ServiceBindingBuilder;
@@ -25,10 +23,6 @@ import io.fabric8.servicecatalog.client.ServiceCatalogClient;
 import io.fabric8.servicecatalog.client.dsl.ServiceInstanceResource;
 
 public class ServiceInstanceOperationsImpl extends ExtensibleResourceAdapter<ServiceInstance> implements ServiceInstanceResource {
-
-    public ServiceInstanceOperationsImpl(ExtensibleResource<ServiceInstance> resource, Client client) {
-        super(resource, client);
-    }
 
     @Override
     public ServiceBinding bind(String secretName) {

--- a/extensions/tekton/client/pom.xml
+++ b/extensions/tekton/client/pom.xml
@@ -70,7 +70,12 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
@@ -15,17 +15,16 @@
  */
 package io.fabric8.tekton.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.tekton.client.dsl.V1alpha1APIGroupDSL;
 import io.fabric8.tekton.client.dsl.V1beta1APIGroupDSL;
 
-public class DefaultTektonClient extends BaseClient implements NamespacedTektonClient {
+public class DefaultTektonClient extends ClientAdapter<NamespacedTektonClient> implements NamespacedTektonClient {
 
   public DefaultTektonClient() {
     super();
@@ -35,22 +34,13 @@ public class DefaultTektonClient extends BaseClient implements NamespacedTektonC
     super(configuration);
   }
 
-  public DefaultTektonClient(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultTektonClient(Client client) {
+    super(client);
   }
 
   @Override
-  public NamespacedTektonClient inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedTektonClient inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration())
-      .withNamespace(namespace)
-      .build();
-
-    return new DefaultTektonClient(newState(updated));
+  protected NamespacedTektonClient newInstance(Client client) {
+    return new DefaultTektonClient(client);
   }
 
   @Override

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1alpha1APIGroupClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1alpha1APIGroupClient.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.tekton.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.tekton.client.dsl.V1alpha1APIGroupDSL;
 import io.fabric8.tekton.pipeline.v1alpha1.ClusterTask;
 import io.fabric8.tekton.pipeline.v1alpha1.ClusterTaskList;
@@ -49,77 +48,82 @@ import io.fabric8.tekton.triggers.v1alpha1.TriggerList;
 import io.fabric8.tekton.triggers.v1alpha1.TriggerTemplate;
 import io.fabric8.tekton.triggers.v1alpha1.TriggerTemplateList;
 
-public class V1alpha1APIGroupClient extends BaseClient implements V1alpha1APIGroupDSL {
+public class V1alpha1APIGroupClient extends ClientAdapter<V1alpha1APIGroupDSL> implements V1alpha1APIGroupDSL {
   public V1alpha1APIGroupClient() {
     super();
   }
 
-  public V1alpha1APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1alpha1APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1alpha1APIGroupDSL newInstance(Client client) {
+    return new V1alpha1APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Pipeline, PipelineList, Resource<Pipeline>> pipelines() {
-    return Handlers.getOperation(Pipeline.class, PipelineList.class, this);
+    return resources(Pipeline.class, PipelineList.class);
   }
 
   @Override
   public MixedOperation<PipelineRun, PipelineRunList, Resource<PipelineRun>> pipelineRuns() {
-    return Handlers.getOperation(PipelineRun.class, PipelineRunList.class, this);
+    return resources(PipelineRun.class, PipelineRunList.class);
   }
 
   @Override
   public MixedOperation<PipelineResource, PipelineResourceList, Resource<PipelineResource>> pipelineResources() {
-    return Handlers.getOperation(PipelineResource.class, PipelineResourceList.class, this);
+    return resources(PipelineResource.class, PipelineResourceList.class);
   }
 
   @Override
   public MixedOperation<Task, TaskList, Resource<Task>> tasks() {
-    return Handlers.getOperation(Task.class, TaskList.class, this);
+    return resources(Task.class, TaskList.class);
   }
 
   @Override
   public MixedOperation<TaskRun, TaskRunList, Resource<TaskRun>> taskRuns() {
-    return Handlers.getOperation(TaskRun.class, TaskRunList.class, this);
+    return resources(TaskRun.class, TaskRunList.class);
   }
 
   @Override
   public MixedOperation<Condition, ConditionList, Resource<Condition>> conditions() {
-    return Handlers.getOperation(Condition.class, ConditionList.class, this);
+    return resources(Condition.class, ConditionList.class);
   }
 
   @Override
   public MixedOperation<TriggerTemplate, TriggerTemplateList, Resource<TriggerTemplate>> triggerTemplates() {
-    return Handlers.getOperation(TriggerTemplate.class, TriggerTemplateList.class, this);
+    return resources(TriggerTemplate.class, TriggerTemplateList.class);
   }
 
   @Override
   public MixedOperation<TriggerBinding, TriggerBindingList, Resource<TriggerBinding>> triggerBindings() {
-    return Handlers.getOperation(TriggerBinding.class, TriggerBindingList.class, this);
+    return resources(TriggerBinding.class, TriggerBindingList.class);
   }
 
   @Override
   public MixedOperation<Trigger, TriggerList, Resource<Trigger>> triggers() {
-    return Handlers.getOperation(Trigger.class, TriggerList.class, this);
+    return resources(Trigger.class, TriggerList.class);
   }
 
   @Override
   public MixedOperation<EventListener, EventListenerList, Resource<EventListener>> eventListeners() {
-    return Handlers.getOperation(EventListener.class, EventListenerList.class, this);
+    return resources(EventListener.class, EventListenerList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterTask, ClusterTaskList, Resource<ClusterTask>> clusterTasks() {
-    return Handlers.getOperation(ClusterTask.class, ClusterTaskList.class, this);
+    return resources(ClusterTask.class, ClusterTaskList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterTriggerBinding, ClusterTriggerBindingList, Resource<ClusterTriggerBinding>> clusterTriggerBindings() {
-    return Handlers.getOperation(ClusterTriggerBinding.class, ClusterTriggerBindingList.class, this);
+    return resources(ClusterTriggerBinding.class, ClusterTriggerBindingList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterInterceptor, ClusterInterceptorList, Resource<ClusterInterceptor>> clusterInterceptors() {
-    return Handlers.getOperation(ClusterInterceptor.class, ClusterInterceptorList.class, this);
+    return resources(ClusterInterceptor.class, ClusterInterceptorList.class);
   }
 }

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1beta1APIGroupClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/V1beta1APIGroupClient.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.tekton.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.tekton.client.dsl.V1beta1APIGroupDSL;
 import io.fabric8.tekton.pipeline.v1beta1.ClusterTask;
 import io.fabric8.tekton.pipeline.v1beta1.ClusterTaskList;
@@ -33,37 +32,42 @@ import io.fabric8.tekton.pipeline.v1beta1.TaskList;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRunList;
 
-public class V1beta1APIGroupClient extends BaseClient implements V1beta1APIGroupDSL {
+public class V1beta1APIGroupClient extends ClientAdapter<V1beta1APIGroupDSL> implements V1beta1APIGroupDSL {
   public V1beta1APIGroupClient() {
     super();
   }
 
-  public V1beta1APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1beta1APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1beta1APIGroupDSL newInstance(Client client) {
+    return new V1beta1APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<Pipeline, PipelineList, Resource<Pipeline>> pipelines() {
-    return Handlers.getOperation(Pipeline.class, PipelineList.class, this);
+    return resources(Pipeline.class, PipelineList.class);
   }
 
   @Override
   public MixedOperation<PipelineRun, PipelineRunList, Resource<PipelineRun>> pipelineRuns() {
-    return Handlers.getOperation(PipelineRun.class, PipelineRunList.class, this);
+    return resources(PipelineRun.class, PipelineRunList.class);
   }
 
   @Override
   public MixedOperation<Task, TaskList, Resource<Task>> tasks() {
-    return Handlers.getOperation(Task.class, TaskList.class, this);
+    return resources(Task.class, TaskList.class);
   }
 
   @Override
   public MixedOperation<TaskRun, TaskRunList, Resource<TaskRun>> taskRuns() {
-    return Handlers.getOperation(TaskRun.class, TaskRunList.class, this);
+    return resources(TaskRun.class, TaskRunList.class);
   }
 
   @Override
   public NonNamespaceOperation<ClusterTask, ClusterTaskList, Resource<ClusterTask>> clusterTasks() {
-    return Handlers.getOperation(ClusterTask.class, ClusterTaskList.class, this);
+    return resources(ClusterTask.class, ClusterTaskList.class);
   }
 }

--- a/extensions/verticalpodautoscaler/client/pom.xml
+++ b/extensions/verticalpodautoscaler/client/pom.xml
@@ -60,11 +60,15 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>verticalpodautoscaler-model-v1</artifactId>
-      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/extensions/verticalpodautoscaler/client/src/main/java/io/fabric8/verticalpodautoscaler/client/DefaultVerticalPodAutoscalerClient.java
+++ b/extensions/verticalpodautoscaler/client/src/main/java/io/fabric8/verticalpodautoscaler/client/DefaultVerticalPodAutoscalerClient.java
@@ -15,16 +15,15 @@
  */
 package io.fabric8.verticalpodautoscaler.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.verticalpodautoscaler.client.dsl.V1APIGroupDSL;
 
-public class DefaultVerticalPodAutoscalerClient extends BaseClient implements NamespacedVerticalPodAutoscalerClient {
+public class DefaultVerticalPodAutoscalerClient extends ClientAdapter<NamespacedVerticalPodAutoscalerClient> implements NamespacedVerticalPodAutoscalerClient {
 
   public DefaultVerticalPodAutoscalerClient() {
     super();
@@ -34,22 +33,13 @@ public class DefaultVerticalPodAutoscalerClient extends BaseClient implements Na
     super(configuration);
   }
 
-  public DefaultVerticalPodAutoscalerClient(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultVerticalPodAutoscalerClient(Client client) {
+    super(client);
   }
 
   @Override
-  public NamespacedVerticalPodAutoscalerClient inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedVerticalPodAutoscalerClient inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration())
-      .withNamespace(namespace)
-      .build();
-
-    return new DefaultVerticalPodAutoscalerClient(newState(updated));
+  protected NamespacedVerticalPodAutoscalerClient newInstance(Client client) {
+    return new DefaultVerticalPodAutoscalerClient(client);
   }
 
   @Override

--- a/extensions/verticalpodautoscaler/client/src/main/java/io/fabric8/verticalpodautoscaler/client/V1APIGroupClient.java
+++ b/extensions/verticalpodautoscaler/client/src/main/java/io/fabric8/verticalpodautoscaler/client/V1APIGroupClient.java
@@ -15,31 +15,35 @@
  */
 package io.fabric8.verticalpodautoscaler.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.verticalpodautoscaler.api.model.v1.VerticalPodAutoscaler;
 import io.fabric8.verticalpodautoscaler.api.model.v1.VerticalPodAutoscalerCheckpoint;
 import io.fabric8.verticalpodautoscaler.api.model.v1.VerticalPodAutoscalerCheckpointList;
 import io.fabric8.verticalpodautoscaler.api.model.v1.VerticalPodAutoscalerList;
 import io.fabric8.verticalpodautoscaler.client.dsl.V1APIGroupDSL;
 
-public class V1APIGroupClient extends BaseClient implements V1APIGroupDSL {
+public class V1APIGroupClient extends ClientAdapter<V1APIGroupDSL> implements V1APIGroupDSL {
   public V1APIGroupClient() {super();}
 
-  public V1APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1APIGroupDSL newInstance(Client client) {
+    return new V1APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<VerticalPodAutoscaler, VerticalPodAutoscalerList, Resource<VerticalPodAutoscaler>> verticalpodautoscalers() {
-    return Handlers.getOperation(VerticalPodAutoscaler.class, VerticalPodAutoscalerList.class, this);
+    return resources(VerticalPodAutoscaler.class, VerticalPodAutoscalerList.class);
   }
 
   @Override
   public MixedOperation<VerticalPodAutoscalerCheckpoint, VerticalPodAutoscalerCheckpointList, Resource<VerticalPodAutoscalerCheckpoint>> verticalpodautoscalercheckpoints() {
-    return Handlers.getOperation(VerticalPodAutoscalerCheckpoint.class, VerticalPodAutoscalerCheckpointList.class, this);
+    return resources(VerticalPodAutoscalerCheckpoint.class, VerticalPodAutoscalerCheckpointList.class);
   }
 }

--- a/extensions/verticalpodautoscaler/examples/pom.xml
+++ b/extensions/verticalpodautoscaler/examples/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>verticalpodautoscaler-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/extensions/volcano/client/pom.xml
+++ b/extensions/volcano/client/pom.xml
@@ -60,11 +60,15 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>volcano-model-v1beta1</artifactId>
-      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/extensions/volcano/client/src/main/java/io/fabric8/volcano/client/DefaultVolcanoClient.java
+++ b/extensions/volcano/client/src/main/java/io/fabric8/volcano/client/DefaultVolcanoClient.java
@@ -15,23 +15,21 @@
  */
 package io.fabric8.volcano.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.Handlers;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.volcano.client.dsl.V1beta1APIGroupDSL;
 import io.fabric8.volcano.scheduling.v1beta1.PodGroup;
 import io.fabric8.volcano.scheduling.v1beta1.PodGroupList;
 import io.fabric8.volcano.scheduling.v1beta1.Queue;
 import io.fabric8.volcano.scheduling.v1beta1.QueueList;
 
-public class DefaultVolcanoClient extends BaseClient implements NamespacedVolcanoClient {
+public class DefaultVolcanoClient extends ClientAdapter<NamespacedVolcanoClient> implements NamespacedVolcanoClient {
 
   public DefaultVolcanoClient() {
     super();
@@ -41,21 +39,13 @@ public class DefaultVolcanoClient extends BaseClient implements NamespacedVolcan
     super(configuration);
   }
 
-  public DefaultVolcanoClient(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultVolcanoClient(Client client) {
+    super(client);
   }
 
   @Override
-  public NamespacedVolcanoClient inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedVolcanoClient inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration())
-      .withNamespace(namespace)
-      .build();
-    return new DefaultVolcanoClient(newState(updated));
+  protected NamespacedVolcanoClient newInstance(Client client) {
+    return new DefaultVolcanoClient(client);
   }
 
   @Override
@@ -66,13 +56,13 @@ public class DefaultVolcanoClient extends BaseClient implements NamespacedVolcan
   @Override
   public MixedOperation<PodGroup, PodGroupList, Resource<PodGroup>> podGroups() {
     // By default, client.podGroups() use v1beta1 version,
-    return Handlers.getOperation(PodGroup.class, PodGroupList.class, this);
+    return resources(PodGroup.class, PodGroupList.class);
   }
 
   @Override
   public MixedOperation<Queue, QueueList, Resource<Queue>> queues() {
     // By default, client.podGroups() use v1beta1 version,
-    return Handlers.getOperation(Queue.class, QueueList.class, this);
+    return resources(Queue.class, QueueList.class);
   }
 
 

--- a/extensions/volcano/client/src/main/java/io/fabric8/volcano/client/V1beta1APIGroupClient.java
+++ b/extensions/volcano/client/src/main/java/io/fabric8/volcano/client/V1beta1APIGroupClient.java
@@ -15,30 +15,34 @@
  */
 package io.fabric8.volcano.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.Handlers;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.volcano.client.dsl.V1beta1APIGroupDSL;
 import io.fabric8.volcano.scheduling.v1beta1.PodGroup;
 import io.fabric8.volcano.scheduling.v1beta1.PodGroupList;
 import io.fabric8.volcano.scheduling.v1beta1.Queue;
 import io.fabric8.volcano.scheduling.v1beta1.QueueList;
 
-public class V1beta1APIGroupClient  extends BaseClient implements V1beta1APIGroupDSL {
+public class V1beta1APIGroupClient extends ClientAdapter<V1beta1APIGroupDSL> implements V1beta1APIGroupDSL {
 
-  public V1beta1APIGroupClient(ClientContext clientContext) {
-    super(clientContext);
+  public V1beta1APIGroupClient(Client client) {
+    super(client);
+  }
+
+  @Override
+  protected V1beta1APIGroupDSL newInstance(Client client) {
+    return new V1beta1APIGroupClient(client);
   }
 
   @Override
   public MixedOperation<PodGroup, PodGroupList, Resource<PodGroup>> podGroups() {
-    return Handlers.getOperation(PodGroup.class, PodGroupList.class, this);
+    return resources(PodGroup.class, PodGroupList.class);
   }
 
   @Override
   public MixedOperation<Queue, QueueList, Resource<Queue>> queues() {
-    return Handlers.getOperation(Queue.class, QueueList.class, this);
+    return resources(Queue.class, QueueList.class);
   }
 }

--- a/extensions/volcano/examples/pom.xml
+++ b/extensions/volcano/examples/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>volcano-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/extensions/volumesnapshot/client/pom.xml
+++ b/extensions/volumesnapshot/client/pom.xml
@@ -53,12 +53,11 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>volumesnapshot-model</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
+      <artifactId>kubernetes-client-api</artifactId>
       <exclusions>
         <exclusion>
           <groupId>io.sundr</groupId>
@@ -67,6 +66,11 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/DefaultVolumeSnapshotClient.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/DefaultVolumeSnapshotClient.java
@@ -15,29 +15,22 @@
  */
 package io.fabric8.volumesnapshot.client;
 
-import io.fabric8.kubernetes.client.BaseClient;
-import io.fabric8.kubernetes.client.ClientContext;
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.WithRequestCallable;
 import io.fabric8.kubernetes.client.dsl.FunctionCallable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.extension.ClientAdapter;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshot;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClass;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClassList;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContent;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContentList;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotList;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotClassOperationsImpl;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotClassResource;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotContentOperationsImpl;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotContentResource;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotOperationsImpl;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotResource;
 
-public class DefaultVolumeSnapshotClient extends BaseClient implements NamespacedVolumeSnapshotClient {
+public class DefaultVolumeSnapshotClient extends ClientAdapter<NamespacedVolumeSnapshotClient> implements NamespacedVolumeSnapshotClient {
 
   public DefaultVolumeSnapshotClient() {
     super();
@@ -47,37 +40,28 @@ public class DefaultVolumeSnapshotClient extends BaseClient implements Namespace
     super(configuration);
   }
 
-  public DefaultVolumeSnapshotClient(ClientContext clientContext) {
-    super(clientContext);
+  public DefaultVolumeSnapshotClient(Client client) {
+    super(client);
   }
 
   @Override
-public NonNamespaceOperation<VolumeSnapshotClass, VolumeSnapshotClassList, VolumeSnapshotClassResource> volumeSnapshotClasses() {
-    return new VolumeSnapshotClassOperationsImpl(this);
+  protected NamespacedVolumeSnapshotClient newInstance(Client client) {
+    return new DefaultVolumeSnapshotClient(client);
   }
 
   @Override
-public NonNamespaceOperation<VolumeSnapshotContent, VolumeSnapshotContentList, VolumeSnapshotContentResource> volumeSnapshotContents() {
-    return new VolumeSnapshotContentOperationsImpl(this);
+  public NonNamespaceOperation<VolumeSnapshotClass, VolumeSnapshotClassList, VolumeSnapshotClassResource> volumeSnapshotClasses() {
+    return resources(VolumeSnapshotClass.class, VolumeSnapshotClassList.class, VolumeSnapshotClassResource.class);
   }
 
   @Override
-public MixedOperation<VolumeSnapshot, VolumeSnapshotList, VolumeSnapshotResource> volumeSnapshots() {
-    return new VolumeSnapshotOperationsImpl(this);
+  public NonNamespaceOperation<VolumeSnapshotContent, VolumeSnapshotContentList, VolumeSnapshotContentResource> volumeSnapshotContents() {
+    return resources(VolumeSnapshotContent.class, VolumeSnapshotContentList.class, VolumeSnapshotContentResource.class);
   }
 
   @Override
-  public NamespacedVolumeSnapshotClient inAnyNamespace() {
-    return inNamespace(null);
-  }
-
-  @Override
-  public NamespacedVolumeSnapshotClient inNamespace(String namespace) {
-    Config updated = new ConfigBuilder(getConfiguration())
-      .withNamespace(namespace)
-      .build();
-
-    return new DefaultVolumeSnapshotClient(newState(updated));
+  public MixedOperation<VolumeSnapshot, VolumeSnapshotList, VolumeSnapshotResource> volumeSnapshots() {
+    return resources(VolumeSnapshot.class, VolumeSnapshotList.class, VolumeSnapshotResource.class);
   }
 
   @Override

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotClassResource.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotClassResource.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.volumesnapshot.client.internal;
+package io.fabric8.volumesnapshot.client;
 
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContent;
+import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClass;
+import io.fabric8.volumesnapshot.api.model.VolumeSnapshotList;
 
-
-public interface VolumeSnapshotContentResource extends Resource<VolumeSnapshotContent> {
+public interface VolumeSnapshotClassResource extends Resource<VolumeSnapshotClass> {
+  VolumeSnapshotList listSnapshots();
 }

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotClient.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotClient.java
@@ -25,9 +25,6 @@ import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClassList;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContent;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContentList;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotList;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotClassResource;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotContentResource;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotResource;
 
 /**
  * Main interface for VolumeSnapshot Client library.

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotContentResource.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotContentResource.java
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.volumesnapshot.client.internal;
+package io.fabric8.volumesnapshot.client;
 
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClass;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotList;
+import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContent;
 
-public interface VolumeSnapshotClassResource extends Resource<VolumeSnapshotClass> {
-  VolumeSnapshotList listSnapshots();
+
+public interface VolumeSnapshotContentResource extends Resource<VolumeSnapshotContent> {
 }

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotExtensionAdapter.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotExtensionAdapter.java
@@ -18,8 +18,6 @@ package io.fabric8.volumesnapshot.client;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.ExtensionAdapter;
 import io.fabric8.kubernetes.client.ExtensionAdapterSupport;
-import io.fabric8.kubernetes.client.Handlers;
-import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshot;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClass;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContent;
@@ -32,12 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class VolumeSnapshotExtensionAdapter extends ExtensionAdapterSupport implements ExtensionAdapter<VolumeSnapshotClient> {
-
-  static {
-    Handlers.register(VolumeSnapshotClass.class, VolumeSnapshotClassOperationsImpl::new);
-    Handlers.register(VolumeSnapshotContent.class, VolumeSnapshotContentOperationsImpl::new);
-    Handlers.register(VolumeSnapshot.class, VolumeSnapshotOperationsImpl::new);
-  }
 
   static final ConcurrentMap<URL, Boolean> IS_VOLUME_SNAPSHOT = new ConcurrentHashMap<>();
   static final ConcurrentMap<URL, Boolean> USES_VOLUME_SNAPSHOT_APIGROUPS = new ConcurrentHashMap<>();
@@ -56,6 +48,13 @@ public class VolumeSnapshotExtensionAdapter extends ExtensionAdapterSupport impl
   @Override
   public VolumeSnapshotClient adapt(Client client) {
     return new DefaultVolumeSnapshotClient(client);
+  }
+
+  @Override
+  public void registerHandlers(HandlerFactory factory) {
+    factory.register(VolumeSnapshotClass.class, VolumeSnapshotClassOperationsImpl::new);
+    factory.register(VolumeSnapshotContent.class, VolumeSnapshotContentOperationsImpl::new);
+    factory.register(VolumeSnapshot.class, VolumeSnapshotOperationsImpl::new);
   }
 
 }

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotResource.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/VolumeSnapshotResource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.volumesnapshot.client.internal;
+package io.fabric8.volumesnapshot.client;
 
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshot;

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/internal/VolumeSnapshotClassOperationsImpl.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/internal/VolumeSnapshotClassOperationsImpl.java
@@ -15,54 +15,24 @@
  */
 package io.fabric8.volumesnapshot.client.internal;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
-import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
-import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
+import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClass;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClassBuilder;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClassList;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotList;
+import io.fabric8.volumesnapshot.client.VolumeSnapshotClassResource;
+import io.fabric8.volumesnapshot.client.VolumeSnapshotClient;
 
 import java.util.HashMap;
 import java.util.Map;
 
 
-public class VolumeSnapshotClassOperationsImpl extends HasMetadataOperation<VolumeSnapshotClass, VolumeSnapshotClassList, VolumeSnapshotClassResource> implements VolumeSnapshotClassResource {
-
-  public VolumeSnapshotClassOperationsImpl(ClientContext clientContext) {
-    this(HasMetadataOperationsImpl.defaultContext(clientContext));
-  }
-
-  public VolumeSnapshotClassOperationsImpl(OperationContext context) {
-    super(context.withApiGroupName("snapshot.storage.k8s.io").withApiGroupVersion("v1").withPlural("volumesnapshotclasses"),
-            VolumeSnapshotClass.class, VolumeSnapshotClassList.class);
-  }
-
-  @Override
-  public VolumeSnapshotClassOperationsImpl newInstance(OperationContext context) {
-    return new VolumeSnapshotClassOperationsImpl(context);
-  }
-
-  @Override
-  public boolean isResourceNamespaced() {
-    return false;
-  }
+public class VolumeSnapshotClassOperationsImpl extends ExtensibleResourceAdapter<VolumeSnapshotClass> implements VolumeSnapshotClassResource {
 
   @Override
   public VolumeSnapshotList listSnapshots() {
     VolumeSnapshotClass item = get();
     Map<String, String> fields = new HashMap<>();
     fields.put("spec.volumeSnapshotClassName", item.getMetadata().getName());
-    return new VolumeSnapshotOperationsImpl(context.withName(null))
-      .withFields(fields)
-      .list();
-  }
-
-  @Override
-  public VolumeSnapshotClass edit(Visitor... visitors) {
-    return patch(new VolumeSnapshotClassBuilder(getMandatory()).accept(visitors).build());
+    return client.adapt(VolumeSnapshotClient.class).volumeSnapshots().withFields(fields).list();
   }
 
 }

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/internal/VolumeSnapshotContentOperationsImpl.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/internal/VolumeSnapshotContentOperationsImpl.java
@@ -15,39 +15,11 @@
  */
 package io.fabric8.volumesnapshot.client.internal;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
-import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
-import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
+import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContent;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContentBuilder;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotContentList;
+import io.fabric8.volumesnapshot.client.VolumeSnapshotContentResource;
 
 
-public class VolumeSnapshotContentOperationsImpl extends HasMetadataOperation<VolumeSnapshotContent, VolumeSnapshotContentList, VolumeSnapshotContentResource> implements VolumeSnapshotContentResource {
+public class VolumeSnapshotContentOperationsImpl extends ExtensibleResourceAdapter<VolumeSnapshotContent> implements VolumeSnapshotContentResource {
 
-  public VolumeSnapshotContentOperationsImpl(ClientContext clientContext) {
-    this(HasMetadataOperationsImpl.defaultContext(clientContext));
-  }
-
-  public VolumeSnapshotContentOperationsImpl(OperationContext context) {
-    super(context.withApiGroupName("snapshot.storage.k8s.io").withApiGroupVersion("v1").withPlural("volumesnapshotcontents"),
-            VolumeSnapshotContent.class, VolumeSnapshotContentList.class);
-  }
-
-  @Override
-  public VolumeSnapshotContentOperationsImpl newInstance(OperationContext context) {
-    return new VolumeSnapshotContentOperationsImpl(context);
-  }
-
-  @Override
-  public VolumeSnapshotContent edit(Visitor... visitors) {
-    return patch(new VolumeSnapshotContentBuilder(getMandatory()).accept(visitors).build());
-  }
-
-  @Override
-  public boolean isResourceNamespaced() {
-    return false;
-  }
 }

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/internal/VolumeSnapshotOperationsImpl.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/internal/VolumeSnapshotOperationsImpl.java
@@ -15,31 +15,10 @@
  */
 package io.fabric8.volumesnapshot.client.internal;
 
-import io.fabric8.kubernetes.client.ClientContext;
-import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
-import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
-import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
+import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshot;
-import io.fabric8.volumesnapshot.api.model.VolumeSnapshotList;
+import io.fabric8.volumesnapshot.client.VolumeSnapshotResource;
 
-public class VolumeSnapshotOperationsImpl extends HasMetadataOperation<VolumeSnapshot, VolumeSnapshotList, VolumeSnapshotResource> implements VolumeSnapshotResource {
+public class VolumeSnapshotOperationsImpl extends ExtensibleResourceAdapter<VolumeSnapshot> implements VolumeSnapshotResource {
 
-  public VolumeSnapshotOperationsImpl(ClientContext clientContext) {
-    this(HasMetadataOperationsImpl.defaultContext(clientContext));
-  }
-
-  public VolumeSnapshotOperationsImpl(OperationContext ctx) {
-    super(ctx.withApiGroupName("snapshot.storage.k8s.io").withApiGroupVersion("v1").withPlural("volumesnapshots"),
-            VolumeSnapshot.class, VolumeSnapshotList.class);
-  }
-
-  @Override
-  public VolumeSnapshotOperationsImpl newInstance(OperationContext context) {
-    return new VolumeSnapshotOperationsImpl(context);
-  }
-
-  @Override
-  public boolean isResourceNamespaced() {
-    return true;
-  }
 }

--- a/extensions/volumesnapshot/tests/src/test/java/io/fabric8/volumesnapshot/test/crud/VolumeSnapshotClassTest.java
+++ b/extensions/volumesnapshot/tests/src/test/java/io/fabric8/volumesnapshot/test/crud/VolumeSnapshotClassTest.java
@@ -19,8 +19,8 @@ package io.fabric8.volumesnapshot.test.crud;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClass;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClassBuilder;
 import io.fabric8.volumesnapshot.api.model.VolumeSnapshotClassList;
+import io.fabric8.volumesnapshot.client.VolumeSnapshotClassResource;
 import io.fabric8.volumesnapshot.client.VolumeSnapshotClient;
-import io.fabric8.volumesnapshot.client.internal.VolumeSnapshotClassResource;
 import io.fabric8.volumesnapshot.server.mock.EnableVolumeSnapshotMockClient;
 import org.junit.jupiter.api.Test;
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ExtensionAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ExtensionAdapter.java
@@ -17,10 +17,9 @@
 package io.fabric8.kubernetes.client;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.extension.ExtensibleResource;
+import io.fabric8.kubernetes.client.extension.ExtensibleResourceAdapter;
 
-import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 /**
  * An Adapter that can be used to adapt an instance of the {@link Client} .
@@ -30,7 +29,7 @@ import java.util.function.BiFunction;
 public interface ExtensionAdapter<C> {
 
   public interface HandlerFactory {
-    <T extends HasMetadata, R extends Resource<T>> void register(Class<T> type, BiFunction<ExtensibleResource<T>, Client, R> target);
+    <T extends HasMetadata, R extends ExtensibleResourceAdapter<T>> void register(Class<T> type, Supplier<R> target);
   }
 
   /**

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ClientAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ClientAdapter.java
@@ -123,7 +123,7 @@ public abstract class ClientAdapter<C extends Client> implements Client {
   }
 
   public C inAnyNamespace() {
-    return inNamespace(null);
+    return newInstance(client.adapt(NamespacedKubernetesClient.class).inAnyNamespace());
   }
 
   public C inNamespace(String namespace) {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
@@ -34,8 +34,16 @@ public class ExtensibleResourceAdapter<T> extends ResourceAdapter<T> implements 
   protected ExtensibleResource<T> resource;
   protected Client client;
 
+  public ExtensibleResourceAdapter() {
+
+  }
+
   public ExtensibleResourceAdapter(ExtensibleResource<T> resource, Client client) {
-    super(resource);
+    init(resource, client);
+  }
+
+  public void init(ExtensibleResource<T> resource, Client client) {
+    super.resource = resource;
     this.resource = resource;
     this.client = client;
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -53,6 +53,10 @@ public class ResourceAdapter<T> implements Resource<T> {
 
   protected Resource<T> resource;
 
+  public ResourceAdapter() {
+
+  }
+
   public ResourceAdapter(Resource<T> resource) {
     this.resource = resource;
   }


### PR DESCRIPTION
## Description
fix #3876: moving the rest of the extensions to just the api - this also requires the use of ExtensionResourceAdapter so that an
explicit constructor is no longer required

These changes also ensure the namespace handling of extensions is now consistent with everything else.

This does not yet address the usage of KubernetesResourceMappingProvider for making the model classes available to the derserializer - ideally that responsibility would be moved to the extension adapter.

I've also not yet added any development guide - other than the migration doc pointing to the extensions... so that could be considered self documenting

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
