### PR TITLE
decoupling unmatched handling from kubernetesdeserializer

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegate.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegate.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.deser.SettableAnyProperty;
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -41,13 +40,13 @@ public class SettableBeanPropertyDelegate extends SettableBeanProperty {
 
   private final SettableBeanProperty delegate;
   private final SettableAnyProperty anySetter;
-  private final transient Supplier<Boolean> restrictToTemplates;
+  private final transient Supplier<Boolean> useAnySetter;
 
-  SettableBeanPropertyDelegate(SettableBeanProperty delegate, SettableAnyProperty anySetter, Supplier<Boolean> restrictToTemplates) {
+  SettableBeanPropertyDelegate(SettableBeanProperty delegate, SettableAnyProperty anySetter, Supplier<Boolean> useAnySetter) {
     super(delegate);
     this.delegate = delegate;
     this.anySetter = anySetter;
-    this.restrictToTemplates = restrictToTemplates;
+    this.useAnySetter = useAnySetter;
   }
 
   /**
@@ -55,7 +54,7 @@ public class SettableBeanPropertyDelegate extends SettableBeanProperty {
    */
   @Override
   public SettableBeanProperty withValueDeserializer(JsonDeserializer<?> deser) {
-    return new SettableBeanPropertyDelegate(delegate.withValueDeserializer(deser), anySetter, restrictToTemplates);
+    return new SettableBeanPropertyDelegate(delegate.withValueDeserializer(deser), anySetter, useAnySetter);
   }
 
   /**
@@ -63,7 +62,7 @@ public class SettableBeanPropertyDelegate extends SettableBeanProperty {
    */
   @Override
   public SettableBeanProperty withName(PropertyName newName) {
-    return new SettableBeanPropertyDelegate(delegate.withName(newName), anySetter, restrictToTemplates);
+    return new SettableBeanPropertyDelegate(delegate.withName(newName), anySetter, useAnySetter);
   }
 
   /**
@@ -71,7 +70,7 @@ public class SettableBeanPropertyDelegate extends SettableBeanProperty {
    */
   @Override
   public SettableBeanProperty withNullProvider(NullValueProvider nva) {
-    return new SettableBeanPropertyDelegate(delegate.withNullProvider(nva), anySetter, restrictToTemplates);
+    return new SettableBeanPropertyDelegate(delegate.withNullProvider(nva), anySetter, useAnySetter);
   }
 
   /**
@@ -171,9 +170,6 @@ public class SettableBeanPropertyDelegate extends SettableBeanProperty {
     if (anySetter == null) {
       return false;
     }
-    if (Boolean.TRUE.equals(restrictToTemplates.get()) ) {
-      return KubernetesDeserializer.isInTemplate();
-    }
-    return true;
+    return Boolean.TRUE.equals(useAnySetter.get());
   }
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegateTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/serialization/SettableBeanPropertyDelegateTest.java
@@ -46,7 +46,7 @@ class SettableBeanPropertyDelegateTest {
   void setUp() {
     delegateMock = mock(SettableBeanProperty.class, RETURNS_DEEP_STUBS);
     anySetterMock = mock(SettableAnyProperty.class);
-    settableBeanPropertyDelegate = new SettableBeanPropertyDelegate(delegateMock, anySetterMock, () -> false);
+    settableBeanPropertyDelegate = new SettableBeanPropertyDelegate(delegateMock, anySetterMock, () -> true);
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -75,17 +75,10 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
 
     }
 
-    private static final String TEMPLATE_CLASS_NAME = "io.fabric8.openshift.api.model.Template";
     private static final String KIND = "kind";
     private static final String API_VERSION = "apiVersion";
 
     private static final Mapping mapping = new Mapping();
-
-    private static final ThreadLocal<Boolean> IN_TEMPLATE = ThreadLocal.withInitial(() -> false);
-
-    public static boolean isInTemplate() {
-        return IN_TEMPLATE.get();
-    }
 
     @Override
     public KubernetesResource deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
@@ -121,18 +114,7 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
             if (resourceType == null) {
               return jp.getCodec().treeToValue(node, GenericKubernetesResource.class);
             } else if (KubernetesResource.class.isAssignableFrom(resourceType)){
-              boolean inTemplate = false;
-              if (TEMPLATE_CLASS_NAME.equals(resourceType.getName())) {
-                inTemplate = true;
-                IN_TEMPLATE.set(true);
-              }
-              try {
-                return jp.getCodec().treeToValue(node, resourceType);
-              } finally {
-                if (inTemplate) {
-                  IN_TEMPLATE.remove();
-                }
-              }
+              return jp.getCodec().treeToValue(node, resourceType);
             }
         }
         return null;


### PR DESCRIPTION
## Description
As either a stand alone change or part of one of the other serialization issues #3972 or #4024 I'd like to remove the coupling between the KubernetesDeserializer and the unmatched property handling.  This change elevates that to the Serialization level.  This will further allow us to change the handling of parsing / processing parameters - that has been embedded down in the serialization layer as raw string processing, but it doesn't need to be.  Parsing with unmatched type handling on, or parsing as a map would allow for post processing of property substitution.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
