### PR TITLE
mock: generation is an Integer field

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ What types of changes does your code introduce? Put an `x` in all the boxes that
 
 ## Checklist
  - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
- - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
+ - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
  - [ ] I have implemented unit tests to cover my changes
  - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
  - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #3582: SSL truststore can be loaded in FIPS enabled environments
 * Fix #3818: adding missing throws to launderThrowable
 * Fix #3859: refined how a deserialization class is chosen to not confuse types with the same kind
+* Fix #3936: Kubernetes Mock Server .metadata.generation field is an integer
 
 #### Improvements
 * Fix #3811: Reintroduce `Replaceable` interface in `NonNamespaceOperation`

--- a/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
+++ b/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
@@ -112,7 +112,7 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Resetabl
 
   /**
    * Replace the object on `path` endpoint with the object represented by `s`
-   * 
+   *
    * @param path String
    * @param s String
    * @return The {@link MockResponse}
@@ -470,7 +470,7 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Resetabl
       metadata.put("namespace", pathValues.get(KubernetesAttributesExtractor.NAMESPACE));
     }
     metadata.put("uid", getOrDefault(existingMetadata, "uid", uuid.toString()));
-    metadata.put(GENERATION, getOrDefault(existingMetadata, GENERATION, "1"));
+    metadata.put(GENERATION, Integer.parseInt(getOrDefault(existingMetadata, GENERATION, "1")));
     metadata.put("creationTimestamp", getOrDefault(existingMetadata, "creationTimestamp",
         ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT)));
 


### PR DESCRIPTION
## Description
<!--
-->
The generation field in the Object Metadata should be an Integer (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta).
I'm using the Mock to test the api from https://github.com/kubernetes-client/c and it fails to parse the generation field because it is actually a string.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
