### PR TITLE
Several informer related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Fix #1285: removed references to manually calling registerCustomKind
 * Fix #3334: adding basic support for server side apply.  Use patch(PatchContext.of(PatchType.SERVER_SIDE_APPLY), service), or new PatchContext.Builder().withPatchType(PatchType.SERVER_SIDE_APPLY).withForce(true).build() to override conflicts.
 * Fix #3969: relist will not trigger sync events
+* Fix #3968: SharedInformer.initialState can be used to set the store state before the informer starts. 
+SharedIndexInformer allows for the addition and removal of indexes even after starting, and you can remove the default namespace index if you wish.
+And Store.getKey can be used rather than directly referencing static Cache functions.
 
 #### Dependency Upgrade
 * Fix #3788: Point CamelK Extension model to latest released version v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix #3889 : remove piped stream for file download
 * Fix #1285: removed references to manually calling registerCustomKind
 * Fix #3334: adding basic support for server side apply.  Use patch(PatchContext.of(PatchType.SERVER_SIDE_APPLY), service), or new PatchContext.Builder().withPatchType(PatchType.SERVER_SIDE_APPLY).withForce(true).build() to override conflicts.
+* Fix #3969: relist will not trigger sync events
 
 #### Dependency Upgrade
 * Fix #3788: Point CamelK Extension model to latest released version v1.8.0

--- a/doc/MIGRATION-v6.md
+++ b/doc/MIGRATION-v6.md
@@ -178,6 +178,8 @@ Client.isAdaptable and Client.adapt will check first if the existing instance is
 
 - Extension specific EnableXXXMockClient and XXXMockServer classes have been deprecated.  You can simply use EnableKubernetesMockClient and KubernetesMockServer instead. Dependencies on the xxx-mock jar are then no longer needed, just a dependency to kubernetes-server-mock.
 
+- Informable.withIndexers has been deprecated.  Indexers can be added/removed after the creation of the informer.
+
 ## Object Sorting
 
 KubernetesList and Template will no longer automatically sort their objects by default.  You may use the HasMetadataComparator to sort the items as needed.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Informable.java
@@ -29,68 +29,85 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 public interface Informable<T> {
-  
+
   /**
    * The indexers to add to {@link SharedInformer}s created by subsequent inform calls;
+   * 
    * @param indexers to customize the indexing
    * @return the current {@link Informable}
+   * @deprecated please use methods on the {@link SharedIndexInformer} to add/remove indexes
    */
+  @Deprecated
   Informable<T> withIndexers(Map<String, Function<T, List<String>>> indexers);
-  
+
   /**
-   * Set the limit to the number of resources to list at one time.  This means that longer
+   * Set the limit to the number of resources to list at one time. This means that longer
    * lists will take multiple requests to fetch.
-   * <p>If the list fails to complete it will be re-attempted with this limit, rather than
-   * falling back to the full list.  You should ensure that your handlers are either async or 
+   * <p>
+   * If the list fails to complete it will be re-attempted with this limit, rather than
+   * falling back to the full list. You should ensure that your handlers are either async or
    * fast acting to prevent long delays in list processing that may cause results to expire
    * before reaching the end of the list.
-   * <p>WARNING As noted in the go client: "paginated lists are always served directly from
+   * <p>
+   * WARNING As noted in the go client: "paginated lists are always served directly from
    * etcd, which is significantly less efficient and may lead to serious performance and
    * scalability problems."
+   * 
    * @param limit of a items in a list fetch
    * @return the current {@link Informable}
    */
   Informable<T> withLimit(Long limit);
-  
+
   /**
    * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
    * and provides a store of all the current resources.
-   * <p>This returned informer will not support resync.
-   * <p>This call will be blocking for the initial list and watch.
-   * <p>You are expected to call stop to terminate the underlying Watch.
-   * <p>Additional handlers can be added, but processing of the events will be in the websocket thread, 
+   * <p>
+   * This returned informer will not support resync.
+   * <p>
+   * This call will be blocking for the initial list and watch.
+   * <p>
+   * You are expected to call stop to terminate the underlying Watch.
+   * <p>
+   * Additional handlers can be added, but processing of the events will be in the websocket thread,
    * so consider non-blocking handler operations for more than one handler.
-   * 
+   *
    * @return a running {@link SharedIndexInformer}
    */
   default SharedIndexInformer<T> inform() {
     return inform(null, 0);
   }
-  
+
   /**
    * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
    * and provides a store of all the current resources.
-   * <p>This returned informer will not support resync.
-   * <p>This call will be blocking for the initial list and watch.
-   * <p>You are expected to call stop to terminate the underlying Watch.
-   * <p>Additional handlers can be added, but processing of the events will be in the websocket thread, 
+   * <p>
+   * This returned informer will not support resync.
+   * <p>
+   * This call will be blocking for the initial list and watch.
+   * <p>
+   * You are expected to call stop to terminate the underlying Watch.
+   * <p>
+   * Additional handlers can be added, but processing of the events will be in the websocket thread,
    * so consider non-blocking handler operations for more than one handler.
-   * 
+   *
    * @param handler to notify
    * @return a running {@link SharedIndexInformer}
    */
   default SharedIndexInformer<T> inform(ResourceEventHandler<? super T> handler) {
     return inform(handler, 0);
   }
-  
+
   /**
    * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
    * and provides a store of all the current resources.
-   * <p>This call will be blocking for the initial list and watch.
-   * <p>You are expected to call stop to terminate the underlying Watch.
-   * <p>Additional handlers can be added, but processing of the events will be in the websocket thread, 
+   * <p>
+   * This call will be blocking for the initial list and watch.
+   * <p>
+   * You are expected to call stop to terminate the underlying Watch.
+   * <p>
+   * Additional handlers can be added, but processing of the events will be in the websocket thread,
    * so consider non-blocking handler operations for more than one handler.
-   * 
+   *
    * @param handler to notify
    * @param resync the resync period or 0 for no resync
    * @return a running {@link SharedIndexInformer}
@@ -100,19 +117,22 @@ public interface Informable<T> {
   /**
    * Similar to a {@link Watch}, but will attempt to handle failures after successfully started.
    * and provides a store of all the current resources.
-   * <p>You are expected to call stop to terminate the underlying Watch.
-   * <p>Additional handlers can be added, but processing of the events will be in the websocket thread,
+   * <p>
+   * You are expected to call stop to terminate the underlying Watch.
+   * <p>
+   * Additional handlers can be added, but processing of the events will be in the websocket thread,
    * so consider non-blocking handler operations for more than one handler.
    *
    * @param resync the resync period or 0 for no resync
    * @return a non-running {@link SharedIndexInformer}
    */
   SharedIndexInformer<T> runnableInformer(long resync);
-  
+
   /**
    * Return a {@link Future} when the list at this context satisfies the given {@link Predicate}.
    * The predicate will be tested against the state of the underlying informer store on every event.
    * The returned future should be cancelled by the caller if not waiting for completion to close the underlying informer
+   * 
    * @param condition the {@link Predicate} to test
    * @return a {@link CompletableFuture} of the list of items after the condition is met
    */

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedIndexInformer.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedIndexInformer.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.informers;
 
+import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.fabric8.kubernetes.client.informers.cache.Indexer;
 
 import java.util.List;
@@ -32,6 +33,23 @@ public interface SharedIndexInformer<T> extends SharedInformer<T> {
    * @param indexers indexers
    */
   void addIndexers(Map<String, Function<T, List<String>>> indexers);
+
+  /**
+   * Remove the namesapce index
+   *
+   * @return this
+   */
+  default SharedIndexInformer<T> removeNamespaceIndex() {
+    return removeIndexer(Cache.NAMESPACE_INDEX);
+  }
+
+  /**
+   * Remove the named index
+   *
+   * @param name
+   * @return this
+   */
+  SharedIndexInformer<T> removeIndexer(String name);
 
   /**
    * returns the internal indexer store.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformer.java
@@ -17,10 +17,13 @@ package io.fabric8.kubernetes.client.informers;
 
 import io.fabric8.kubernetes.client.informers.cache.Store;
 
+import java.util.stream.Stream;
+
 /**
  * SharedInformer defines basic methods of an informer.
  *
- * This has been ported from official go client: https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go
+ * This has been ported from official go client:
+ * https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go
  */
 public interface SharedInformer<T> extends AutoCloseable {
 
@@ -43,18 +46,20 @@ public interface SharedInformer<T> extends AutoCloseable {
 
   /**
    * Starts the shared informer, which will be stopped when {@link #stop()} is called.
-   * 
-   * <br>Only one start attempt is made - subsequent calls will not re-start the informer.
-   * 
-   * <br>If the informer is not already running, this is a blocking call
+   *
+   * <br>
+   * Only one start attempt is made - subsequent calls will not re-start the informer.
+   *
+   * <br>
+   * If the informer is not already running, this is a blocking call
    */
   void run();
 
   /**
-   * Stops the shared informer.  The informer cannot be started again.
+   * Stops the shared informer. The informer cannot be started again.
    */
   void stop();
-  
+
   @Override
   default void close() {
     stop();
@@ -75,7 +80,7 @@ public interface SharedInformer<T> extends AutoCloseable {
    * @return string value or null if never synced
    */
   String lastSyncResourceVersion();
-  
+
   /**
    * Return true if the informer is running
    */
@@ -85,16 +90,29 @@ public interface SharedInformer<T> extends AutoCloseable {
    * Return the class this informer is watching
    */
   Class<T> getApiTypeClass();
-  
+
   /**
    * Return true if the informer is actively watching
-   * <br>Will return false when {@link #isRunning()} is true when the watch needs to be re-established.
+   * <br>
+   * Will return false when {@link #isRunning()} is true when the watch needs to be re-established.
    */
   boolean isWatching();
-  
+
   /**
    * Return the Store associated with this informer
+   * 
    * @return the store
    */
   Store<T> getStore();
+
+  /**
+   * Sets the initial state of the informer store, which will
+   * be replaced by the initial list operation. This will emit
+   * relevant delete and update events, rather than just adds.
+   * <br>
+   * Can only be called before the informer is running
+   * 
+   * @param items
+   */
+  SharedIndexInformer<T> initialState(Stream<T> items);
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/cache/Indexer.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/cache/Indexer.java
@@ -22,7 +22,8 @@ import java.util.function.Function;
 /**
  * Indexer extends Store interface and add index/de-index methods.
  *
- * This implementation has been taken from official client: https://github.com/kubernetes-client/java/blob/master/util/src/main/java/io/kubernetes/client/informer/cache/Indexer.java
+ * This implementation has been taken from official client:
+ * https://github.com/kubernetes-client/java/blob/master/util/src/main/java/io/kubernetes/client/informer/cache/Indexer.java
  * which has been ported from official go client: https://github.com/kubernetes/client-go/blob/master/tools/cache/index.go
  *
  * @param <T> resource
@@ -68,4 +69,11 @@ public interface Indexer<T> extends Store<T> {
    * @param indexers indexers to add
    */
   void addIndexers(Map<String, Function<T, List<String>>> indexers);
+
+  /**
+   * Remove the named index
+   *
+   * @param name
+   */
+  void removeIndexer(String name);
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/cache/Store.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/cache/Store.java
@@ -29,14 +29,15 @@ import java.util.List;
  *
  * This is ported from official go client: https://github.com/kubernetes/client-go/blob/master/tools/cache/store.go
  * 
- * <br>Refactored to only expose read methods
+ * <br>
+ * Refactored to only expose read methods
  *
  * @param <T> resource
  */
 public interface Store<T> {
 
   /**
-   *  Returns a list of all the items.
+   * Returns a list of all the items.
    *
    * @return list of all items
    */
@@ -64,5 +65,13 @@ public interface Store<T> {
    * @return the requested item
    */
   T getByKey(String key);
+
+  /**
+   * Use the key function to extract the object's key.
+   *
+   * @param object object
+   * @return the key
+   */
+  String getKey(T object);
 
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/MapIndexer.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/MapIndexer.java
@@ -55,6 +55,11 @@ public class MapIndexer<T> implements Indexer<T> {
   }
 
   @Override
+  public void removeIndexer(String name) {
+
+  }
+
+  @Override
   public List<T> list() {
     return map.values().stream().flatMap(m -> m.values().stream()).collect(Collectors.toList());
   }
@@ -81,5 +86,10 @@ public class MapIndexer<T> implements Indexer<T> {
 
   protected void put(String index, String key, T object) {
     map.compute(index, (k, v) -> v == null ? new HashMap<>() : v).put(key, object);
+  }
+
+  @Override
+  public String getKey(T object) {
+    return null;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorListener.java
@@ -22,12 +22,15 @@ import java.time.temporal.ChronoUnit;
 
 /**
  * ProcessorListener implements Runnable interface. It's supposed to run in background
- * and actually executes its event handler on notification. 
+ * and actually executes its event handler on notification.
  *
- * This has been taken from official client: https://github.com/kubernetes-client/java/blob/master/util/src/main/java/io/kubernetes/client/informer/cache/ProcessorListener.java
- * which has been ported from official go client: https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go#L570
- * 
- * <br>Modified to execute loosely coupled from its processing thread
+ * This has been taken from official client:
+ * https://github.com/kubernetes-client/java/blob/master/util/src/main/java/io/kubernetes/client/informer/cache/ProcessorListener.java
+ * which has been ported from official go client:
+ * https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go#L570
+ *
+ * <br>
+ * Modified to execute loosely coupled from its processing thread
  *
  * @param <T> type of ProcessorListener
  */
@@ -35,7 +38,7 @@ public class ProcessorListener<T> {
   private long resyncPeriodInMillis;
   private ZonedDateTime nextResync;
   private ResourceEventHandler<? super T> handler;
-  
+
   public ProcessorListener(ResourceEventHandler<? super T> handler, long resyncPeriodInMillis) {
     this.resyncPeriodInMillis = resyncPeriodInMillis;
     this.handler = handler;
@@ -49,6 +52,10 @@ public class ProcessorListener<T> {
 
   public void determineNextResync(ZonedDateTime now) {
     this.nextResync = now.plus(this.resyncPeriodInMillis, ChronoUnit.MILLIS);
+  }
+
+  public boolean isReSync() {
+    return resyncPeriodInMillis != 0;
   }
 
   public boolean shouldResync(ZonedDateTime now) {
@@ -98,13 +105,13 @@ public class ProcessorListener<T> {
   }
 
   public static final class DeleteNotification<T> extends Notification<T> {
-      
+
     private boolean unknownFinalState;
-    
+
     public DeleteNotification(T oldObject) {
-        this(oldObject, false);
+      this(oldObject, false);
     }
-    
+
     public DeleteNotification(T oldObject, boolean unknownFinalState) {
       super(oldObject, null);
       this.unknownFinalState = unknownFinalState;
@@ -115,7 +122,7 @@ public class ProcessorListener<T> {
       resourceEventHandler.onDelete(getOldObject(), unknownFinalState);
     }
   }
-  
+
   public ResourceEventHandler<? super T> getHandler() {
     return handler;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
@@ -45,8 +45,9 @@ public class ProcessorStore<T extends HasMetadata> implements SyncableStore<T> {
   public void update(T obj) {
     T oldObj = this.cache.put(obj);
     if (oldObj != null) {
-      this.processor.distribute(new ProcessorListener.UpdateNotification<>(oldObj, obj),
-          Objects.equals(oldObj.getMetadata().getResourceVersion(), obj.getMetadata().getResourceVersion()));
+      if (!Objects.equals(oldObj.getMetadata().getResourceVersion(), obj.getMetadata().getResourceVersion())) {
+        this.processor.distribute(new ProcessorListener.UpdateNotification<>(oldObj, obj), false);
+      }
     } else {
       this.processor.distribute(new ProcessorListener.AddNotification<>(obj), false);
     }
@@ -91,11 +92,11 @@ public class ProcessorStore<T extends HasMetadata> implements SyncableStore<T> {
       String key = cache.getKey(v);
       if (!nextKeys.contains(key)) {
         cache.remove(v);
-        this.processor.distribute(new ProcessorListener.DeleteNotification<>(v, true), false);        
+        this.processor.distribute(new ProcessorListener.DeleteNotification<>(v, true), false);
       }
     });
   }
-  
+
   @Override
   public String getKey(T obj) {
     return cache.getKey(obj);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/SyncableStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/SyncableStore.java
@@ -19,6 +19,10 @@ import io.fabric8.kubernetes.client.informers.cache.Store;
 
 import java.util.Set;
 
+/**
+ * Extends a {@link Store}, but also has the responsibility of
+ * notifying listeners on all operations.
+ */
 public interface SyncableStore<T> extends Store<T> {
 
   /**
@@ -29,7 +33,7 @@ public interface SyncableStore<T> extends Store<T> {
   void add(T obj);
 
   /**
-   * Sets an item  in the store to its updated state.
+   * Sets an item in the store to its updated state.
    *
    * @param obj object
    */
@@ -41,21 +45,15 @@ public interface SyncableStore<T> extends Store<T> {
    * @param obj object
    */
   void delete(T obj);
-  
+
   /**
    * Sends a resync event for each item.
    */
   void resync();
-  
-  /**
-   * Get the key for the given object
-   * @param obj object
-   * @return the key
-   */
-  String getKey(T obj);
 
   /**
    * Retain only the values with keys in the given set
+   *
    * @param nextKeys to retain
    */
   void retainAll(Set<String> nextKeys);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStoreTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStoreTest.java
@@ -60,21 +60,19 @@ class ProcessorStoreTest {
     Mockito.when(podCache.remove(pod)).thenReturn(pod);
     processorStore.delete(pod);
 
-    Mockito.verify(processor, Mockito.times(4)).distribute(notificationCaptor.capture(), syncCaptor.capture());
+    Mockito.verify(processor, Mockito.times(3)).distribute(notificationCaptor.capture(), syncCaptor.capture());
 
     List<Notification<Pod>> notifications = notificationCaptor.getAllValues();
 
     assertThat(notifications.get(0)).isInstanceOf(AddNotification.class);
     assertThat(notifications.get(1)).isInstanceOf(AddNotification.class);
-    assertThat(notifications.get(2)).isInstanceOf(UpdateNotification.class);
-    assertThat(notifications.get(3)).isInstanceOf(DeleteNotification.class);
+    assertThat(notifications.get(2)).isInstanceOf(DeleteNotification.class);
 
     List<Boolean> syncValues = syncCaptor.getAllValues();
 
     assertThat(syncValues.get(0)).isFalse();
     assertThat(syncValues.get(1)).isFalse();
-    assertThat(syncValues.get(2)).isTrue(); // same object/revision, so it's sync
-    assertThat(syncValues.get(3)).isFalse();
+    assertThat(syncValues.get(2)).isFalse();
   }
 
   @Test
@@ -86,8 +84,8 @@ class ProcessorStoreTest {
 
     ProcessorStore<Pod> processorStore = new ProcessorStore<>(podCache, processor);
 
-    Pod pod = new PodBuilder().withNewMetadata().endMetadata().build();
-    Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").endMetadata().build();
+    Pod pod = new PodBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
+    Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withResourceVersion("2").endMetadata().build();
 
     // replace empty store with two values
     processorStore.add(pod);
@@ -107,12 +105,12 @@ class ProcessorStoreTest {
     assertThat(notifications.get(1)).isInstanceOf(AddNotification.class);
     assertThat(notifications.get(2)).isInstanceOf(UpdateNotification.class);
     assertThat(notifications.get(3)).isInstanceOf(UpdateNotification.class);
-    assertTrue(syncCaptor.getAllValues().subList(0, 2).stream().allMatch(s->!s.booleanValue()));
-    assertTrue(syncCaptor.getAllValues().subList(2, 4).stream().allMatch(s->s.booleanValue()));
+    assertTrue(syncCaptor.getAllValues().subList(0, 2).stream().allMatch(s -> !s.booleanValue()));
+    assertTrue(syncCaptor.getAllValues().subList(2, 4).stream().allMatch(s -> s.booleanValue()));
 
     assertThat(notifications.get(4)).isInstanceOf(DeleteNotification.class);
     assertThat(notifications.get(5)).isInstanceOf(DeleteNotification.class);
-    assertTrue(syncCaptor.getAllValues().subList(4, 6).stream().allMatch(s->!s.booleanValue()));
+    assertTrue(syncCaptor.getAllValues().subList(4, 6).stream().allMatch(s -> !s.booleanValue()));
   }
 
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -112,33 +112,33 @@ class ResourceTest {
     assertThrows(KubernetesClientException.class, podOperation::createOrReplace);
   }
 
-    @Test
-    void testCreateWithExplicitNamespace() {
-      Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+  @Test
+  void testCreateWithExplicitNamespace() {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-      server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
 
-      HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
-      assertEquals(pod1, response);
-    }
+    HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
+    assertEquals(pod1, response);
+  }
 
-    @Test
-    void testCreateOrReplaceWithDeleteExisting() throws Exception {
-      Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+  @Test
+  void testCreateOrReplaceWithDeleteExisting() throws Exception {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-      server.expect().delete().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
-      server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().delete().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
 
-      Resource<Pod> resource = client.resource(pod1).inNamespace("ns1");
-      resource.delete();
-      HasMetadata response = resource.createOrReplace();
-      assertEquals(pod1, response);
+    Resource<Pod> resource = client.resource(pod1).inNamespace("ns1");
+    resource.delete();
+    HasMetadata response = resource.createOrReplace();
+    assertEquals(pod1, response);
 
-      RecordedRequest request = server.getLastRequest();
-      assertEquals(2, server.getRequestCount());
-      assertEquals("/api/v1/namespaces/ns1/pods", request.getPath());
-      assertEquals("POST", request.getMethod());
-    }
+    RecordedRequest request = server.getLastRequest();
+    assertEquals(2, server.getRequestCount());
+    assertEquals("/api/v1/namespaces/ns1/pods", request.getPath());
+    assertEquals("POST", request.getMethod());
+  }
 
   @Test
   void itPassesPropagationPolicyWithDeleteExisting() throws InterruptedException {
@@ -178,13 +178,13 @@ class ResourceTest {
     assertThrows(KubernetesClientException.class, podOperation::createOrReplace);
   }
 
-    @Test
-    void testRequire() {
-      server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_NOT_FOUND, "").once();
-      PodResource<Pod> podOp = client.pods().inNamespace("ns1").withName("pod1");
+  @Test
+  void testRequire() {
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_NOT_FOUND, "").once();
+    PodResource<Pod> podOp = client.pods().inNamespace("ns1").withName("pod1");
 
-      Assertions.assertThrows(ResourceNotFoundException.class, podOp::require);
-    }
+    Assertions.assertThrows(ResourceNotFoundException.class, podOp::require);
+  }
 
   @Test
   void testDelete() {
@@ -192,8 +192,8 @@ class ResourceTest {
     Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("ns1").and().build();
     Pod pod3 = new PodBuilder().withNewMetadata().withName("pod3").withNamespace("any").and().build();
 
-   server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
-   server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, pod2).once();
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
+    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, pod2).once();
 
     Boolean deleted = client.resource(pod1).delete();
     assertTrue(deleted);
@@ -204,22 +204,23 @@ class ResourceTest {
     assertFalse(deleted);
   }
 
-
   @Test
   void testWatch() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
         .withName("pod1")
         .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withNamespace("test").and().build();
 
-      server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pod1).once();
-      server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, pod1).once();
+    server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, pod1).once();
 
-     server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
+    server.expect().get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
         .open()
-          .waitFor(1000).andEmit(new WatchEvent(pod1, "DELETED"))
+        .waitFor(1000).andEmit(new WatchEvent(pod1, "DELETED"))
         .done()
-      .always();
+        .always();
 
     final CountDownLatch latch = new CountDownLatch(1);
 
@@ -238,25 +239,25 @@ class ResourceTest {
     watch.close();
   }
 
-
   @Test
   void testWaitUntilReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -269,7 +270,8 @@ class ResourceTest {
   static void list(KubernetesMockServer server, Pod pod) {
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/"+pod.getMetadata().getNamespace()+"/pods?fieldSelector=metadata.name%3D"+pod.getMetadata().getName())
+        .withPath("/api/v1/namespaces/" + pod.getMetadata().getNamespace() + "/pods?fieldSelector=metadata.name%3D"
+            + pod.getMetadata().getName())
         .andReturn(200,
             new PodListBuilder().withItems(pod).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
@@ -278,22 +280,24 @@ class ResourceTest {
   @Test
   void testWaitUntilExistsThenReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "1");
+    Pod ready = createReadyFrom(pod1, "True", "2");
 
     // and again so that "periodicWatchUntilReady" successfully begins
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, noReady).times(2);
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, noReady)
+        .times(2);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(100).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(100).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.pods().withName("pod1").waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -302,84 +306,88 @@ class ResourceTest {
   @Test
   void testWaitUntilCondition() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "1");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
-    Pod withConditionBeingFalse = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .addNewCondition()
-      .withType("dummy")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod withConditionBeingFalse = new PodBuilder(pod1).editMetadata().withResourceVersion("2").endMetadata()
+        .withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .addNewCondition()
+        .withType("dummy")
+        .withStatus("False")
+        .endCondition()
+        .endStatus()
+        .build();
 
-    Pod withConditionBeingTrue = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .addNewCondition()
-      .withType("Dummy")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod withConditionBeingTrue = new PodBuilder(pod1).editMetadata().withResourceVersion("4").endMetadata()
+        .withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .addNewCondition()
+        .withType("Dummy")
+        .withStatus("True")
+        .endCondition()
+        .endStatus()
+        .build();
 
     // at first the pod is non-ready
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .waitFor(2000).andEmit(new WatchEvent(withConditionBeingFalse, "MODIFIED"))
-      .waitFor(2500).andEmit(new WatchEvent(withConditionBeingTrue, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .waitFor(2000).andEmit(new WatchEvent(withConditionBeingFalse, "MODIFIED"))
+        .waitFor(2500).andEmit(new WatchEvent(withConditionBeingTrue, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.pods().withName("pod1").waitUntilCondition(
-      r -> r.getStatus().getConditions()
+        r -> r.getStatus().getConditions()
             .stream()
             .anyMatch(c -> "Dummy".equals(c.getType()) && "True".equals(c.getStatus())),
-      8, SECONDS
-    );
+        8, SECONDS);
 
     assertThat(p.getStatus().getConditions())
-      .extracting("type", "status")
-      .containsExactly(tuple("Ready", "True"), tuple("Dummy", "True"));
+        .extracting("type", "status")
+        .containsExactly(tuple("Ready", "True"), tuple("Dummy", "True"));
   }
 
   @Test
   void tesErrorEventDuringWaitReturnFromAPIIfMatch() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     Status status = new StatusBuilder()
-      .withCode(HttpURLConnection.HTTP_FORBIDDEN)
-      .build();
+        .withCode(HttpURLConnection.HTTP_FORBIDDEN)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
+        .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .once();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -388,32 +396,35 @@ class ResourceTest {
   @Test
   void testRetryOnErrorEventDuringWait() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     Status status = new StatusBuilder()
-      .withCode(HttpURLConnection.HTTP_FORBIDDEN)
-      .build();
+        .withCode(HttpURLConnection.HTTP_FORBIDDEN)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
+        .done()
+        .once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .once();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .once();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -422,12 +433,12 @@ class ResourceTest {
   @Test
   void testSkipWatchIfAlreadyMatchingCondition() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     // once not ready, to begin watch
     list(ready);
@@ -443,21 +454,23 @@ class ResourceTest {
         .withResourceVersion("1")
         .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     Status status = new StatusBuilder()
-      .withCode(HTTP_GONE)
-      .build();
+        .withCode(HTTP_GONE)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
+        .done()
+        .once();
 
     list(ready);
 
@@ -467,48 +480,50 @@ class ResourceTest {
   @Test
   void testWaitOnConditionDeleted() throws InterruptedException {
     Pod ready = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .endStatus()
+        .build();
 
     list(ready);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "DELETED"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000).andEmit(new WatchEvent(ready, "DELETED"))
+        .done()
+        .once();
 
-
-    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull,8, SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 8, SECONDS);
     assertNull(p);
   }
 
   @Test
   void testCreateAndWaitUntilReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     list(noReady);
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, noReady).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     NamespaceableResource<Pod> resource = client.resource(noReady);
     resource.create();
@@ -519,14 +534,13 @@ class ResourceTest {
   @Test
   void testFromServerGet() {
     Pod pod = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withNamespace("test")
-      .withResourceVersion("1")
-      .and()
-      .build();
+        .withName("pod1")
+        .withNamespace("test")
+        .withResourceVersion("1")
+        .and()
+        .build();
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod).once();
-
 
     HasMetadata response = client.resource(pod).fromServer().get();
     assertEquals(pod, response);
@@ -537,28 +551,30 @@ class ResourceTest {
   void testFromServerWaitUntilConditionAlwaysGetsResourceFromServer() throws Exception {
     // Given
     final Pod conditionNotMetPod = new PodBuilder().withNewMetadata()
-      .withName("pod")
-      .withNamespace("test")
-      .addToLabels("CONDITION", "NOT_MET")
-      .endMetadata().build();
+        .withName("pod")
+        .withNamespace("test")
+        .withResourceVersion("1")
+        .addToLabels("CONDITION", "NOT_MET")
+        .endMetadata().build();
     final Pod conditionMetPod = new PodBuilder().withNewMetadata()
-      .withName("pod")
-      .withNamespace("test")
-      .withResourceVersion("1")
-      .addToLabels("CONDITION", "MET")
-      .endMetadata()
-      .build();
+        .withName("pod")
+        .withNamespace("test")
+        .withResourceVersion("2")
+        .addToLabels("CONDITION", "MET")
+        .endMetadata()
+        .build();
     list(conditionNotMetPod);
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket().open()
-      .immediately().andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
-      .waitFor(10).andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket().open()
+        .immediately().andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
+        .waitFor(10).andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
+        .done()
+        .once();
     // When
     HasMetadata response = client
-      .resource(new PodBuilder(conditionMetPod).build())
-      .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
+        .resource(new PodBuilder(conditionMetPod).build())
+        .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
     // Then
     assertEquals(conditionMetPod, response);
     assertEquals(2, server.getRequestCount());
@@ -567,25 +583,27 @@ class ResourceTest {
   @Test
   void testWaitNullDoesntExist() throws InterruptedException {
     server.expect()
-      .get()
-      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
-      .andReturn(200,
-        new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
-      .once();
+        .get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .andReturn(200,
+            new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
+        .once();
 
     Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 1, SECONDS);
     assertNull(p);
   }
 
-  private static Pod createReadyFrom(Pod pod, String status) {
+  static Pod createReadyFrom(Pod pod, String status, String resourceVersion) {
     return new PodBuilder(pod)
-      .withNewStatus()
+        .editMetadata()
+        .withResourceVersion(resourceVersion)
+        .endMetadata()
+        .withNewStatus()
         .addNewCondition()
-          .withType("Ready")
-          .withStatus(status)
+        .withType("Ready")
+        .withStatus(status)
         .endCondition()
-      .endStatus()
-      .build();
+        .endStatus()
+        .build();
   }
 }
-


### PR DESCRIPTION
## Description
This addresses a host of informer related requests:

Fix #3969 - stop emitting sync events on relist - it was simplest to make this change to support #3968
Fix #3968 - added SharedInformer.initialState to set

Also took the parts of #3943 that were most general purpose, such as being able to add/remove indexers at any time, along with deprecating Informable.withIndexers

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
