### PR TITLE
fix #3957: Lister `onOpen` should be called before marking the connection open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix #3859: refined how a deserialization class is chosen to not confuse types with the same kind
 * Fix #3745: the client will throw better exceptions when a namespace is not discernible for an operation
 * Fix #3936: Kubernetes Mock Server .metadata.generation field is an integer
+* Fix #3957: Lister `onOpen` should be called before marking the connection as open
 
 #### Improvements
 * Fix #3811: Reintroduce `Replaceable` interface in `NonNamespaceOperation`

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
@@ -32,16 +32,16 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 class OkHttpWebSocketImpl implements WebSocket {
-  
+
   static class BuilderImpl implements WebSocket.Builder {
-    
+
     private Request.Builder builder = new Request.Builder();
     private OkHttpClient httpClient;
 
     public BuilderImpl(OkHttpClient httpClient) {
       this.httpClient = httpClient;
     }
-    
+
     @Override
     public Builder uri(URI uri) {
       builder.url(HttpUrl.get(uri));
@@ -53,8 +53,8 @@ class OkHttpWebSocketImpl implements WebSocket {
       Request request = builder.build();
       CompletableFuture<WebSocket> future = new CompletableFuture<>();
       httpClient.newWebSocket(request, new WebSocketListener() {
-        private volatile boolean opened; 
-        
+        private volatile boolean opened;
+
         @Override
         public void onFailure(okhttp3.WebSocket webSocket, Throwable t, Response response) {
           if (response != null) {
@@ -63,10 +63,11 @@ class OkHttpWebSocketImpl implements WebSocket {
           if (!opened) {
             if (response != null) {
               try {
-                future.completeExceptionally(new WebSocketHandshakeException(new OkHttpResponseImpl<>(response, null)).initCause(t));
+                future.completeExceptionally(
+                    new WebSocketHandshakeException(new OkHttpResponseImpl<>(response, null)).initCause(t));
               } catch (IOException e) {
                 // can't happen
-              } 
+              }
             } else {
               future.completeExceptionally(t);
             }
@@ -74,7 +75,7 @@ class OkHttpWebSocketImpl implements WebSocket {
             listener.onError(new OkHttpWebSocketImpl(webSocket), t);
           }
         }
-        
+
         @Override
         public void onOpen(okhttp3.WebSocket webSocket, Response response) {
           opened = true;
@@ -82,25 +83,25 @@ class OkHttpWebSocketImpl implements WebSocket {
             response.close();
           }
           OkHttpWebSocketImpl value = new OkHttpWebSocketImpl(webSocket);
-          future.complete(value);
           listener.onOpen(value);
+          future.complete(value);
         }
-        
+
         @Override
         public void onMessage(okhttp3.WebSocket webSocket, ByteString bytes) {
           listener.onMessage(new OkHttpWebSocketImpl(webSocket), bytes.asByteBuffer());
         }
-        
+
         @Override
         public void onMessage(okhttp3.WebSocket webSocket, String text) {
           listener.onMessage(new OkHttpWebSocketImpl(webSocket), text);
         }
-        
+
         @Override
         public void onClosing(okhttp3.WebSocket webSocket, int code, String reason) {
           listener.onClose(new OkHttpWebSocketImpl(webSocket), code, reason);
         }
-        
+
       });
       return future;
     }
@@ -110,23 +111,23 @@ class OkHttpWebSocketImpl implements WebSocket {
       builder = builder.addHeader(name, value);
       return this;
     }
-    
+
     @Override
     public WebSocket.Builder setHeader(String k, String v) {
       builder = builder.header(k, v);
       return this;
     }
-    
+
     @Override
     public Builder subprotocol(String protocol) {
       builder.header("Sec-WebSocket-Protocol", protocol);
       return this;
     }
-    
+
   }
-  
+
   private okhttp3.WebSocket webSocket;
-  
+
   public OkHttpWebSocketImpl(okhttp3.WebSocket webSocket) {
     this.webSocket = webSocket;
   }
@@ -140,10 +141,10 @@ class OkHttpWebSocketImpl implements WebSocket {
   public boolean sendClose(int code, String reason) {
     return webSocket.close(code, reason);
   }
-  
+
   @Override
   public long queueSize() {
     return webSocket.queueSize();
   }
-  
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
@@ -24,20 +24,32 @@ public interface WebSocket {
 
   public interface Listener {
 
-    default void onOpen(WebSocket webSocket) { }
+    default void onOpen(WebSocket webSocket) {
+    }
 
-    default void onMessage(WebSocket webSocket, String text) {}
+    default void onMessage(WebSocket webSocket, String text) {
+    }
 
-    default void onMessage(WebSocket webSocket, ByteBuffer bytes) {}
+    default void onMessage(WebSocket webSocket, ByteBuffer bytes) {
+    }
 
-    default void onClose(WebSocket webSocket, int code, String reason) {}
+    default void onClose(WebSocket webSocket, int code, String reason) {
+    }
 
-    default void onError(WebSocket webSocket, Throwable error) {}
+    default void onError(WebSocket webSocket, Throwable error) {
+    }
 
   }
 
   public interface Builder extends BasicBuilder {
 
+    /**
+     * Builds a new WebSocket connection and waits asynchronously until the connection is opened.
+     * The listener onOpen callback is called before the returned future is completed.
+     *
+     * @param listener
+     * @return CompletableFuture which is completed after connection is opened
+     */
     CompletableFuture<WebSocket> buildAsync(Listener listener);
 
     Builder subprotocol(String protocol);
@@ -55,12 +67,14 @@ public interface WebSocket {
 
   /**
    * Send some data
+   * 
    * @return true if the message was successfully enqueued.
    */
   boolean send(ByteBuffer buffer);
 
   /**
    * Send a close message
+   * 
    * @return true if the message was successfully enqueued.
    */
   boolean sendClose(int code, String reason);


### PR DESCRIPTION
## Description
Fix #3957 

In `PodOperationsImpl` class the `buildAsync` method is called with `ExecWebSocketListener`.
The `ExecWebSocketListener` is opening `outputPipe` and `errorPipe` in `onOpen`.
If the `future` is completed before the `outputPipe` and `errorPipe` are open, then the consumer can read from the pipes before  they are open. 

The pipes should be open first and then the future should be marked as complete. 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
