### PR TITLE
Consistent/expanded usage of the resource term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 * Fix #3407: Added Itemable.withItem to directly associate a resource with the DSL.  It can be used as an alternative to Loadable.load when you already have the item.  There is also client.resourceList(...).getResources() - that will provide the resource list as Resources.  This allows you to implement composite operations easily with lambda: client.resourceList(...).getResources().forEach(r -> r.delete());
 * Fix #3922: added Client.supports and Client.hasApiGroup methods
 * KubernetesMockServer has new methods - unsupported and reset - to control what apis are unsupported and to reset its state.
+* Fix #3407 #3973: Added Resourceable.resource to directly associate a resource with the DSL.  It can be used as an alternative to Loadable.load when you already have the item.  
+There is also client.resourceList(...).resources() and client.configMaps().resources() - that will provide a Resource stream.
+This allows you to implement composite operations easily with lambda: client.secrets().resources().forEach(r -> r.delete());
 
 #### _**Note**_: Breaking changes in the API
 Please see the [migration guide](doc/MIGRATION-v6.md)

--- a/doc/MIGRATION-v6.md
+++ b/doc/MIGRATION-v6.md
@@ -13,7 +13,7 @@
 - [Adapt Changes](#adapt-changes)
 - [Deprecations](#deprecations)
 - [Object sorting](#object-sorting)
-- [Boolean Changes](#boolean-changes)
+- [DSL Interface Changes](#dsl-interface-changes)
 - [evict Changes](#evict-changes)
 
 ## Namespace Changes
@@ -190,10 +190,15 @@ Client.adapt will no longer perform the isAdaptable check - that is you may free
 
 KubernetesList and Template will no longer automatically sort their objects by default.  You may use the HasMetadataComparator to sort the items as needed.
 
-## Boolean Changes
+## DSL Interface Changes
 
-The usage of Boolean in the api was removed where it was not a nullable value.  Please expect a boolean primitive from methods such as delete, copy, or as an argument in Loggable.getLog
+- The usage of Boolean in the api was removed where it was not a nullable value.  Please expect a boolean primitive from methods such as delete, copy, or as an argument in Loggable.getLog
+
+- WatchListDeletable now takes three type parameters to include the Resource type.
+
+- PodResource is no longer generic.
 
 ## Evict Changes
 
 Evictable.evict will throw an exception rather than returning false if the pod is not found.  This ensures that false strictly means that the evict failed.
+

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceBrokerOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceBrokerOperationsImpl.java
@@ -69,7 +69,7 @@ public class ClusterServiceBrokerOperationsImpl extends ExtensibleResourceAdapte
           + "found for ClusterServiceBroker: " + item.getMetadata().getName());
     }
     ClusterServiceClass c = list.get(0);
-    return client.adapt(ServiceCatalogClient.class).clusterServiceClasses().withItem(c);
+    return client.adapt(ServiceCatalogClient.class).clusterServiceClasses().resource(c);
   }
 
 }

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceClassOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServiceClassOperationsImpl.java
@@ -65,7 +65,7 @@ public class ClusterServiceClassOperationsImpl extends ExtensibleResourceAdapter
           + " and ClusterServiceClass: " + item.getSpec().getExternalName() + ".");
     }
     ClusterServicePlan plan = list.get(0);
-    return client.adapt(ServiceCatalogClient.class).clusterServicePlans().withItem(plan);
+    return client.adapt(ServiceCatalogClient.class).clusterServicePlans().resource(plan);
   }
 
   @Override

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServicePlanOperationsImpl.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/internal/ClusterServicePlanOperationsImpl.java
@@ -65,7 +65,7 @@ public class ClusterServicePlanOperationsImpl extends ExtensibleResourceAdapter<
   @Override
   public ServiceInstanceResource instantiateAnd(String... args) {
     ServiceInstance item = instantiate(args);
-    return client.adapt(ServiceCatalogClient.class).serviceInstances().withItem(item);
+    return client.adapt(ServiceCatalogClient.class).serviceInstances().resource(item);
   }
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -130,13 +130,13 @@ public interface KubernetesClient extends Client {
    * specific to CustomResource.
    *
    * <p>
-   *   Note: your CustomResource POJO (T in this context) must implement
-   *   {@link io.fabric8.kubernetes.api.model.Namespaced} if it is a namespace-scoped resource.
+   * Note: your CustomResource POJO (T in this context) must implement
+   * {@link io.fabric8.kubernetes.api.model.Namespaced} if it is a namespace-scoped resource.
    * </p>
    *
    * @param resourceType Class for CustomResource
    * @param <T> T type represents CustomResource type. If it's a namespaced resource, it must implement
-   *           {@link io.fabric8.kubernetes.api.model.Namespaced}
+   *        {@link io.fabric8.kubernetes.api.model.Namespaced}
    * @return returns a MixedOperation object with which you can do basic CustomResource operations
    * @deprecated use {@link #resources(Class)} instead
    */
@@ -147,14 +147,15 @@ public interface KubernetesClient extends Client {
    * Typed API for managing resources. Any properly annotated POJO can be utilized as a resource.
    *
    * <p>
-   *   Note: your resource POJO (T in this context) must implement
-   *   {@link io.fabric8.kubernetes.api.model.Namespaced} if it is a namespace-scoped resource.
+   * Note: your resource POJO (T in this context) must implement
+   * {@link io.fabric8.kubernetes.api.model.Namespaced} if it is a namespace-scoped resource.
    * </p>
    *
    * @param resourceType Class for resource
    * @param <T> T type represents resource type. If it's a namespaced resource, it must implement
-   *           {@link io.fabric8.kubernetes.api.model.Namespaced}
-   * @return returns a MixedOperation object with which you can do basic resource operations.  If the class is a known type the dsl operation logic will be used.
+   *        {@link io.fabric8.kubernetes.api.model.Namespaced}
+   * @return returns a MixedOperation object with which you can do basic resource operations. If the class is a known type the
+   *         dsl operation logic will be used.
    */
   default <T extends HasMetadata> MixedOperation<T, KubernetesResourceList<T>, Resource<T>> resources(Class<T> resourceType) {
     return resources(resourceType, null);
@@ -166,20 +167,21 @@ public interface KubernetesClient extends Client {
    * specific to CustomResource.
    *
    * <p>
-   *   Note: your CustomResource POJO (T in this context) must implement
-   *   {@link io.fabric8.kubernetes.api.model.Namespaced} if it is a namespace-scoped resource.
+   * Note: your CustomResource POJO (T in this context) must implement
+   * {@link io.fabric8.kubernetes.api.model.Namespaced} if it is a namespace-scoped resource.
    * </p>
    *
    * @param resourceType Class for CustomResource
    * @param listClass Class for list object for CustomResource
    * @param <T> T type represents CustomResource type. If it's a namespace-scoped resource, it must implement
-   *           {@link io.fabric8.kubernetes.api.model.Namespaced}
+   *        {@link io.fabric8.kubernetes.api.model.Namespaced}
    * @param <L> L type represents CustomResourceList type
    * @return returns a MixedOperation object with which you can do basic CustomResource operations
    * @deprecated use {@link #resources(Class, Class)} instead
    */
   @Deprecated
-  <T extends CustomResource, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(Class<T> resourceType, Class<L> listClass);
+  <T extends CustomResource, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(
+      Class<T> resourceType, Class<L> listClass);
 
   /**
    * Typed API for managing CustomResources. You would need to provide POJOs for
@@ -187,10 +189,11 @@ public interface KubernetesClient extends Client {
    * specific to CustomResource.
    *
    * <p>
-   *   Note: your CustomResource POJO (T in this context) must implement
-   *   <a href="https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Namespaced.java">
-   *     io.fabric8.kubernetes.api.model.Namespaced
-   *   </a> if it is a Namespaced scoped resource.
+   * Note: your CustomResource POJO (T in this context) must implement
+   * <a href=
+   * "https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Namespaced.java">
+   * io.fabric8.kubernetes.api.model.Namespaced
+   * </a> if it is a Namespaced scoped resource.
    * </p>
    *
    * @deprecated Since 5.x versions of client {@link CustomResourceDefinitionContext} is now configured via annotations
@@ -199,12 +202,13 @@ public interface KubernetesClient extends Client {
    * @param resourceType Class for CustomResource
    * @param listClass Class for list object for CustomResource
    * @param <T> T type represents CustomResource type. If it's Namespaced resource, it must implement
-   *           io.fabric8.kubernetes.api.model.Namespaced
+   *        io.fabric8.kubernetes.api.model.Namespaced
    * @param <L> L type represents CustomResourceList type
    * @return returns a MixedOperation object with which you can do basic CustomResource operations
    */
   @Deprecated
-  <T extends HasMetadata, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(ResourceDefinitionContext context, Class<T> resourceType, Class<L> listClass);
+  <T extends HasMetadata, L extends KubernetesResourceList<T>> MixedOperation<T, L, Resource<T>> customResources(
+      ResourceDefinitionContext context, Class<T> resourceType, Class<L> listClass);
 
   /**
    * Semi-Typed API for managing {@link GenericKubernetesResource}s which can represent any resource.
@@ -226,7 +230,8 @@ public interface KubernetesClient extends Client {
    * @param kind the resource kind
    * @return returns a MixedOperation object with which you can do basic resource operations.
    */
-  MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericKubernetesResources(String apiVersion, String kind);
+  MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> genericKubernetesResources(
+      String apiVersion, String kind);
 
   /**
    * Discovery API entrypoint for APIGroup discovery.k8s.io
@@ -389,7 +394,8 @@ public interface KubernetesClient extends Client {
    * @param items a collection containing HasMetadata values
    * @return operations object for Kubernetes list
    */
-  NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> resourceList(Collection<? extends HasMetadata> items);
+  NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> resourceList(
+      Collection<? extends HasMetadata> items);
 
   /**
    * KubernetesResource operations. You can pass any Kubernetes resource as a HasMetadata object and do
@@ -429,7 +435,7 @@ public interface KubernetesClient extends Client {
    *
    * @return NonNamespaceOperation object for Namespace related operations
    */
-  NonNamespaceOperation< Namespace, NamespaceList, Resource<Namespace>> namespaces();
+  NonNamespaceOperation<Namespace, NamespaceList, Resource<Namespace>> namespaces();
 
   /**
    * API entrypoint for node related operations in Kubernetes. Node (core/v1)
@@ -457,7 +463,7 @@ public interface KubernetesClient extends Client {
    *
    * @return MixedOperation object for Pod related operations
    */
-  MixedOperation<Pod, PodList, PodResource<Pod>> pods();
+  MixedOperation<Pod, PodList, PodResource> pods();
 
   /**
    * API entrypoint for ReplicationController related operations. ReplicationController (core/v1)

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/FilterWatchListDeletable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/FilterWatchListDeletable.java
@@ -15,12 +15,14 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface FilterWatchListDeletable<T, L> extends Filterable<FilterWatchListDeletable<T, L>>, WatchListDeletable<T, L> {
-  
+public interface FilterWatchListDeletable<T, L, R>
+    extends Filterable<FilterWatchListDeletable<T, L, R>>, WatchListDeletable<T, L, R> {
+
   /**
    * Accumulate a filter on the context, when done {@link FilterNested#endFilter()} or and must be called
+   * 
    * @return a {@link FilterNested}
    */
-  FilterNested<FilterWatchListDeletable<T, L>> withNewFilter(); 
+  FilterNested<FilterWatchListDeletable<T, L, R>> withNewFilter();
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/FilterWatchListMultiDeletable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/FilterWatchListMultiDeletable.java
@@ -15,6 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface FilterWatchListMultiDeletable<T, L> extends FilterWatchListDeletable<T, L>, MultiDeleteable<T> {
+public interface FilterWatchListMultiDeletable<T, L, R> extends FilterWatchListDeletable<T, L, R>, MultiDeleteable<T> {
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ListVisitFromServerGetDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ListVisitFromServerGetDeleteRecreateWaitApplicable.java
@@ -20,18 +20,20 @@ import io.fabric8.kubernetes.api.builder.Visitable;
 import io.fabric8.kubernetes.client.FromServerGettable;
 
 import java.util.List;
+import java.util.stream.Stream;
 
-public interface ListVisitFromServerGetDeleteRecreateWaitApplicable<T> extends Visitable<ListVisitFromServerGetDeleteRecreateWaitApplicable<T>>,
-  FromServerGettable<List<T>>,
-  Waitable<List<T>, T>,
-  ListVisitFromServerWritable<T>,
-  DryRunable<ListVisitFromServerWritable<T>> {
-
+public interface ListVisitFromServerGetDeleteRecreateWaitApplicable<T>
+    extends Visitable<ListVisitFromServerGetDeleteRecreateWaitApplicable<T>>,
+    FromServerGettable<List<T>>,
+    Waitable<List<T>, T>,
+    ListVisitFromServerWritable<T>,
+    DryRunable<ListVisitFromServerWritable<T>> {
 
   /**
    * Get each item as as a {@link Resource}
-   * @return the resources
+   *
+   * @return the {@link Resource} steam
    */
-  List<? extends Resource<T>> getResources();
+  Stream<? extends Resource<T>> resources();
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable.java
@@ -16,14 +16,13 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 public interface NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<T> extends
-  ListVisitFromServerGetDeleteRecreateWaitApplicable<T>,
-        Namespaceable<ListVisitFromServerGetDeleteRecreateWaitApplicable<T>>
-{
+    ListVisitFromServerGetDeleteRecreateWaitApplicable<T>,
+    Namespaceable<ListVisitFromServerGetDeleteRecreateWaitApplicable<T>> {
 
   @Override
-  List<NamespaceableResource<T>> getResources();
+  Stream<NamespaceableResource<T>> resources();
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonNamespaceOperation.java
@@ -18,19 +18,19 @@ package io.fabric8.kubernetes.client.dsl;
 /**
  * The entry point to client operations that are either "cross namespace resources", or are available in the invocation chain
  * after a namespace has already been specified.
- * 
+ *
  * @param <T> The Kubernetes resource type.
  * @param <L> The list variant of the Kubernetes resource type.
  * @param <R> The resource operations.
  */
 public interface NonNamespaceOperation<T, L, R> extends
     Nameable<R>,
-    FilterWatchListMultiDeletable<T, L>,
+    FilterWatchListMultiDeletable<T, L, R>,
     Createable<T>,
     CreateOrReplaceable<T>,
     DryRunable<WritableOperation<T>>,
     Replaceable<T>,
     StatusReplaceable<T>,
     Loadable<R>,
-    Itemable<T, R> {
+    Resourceable<T, R> {
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Operation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Operation.java
@@ -17,16 +17,16 @@ package io.fabric8.kubernetes.client.dsl;
 
 /**
  * The entry point to client operations.
- * 
+ *
  * @param <T> The Kubernetes resource type.
  * @param <L> The list variant of the Kubernetes resource type.
  * @param <R> The resource operations.
  */
 public interface Operation<T, L, R>
     extends
-    AnyNamespaceable<FilterWatchListMultiDeletable<T, L>>,
+    AnyNamespaceable<FilterWatchListMultiDeletable<T, L, R>>,
     Namespaceable<NonNamespaceOperation<T, L, R>>,
-    FilterWatchListMultiDeletable<T, L>,
+    FilterWatchListMultiDeletable<T, L, R>,
     Loadable<R>,
-    Itemable<T, R> {
+    Resourceable<T, R> {
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.PortForward;
 
@@ -25,10 +26,10 @@ import java.io.PipedOutputStream;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
-public interface PodResource<T> extends Resource<T>,
-        Loggable<LogWatch>,
-        Containerable<String, ContainerResource<LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, InputStream>>,
-        ContainerResource<LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, InputStream>,
-        PortForwardable<PortForward, LocalPortForward, ReadableByteChannel, WritableByteChannel>,
-        Evictable{
+public interface PodResource extends Resource<Pod>,
+    Loggable<LogWatch>,
+    Containerable<String, ContainerResource<LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, InputStream>>,
+    ContainerResource<LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, InputStream>,
+    PortForwardable<PortForward, LocalPortForward, ReadableByteChannel, WritableByteChannel>,
+    Evictable {
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Resourceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Resourceable.java
@@ -15,8 +15,8 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface Itemable<T, R> {
+public interface Resourceable<T, R> {
 
-  R withItem(T item);
+  R resource(T item);
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/WatchListDeletable.java
@@ -19,10 +19,20 @@ import io.fabric8.kubernetes.client.GracePeriodConfigurable;
 import io.fabric8.kubernetes.client.PropagationPolicyConfigurable;
 import io.fabric8.kubernetes.client.Watcher;
 
-public interface WatchListDeletable<T, L> extends Watchable<Watcher<T>>, Versionable<WatchAndWaitable<T>>, Listable<L>, Deletable,
-                                                        GracePeriodConfigurable<Deletable>,
-                                                        PropagationPolicyConfigurable<EditReplacePatchDeletable<T>>,
-                                                        StatusUpdatable<T>,
-                                                        Informable<T>
-{
+import java.util.stream.Stream;
+
+public interface WatchListDeletable<T, L, R>
+    extends Watchable<Watcher<T>>, Versionable<WatchAndWaitable<T>>, Listable<L>, Deletable,
+    GracePeriodConfigurable<Deletable>,
+    PropagationPolicyConfigurable<EditReplacePatchDeletable<T>>,
+    StatusUpdatable<T>,
+    Informable<T> {
+
+  /**
+   * Perform a list operation and return the items as a stream of {@link Resource}s
+   *
+   * @return the {@link Resource} steam
+   */
+  Stream<R> resources();
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -135,7 +135,7 @@ import java.util.concurrent.ExecutorService;
 /**
  * Class for Default Kubernetes Client implementing KubernetesClient interface.
  * It is thread safe.
- * 
+ *
  * @deprecated direct usage should no longer be needed. Please use the {@link KubernetesClientBuilder} instead.
  */
 @Deprecated
@@ -381,7 +381,7 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
    * {@inheritDoc}
    */
   @Override
-  public MixedOperation<Pod, PodList, PodResource<Pod>> pods() {
+  public MixedOperation<Pod, PodList, PodResource> pods() {
     return new PodOperationsImpl(this);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/NamespaceableResourceAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/NamespaceableResourceAdapter.java
@@ -29,27 +29,30 @@ import io.fabric8.kubernetes.client.extension.ResourceAdapter;
  * {@link NamespaceableResource} is not {@link Namespaceable} to allow for future versions of the logic
  * to be consolidated.
  * <p>
- * With generic typed interface design Namespacable&lt;X&gt; and Namespaceable&lt;Y&gt; are considered incompatible no matter the types for X and Y,
- * but NamespaceableX and NamespaceableY can be polymorphic.  As long as there is no usage expectation
+ * With generic typed interface design Namespacable&lt;X&gt; and Namespaceable&lt;Y&gt; are considered incompatible no matter
+ * the types for X and Y,
+ * but NamespaceableX and NamespaceableY can be polymorphic. As long as there is no usage expectation
  * like instanceof Namespaceable - then it would be fine to have the non-generic versions.
  * <p>
- * The constructor and the inNamespace method determine the namespacing rules: 
- *   - if the item is namespaced, the resource context will use that namespace as that is not currently the default behavior of withItem
+ * The constructor and the inNamespace method determine the namespacing rules:
+ * - if the item is namespaced, the resource context will use that namespace as that is not currently the default behavior of
+ * withItem
  */
-public class NamespaceableResourceAdapter<T extends HasMetadata> extends ResourceAdapter<T> implements NamespaceableResource<T> {
-  
+public class NamespaceableResourceAdapter<T extends HasMetadata> extends ResourceAdapter<T>
+    implements NamespaceableResource<T> {
+
   protected final T item;
   protected final HasMetadataOperation<T, ?, ?> operation;
-  
+
   public NamespaceableResourceAdapter(T item, HasMetadataOperation<T, ?, ?> op) {
-    super(op.withItem(item));
+    super(op.resource(item));
     this.operation = op;
     this.item = item;
   }
 
   @Override
   public Resource<T> inNamespace(String name) {
-    return operation.inNamespace(name).withItem(item);
+    return operation.inNamespace(name).resource(item);
   }
-  
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CreateOnlyResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/CreateOnlyResourceOperation.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ExecutionException;
 
 public class CreateOnlyResourceOperation<I, O> extends OperationSupport implements InOutCreateable<I, O> {
   protected Class<O> type;
-  
+
   protected CreateOnlyResourceOperation(OperationContext ctx) {
     super(ctx);
   }
@@ -31,7 +31,7 @@ public class CreateOnlyResourceOperation<I, O> extends OperationSupport implemen
   public Class<O> getType() {
     return type;
   }
-  
+
   protected O handleCreate(I resource) throws ExecutionException, InterruptedException, IOException {
     return handleCreate(resource, getType());
   }
@@ -39,19 +39,12 @@ public class CreateOnlyResourceOperation<I, O> extends OperationSupport implemen
   @SafeVarargs
   @Override
   public final O create(I... resources) {
-    try {
-      if (resources.length > 1) {
-        throw new IllegalArgumentException("Too many items to create.");
-      } else if (resources.length == 1) {
-        return handleCreate(resources[0]);
-      } else {
-        return handleCreate(getItem());
-      }
-    } catch (ExecutionException | IOException e) {
-      throw KubernetesClientException.launderThrowable(e);
-    } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
-      throw KubernetesClientException.launderThrowable(ie);
+    if (resources.length > 1) {
+      throw new IllegalArgumentException("Too many items to create.");
+    } else if (resources.length == 1) {
+      return create(resources[0]);
+    } else {
+      return create(getItem());
     }
   }
 
@@ -70,5 +63,5 @@ public class CreateOnlyResourceOperation<I, O> extends OperationSupport implemen
   public I getItem() {
     return (I) context.getItem();
   }
-  
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/FilterNestedImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/FilterNestedImpl.java
@@ -31,8 +31,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>> implements FilterNested<FilterWatchListDeletable<T, L>> {
-  
+final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>>
+    implements FilterNested<FilterWatchListDeletable<T, L, R>> {
+
   private static final String INVOLVED_OBJECT_NAME = "involvedObject.name";
   private static final String INVOLVED_OBJECT_NAMESPACE = "involvedObject.namespace";
   private static final String INVOLVED_OBJECT_KIND = "involvedObject.kind";
@@ -40,7 +41,7 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
   private static final String INVOLVED_OBJECT_RESOURCE_VERSION = "involvedObject.resourceVersion";
   private static final String INVOLVED_OBJECT_API_VERSION = "involvedObject.apiVersion";
   private static final String INVOLVED_OBJECT_FIELD_PATH = "involvedObject.fieldPath";
-  
+
   private final BaseOperation<T, L, R> baseOperation;
   private OperationContext context;
 
@@ -61,39 +62,39 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withLabels(Map<String, String> labels) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withLabels(Map<String, String> labels) {
     this.context.labels.putAll(labels);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withoutLabels(Map<String, String> labels) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withoutLabels(Map<String, String> labels) {
     // Re-use "withoutLabel" to convert values from String to String[]
     labels.forEach(this::withoutLabel);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withLabelIn(String key, String... values) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withLabelIn(String key, String... values) {
     context.labelsIn.put(key, values);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withLabelNotIn(String key, String... values) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withLabelNotIn(String key, String... values) {
     context.labelsNotIn.put(key, values);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withLabel(String key, String value) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withLabel(String key, String value) {
     context.labels.put(key, value);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withoutLabel(String key, String value) {
-    context.labelsNot.merge(key, new String[]{value}, (oldList, newList) -> {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withoutLabel(String key, String value) {
+    context.labelsNot.merge(key, new String[] { value }, (oldList, newList) -> {
       final String[] concatList = (String[]) Array.newInstance(String.class, oldList.length + newList.length);
       System.arraycopy(oldList, 0, concatList, 0, oldList.length);
       System.arraycopy(newList, 0, concatList, oldList.length, newList.length);
@@ -103,27 +104,27 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withFields(Map<String, String> fields) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withFields(Map<String, String> fields) {
     this.context.fields.putAll(fields);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withField(String key, String value) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withField(String key, String value) {
     this.context.fields.put(key, value);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withoutFields(Map<String, String> fields) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withoutFields(Map<String, String> fields) {
     // Re-use "withoutField" to convert values from String to String[]
     fields.forEach(this::withoutField);
     return this;
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withoutField(String key, String value) {
-    context.fieldsNot.merge(key, new String[]{value}, (oldList, newList) -> {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withoutField(String key, String value) {
+    context.fieldsNot.merge(key, new String[] { value }, (oldList, newList) -> {
       if (Utils.isNotNullOrEmpty(newList[0])) { // Only add new values when not null
         final String[] concatList = (String[]) Array.newInstance(String.class, oldList.length + newList.length);
         System.arraycopy(oldList, 0, concatList, 0, oldList.length);
@@ -137,7 +138,7 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withLabelSelector(LabelSelector selector) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withLabelSelector(LabelSelector selector) {
     Map<String, String> matchLabels = selector.getMatchLabels();
     if (matchLabels != null) {
       withLabels(matchLabels);
@@ -149,10 +150,10 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
         String key = req.getKey();
         switch (operator) {
           case "In":
-            withLabelIn(key, req.getValues().toArray(new String[]{}));
+            withLabelIn(key, req.getValues().toArray(new String[] {}));
             break;
           case "NotIn":
-            withLabelNotIn(key, req.getValues().toArray(new String[]{}));
+            withLabelNotIn(key, req.getValues().toArray(new String[] {}));
             break;
           case "DoesNotExist":
             withoutLabel(key);
@@ -169,7 +170,7 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
   }
 
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withInvolvedObject(ObjectReference objectReference) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withInvolvedObject(ObjectReference objectReference) {
     if (objectReference.getName() != null) {
       context.fields.put(INVOLVED_OBJECT_NAME, objectReference.getName());
     }
@@ -195,13 +196,12 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
   }
 
   @Override
-  public FilterWatchListDeletable<T, L> and() {
+  public FilterWatchListDeletable<T, L, R> and() {
     return this.baseOperation.newInstance(context);
   }
 
-
   @Override
-  public FilterNested<FilterWatchListDeletable<T, L>> withLabelSelector(String selectorAsString) {
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withLabelSelector(String selectorAsString) {
     this.context.selectorAsString = selectorAsString;
     return this;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -63,6 +63,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl
     implements ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata>,
@@ -120,10 +121,13 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImp
   }
 
   @Override
-  public List<NamespaceableResource<io.fabric8.kubernetes.api.model.HasMetadata>> getResources() {
+  public Stream<NamespaceableResource<HasMetadata>> resources() {
     return getItems().stream()
-        .map(this::getResource)
-        .collect(Collectors.toList());
+        .map(this::getResource);
+  }
+
+  public List<NamespaceableResource<io.fabric8.kubernetes.api.model.HasMetadata>> getResources() {
+    return resources().collect(Collectors.toList());
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentRollingUpdater.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.Operation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.WatchListDeletable;
 
@@ -51,7 +52,7 @@ class DeploymentRollingUpdater extends RollingUpdater<Deployment, DeploymentList
   }
 
   @Override
-  protected WatchListDeletable<Pod, PodList> selectedPodLister(Deployment obj) {
+  protected WatchListDeletable<Pod, PodList, PodResource> selectedPodLister(Deployment obj) {
     return selectedPodLister(obj.getSpec().getSelector());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
@@ -159,7 +159,7 @@ public class ReplicaSetOperationsImpl
     return PodOperationUtil.getLog(doGetLog(isPretty), isPretty);
   }
 
-  private List<PodResource<Pod>> doGetLog(boolean isPretty) {
+  private List<PodResource> doGetLog(boolean isPretty) {
     ReplicaSet replicaSet = requireFromServer();
     return PodOperationUtil.getPodOperationsForController(context, replicaSet.getMetadata().getUid(),
         getReplicaSetSelectorLabels(replicaSet), isPretty, rollingOperationContext.getLogWaitTimeout(),

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetList;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.Operation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.WatchListDeletable;
 
@@ -51,7 +52,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
   }
 
   @Override
-  protected WatchListDeletable<Pod, PodList> selectedPodLister(ReplicaSet obj) {
+  protected WatchListDeletable<Pod, PodList, PodResource> selectedPodLister(ReplicaSet obj) {
     return selectedPodLister(obj.getSpec().getSelector());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
@@ -79,7 +79,7 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
 
   protected abstract T createClone(T obj, String newName, String newDeploymentHash);
 
-  protected abstract WatchListDeletable<Pod, PodList> selectedPodLister(T obj);
+  protected abstract WatchListDeletable<Pod, PodList, PodResource> selectedPodLister(T obj);
 
   protected abstract T updateDeploymentKey(String name, String hash);
 
@@ -264,11 +264,11 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
 
   protected abstract Operation<T, L, RollableScalableResource<T>> resources();
 
-  protected Operation<Pod, PodList, PodResource<Pod>> pods() {
+  protected Operation<Pod, PodList, PodResource> pods() {
     return new PodOperationsImpl(client);
   }
 
-  protected FilterWatchListDeletable<Pod, PodList> selectedPodLister(LabelSelector selector) {
+  protected FilterWatchListDeletable<Pod, PodList, PodResource> selectedPodLister(LabelSelector selector) {
     return pods().inNamespace(namespace).withLabelSelector(selector);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
@@ -143,7 +143,7 @@ public class StatefulSetOperationsImpl
     return PodOperationUtil.getLog(doGetLog(isPretty), isPretty);
   }
 
-  private List<PodResource<Pod>> doGetLog(boolean isPretty) {
+  private List<PodResource> doGetLog(boolean isPretty) {
     StatefulSet statefulSet = requireFromServer();
 
     return PodOperationUtil.getPodOperationsForController(context, statefulSet.getMetadata().getUid(),

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetRollingUpdater.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetList;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.Operation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.WatchListDeletable;
 
@@ -51,7 +52,7 @@ class StatefulSetRollingUpdater extends RollingUpdater<StatefulSet, StatefulSetL
   }
 
   @Override
-  protected WatchListDeletable<Pod, PodList> selectedPodLister(StatefulSet obj) {
+  protected WatchListDeletable<Pod, PodList, PodResource> selectedPodLister(StatefulSet obj) {
     return selectedPodLister(obj.getSpec().getSelector());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.batch.v1;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobList;
@@ -118,14 +117,14 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
   @Override
   public String getLog(boolean isPretty) {
     StringBuilder stringBuilder = new StringBuilder();
-    List<PodResource<Pod>> podOperationList = doGetLog(false);
-    for (PodResource<Pod> podOperation : podOperationList) {
+    List<PodResource> podOperationList = doGetLog(false);
+    for (PodResource podOperation : podOperationList) {
       stringBuilder.append(podOperation.getLog(isPretty));
     }
     return stringBuilder.toString();
   }
 
-  private List<PodResource<Pod>> doGetLog(boolean isPretty) {
+  private List<PodResource> doGetLog(boolean isPretty) {
     Job job = requireFromServer();
 
     return PodOperationUtil.getPodOperationsForController(context, job.getMetadata().getUid(),

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -85,8 +85,8 @@ import java.util.concurrent.TimeUnit;
 
 import static io.fabric8.kubernetes.client.utils.internal.OptionalDependencyWrapper.wrapRunWithOptionalDependency;
 
-public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodResource<Pod>>
-    implements PodResource<Pod>, CopyOrReadable<InputStream> {
+public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodResource>
+    implements PodResource, CopyOrReadable<InputStream> {
 
   public static final int HTTP_TOO_MANY_REQUESTS = 429;
   private static final Integer DEFAULT_POD_LOG_WAIT_TIMEOUT = 5;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
@@ -141,7 +141,7 @@ public class ReplicationControllerOperationsImpl extends
     return PodOperationUtil.getLog(doGetLog(isPretty), isPretty);
   }
 
-  private List<PodResource<Pod>> doGetLog(boolean isPretty) {
+  private List<PodResource> doGetLog(boolean isPretty) {
     ReplicationController rc = requireFromServer();
 
     return PodOperationUtil.getPodOperationsForController(context, rc.getMetadata().getUid(),

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerRollingUpdater.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerList;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.Operation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.WatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
@@ -51,7 +52,7 @@ class ReplicationControllerRollingUpdater extends RollingUpdater<ReplicationCont
   }
 
   @Override
-  protected WatchListDeletable<Pod, PodList> selectedPodLister(ReplicationController obj) {
+  protected WatchListDeletable<Pod, PodList, PodResource> selectedPodLister(ReplicationController obj) {
     return pods().inNamespace(namespace).withLabels(obj.getSpec().getSelector());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentRollingUpdater.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentList;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.Operation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.WatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
@@ -52,7 +53,7 @@ class DeploymentRollingUpdater extends RollingUpdater<Deployment, DeploymentList
   }
 
   @Override
-  protected WatchListDeletable<Pod, PodList> selectedPodLister(Deployment obj) {
+  protected WatchListDeletable<Pod, PodList, PodResource> selectedPodLister(Deployment obj) {
     return selectedPodLister(obj.getSpec().getSelector());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
@@ -159,14 +159,14 @@ public class ReplicaSetOperationsImpl
   @Override
   public String getLog(boolean isPretty) {
     StringBuilder stringBuilder = new StringBuilder();
-    List<PodResource<Pod>> podOperationList = doGetLog(isPretty);
-    for (PodResource<Pod> podOperation : podOperationList) {
+    List<PodResource> podOperationList = doGetLog(isPretty);
+    for (PodResource podOperation : podOperationList) {
       stringBuilder.append(podOperation.getLog(isPretty));
     }
     return stringBuilder.toString();
   }
 
-  private List<PodResource<Pod>> doGetLog(boolean isPretty) {
+  private List<PodResource> doGetLog(boolean isPretty) {
     ReplicaSet replicaSet = requireFromServer();
     return PodOperationUtil.getPodOperationsForController(context, replicaSet.getMetadata().getUid(),
         getReplicaSetSelectorLabels(replicaSet), isPretty, rollingOperationContext.getLogWaitTimeout(),

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetRollingUpdater.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetList;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.dsl.Operation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.WatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
@@ -52,7 +53,7 @@ class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList
   }
 
   @Override
-  protected WatchListDeletable<Pod, PodList> selectedPodLister(ReplicaSet obj) {
+  protected WatchListDeletable<Pod, PodList, PodResource> selectedPodLister(ReplicaSet obj) {
     return selectedPodLister(obj.getSpec().getSelector());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -314,7 +314,7 @@ public class ManagedKubernetesClient implements NamespacedKubernetesClient {
   }
 
   @Override
-  public MixedOperation<Pod, PodList, PodResource<Pod>> pods() {
+  public MixedOperation<Pod, PodList, PodResource> pods() {
     return delegate.pods();
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtil.java
@@ -36,7 +36,9 @@ import java.util.concurrent.TimeUnit;
 
 public class PodOperationUtil {
   private static final Logger LOG = LoggerFactory.getLogger(PodOperationUtil.class);
-  private PodOperationUtil() { }
+
+  private PodOperationUtil() {
+  }
 
   /**
    * Gets PodOperations for Pods specific to a controller
@@ -46,8 +48,9 @@ public class PodOperationUtil {
    * @param controllerUid UID of Controller
    * @return returns list of PodOperations with pods whose owner's UID is of the provided controller
    */
-  public static List<PodResource<Pod>> getFilteredPodsForLogs(PodOperationsImpl podOperations, PodList controllerPodList, String controllerUid) {
-    List<PodResource<Pod>> pods = new ArrayList<>();
+  public static List<PodResource> getFilteredPodsForLogs(PodOperationsImpl podOperations, PodList controllerPodList,
+      String controllerUid) {
+    List<PodResource> pods = new ArrayList<>();
     for (Pod pod : controllerPodList.getItems()) {
       OwnerReference ownerReference = KubernetesResourceUtil.getControllerUid(pod);
       if (ownerReference != null && ownerReference.getUid().equals(controllerUid)) {
@@ -57,20 +60,24 @@ public class PodOperationUtil {
     return pods;
   }
 
-  public static PodOperationsImpl getGenericPodOperations(OperationContext context, boolean isPretty, Integer podLogWaitTimeout, String containerId) {
+  public static PodOperationsImpl getGenericPodOperations(OperationContext context, boolean isPretty, Integer podLogWaitTimeout,
+      String containerId) {
     return new PodOperationsImpl(new PodOperationContext(containerId,
-      null, null, null, null, null,
-      null, null, null, false, false,
-      false, null, null, null, isPretty,
-      null, null, null,
-      null, null, podLogWaitTimeout), context.withName(null).withApiGroupName(null).withApiGroupVersion("v1"));
+        null, null, null, null, null,
+        null, null, null, false, false,
+        false, null, null, null, isPretty,
+        null, null, null,
+        null, null, podLogWaitTimeout), context.withName(null).withApiGroupName(null).withApiGroupVersion("v1"));
   }
 
-  public static List<PodResource<Pod>> getPodOperationsForController(OperationContext context, String controllerUid, Map<String, String> selectorLabels, boolean isPretty, Integer podLogWaitTimeout, String containerId) {
-    return getPodOperationsForController(PodOperationUtil.getGenericPodOperations(context, isPretty, podLogWaitTimeout, containerId), controllerUid, selectorLabels);
+  public static List<PodResource> getPodOperationsForController(OperationContext context, String controllerUid,
+      Map<String, String> selectorLabels, boolean isPretty, Integer podLogWaitTimeout, String containerId) {
+    return getPodOperationsForController(
+        PodOperationUtil.getGenericPodOperations(context, isPretty, podLogWaitTimeout, containerId), controllerUid,
+        selectorLabels);
   }
 
-  public static LogWatch watchLog(List<PodResource<Pod>> podResources, OutputStream out) {
+  public static LogWatch watchLog(List<PodResource> podResources, OutputStream out) {
     if (!podResources.isEmpty()) {
       if (podResources.size() > 1) {
         LOG.debug("Found {} pods, Using first one to watch logs", podResources.size());
@@ -80,7 +87,7 @@ public class PodOperationUtil {
     return null;
   }
 
-  public static Reader getLogReader(List<PodResource<Pod>> podResources) {
+  public static Reader getLogReader(List<PodResource> podResources) {
     if (!podResources.isEmpty()) {
       if (podResources.size() > 1) {
         LOG.debug("Found {} pods, Using first one to get log reader", podResources.size());
@@ -90,21 +97,22 @@ public class PodOperationUtil {
     return null;
   }
 
-  public static String getLog(List<PodResource<Pod>> podOperationList, Boolean isPretty) {
+  public static String getLog(List<PodResource> podOperationList, Boolean isPretty) {
     StringBuilder stringBuilder = new StringBuilder();
-    for (PodResource<Pod> podOperation : podOperationList) {
+    for (PodResource podOperation : podOperationList) {
       stringBuilder.append(podOperation.getLog(isPretty));
     }
     return stringBuilder.toString();
   }
 
-  public static List<PodResource<Pod>> getPodOperationsForController(PodOperationsImpl podOperations, String controllerUid, Map<String, String> selectorLabels) {
+  public static List<PodResource> getPodOperationsForController(PodOperationsImpl podOperations, String controllerUid,
+      Map<String, String> selectorLabels) {
     PodList controllerPodList = podOperations.withLabels(selectorLabels).list();
 
     return PodOperationUtil.getFilteredPodsForLogs(podOperations, controllerPodList, controllerUid);
   }
 
-  public static void waitUntilReadyBeforeFetchingLogs(PodResource<Pod> podOperation, Integer logWaitTimeout) {
+  public static void waitUntilReadyBeforeFetchingLogs(PodResource podOperation, Integer logWaitTimeout) {
     try {
       // Wait for Pod to become ready
       Pod pod = podOperation.fromServer().get();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/PatchTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/PatchTest.java
@@ -75,7 +75,7 @@ class PatchTest {
 
     // When
     kubernetesClient.pods().inNamespace("ns1").withName("foo")
-      .patch("{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
+        .patch("{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
 
     // Then
     verify(mockClient, times(2)).send(any(), any());
@@ -87,12 +87,12 @@ class PatchTest {
   void testJsonMergePatch() throws IOException {
     // Given
     PatchContext patchContext = new PatchContext.Builder()
-      .withPatchType(PatchType.JSON_MERGE)
-      .build();
+        .withPatchType(PatchType.JSON_MERGE)
+        .build();
 
     // When
     kubernetesClient.pods().inNamespace("ns1").withName("foo")
-      .patch(patchContext, "{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
+        .patch(patchContext, "{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
 
     // Then
     verify(mockClient, times(2)).send(any(), any());
@@ -120,7 +120,7 @@ class PatchTest {
     when(mockClient.send(any(), Mockito.eq(InputStream.class))).thenReturn(mockResponse);
 
     // When
-    PodResource<Pod> podResource = kubernetesClient.pods()
+    PodResource podResource = kubernetesClient.pods()
         .inNamespace("ns1")
         .withName("foo");
     KubernetesClientException e = assertThrows(KubernetesClientException.class,
@@ -139,7 +139,8 @@ class PatchTest {
 
     // When
     kubernetesClient.pods().inNamespace("ns1").withName("foo")
-      .patch(patchContext, "[{\"op\": \"replace\", \"path\":\"/spec/containers/0/image\", \"value\":\"foo/gb-frontend:v4\"}]");
+        .patch(patchContext,
+            "[{\"op\": \"replace\", \"path\":\"/spec/containers/0/image\", \"value\":\"foo/gb-frontend:v4\"}]");
 
     // Then
     verify(mockClient, times(2)).send(any(), any());
@@ -153,21 +154,22 @@ class PatchTest {
 
     // When
     kubernetesClient.pods().inNamespace("ns1").withName("foo")
-      .patch(new PatchContext.Builder()
-        .withFieldManager("fabric8")
-        .withDryRun(Collections.singletonList("All"))
-        .build(), "{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
+        .patch(new PatchContext.Builder()
+            .withFieldManager("fabric8")
+            .withDryRun(Collections.singletonList("All"))
+            .build(), "{\"metadata\":{\"annotations\":{\"bob\":\"martin\"}}}");
 
     // Then
     verify(mockClient, times(2)).send(any(), any());
     assertRequest("GET", "/api/v1/namespaces/ns1/pods/foo", null);
-    assertRequest(1, "PATCH", "/api/v1/namespaces/ns1/pods/foo", "fieldManager=fabric8&dryRun=All", OperationSupport.STRATEGIC_MERGE_JSON_PATCH);
+    assertRequest(1, "PATCH", "/api/v1/namespaces/ns1/pods/foo", "fieldManager=fabric8&dryRun=All",
+        OperationSupport.STRATEGIC_MERGE_JSON_PATCH);
   }
 
   private void assertRequest(String method, String url, String queryParam) {
     assertRequest(0, method, url, queryParam, null);
   }
-  
+
   private void assertRequest(int index, String method, String url, String queryParam, String contentType) {
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Builder mock = builders.get(index);
@@ -176,33 +178,32 @@ class PatchTest {
     assertEquals(url, capturedURL.getPath());
 
     validateMethod(method, contentType, mock);
-    
+
     assertEquals(queryParam, capturedURL.getQuery());
   }
 
   static void validateMethod(String method, String contentType, Builder mock) {
     ArgumentCaptor<String> contentTypeCaptor = ArgumentCaptor.forClass(String.class);
     switch (method) {
-    case "DELETE":
-      Mockito.verify(mock).delete(contentTypeCaptor.capture(), any());
-      break;
-    case "POST":
-      Mockito.verify(mock).post(contentTypeCaptor.capture(), any(String.class));
-      break;
-    case "PUT":
-      Mockito.verify(mock).put(contentTypeCaptor.capture(), any());
-      break;
-    case "PATCH":
-      Mockito.verify(mock).patch(contentTypeCaptor.capture(), any());
-      break;
-    default:
-      break; //TODO: validate GET, but that explicit call was removed
+      case "DELETE":
+        Mockito.verify(mock).delete(contentTypeCaptor.capture(), any());
+        break;
+      case "POST":
+        Mockito.verify(mock).post(contentTypeCaptor.capture(), any(String.class));
+        break;
+      case "PUT":
+        Mockito.verify(mock).put(contentTypeCaptor.capture(), any());
+        break;
+      case "PATCH":
+        Mockito.verify(mock).patch(contentTypeCaptor.capture(), any());
+        break;
+      default:
+        break; //TODO: validate GET, but that explicit call was removed
     }
-    
+
     if (contentType != null) {
       assertEquals(contentType, contentTypeCaptor.getValue());
     }
   }
-  
-  
+
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CreatePod.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CreatePod.java
@@ -68,10 +68,10 @@ public class CreatePod {
         return;
       }
       HasMetadata resource = resources.get(0);
-      if (resource instanceof Pod){
+      if (resource instanceof Pod) {
         Pod pod = (Pod) resource;
         logger.info("Creating pod in namespace {}", namespace);
-        NonNamespaceOperation<Pod, PodList, PodResource<Pod>> pods = client.pods().inNamespace(namespace);
+        NonNamespaceOperation<Pod, PodList, PodResource> pods = client.pods().inNamespace(namespace);
         Pod result = pods.create(pod);
         logger.info("Created pod {}", result.getMetadata().getName());
       } else {

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -274,7 +274,7 @@ public class PodIT {
   }
 
   private void assertUploaded(Pod pod1, final Path tmpFile, String filename) throws IOException {
-    PodResource<Pod> podResource = client.pods().inNamespace(session.getNamespace())
+    PodResource podResource = client.pods().inNamespace(session.getNamespace())
         .withName(pod1.getMetadata().getName());
 
     podResource.file(filename).upload(tmpFile);
@@ -301,7 +301,7 @@ public class PodIT {
       Files.write(Files.createFile(file), Arrays.asList("I'm uploaded", fileName));
     }
 
-    PodResource<Pod> podResource = client.pods().inNamespace(session.getNamespace())
+    PodResource podResource = client.pods().inNamespace(session.getNamespace())
         .withName(pod1.getMetadata().getName());
 
     podResource.dir("/tmp/uploadDir").upload(tmpDir);
@@ -325,7 +325,7 @@ public class PodIT {
 
     final Path tmpDir = Files.createTempDirectory("copyFile");
 
-    PodResource<Pod> podResource = client.pods().inNamespace(session.getNamespace())
+    PodResource podResource = client.pods().inNamespace(session.getNamespace())
         .withName(pod1.getMetadata().getName());
     podResource.writingOutput(System.out).exec("sh", "-c", "echo 'hello' > /msg.txt");
     podResource.file("/msg.txt").copy(tmpDir);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServerSideApplyIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServerSideApplyIT.java
@@ -64,7 +64,7 @@ public class ServerSideApplyIT {
       .endSpec()
       .build();
 
-    Resource<Service> resource = client.services().inNamespace(session.getNamespace()).withItem(service);
+    Resource<Service> resource = client.services().inNamespace(session.getNamespace()).resource(service);
     resource.delete();
 
     // 1st apply - create must be a server side apply - otherwise the later operations will need to force

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
@@ -55,15 +55,16 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should replace an existing resource in Kubernetes Cluster")
   void testResourceReplace() {
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).always();
+        .withNewMetadata().withResourceVersion("12345").and().build()).always();
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).times(2);
+        .withNewMetadata().withResourceVersion("12345").and().build()).times(2);
 
     server.expect().put().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
-    Pod pod = client.resource(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build()).createOrReplace();
+    Pod pod = client.resource(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build())
+        .createOrReplace();
     assertNotNull(pod);
     assertEquals("12345", pod.getMetadata().getResourceVersion());
   }
@@ -72,9 +73,10 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should create a new resource in Kubernetes Cluster")
   void testResourceCreate() {
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
-    HasMetadata result = client.resource(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build()).createOrReplace();
+    HasMetadata result = client
+        .resource(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build()).createOrReplace();
     assertNotNull(result);
     assertEquals("12345", result.getMetadata().getResourceVersion());
   }
@@ -83,9 +85,12 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should throw Exception on failed create")
   void testResourceCreateFailure() {
     // Given
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_BAD_REQUEST, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").endMetadata().build()).once();
-    NamespaceableResource<Pod> podOperation = client.resource(new PodBuilder().withNewMetadata().withName("pod123").endMetadata().build());
+    server.expect().post().withPath("/api/v1/namespaces/test/pods")
+        .andReturn(HttpURLConnection.HTTP_BAD_REQUEST, new PodBuilder()
+            .withNewMetadata().withResourceVersion("12345").endMetadata().build())
+        .once();
+    NamespaceableResource<Pod> podOperation = client
+        .resource(new PodBuilder().withNewMetadata().withName("pod123").endMetadata().build());
 
     // When
     assertThrows(KubernetesClientException.class, podOperation::createOrReplace);
@@ -95,9 +100,10 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should create a new resource in Kubernetes Cluster")
   void testCreate() {
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
-    Pod pod = client.pods().createOrReplace(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build());
+    Pod pod = client.pods()
+        .createOrReplace(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build());
     assertNotNull(pod);
     assertEquals("12345", pod.getMetadata().getResourceVersion());
   }
@@ -105,13 +111,17 @@ class CreateOrReplaceResourceTest {
   @Test
   @DisplayName("Shoulc replace an existing resource in Kubernetes Cluster")
   void testReplace() {
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).always();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT,
+        new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).always();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).times(2);
+    server.expect().get().withPath("/api/v1/namespaces/test/pods/pod123")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build())
+        .times(2);
     server.expect().put().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
-    Pod pod = client.pods().createOrReplace(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build());
+    Pod pod = client.pods()
+        .createOrReplace(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build());
     assertNotNull(pod);
     assertEquals("12345", pod.getMetadata().getResourceVersion());
   }
@@ -120,12 +130,17 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should throw exception on failed replace")
   void testFailedReplace() {
     // Given
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).always();
-    server.expect().get().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).times(2);
-    server.expect().put().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_BAD_REQUEST, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT,
+        new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).always();
+    server.expect().get().withPath("/api/v1/namespaces/test/pods/pod123")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build())
+        .times(2);
+    server.expect().put().withPath("/api/v1/namespaces/test/pods/pod123")
+        .andReturn(HttpURLConnection.HTTP_BAD_REQUEST, new PodBuilder()
+            .withNewMetadata().withResourceVersion("12345").and().build())
+        .once();
     final Pod toCreate = new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build();
-    final MixedOperation<Pod, PodList, PodResource<Pod>> pods = client.pods();
+    final MixedOperation<Pod, PodList, PodResource> pods = client.pods();
     // When
     assertThrows(KubernetesClientException.class, () -> pods.create(toCreate));
   }
@@ -134,7 +149,7 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should create a new resource in Kubernetes Cluster")
   void testResourceCreateFromLoad() throws Exception {
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
     List<HasMetadata> result = client.load(getClass().getResourceAsStream("/test-pod-create-from-load.yml")).createOrReplace();
     assertNotNull(result);
@@ -151,11 +166,14 @@ class CreateOrReplaceResourceTest {
   @Test
   @DisplayName("Should replace an existing resource in Kubernetes Cluster")
   void testResourceReplaceFromLoad() throws Exception {
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).always();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT,
+        new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).always();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods/nginx").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build()).times(2);
+    server.expect().get().withPath("/api/v1/namespaces/test/pods/nginx")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().withNewMetadata().withResourceVersion("12345").and().build())
+        .times(2);
     server.expect().put().withPath("/api/v1/namespaces/test/pods/nginx").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
     List<HasMetadata> result = client.load(getClass().getResourceAsStream("/test-pod-create-from-load.yml")).createOrReplace();
     assertNotNull(result);
@@ -172,7 +190,7 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should create a new resource from yaml")
   void testCreateFromLoad() throws Exception {
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
     Pod pod = client.pods().load(getClass().getResourceAsStream("/test-pod-create-from-load.yml")).createOrReplace();
     assertNotNull(pod);
@@ -185,16 +203,17 @@ class CreateOrReplaceResourceTest {
   @Test
   @DisplayName("Should update existing resource")
   void testReplaceFromLoad() throws Exception {
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, new PodBuilder().build()).always();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods")
+        .andReturn(HttpURLConnection.HTTP_CONFLICT, new PodBuilder().build()).always();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods/nginx").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().build()).times(2);
+    server.expect().get().withPath("/api/v1/namespaces/test/pods/nginx")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().build()).times(2);
     server.expect().put().withPath("/api/v1/namespaces/test/pods/nginx").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
-      .withNewMetadata().withResourceVersion("12345").and().build()).once();
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
 
     Pod pod = client.pods().load(getClass().getResourceAsStream("/test-pod-create-from-load.yml")).createOrReplace();
     assertNotNull(pod);
     assertEquals("12345", pod.getMetadata().getResourceVersion());
-
 
     RecordedRequest request = server.getLastRequest();
     assertEquals("/api/v1/namespaces/test/pods/nginx", request.getPath());
@@ -205,74 +224,89 @@ class CreateOrReplaceResourceTest {
   @Test
   void testReplaceWithItemResourceVersion() throws Exception {
     server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1")
-      .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
-      .withNewMetadata().withResourceVersion("1001").and().build()).once();
+        .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
+            .withNewMetadata().withResourceVersion("1001").and().build())
+        .once();
 
     // when you try to replace with a resource version specified, it will try the existing one first
     ConfigMap map = client.configMaps().withName("map1").replace(new ConfigMapBuilder()
-      .withNewMetadata().withName("map1").withResourceVersion("1000").and().build());
+        .withNewMetadata().withName("map1").withResourceVersion("1000").and().build());
     assertNotNull(map);
     assertEquals("1001", map.getMetadata().getResourceVersion());
 
-    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class).readValue(server.getLastRequest().getBody().inputStream());
+    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class)
+        .readValue(server.getLastRequest().getBody().inputStream());
     assertEquals("1000", replacedMap.getMetadata().getResourceVersion());
   }
 
   @Test
   void testReplaceWithItemResourceVersionRetry() throws Exception {
-    server.expect().get().withPath("/api/v1/namespaces/test/configmaps/map1").andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
-      .withNewMetadata().withResourceVersion("1000").and().build()).always();
+    server.expect().get().withPath("/api/v1/namespaces/test/configmaps/map1")
+        .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
+            .withNewMetadata().withResourceVersion("1000").and().build())
+        .always();
 
     server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1")
-      .andReturn(HttpURLConnection.HTTP_CONFLICT, new StatusBuilder().withCode(HttpURLConnection.HTTP_CONFLICT).build()).once();
+        .andReturn(HttpURLConnection.HTTP_CONFLICT, new StatusBuilder().withCode(HttpURLConnection.HTTP_CONFLICT).build())
+        .once();
 
     server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1")
-      .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
-      .withNewMetadata().withResourceVersion("1001").and().build()).once();
+        .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
+            .withNewMetadata().withResourceVersion("1001").and().build())
+        .once();
 
     // when you try to replace with a resource version specified, it will try the existing one first
     ConfigMap map = client.configMaps().withName("map1").replace(new ConfigMapBuilder()
-      .withNewMetadata().withName("map1").withResourceVersion("999").and().build());
+        .withNewMetadata().withName("map1").withResourceVersion("999").and().build());
     assertNotNull(map);
     assertEquals("1001", map.getMetadata().getResourceVersion());
 
-    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class).readValue(server.getLastRequest().getBody().inputStream());
+    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class)
+        .readValue(server.getLastRequest().getBody().inputStream());
     assertEquals("1000", replacedMap.getMetadata().getResourceVersion());
   }
 
   @Test
   @DisplayName("Should replace an existing ConfigMap without lock")
   void testReplaceWithoutLock() throws Exception {
-    server.expect().get().withPath("/api/v1/namespaces/test/configmaps/map1").andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
-      .withNewMetadata().withResourceVersion("1000").and().build()).always();
+    server.expect().get().withPath("/api/v1/namespaces/test/configmaps/map1")
+        .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
+            .withNewMetadata().withResourceVersion("1000").and().build())
+        .always();
 
-    server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1").andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
-      .withNewMetadata().withResourceVersion("1001").and().build()).once();
+    server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1")
+        .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
+            .withNewMetadata().withResourceVersion("1001").and().build())
+        .once();
 
     ConfigMap original = new ConfigMapBuilder()
-      .withNewMetadata().withName("map1").and().build();
+        .withNewMetadata().withName("map1").and().build();
     ConfigMap map = client.configMaps().withName("map1").replace(original);
     assertNotNull(map);
     assertEquals("1001", map.getMetadata().getResourceVersion());
     assertNull(original.getMetadata().getResourceVersion());
 
-    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class).readValue(server.getLastRequest().getBody().inputStream());
+    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class)
+        .readValue(server.getLastRequest().getBody().inputStream());
     assertEquals("1000", replacedMap.getMetadata().getResourceVersion());
   }
 
   @Test
   @DisplayName("Should replace an existing resource with lock")
   void testReplaceWithLock() throws Exception {
-    server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1").andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
-      .withNewMetadata().withResourceVersion("1001").and().build()).once();
+    server.expect().put().withPath("/api/v1/namespaces/test/configmaps/map1")
+        .andReturn(HttpURLConnection.HTTP_OK, new ConfigMapBuilder()
+            .withNewMetadata().withResourceVersion("1001").and().build())
+        .once();
 
     ConfigMap map = client.configMaps().withName("map1")
-      .lockResourceVersion("900")
-      .replace(new ConfigMapBuilder().withNewMetadata().withName("map1").and().build());
+        .lockResourceVersion("900")
+        .replace(new ConfigMapBuilder().withNewMetadata().withName("map1").and().build());
     assertNotNull(map);
     assertEquals("1001", map.getMetadata().getResourceVersion());
 
-    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class).readValue(server.getLastRequest().getBody().inputStream());
+    ConfigMap replacedMap = new ObjectMapper().readerFor(ConfigMap.class)
+        .readValue(server.getLastRequest().getBody().inputStream());
     assertEquals("900", replacedMap.getMetadata().getResourceVersion());
   }
 
@@ -280,16 +314,17 @@ class CreateOrReplaceResourceTest {
   @DisplayName("Should delete an existing resource with lock")
   void testDeleteWithLock() throws Exception {
     server.expect().delete()
-      .withPath("/api/v1/namespaces/test/configmaps/map1")
-      .andReturn(HttpURLConnection.HTTP_OK, null)
-      .once();
+        .withPath("/api/v1/namespaces/test/configmaps/map1")
+        .andReturn(HttpURLConnection.HTTP_OK, null)
+        .once();
 
     Boolean deleted = client.configMaps().withName("map1")
-      .lockResourceVersion("800")
-      .delete();
+        .lockResourceVersion("800")
+        .delete();
     assertTrue(deleted);
 
-    DeleteOptions options = new ObjectMapper().readerFor(DeleteOptions.class).readValue(server.getLastRequest().getBody().inputStream());
+    DeleteOptions options = new ObjectMapper().readerFor(DeleteOptions.class)
+        .readValue(server.getLastRequest().getBody().inputStream());
     assertEquals("800", options.getPreconditions().getResourceVersion());
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
@@ -20,6 +20,8 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,31 +42,31 @@ class DeploymentCrudTest {
   void testCrud() {
 
     Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
-      .withName("deployment1")
-      .withNamespace("ns1")
-      .addToLabels("testKey", "testValue")
-      .endMetadata()
-      .withNewSpec()
-      .endSpec()
-      .build();
+        .withName("deployment1")
+        .withNamespace("ns1")
+        .addToLabels("testKey", "testValue")
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
 
     Deployment deployment2 = new DeploymentBuilder().withNewMetadata()
-      .withName("deployment2")
-      .withNamespace("ns1")
-      .addToLabels("testKey", "testValue")
-      .endMetadata()
-      .withNewSpec()
-      .endSpec()
-      .build();
+        .withName("deployment2")
+        .withNamespace("ns1")
+        .addToLabels("testKey", "testValue")
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
 
     Deployment deployment3 = new DeploymentBuilder().withNewMetadata()
-      .withName("deployment3")
-      .addToLabels("testKey", "testValue")
-      .withNamespace("ns2")
-      .endMetadata()
-      .withNewSpec()
-      .endSpec()
-      .build();
+        .withName("deployment3")
+        .addToLabels("testKey", "testValue")
+        .withNamespace("ns2")
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
 
     client.apps().deployments().inNamespace("ns1").create(deployment1);
     client.apps().deployments().inNamespace("ns1").create(deployment2);
@@ -78,23 +80,23 @@ class DeploymentCrudTest {
     assertNotNull(aDeploymentList);
     assertEquals(2, aDeploymentList.getItems().size());
 
-    aDeploymentList = client.apps()
-      .deployments()
-      .inAnyNamespace()
-      .withLabels(Collections.singletonMap("testKey", "testValue"))
-      .list();
+    FilterWatchListDeletable<Deployment, DeploymentList, RollableScalableResource<Deployment>> withLabels = client.apps()
+        .deployments()
+        .inAnyNamespace()
+        .withLabels(Collections.singletonMap("testKey", "testValue"));
+    aDeploymentList = withLabels.list();
     assertNotNull(aDeploymentList);
     assertEquals(3, aDeploymentList.getItems().size());
 
+    assertEquals(3, withLabels.resources().count());
 
     boolean bDeleted = client.apps().deployments().inNamespace("ns2").withName("deployment3").delete();
     assertTrue(bDeleted);
 
-
     deployment2 = client.apps().deployments()
-      .inNamespace("ns1").withName("deployment2").edit(d -> new DeploymentBuilder(d)
-      .editMetadata().addToLabels("key1", "value1").endMetadata()
-      .build());
+        .inNamespace("ns1").withName("deployment2").edit(d -> new DeploymentBuilder(d)
+            .editMetadata().addToLabels("key1", "value1").endMetadata()
+            .build());
 
     assertNotNull(deployment2);
     assertEquals("value1", deployment2.getMetadata().getLabels().get("key1"));
@@ -105,13 +107,13 @@ class DeploymentCrudTest {
   void testReplace() {
     // Given
     Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
-      .withName("d1")
-      .withNamespace("ns1")
-      .addToLabels("testKey", "testValue")
-      .endMetadata()
-      .withNewSpec()
-      .endSpec()
-      .build();
+        .withName("d1")
+        .withNamespace("ns1")
+        .addToLabels("testKey", "testValue")
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
     deployment1 = client.apps().deployments().inNamespace("ns1").create(deployment1);
 
     // When
@@ -125,4 +127,3 @@ class DeploymentCrudTest {
     assertEquals("one", replacedDeployment.getMetadata().getLabels().get("testKey"));
   }
 }
-

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetadataCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetadataCrudTest.java
@@ -40,7 +40,7 @@ class MetadataCrudTest {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build();
     Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").addToLabels("testKey", "testValue").endMetadata().build();
 
-    NonNamespaceOperation<Pod, PodList, PodResource<Pod>> podClient = client.pods().inNamespace("ns1");
+    NonNamespaceOperation<Pod, PodList, PodResource> podClient = client.pods().inNamespace("ns1");
     pod1 = podClient.create(pod1);
     pod2 = podClient.create(pod2);
 
@@ -55,7 +55,7 @@ class MetadataCrudTest {
     assertEquals("1", pod1.getMetadata().getResourceVersion());
 
     // should increment
-    pod1 = podClient.withName("pod1").editStatus(p->new PodBuilder(p).withStatus(new PodStatus()).build());
+    pod1 = podClient.withName("pod1").editStatus(p -> new PodBuilder(p).withStatus(new PodStatus()).build());
     assertEquals("3", pod1.getMetadata().getResourceVersion());
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -88,16 +88,16 @@ class PodTest {
 
   @Test
   void testList() {
-   server.expect().withPath("/api/v1/namespaces/test/pods").andReturn(200, new PodListBuilder().build()).once();
-   server.expect().withPath("/api/v1/namespaces/ns1/pods").andReturn(200, new PodListBuilder()
-      .addNewItem().and()
-      .addNewItem().and().build()).once();
+    server.expect().withPath("/api/v1/namespaces/test/pods").andReturn(200, new PodListBuilder().build()).once();
+    server.expect().withPath("/api/v1/namespaces/ns1/pods").andReturn(200, new PodListBuilder()
+        .addNewItem().and()
+        .addNewItem().and().build()).once();
 
-   server.expect().withPath("/api/v1/pods").andReturn(200, new PodListBuilder()
-      .addNewItem().and()
-      .addNewItem().and()
-      .addNewItem()
-      .and().build()).once();
+    server.expect().withPath("/api/v1/pods").andReturn(200, new PodListBuilder()
+        .addNewItem().and()
+        .addNewItem().and()
+        .addNewItem()
+        .and().build()).once();
 
     PodList podList = client.pods().list();
     assertNotNull(podList);
@@ -114,27 +114,30 @@ class PodTest {
 
   @Test
   void testListWithLabels() {
-   server.expect().withPath("/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3=value3")).andReturn(200, new PodListBuilder().build()).always();
-   server.expect().withPath("/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2")).andReturn(200, new PodListBuilder()
-      .addNewItem().and()
-      .addNewItem().and()
-      .addNewItem().and()
-      .build()).once();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3=value3"))
+        .andReturn(200, new PodListBuilder().build()).always();
+    server.expect().withPath("/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2"))
+        .andReturn(200, new PodListBuilder()
+            .addNewItem().and()
+            .addNewItem().and()
+            .addNewItem().and()
+            .build())
+        .once();
 
     PodList podList = client.pods()
-      .withLabel("key1", "value1")
-      .withLabel("key2","value2")
-      .withLabel("key3","value3")
-      .list();
-
+        .withLabel("key1", "value1")
+        .withLabel("key2", "value2")
+        .withLabel("key3", "value3")
+        .list();
 
     assertNotNull(podList);
     assertEquals(0, podList.getItems().size());
 
     podList = client.pods()
-      .withLabel("key1", "value1")
-      .withLabel("key2","value2")
-      .list();
+        .withLabel("key1", "value1")
+        .withLabel("key2", "value2")
+        .list();
 
     assertNotNull(podList);
     assertEquals(3, podList.getItems().size());
@@ -142,22 +145,24 @@ class PodTest {
 
   @Test
   void testListWithFields() {
-   server.expect().withPath("/api/v1/namespaces/test/pods?fieldSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3!=value3,key3!=value4")).andReturn(200, new PodListBuilder()
-      .addNewItem().and()
-      .addNewItem().and()
-      .build()).once();
+    server.expect().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3!=value3,key3!=value4"))
+        .andReturn(200, new PodListBuilder()
+            .addNewItem().and()
+            .addNewItem().and()
+            .build())
+        .once();
 
     PodList podList = client.pods()
-      .withField("key1", "value1")
-      .withField("key2","value2")
-      .withoutField("key3","value3")
-      .withoutField("key3", "value4")
-      .list();
+        .withField("key1", "value1")
+        .withField("key2", "value2")
+        .withoutField("key3", "value3")
+        .withoutField("key3", "value4")
+        .list();
 
     assertNotNull(podList);
     assertEquals(2, podList.getItems().size());
   }
-
 
   @Test
   void testEditMissing() {
@@ -165,7 +170,7 @@ class PodTest {
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(404, "error message from kubernetes").always();
 
     // When
-    PodResource<Pod> podOp = client.pods().withName("pod1");
+    PodResource podOp = client.pods().withName("pod1");
 
     // Then
     Assertions.assertThrows(KubernetesClientException.class, () -> podOp.edit(p -> p));
@@ -173,9 +178,8 @@ class PodTest {
 
   @Test
   void testDelete() {
-   server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder().build()).once();
-   server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, new PodBuilder().build()).once();
-
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder().build()).once();
+    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, new PodBuilder().build()).once();
 
     Boolean deleted = client.pods().withName("pod1").delete();
     assertTrue(deleted);
@@ -193,8 +197,8 @@ class PodTest {
     Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("ns1").and().build();
     Pod pod3 = new PodBuilder().withNewMetadata().withName("pod3").withNamespace("any").and().build();
 
-   server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
-   server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, pod2).once();
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
+    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, pod2).once();
 
     Boolean deleted = client.pods().inAnyNamespace().delete(pod1, pod2);
     assertTrue(deleted);
@@ -209,7 +213,7 @@ class PodTest {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
     // When + Then
-    NonNamespaceOperation<Pod, PodList, PodResource<Pod>> podOp = client.pods().inNamespace("test1");
+    NonNamespaceOperation<Pod, PodList, PodResource> podOp = client.pods().inNamespace("test1");
     assertFalse(podOp.delete(pod1));
   }
 
@@ -218,7 +222,8 @@ class PodTest {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
 
-    Boolean deleted = client.pods().inNamespace("test").withName("pod1").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+    Boolean deleted = client.pods().inNamespace("test").withName("pod1").withPropagationPolicy(DeletionPropagation.FOREGROUND)
+        .delete();
     assertTrue(deleted);
   }
 
@@ -226,7 +231,8 @@ class PodTest {
   void testEvict() {
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1/eviction").andReturn(200, new PodBuilder().build()).once();
     server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2/eviction").andReturn(200, new PodBuilder().build()).once();
-    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod3/eviction").andReturn(PodOperationsImpl.HTTP_TOO_MANY_REQUESTS, new PodBuilder().build()).once();
+    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod3/eviction")
+        .andReturn(PodOperationsImpl.HTTP_TOO_MANY_REQUESTS, new PodBuilder().build()).once();
     server.expect().withPath("/api/v1/namespaces/ns1/pods/pod3/eviction").andReturn(200, new PodBuilder().build()).once();
     server.expect().withPath("/api/v1/namespaces/ns1/pods/pod4/eviction").andReturn(500, new PodBuilder().build()).once();
 
@@ -234,7 +240,7 @@ class PodTest {
     assertTrue(deleted);
 
     // not found
-    PodResource<Pod> podResource = client.pods().withName("pod2");
+    PodResource podResource = client.pods().withName("pod2");
     assertThrows(KubernetesClientException.class, () -> podResource.evict());
 
     deleted = client.pods().inNamespace("ns1").withName("pod2").evict();
@@ -248,7 +254,7 @@ class PodTest {
     assertTrue(deleted);
 
     // unhandled error
-    PodResource<Pod> resource = client.pods().inNamespace("ns1").withName("pod4");
+    PodResource resource = client.pods().inNamespace("ns1").withName("pod4");
     assertThrows(KubernetesClientException.class, resource::evict);
   }
 
@@ -256,9 +262,9 @@ class PodTest {
   void testEvictWithPolicyV1Eviction() {
     // Given
     server.expect().post()
-      .withPath("/api/v1/namespaces/ns1/pods/foo/eviction")
-      .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().build())
-      .once();
+        .withPath("/api/v1/namespaces/ns1/pods/foo/eviction")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().build())
+        .once();
 
     // When
     boolean evicted = client.pods().inNamespace("ns1").withName("foo").evict(new EvictionBuilder()
@@ -267,7 +273,7 @@ class PodTest {
         .withNamespace("ns1")
         .endMetadata()
         .withDeleteOptions(new DeleteOptionsBuilder().build())
-      .build());
+        .build());
 
     // Then
     assertTrue(evicted);
@@ -277,7 +283,7 @@ class PodTest {
   void testCreateWithNameMismatch() {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-    PodResource<Pod> podOp = client.pods().inNamespace("test1").withName("mypod1");
+    PodResource podOp = client.pods().inNamespace("test1").withName("mypod1");
     Assertions.assertThrows(KubernetesClientException.class, () -> podOp.create(pod1));
   }
 
@@ -288,12 +294,16 @@ class PodTest {
     String pod3Log = "pod3Log";
     String pod4Log = "pod4Log";
 
-   server.expect().withPath("/api/v1/namespaces/test/pods/pod1/log?pretty=true").andReturn(200, pod1Log).once();
-   server.expect().withPath("/api/v1/namespaces/test/pods/pod2/log?pretty=false").andReturn(200, pod2Log).once();
-   server.expect().withPath("/api/v1/namespaces/test/pods/pod3/log?pretty=false&container=cnt3").andReturn(200, pod3Log).once();
-   server.expect().withPath("/api/v1/namespaces/test4/pods/pod4/log?pretty=true&container=cnt4").andReturn(200, pod4Log).once();
-   server.expect().withPath("/api/v1/namespaces/test4/pods/pod1/log?pretty=false&limitBytes=100").andReturn(200, pod1Log).once();
-   server.expect().withPath("/api/v1/namespaces/test5/pods/pod1/log?pretty=false&tailLines=1&timestamps=true").andReturn(200, pod1Log).once();
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod1/log?pretty=true").andReturn(200, pod1Log).once();
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod2/log?pretty=false").andReturn(200, pod2Log).once();
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod3/log?pretty=false&container=cnt3").andReturn(200, pod3Log)
+        .once();
+    server.expect().withPath("/api/v1/namespaces/test4/pods/pod4/log?pretty=true&container=cnt4").andReturn(200, pod4Log)
+        .once();
+    server.expect().withPath("/api/v1/namespaces/test4/pods/pod1/log?pretty=false&limitBytes=100").andReturn(200, pod1Log)
+        .once();
+    server.expect().withPath("/api/v1/namespaces/test5/pods/pod1/log?pretty=false&tailLines=1&timestamps=true")
+        .andReturn(200, pod1Log).once();
 
     String log = client.pods().withName("pod1").getLog(true);
     assertEquals(pod1Log, log);
@@ -318,10 +328,10 @@ class PodTest {
   void testExec() throws InterruptedException {
     String expectedOutput = "file1 file2";
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1/exec?command=ls&stdout=true")
-            .andUpgradeToWebSocket()
-                .open(new OutputStreamMessage(expectedOutput))
-                .done()
-            .always();
+        .andUpgradeToWebSocket()
+        .open(new OutputStreamMessage(expectedOutput))
+        .done()
+        .always();
 
     final CountDownLatch execLatch = new CountDownLatch(1);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -344,30 +354,29 @@ class PodTest {
     watch.close();
   }
 
-
   @Test
   void testWatch() throws InterruptedException {
     // Given
     //We start with a list
     Pod pod1 = new PodBuilder()
-      .withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .endMetadata()
-      .build();
+        .withNewMetadata()
+        .withName("pod1")
+        .withResourceVersion("1")
+        .endMetadata()
+        .build();
     server.expect().withPath("/api/v1/namespaces/test/pods").andReturn(200, new PodListBuilder()
-      .withNewMetadata()
-      .withResourceVersion("1")
-      .endMetadata()
-      .addToItems(pod1)
-      .build()
-    ).once();
-    server.expect().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket()
-      .open()
-      .waitFor(50).andEmit(new WatchEvent(pod1, "DELETED"))
-      .done()
-      .always();
+        .withNewMetadata()
+        .withResourceVersion("1")
+        .endMetadata()
+        .addToItems(pod1)
+        .build()).once();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(50).andEmit(new WatchEvent(pod1, "DELETED"))
+        .done()
+        .always();
     final CountDownLatch deleteLatch = new CountDownLatch(1);
     final Watcher<Pod> watcher = new Watcher<Pod>() {
       @Override
@@ -389,11 +398,10 @@ class PodTest {
     watch.close();
   }
 
-
   @Test
   void testGetLogNotFound() {
     // Given
-    PodResource<Pod> podOp = client.pods().withName("pod5");
+    PodResource podOp = client.pods().withName("pod5");
 
     // When + Then
     Assertions.assertThrows(KubernetesClientException.class, () -> podOp.getLog(true));
@@ -408,39 +416,41 @@ class PodTest {
   @Test
   void testWait() throws InterruptedException {
     Pod notReady = new PodBuilder()
-      .withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test")
-      .endMetadata()
-      .withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
-
+        .withNewMetadata()
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .endMetadata()
+        .withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("False")
+        .endCondition()
+        .endStatus()
+        .build();
 
     Pod ready = new PodBuilder(notReady)
-      .editMetadata()
-      .withResourceVersion("2")
-      .endMetadata()
-      .withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+        .editMetadata()
+        .withResourceVersion("2")
+        .endMetadata()
+        .withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .endStatus()
+        .build();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, notReady).once();
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, notReady)
+        .once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(50).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(50).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod result = client.pods().withName("pod1").waitUntilReady(5, TimeUnit.SECONDS);
     Assert.assertEquals("2", result.getMetadata().getResourceVersion());
@@ -449,19 +459,18 @@ class PodTest {
   @Test
   void testPortForward() throws IOException {
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1/portforward?ports=123")
-      .andUpgradeToWebSocket()
-      .open()
-      .waitFor(10).andEmit(portForwardEncode(true, "12")) // data channel info
-      .waitFor(10).andEmit(portForwardEncode(false, "12")) // error channel info
-      .waitFor(10).andEmit(portForwardEncode(true, "Hell"))
-      .waitFor(10).andEmit(portForwardEncode(true, "o World"))
-      .done()
-      .once();
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(10).andEmit(portForwardEncode(true, "12")) // data channel info
+        .waitFor(10).andEmit(portForwardEncode(false, "12")) // error channel info
+        .waitFor(10).andEmit(portForwardEncode(true, "Hell"))
+        .waitFor(10).andEmit(portForwardEncode(true, "o World"))
+        .done()
+        .once();
 
-    try(
-      LocalPortForward portForward = client.pods().withName("pod1").portForward(123);
-      SocketChannel channel = SocketChannel.open()
-    ) {
+    try (
+        LocalPortForward portForward = client.pods().withName("pod1").portForward(123);
+        SocketChannel channel = SocketChannel.open()) {
       int localPort = portForward.getLocalPort();
       assertTrue(channel.connect(new InetSocketAddress("localhost", localPort)));
 
@@ -479,7 +488,7 @@ class PodTest {
           }
           read = -1;
         }
-      } while(read >= 0);
+      } while (read >= 0);
       buffer.flip();
       channel.socket().close();
       assertEquals("Hello World", ByteString.of(buffer).utf8());
@@ -493,14 +502,14 @@ class PodTest {
   void testPortForwardWithChannel() throws InterruptedException, IOException {
 
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1/portforward?ports=123")
-      .andUpgradeToWebSocket()
-      .open()
-      .waitFor(10).andEmit(portForwardEncode(true, "12")) // data channel info
-      .waitFor(10).andEmit(portForwardEncode(false, "12")) // error channel info
-      .waitFor(10).andEmit(portForwardEncode(true, "Hell"))
-      .waitFor(10).andEmit(portForwardEncode(true, "o World!"))
-      .done()
-      .once();
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(10).andEmit(portForwardEncode(true, "12")) // data channel info
+        .waitFor(10).andEmit(portForwardEncode(false, "12")) // error channel info
+        .waitFor(10).andEmit(portForwardEncode(true, "Hell"))
+        .waitFor(10).andEmit(portForwardEncode(true, "o World!"))
+        .done()
+        .once();
 
     ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
     ReadableByteChannel inChannel = Channels.newChannel(in);
@@ -508,8 +517,8 @@ class PodTest {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     WritableByteChannel outChannel = Channels.newChannel(out);
 
-    try(PortForward portForward = client.pods().withName("pod1").portForward(123, inChannel, outChannel)) {
-      while(portForward.isAlive()) {
+    try (PortForward portForward = client.pods().withName("pod1").portForward(123, inChannel, outChannel)) {
+      while (portForward.isAlive()) {
         Thread.sleep(100);
       }
     }
@@ -542,27 +551,27 @@ class PodTest {
   @Test
   void testListFromServer() {
     PodBuilder podBuilder = new PodBuilder()
-      .withNewMetadata()
+        .withNewMetadata()
         .withNamespace("test")
         .withName("pod1")
-      .endMetadata();
+        .endMetadata();
 
     Pod clientPod = podBuilder.build();
     Pod serverPod = podBuilder
-      .editMetadata()
+        .editMetadata()
         .withResourceVersion("1")
-      .endMetadata()
-      .withNewStatus()
+        .endMetadata()
+        .withNewStatus()
         .addNewCondition()
-          .withType("Ready")
-          .withStatus("True")
+        .withType("Ready")
+        .withStatus("True")
         .endCondition()
-      .endStatus()
-      .build();
+        .endStatus()
+        .build();
 
     server.expect().get()
-      .withPath("/api/v1/namespaces/test/pods/pod1")
-      .andReturn(200, serverPod).once();
+        .withPath("/api/v1/namespaces/test/pods/pod1")
+        .andReturn(200, serverPod).once();
 
     List<HasMetadata> resources = client.resourceList(clientPod).fromServer().get();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -112,33 +112,33 @@ class ResourceTest {
     assertThrows(KubernetesClientException.class, podOperation::createOrReplace);
   }
 
-    @Test
-    void testCreateWithExplicitNamespace() {
-      Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+  @Test
+  void testCreateWithExplicitNamespace() {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-      server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
 
-      HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
-      assertEquals(pod1, response);
-    }
+    HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
+    assertEquals(pod1, response);
+  }
 
-    @Test
-    void testCreateOrReplaceWithDeleteExisting() throws Exception {
-      Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+  @Test
+  void testCreateOrReplaceWithDeleteExisting() throws Exception {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-      server.expect().delete().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
-      server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().delete().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
 
-      Resource<Pod> resource = client.resource(pod1).inNamespace("ns1");
-      resource.delete();
-      HasMetadata response = resource.createOrReplace();
-      assertEquals(pod1, response);
+    Resource<Pod> resource = client.resource(pod1).inNamespace("ns1");
+    resource.delete();
+    HasMetadata response = resource.createOrReplace();
+    assertEquals(pod1, response);
 
-      RecordedRequest request = server.getLastRequest();
-      assertEquals(2, server.getRequestCount());
-      assertEquals("/api/v1/namespaces/ns1/pods", request.getPath());
-      assertEquals("POST", request.getMethod());
-    }
+    RecordedRequest request = server.getLastRequest();
+    assertEquals(2, server.getRequestCount());
+    assertEquals("/api/v1/namespaces/ns1/pods", request.getPath());
+    assertEquals("POST", request.getMethod());
+  }
 
   @Test
   void itPassesPropagationPolicyWithDeleteExisting() throws InterruptedException {
@@ -178,13 +178,13 @@ class ResourceTest {
     assertThrows(KubernetesClientException.class, podOperation::createOrReplace);
   }
 
-    @Test
-    void testRequire() {
-      server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_NOT_FOUND, "").once();
-      PodResource<Pod> podOp = client.pods().inNamespace("ns1").withName("pod1");
+  @Test
+  void testRequire() {
+    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_NOT_FOUND, "").once();
+    PodResource podOp = client.pods().inNamespace("ns1").withName("pod1");
 
-      Assertions.assertThrows(ResourceNotFoundException.class, podOp::require);
-    }
+    Assertions.assertThrows(ResourceNotFoundException.class, podOp::require);
+  }
 
   @Test
   void testDelete() {
@@ -192,8 +192,8 @@ class ResourceTest {
     Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("ns1").and().build();
     Pod pod3 = new PodBuilder().withNewMetadata().withName("pod3").withNamespace("any").and().build();
 
-   server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
-   server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, pod2).once();
+    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
+    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, pod2).once();
 
     Boolean deleted = client.resource(pod1).delete();
     assertTrue(deleted);
@@ -204,22 +204,23 @@ class ResourceTest {
     assertFalse(deleted);
   }
 
-
   @Test
   void testWatch() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
         .withName("pod1")
         .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withNamespace("test").and().build();
 
-      server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pod1).once();
-      server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, pod1).once();
+    server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, pod1).once();
 
-     server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
+    server.expect().get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
         .open()
-          .waitFor(1000).andEmit(new WatchEvent(pod1, "DELETED"))
+        .waitFor(1000).andEmit(new WatchEvent(pod1, "DELETED"))
         .done()
-      .always();
+        .always();
 
     final CountDownLatch latch = new CountDownLatch(1);
 
@@ -238,25 +239,25 @@ class ResourceTest {
     watch.close();
   }
 
-
   @Test
   void testWaitUntilReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
     Pod noReady = createReadyFrom(pod1, "False");
     Pod ready = createReadyFrom(pod1, "True");
 
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -269,7 +270,8 @@ class ResourceTest {
   static void list(KubernetesMockServer server, Pod pod) {
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/"+pod.getMetadata().getNamespace()+"/pods?fieldSelector=metadata.name%3D"+pod.getMetadata().getName())
+        .withPath("/api/v1/namespaces/" + pod.getMetadata().getNamespace() + "/pods?fieldSelector=metadata.name%3D"
+            + pod.getMetadata().getName())
         .andReturn(200,
             new PodListBuilder().withItems(pod).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
@@ -278,22 +280,24 @@ class ResourceTest {
   @Test
   void testWaitUntilExistsThenReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
     Pod noReady = createReadyFrom(pod1, "False");
     Pod ready = createReadyFrom(pod1, "True");
 
     // and again so that "periodicWatchUntilReady" successfully begins
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, noReady).times(2);
+    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, noReady)
+        .times(2);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(100).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(100).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.pods().withName("pod1").waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -302,84 +306,86 @@ class ResourceTest {
   @Test
   void testWaitUntilCondition() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
     Pod noReady = createReadyFrom(pod1, "False");
     Pod ready = createReadyFrom(pod1, "True");
 
     Pod withConditionBeingFalse = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .addNewCondition()
-      .withType("dummy")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .addNewCondition()
+        .withType("dummy")
+        .withStatus("False")
+        .endCondition()
+        .endStatus()
+        .build();
 
     Pod withConditionBeingTrue = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .addNewCondition()
-      .withType("Dummy")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .addNewCondition()
+        .withType("Dummy")
+        .withStatus("True")
+        .endCondition()
+        .endStatus()
+        .build();
 
     // at first the pod is non-ready
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .waitFor(2000).andEmit(new WatchEvent(withConditionBeingFalse, "MODIFIED"))
-      .waitFor(2500).andEmit(new WatchEvent(withConditionBeingTrue, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .waitFor(2000).andEmit(new WatchEvent(withConditionBeingFalse, "MODIFIED"))
+        .waitFor(2500).andEmit(new WatchEvent(withConditionBeingTrue, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.pods().withName("pod1").waitUntilCondition(
-      r -> r.getStatus().getConditions()
+        r -> r.getStatus().getConditions()
             .stream()
             .anyMatch(c -> "Dummy".equals(c.getType()) && "True".equals(c.getStatus())),
-      8, SECONDS
-    );
+        8, SECONDS);
 
     assertThat(p.getStatus().getConditions())
-      .extracting("type", "status")
-      .containsExactly(tuple("Ready", "True"), tuple("Dummy", "True"));
+        .extracting("type", "status")
+        .containsExactly(tuple("Ready", "True"), tuple("Dummy", "True"));
   }
 
   @Test
   void tesErrorEventDuringWaitReturnFromAPIIfMatch() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
     Pod noReady = createReadyFrom(pod1, "False");
     Pod ready = createReadyFrom(pod1, "True");
 
     Status status = new StatusBuilder()
-      .withCode(HttpURLConnection.HTTP_FORBIDDEN)
-      .build();
+        .withCode(HttpURLConnection.HTTP_FORBIDDEN)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
+        .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .once();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -388,32 +394,35 @@ class ResourceTest {
   @Test
   void testRetryOnErrorEventDuringWait() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
     Pod noReady = createReadyFrom(pod1, "False");
     Pod ready = createReadyFrom(pod1, "True");
 
     Status status = new StatusBuilder()
-      .withCode(HttpURLConnection.HTTP_FORBIDDEN)
-      .build();
+        .withCode(HttpURLConnection.HTTP_FORBIDDEN)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
+        .done()
+        .once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .once();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .once();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -422,9 +431,9 @@ class ResourceTest {
   @Test
   void testSkipWatchIfAlreadyMatchingCondition() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
     Pod noReady = createReadyFrom(pod1, "False");
     Pod ready = createReadyFrom(pod1, "True");
@@ -447,17 +456,19 @@ class ResourceTest {
     Pod ready = createReadyFrom(pod1, "True");
 
     Status status = new StatusBuilder()
-      .withCode(HTTP_GONE)
-      .build();
+        .withCode(HTTP_GONE)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
+        .done()
+        .once();
 
     list(ready);
 
@@ -467,35 +478,36 @@ class ResourceTest {
   @Test
   void testWaitOnConditionDeleted() throws InterruptedException {
     Pod ready = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .endStatus()
+        .build();
 
     list(ready);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "DELETED"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000).andEmit(new WatchEvent(ready, "DELETED"))
+        .done()
+        .once();
 
-
-    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull,8, SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 8, SECONDS);
     assertNull(p);
   }
 
   @Test
   void testCreateAndWaitUntilReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test").and().build();
 
     Pod noReady = createReadyFrom(pod1, "False");
     Pod ready = createReadyFrom(pod1, "True");
@@ -503,12 +515,13 @@ class ResourceTest {
     list(noReady);
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, noReady).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     NamespaceableResource<Pod> resource = client.resource(noReady);
     resource.create();
@@ -519,14 +532,13 @@ class ResourceTest {
   @Test
   void testFromServerGet() {
     Pod pod = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withNamespace("test")
-      .withResourceVersion("1")
-      .and()
-      .build();
+        .withName("pod1")
+        .withNamespace("test")
+        .withResourceVersion("1")
+        .and()
+        .build();
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod).once();
-
 
     HasMetadata response = client.resource(pod).fromServer().get();
     assertEquals(pod, response);
@@ -537,28 +549,29 @@ class ResourceTest {
   void testFromServerWaitUntilConditionAlwaysGetsResourceFromServer() throws Exception {
     // Given
     final Pod conditionNotMetPod = new PodBuilder().withNewMetadata()
-      .withName("pod")
-      .withNamespace("test")
-      .addToLabels("CONDITION", "NOT_MET")
-      .endMetadata().build();
+        .withName("pod")
+        .withNamespace("test")
+        .addToLabels("CONDITION", "NOT_MET")
+        .endMetadata().build();
     final Pod conditionMetPod = new PodBuilder().withNewMetadata()
-      .withName("pod")
-      .withNamespace("test")
-      .withResourceVersion("1")
-      .addToLabels("CONDITION", "MET")
-      .endMetadata()
-      .build();
+        .withName("pod")
+        .withNamespace("test")
+        .withResourceVersion("1")
+        .addToLabels("CONDITION", "MET")
+        .endMetadata()
+        .build();
     list(conditionNotMetPod);
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket().open()
-      .immediately().andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
-      .waitFor(10).andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
-      .done()
-      .once();
+    server.expect().get().withPath(
+        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket().open()
+        .immediately().andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
+        .waitFor(10).andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
+        .done()
+        .once();
     // When
     HasMetadata response = client
-      .resource(new PodBuilder(conditionMetPod).build())
-      .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
+        .resource(new PodBuilder(conditionMetPod).build())
+        .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
     // Then
     assertEquals(conditionMetPod, response);
     assertEquals(2, server.getRequestCount());
@@ -567,11 +580,11 @@ class ResourceTest {
   @Test
   void testWaitNullDoesntExist() throws InterruptedException {
     server.expect()
-      .get()
-      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
-      .andReturn(200,
-        new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
-      .once();
+        .get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .andReturn(200,
+            new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
+        .once();
 
     Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 1, SECONDS);
     assertNull(p);
@@ -579,13 +592,12 @@ class ResourceTest {
 
   private static Pod createReadyFrom(Pod pod, String status) {
     return new PodBuilder(pod)
-      .withNewStatus()
+        .withNewStatus()
         .addNewCondition()
-          .withType("Ready")
-          .withStatus(status)
+        .withType("Ready")
+        .withStatus(status)
         .endCondition()
-      .endStatus()
-      .build();
+        .endStatus()
+        .build();
   }
 }
-

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NamespacedItemTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NamespacedItemTest.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class NamespacedItemTest {
   private OpenShiftClient client;
 
@@ -40,7 +41,7 @@ class NamespacedItemTest {
   void testDefaultNamespace() {
     ConfigMap created = this.client
         .configMaps()
-        .withItem(configmap)
+        .resource(configmap)
         .create();
 
     // should create in the item namespace rather than the default - no exception
@@ -53,7 +54,7 @@ class NamespacedItemTest {
         .inNamespace("explicit");
     ConfigMap created = inNamespace
         .configMaps()
-        .withItem(configmap)
+        .resource(configmap)
         .create();
 
     assertEquals("explicit", inNamespace.getNamespace());
@@ -67,7 +68,7 @@ class NamespacedItemTest {
     ConfigMap created = this.client
         .configMaps()
         .inNamespace("explicit")
-        .withItem(configmap)
+        .resource(configmap)
         .create();
 
     // should create in the explicit, rather than the item - no exception
@@ -76,7 +77,7 @@ class NamespacedItemTest {
     ConfigMap modified = this.client
         .configMaps()
         .inNamespace("explicit")
-        .withItem(configmap)
+        .resource(configmap)
         .get();
 
     // should create in the explicit, rather than the item - no exception

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -259,15 +259,15 @@ public class DeploymentConfigOperationsImpl
 
   private void waitUntilDeploymentConfigPodBecomesReady(DeploymentConfig deploymentConfig) {
     Integer podLogWaitTimeout = rollingOperationContext.getLogWaitTimeout();
-    List<PodResource<Pod>> podOps = PodOperationUtil.getPodOperationsForController(context,
+    List<PodResource> podOps = PodOperationUtil.getPodOperationsForController(context,
         deploymentConfig.getMetadata().getUid(),
         getDeploymentConfigPodLabels(deploymentConfig), false, podLogWaitTimeout, rollingOperationContext.getContainerId());
 
     waitForBuildPodToBecomeReady(podOps, podLogWaitTimeout != null ? podLogWaitTimeout : DEFAULT_POD_LOG_WAIT_TIMEOUT);
   }
 
-  private static void waitForBuildPodToBecomeReady(List<PodResource<Pod>> podOps, Integer podLogWaitTimeout) {
-    for (PodResource<Pod> podOp : podOps) {
+  private static void waitForBuildPodToBecomeReady(List<PodResource> podOps, Integer podLogWaitTimeout) {
+    for (PodResource podOp : podOps) {
       PodOperationUtil.waitUntilReadyBeforeFetchingLogs(podOp, podLogWaitTimeout);
     }
   }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
@@ -136,7 +136,7 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
 
   /**
    * Returns an unclosed Reader. It's the caller responsibility to close it.
-   * 
+   *
    * @return Reader
    */
   @Override
@@ -205,14 +205,14 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
   }
 
   private void waitUntilBuildPodBecomesReady(Build build) {
-    List<PodResource<Pod>> podOps = PodOperationUtil.getPodOperationsForController(context, build.getMetadata().getUid(),
+    List<PodResource> podOps = PodOperationUtil.getPodOperationsForController(context, build.getMetadata().getUid(),
         getBuildPodLabels(build), withPrettyOutput, podLogWaitTimeout, null);
 
     waitForBuildPodToBecomeReady(podOps, podLogWaitTimeout != null ? podLogWaitTimeout : DEFAULT_POD_LOG_WAIT_TIMEOUT);
   }
 
-  private static void waitForBuildPodToBecomeReady(List<PodResource<Pod>> podOps, Integer podLogWaitTimeout) {
-    for (PodResource<Pod> podOp : podOps) {
+  private static void waitForBuildPodToBecomeReady(List<PodResource> podOps, Integer podLogWaitTimeout) {
+    for (PodResource podOp : podOps) {
       PodOperationUtil.waitUntilReadyBeforeFetchingLogs(podOp, podLogWaitTimeout);
     }
   }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -658,7 +658,7 @@ public class ManagedOpenShiftClient implements NamespacedOpenShiftClient {
   }
 
   @Override
-  public MixedOperation<Pod, PodList, PodResource<Pod>> pods() {
+  public MixedOperation<Pod, PodList, PodResource> pods() {
     return delegate.pods();
   }
 


### PR DESCRIPTION
## Description
This implements #3973, it is layered on top of the changes for #3875 to minimize conflicts - so only the last commit is of interest and this will get rebased prior to inclusion.

The change here is instead of withItem, we'll use resource, then instead getResources off of a resourceList, we'll use resources, and finally there's the addition of a convenience method resources, which serves the same purpose as the resourceList method.

This requires making watchlistdeletable more generic as we need the resource type.  It also makes podresource non-generic as that is not needed.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
