### PR TITLE
add a default serialization uid

### DIFF
--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -15,7 +15,9 @@
  */
 package io.fabric8.java.generator.nodes;
 
+import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -114,6 +116,14 @@ public class JCRObject extends AbstractJSONSchema2Pojo {
 
         clz.addExtendedType(crType);
         clz.addImplementedType("io.fabric8.kubernetes.api.model.Namespaced");
+
+        clz.addFieldWithInitializer(
+                "long",
+                "serialVersionUID",
+                new JavaParser().parseExpression("1L").getResult().get(),
+                Modifier.Keyword.PRIVATE,
+                Modifier.Keyword.STATIC,
+                Modifier.Keyword.FINAL);
 
         return new GeneratorResult(
                 Collections.singletonList(new GeneratorResult.ClassResult(className, cu)));

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -18,6 +18,7 @@ package io.fabric8.java.generator.nodes;
 import static io.fabric8.java.generator.nodes.Keywords.ADDITIONAL_PROPERTIES;
 import static io.fabric8.java.generator.nodes.Keywords.JAVA_UTIL_MAP;
 
+import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
@@ -193,6 +194,14 @@ public class JObject extends AbstractJSONSchema2Pojo {
         }
 
         clz.addImplementedType("io.fabric8.kubernetes.api.model.KubernetesResource");
+
+        clz.addFieldWithInitializer(
+                "long",
+                "serialVersionUID",
+                new JavaParser().parseExpression("1L").getResult().get(),
+                Modifier.Keyword.PRIVATE,
+                Modifier.Keyword.STATIC,
+                Modifier.Keyword.FINAL);
 
         List<GeneratorResult.ClassResult> buffer = new ArrayList<>(this.fields.size() + 1);
 


### PR DESCRIPTION
## Description
All generated classed are inheriting the class KubernetesResource which
implements Serializable. For these classes it would be good to generate
a serialVersionUID.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)
It is not really a bug but also not a feature.

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [-] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [-] I have implemented unit tests to cover my changes
 - [-] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
