### PR TITLE
fix: properly extract resource metadata from URI on HTTP request failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Configure SnakeYaml to ignore converting timestamps to Date objects
+* Fix #4049: properly populate exception metadata with resource information if available
 
 #### Improvements
 * Fix #4041: adding Quantity.getNumericalAmount with an explanation about bytes and cores.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientException.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientException.java
@@ -27,6 +27,7 @@ public class KubernetesClientException extends RuntimeException {
   private String version;
   private String resourcePlural;
   private String namespace;
+  private String name;
 
   public KubernetesClientException(String message) {
     super(message);
@@ -41,10 +42,11 @@ public class KubernetesClientException extends RuntimeException {
   }
 
   public KubernetesClientException(String message, int code, Status status) {
-    this(message, code, status, null, null, null, null);
+    this(message, code, status, null, null, null, null, null);
   }
 
-  public KubernetesClientException(String message, int code, Status status, String group, String version, String resourcePlural, String namespace) {
+  public KubernetesClientException(String message, int code, Status status, String group, String version, String resourcePlural,
+      String namespace, String name) {
     super(message);
     this.code = code;
     this.status = status;
@@ -52,14 +54,17 @@ public class KubernetesClientException extends RuntimeException {
     this.version = version;
     this.resourcePlural = resourcePlural;
     this.namespace = namespace;
+    this.name = name;
   }
 
-  public KubernetesClientException(String message, Throwable t, String group, String version, String resourcePlural, String namespace) {
+  public KubernetesClientException(String message, Throwable t, String group, String version, String resourcePlural,
+      String namespace, String name) {
     super(message, t);
     this.group = group;
     this.version = version;
     this.resourcePlural = resourcePlural;
     this.namespace = namespace;
+    this.name = name;
   }
 
   public Status getStatus() {
@@ -86,8 +91,12 @@ public class KubernetesClientException extends RuntimeException {
     return namespace;
   }
 
+  public String getName() {
+    return name;
+  }
+
   public String getFullResourceName() {
-    if(resourcePlural != null && group != null) {
+    if (resourcePlural != null && group != null) {
       return HasMetadata.getFullResourceName(resourcePlural, group);
     }
     return null;
@@ -99,7 +108,8 @@ public class KubernetesClientException extends RuntimeException {
 
   public static RuntimeException launderThrowable(String message, Throwable cause) {
     RuntimeException processed = processCause(cause);
-    if (processed != null) return processed;
+    if (processed != null)
+      return processed;
     throw new KubernetesClientException(message, cause);
   }
 
@@ -116,7 +126,8 @@ public class KubernetesClientException extends RuntimeException {
 
   public static RuntimeException launderThrowable(OperationInfo spec, Throwable cause) {
     RuntimeException processed = processCause(cause);
-    if (processed != null) return processed;
+    if (processed != null)
+      return processed;
 
     StringBuilder sb = new StringBuilder();
     sb.append(describeOperation(spec)).append(" failed.");
@@ -127,7 +138,8 @@ public class KubernetesClientException extends RuntimeException {
       }
     }
 
-    throw new KubernetesClientException(sb.toString(), cause, spec.getGroup(), spec.getVersion(), spec.getPlural(), spec.getNamespace());
+    throw new KubernetesClientException(sb.toString(), cause, spec.getGroup(), spec.getVersion(), spec.getPlural(),
+        spec.getNamespace(), spec.getName());
   }
 
   /**
@@ -136,18 +148,18 @@ public class KubernetesClientException extends RuntimeException {
   @Deprecated
   public static RuntimeException launderThrowable(OperationInfo spec, Status status, Throwable cause) {
     StringBuilder sb = new StringBuilder();
-    sb.append(describeOperation(spec)+ " failed.");
+    sb.append(describeOperation(spec)).append(" failed.");
     if (status != null && Utils.isNotNullOrEmpty(status.getMessage())) {
       sb.append("Reason: ").append(status.getMessage());
     }
     return launderThrowable(sb.toString(), cause);
   }
 
-  private static final String describeOperation(OperationInfo operation) {
+  private static String describeOperation(OperationInfo operation) {
     StringBuilder sb = new StringBuilder();
     sb.append("Operation");
     if (Utils.isNotNullOrEmpty(operation.getOperationType())) {
-      sb.append(": [").append(operation.getOperationType() + "]");
+      sb.append(": [").append(operation.getOperationType()).append("]");
     }
     sb.append(" ");
     sb.append(" for kind: [").append(operation.getKind()).append("] ");

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/KubernetesClientExceptionTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/KubernetesClientExceptionTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.client.http.TestHttpRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class KubernetesClientExceptionTest {
+
+  @DisplayName("Exception from HttpRequest contains resource metadata")
+  @ParameterizedTest(name = "{index} ''{0}'': group: ''{1}'', version: ''{2}'', plural: ''{3}'', namespace: ''{4}'', name: ''{5}''")
+  @MethodSource("exceptionFromHttpRequestContainsExpectedMetadataInput")
+  void exceptionFromHttpRequestContainsExpectedMetadata(String url, String expectedGroup, String expectedVersion,
+      String expectedPlural, String expectedNamespace, String expectedName) {
+    final KubernetesClientException result = new KubernetesClientException(
+        null, null, -1, null, new TestHttpRequest().withUri(url));
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("group", expectedGroup)
+        .hasFieldOrPropertyWithValue("version", expectedVersion)
+        .hasFieldOrPropertyWithValue("resourcePlural", expectedPlural)
+        .hasFieldOrPropertyWithValue("namespace", expectedNamespace)
+        .hasFieldOrPropertyWithValue("name", expectedName);
+  }
+
+  static Stream<Arguments> exceptionFromHttpRequestContainsExpectedMetadataInput() {
+    return Stream.of(
+        arguments("https://localhost:8080/apis/apps/v1/deployments", "apps", "v1", "deployments", null, null),
+        arguments("https://localhost:8080/api/v1/pods", "", "v1", "pods", null, null),
+        arguments("https://localhost:8080/apis/apps/v1/namespaces/foo/deployments",
+            "apps", "v1", "deployments", "foo", null),
+        arguments("https://localhost:8080/api/v1/namespaces/kube-system/pods/coredns-78fcd69978-7ls8f",
+            "", "v1", "pods", "kube-system", "coredns-78fcd69978-7ls8f"),
+        arguments("https://localhost:8080/apis/apps/v1/namespaces/foo/deployments/bar-78fcd69978-7ls8f",
+            "apps", "v1", "deployments", "foo", "bar-78fcd69978-7ls8f"));
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -42,6 +42,8 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.client.utils.internal.ExponentialBackoffIntervalCalculator;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -750,7 +752,8 @@ public class OperationSupport {
     }
 
     static RequestMetadata from(HttpRequest request) {
-      final List<String> segments = Arrays.asList(request.uri().getRawPath().split("\\/"));
+      final List<String> segments = Arrays.stream(request.uri().getRawPath().split("/"))
+        .filter(s -> !s.isEmpty()).collect(Collectors.toList());
       switch (segments.size()) {
         case 4:
           // cluster URL

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -42,8 +42,6 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.client.utils.internal.ExponentialBackoffIntervalCalculator;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +51,7 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,6 +63,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class OperationSupport {
 
@@ -715,7 +716,7 @@ public class OperationSupport {
 
     final RequestMetadata metadata = RequestMetadata.from(request);
     return new KubernetesClientException(sb.toString(), status.getCode(), status, metadata.group, metadata.version,
-        metadata.plural, metadata.namespace);
+        metadata.plural, metadata.namespace, metadata.name);
   }
 
   public static KubernetesClientException requestException(HttpRequest request, Throwable e, String message) {
@@ -730,37 +731,77 @@ public class OperationSupport {
 
     final RequestMetadata metadata = RequestMetadata.from(request);
     return new KubernetesClientException(sb.toString(), e, metadata.group, metadata.version, metadata.plural,
-        metadata.namespace);
+        metadata.namespace, metadata.name);
   }
 
   public static KubernetesClientException requestException(HttpRequest request, Exception e) {
     return requestException(request, e, null);
   }
 
-  private static class RequestMetadata {
-    private final String group;
-    private final String version;
-    private final String plural;
-    private final String namespace;
-    private static final RequestMetadata EMPTY = new RequestMetadata(null, null, null, null);
+  static class RequestMetadata {
+    final String group;
+    final String version;
+    final String plural;
+    final String namespace;
+    final String name;
+    private static final RequestMetadata EMPTY = new RequestMetadata(null, null, null, null, null);
 
-    private RequestMetadata(String group, String version, String plural, String namespace) {
+    RequestMetadata(String group, String version, String plural, String namespace, String name) {
       this.group = group;
       this.version = version;
       this.plural = plural;
       this.namespace = namespace;
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      RequestMetadata that = (RequestMetadata) o;
+      return Objects.equals(group, that.group) && Objects.equals(version,
+          that.version) && Objects.equals(plural, that.plural)
+          && Objects.equals(
+              namespace, that.namespace)
+          && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(group, version, plural, namespace, name);
     }
 
     static RequestMetadata from(HttpRequest request) {
-      final List<String> segments = Arrays.stream(request.uri().getRawPath().split("/"))
-        .filter(s -> !s.isEmpty()).collect(Collectors.toList());
+      return from(request.uri());
+    }
+
+    static RequestMetadata from(URI request) {
+      final List<String> segments = Arrays.stream(request.getRawPath().split("/"))
+          .filter(s -> !s.isEmpty()).collect(Collectors.toList());
       switch (segments.size()) {
+        case 3:
+          // cluster URL for historic resources
+          return new RequestMetadata("", segments.get(1), segments.get(2), null, null);
         case 4:
           // cluster URL
-          return new RequestMetadata(segments.get(1), segments.get(2), segments.get(3), null);
+          return new RequestMetadata(segments.get(1), segments.get(2), segments.get(3), null, null);
         case 6:
-          // namespaced URL
-          return new RequestMetadata(segments.get(1), segments.get(2), segments.get(5), segments.get(4));
+          // namespaced URL with potential name
+          final String root = segments.get(0);
+          if ("api".equals(root)) {
+            return new RequestMetadata("", segments.get(1), segments.get(4), segments.get(3),
+                segments.get(5));
+          }
+          return new RequestMetadata(segments.get(1), segments.get(2), segments.get(5),
+              segments.get(4), null);
+        case 7:
+          // namespaced URL with name
+          return new RequestMetadata(segments.get(1), segments.get(2), segments.get(5),
+              segments.get(4), segments.get(6));
         default:
           return EMPTY;
       }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupportTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupportTest.java
@@ -15,113 +15,54 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.http.HttpRequest;
-import io.fabric8.kubernetes.client.http.HttpResponse;
-import io.fabric8.kubernetes.client.http.TestHttpRequest;
-import io.fabric8.kubernetes.client.http.TestHttpResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport.RequestMetadata;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.URI;
-import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
 
 class OperationSupportTest {
-
-  private OperationSupport operationSupport;
-
-  @BeforeEach
-  void setUp() {
-    final OperationContext context = new OperationContext().withClient(mock(Client.class, RETURNS_DEEP_STUBS));
-    when(context.getClient().getConfiguration()).thenReturn(Config.empty());
-    operationSupport = new OperationSupport(context);
-  }
-
-  @DisplayName("checkName, should use operation or item name")
-  @ParameterizedTest(name = "{index}: operationName: ''{1}'' itemName: ''{2}'', expects: ''{0}''")
-  @MethodSource("checkNameInput")
-  void checkName(String expected, String operationName, String itemName) {
-    // Given
-    operationSupport = new OperationSupport(operationSupport.context.withName(operationName));
-    final Pod item = new PodBuilder().withNewMetadata().withName(itemName).endMetadata().build();
-    // When
-    final String result = operationSupport.checkName(item);
-    // Then
-    assertThat(result).isEqualTo(expected);
-  }
-
-  static Stream<Arguments> checkNameInput() {
-    return Stream.of(
-        arguments(null, null, null),
-        arguments("operation", "operation", null),
-        arguments("item", null, "item"),
-        arguments("operation-item-are-the-same", "operation-item-are-the-same", "operation-item-are-the-same"));
-  }
-
   @Test
-  @DisplayName("checkName, with different operation and item name, throws Exception")
-  void checkNameWithDifferentOperationAndItemNameThrowsException() {
-    // Given
-    operationSupport = new OperationSupport(operationSupport.context.withName("operation-name"));
-    final Pod item = new PodBuilder().withNewMetadata().withName("item-name").endMetadata().build();
-    // When
-    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
-        () -> operationSupport.checkName(item));
-    // Then
-    assertThat(result).hasMessageContaining("Name mismatch. Item name:item-name. Operation name:operation-name.");
+  void shouldProperlyExtractMetadataFromURI() {
+    RequestMetadata metadata = RequestMetadata.from(
+        URI.create("http://localhost:8080/apis/apps/v1/deployments"));
+    assertEquals("apps", metadata.group);
+    assertEquals("v1", metadata.version);
+    assertEquals("deployments", metadata.plural);
+    assertNull(metadata.namespace);
+    assertNull(metadata.name);
+    assertEquals(new RequestMetadata("apps", "v1", "deployments", null, null), metadata);
+
+    metadata = RequestMetadata.from(URI.create("http://localhost:8080/api/v1/pods"));
+    assertEquals("", metadata.group);
+    assertEquals("v1", metadata.version);
+    assertEquals("pods", metadata.plural);
+    assertNull(metadata.namespace);
+    assertNull(metadata.name);
+
+    metadata = RequestMetadata.from(URI.create("http://localhost:8080/apis/apps/v1/namespaces/foo/deployments"));
+    assertEquals("apps", metadata.group);
+    assertEquals("v1", metadata.version);
+    assertEquals("deployments", metadata.plural);
+    assertEquals("foo", metadata.namespace);
+    assertNull(metadata.name);
+
+    metadata = RequestMetadata
+        .from(URI.create("http://localhost:8080/api/v1/namespaces/kube-system/pods/coredns-78fcd69978-7ls8f"));
+    assertEquals("", metadata.group);
+    assertEquals("v1", metadata.version);
+    assertEquals("pods", metadata.plural);
+    assertEquals("kube-system", metadata.namespace);
+    assertEquals("coredns-78fcd69978-7ls8f", metadata.name);
+
+    metadata = RequestMetadata
+        .from(URI.create("http://localhost:8080/apis/apps/v1/namespaces/foo/deployments/bar-78fcd69978-7ls8f"));
+    assertEquals("apps", metadata.group);
+    assertEquals("v1", metadata.version);
+    assertEquals("deployments", metadata.plural);
+    assertEquals("foo", metadata.namespace);
+    assertEquals("bar-78fcd69978-7ls8f", metadata.name);
   }
 
-  @Test
-  @DisplayName("assertResponse, with successful code, should do nothing")
-  void assertResponseCodeSuccessful() {
-    // Given
-    final HttpRequest request = new TestHttpRequest();
-    final HttpResponse<String> response = new TestHttpResponse<String>().withCode(200);
-    // When - Then
-    assertDoesNotThrow(() -> operationSupport.assertResponseCode(request, response));
-  }
-
-  @Test
-  @DisplayName("assertResponse, with client error, should throw exception")
-  void assertResponseCodeClientError() throws Exception {
-    // Given
-    final HttpRequest request = new TestHttpRequest().withMethod("GET").withUri(new URI("https://example.com"));
-    final HttpResponse<String> response = new TestHttpResponse<String>().withCode(400);
-    // When
-    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
-        () -> operationSupport.assertResponseCode(request, response));
-    // Then
-    assertThat(result).hasMessageContaining("Failure executing: GET at: https://example.com. Message: Bad Request.");
-  }
-
-  @Test
-  @DisplayName("assertResponse, with client error and custom message, should throw exception")
-  void assertResponseCodeClientErrorAndCustomMessage() throws Exception {
-    // Given
-    operationSupport.getConfig().getErrorMessages().put(400, "Custom message");
-    final HttpRequest request = new TestHttpRequest().withMethod("GET").withUri(new URI("https://example.com"));
-    final HttpResponse<String> response = new TestHttpResponse<String>().withCode(400);
-    // When
-    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
-        () -> operationSupport.assertResponseCode(request, response));
-    // Then
-    assertThat(result)
-        .hasMessageContaining("Failure executing: GET at: https://example.com. Message: Custom message Bad Request.");
-  }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupportTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupportTest.java
@@ -15,54 +15,113 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
-import io.fabric8.kubernetes.client.dsl.internal.OperationSupport.RequestMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.kubernetes.client.http.TestHttpRequest;
+import io.fabric8.kubernetes.client.http.TestHttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.URI;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OperationSupportTest {
-  @Test
-  void shouldProperlyExtractMetadataFromURI() {
-    RequestMetadata metadata = RequestMetadata.from(
-        URI.create("http://localhost:8080/apis/apps/v1/deployments"));
-    assertEquals("apps", metadata.group);
-    assertEquals("v1", metadata.version);
-    assertEquals("deployments", metadata.plural);
-    assertNull(metadata.namespace);
-    assertNull(metadata.name);
-    assertEquals(new RequestMetadata("apps", "v1", "deployments", null, null), metadata);
 
-    metadata = RequestMetadata.from(URI.create("http://localhost:8080/api/v1/pods"));
-    assertEquals("", metadata.group);
-    assertEquals("v1", metadata.version);
-    assertEquals("pods", metadata.plural);
-    assertNull(metadata.namespace);
-    assertNull(metadata.name);
+  private OperationSupport operationSupport;
 
-    metadata = RequestMetadata.from(URI.create("http://localhost:8080/apis/apps/v1/namespaces/foo/deployments"));
-    assertEquals("apps", metadata.group);
-    assertEquals("v1", metadata.version);
-    assertEquals("deployments", metadata.plural);
-    assertEquals("foo", metadata.namespace);
-    assertNull(metadata.name);
-
-    metadata = RequestMetadata
-        .from(URI.create("http://localhost:8080/api/v1/namespaces/kube-system/pods/coredns-78fcd69978-7ls8f"));
-    assertEquals("", metadata.group);
-    assertEquals("v1", metadata.version);
-    assertEquals("pods", metadata.plural);
-    assertEquals("kube-system", metadata.namespace);
-    assertEquals("coredns-78fcd69978-7ls8f", metadata.name);
-
-    metadata = RequestMetadata
-        .from(URI.create("http://localhost:8080/apis/apps/v1/namespaces/foo/deployments/bar-78fcd69978-7ls8f"));
-    assertEquals("apps", metadata.group);
-    assertEquals("v1", metadata.version);
-    assertEquals("deployments", metadata.plural);
-    assertEquals("foo", metadata.namespace);
-    assertEquals("bar-78fcd69978-7ls8f", metadata.name);
+  @BeforeEach
+  void setUp() {
+    final OperationContext context = new OperationContext().withClient(mock(Client.class, RETURNS_DEEP_STUBS));
+    when(context.getClient().getConfiguration()).thenReturn(Config.empty());
+    operationSupport = new OperationSupport(context);
   }
 
+  @DisplayName("checkName, should use operation or item name")
+  @ParameterizedTest(name = "{index}: operationName: ''{1}'' itemName: ''{2}'', expects: ''{0}''")
+  @MethodSource("checkNameInput")
+  void checkName(String expected, String operationName, String itemName) {
+    // Given
+    operationSupport = new OperationSupport(operationSupport.context.withName(operationName));
+    final Pod item = new PodBuilder().withNewMetadata().withName(itemName).endMetadata().build();
+    // When
+    final String result = operationSupport.checkName(item);
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> checkNameInput() {
+    return Stream.of(
+        arguments(null, null, null),
+        arguments("operation", "operation", null),
+        arguments("item", null, "item"),
+        arguments("operation-item-are-the-same", "operation-item-are-the-same", "operation-item-are-the-same"));
+  }
+
+  @Test
+  @DisplayName("checkName, with different operation and item name, throws Exception")
+  void checkNameWithDifferentOperationAndItemNameThrowsException() {
+    // Given
+    operationSupport = new OperationSupport(operationSupport.context.withName("operation-name"));
+    final Pod item = new PodBuilder().withNewMetadata().withName("item-name").endMetadata().build();
+    // When
+    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
+        () -> operationSupport.checkName(item));
+    // Then
+    assertThat(result).hasMessageContaining("Name mismatch. Item name:item-name. Operation name:operation-name.");
+  }
+
+  @Test
+  @DisplayName("assertResponse, with successful code, should do nothing")
+  void assertResponseCodeSuccessful() {
+    // Given
+    final HttpRequest request = new TestHttpRequest();
+    final HttpResponse<String> response = new TestHttpResponse<String>().withCode(200);
+    // When - Then
+    assertDoesNotThrow(() -> operationSupport.assertResponseCode(request, response));
+  }
+
+  @Test
+  @DisplayName("assertResponse, with client error, should throw exception")
+  void assertResponseCodeClientError() throws Exception {
+    // Given
+    final HttpRequest request = new TestHttpRequest().withMethod("GET").withUri(new URI("https://example.com"));
+    final HttpResponse<String> response = new TestHttpResponse<String>().withCode(400);
+    // When
+    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
+        () -> operationSupport.assertResponseCode(request, response));
+    // Then
+    assertThat(result).hasMessageContaining("Failure executing: GET at: https://example.com. Message: Bad Request.");
+  }
+
+  @Test
+  @DisplayName("assertResponse, with client error and custom message, should throw exception")
+  void assertResponseCodeClientErrorAndCustomMessage() throws Exception {
+    // Given
+    operationSupport.getConfig().getErrorMessages().put(400, "Custom message");
+    final HttpRequest request = new TestHttpRequest().withMethod("GET").withUri(new URI("https://example.com"));
+    final HttpResponse<String> response = new TestHttpResponse<String>().withCode(400);
+    // When
+    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
+        () -> operationSupport.assertResponseCode(request, response));
+    // Then
+    assertThat(result)
+        .hasMessageContaining("Failure executing: GET at: https://example.com. Message: Custom message Bad Request.");
+  }
 }


### PR DESCRIPTION
## Description
Fixes #4049

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
