### PR TITLE
Fix #3950: make sure modifications on jdk websocket done by interceptors are not lost

### DIFF
--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -194,13 +194,13 @@ public class JdkHttpClientImpl implements HttpClient {
 
     CompletableFuture<WebSocket> result = new CompletableFuture<>();
 
-    CompletableFuture<WebSocketResponse> cf = internalBuildAsync(webSocketBuilder, listener);
+    CompletableFuture<WebSocketResponse> cf = internalBuildAsync(copy, listener);
 
     for (Interceptor interceptor : builder.interceptors.values()) {
       cf = cf.thenCompose(response -> {
         if (response.wshse != null && response.wshse.getResponse() != null
             && interceptor.afterFailure(copy, new JdkHttpResponseImpl<>(response.wshse.getResponse()))) {
-          return this.internalBuildAsync(webSocketBuilder, listener);
+          return this.internalBuildAsync(copy, listener);
         }
         return CompletableFuture.completedFuture(response);
       });


### PR DESCRIPTION

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

In JdkHttpClientImpl, webSocketBuilder is copied before going through interceptors. But the original webSocketBuilder is used to make the request to the API server.
This PR changes this by using the copied webSocketBuilder for the request.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
