### PR TITLE
fix #4065: use Client.getAPIResources("v1") for core/legacy resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #3968: SharedIndexInformer.initialState can be used to set the store state before the informer starts. 
 SharedIndexInformer allows for the addition and removal of indexes even after starting, and you can remove the default namespace index if you wish.
 And Store.getKey can be used rather than directly referencing static Cache functions.
+* Fix #4065: Client.getAPIResources("v1") can be used to obtain the core/legacy resources
 
 #### Dependency Upgrade
 * Fix #3788: Point CamelK Extension model to latest released version v1.8.0

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Client.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Client.java
@@ -92,7 +92,7 @@ public interface Client extends HttpClientAware, ConfigAware<Config>, Closeable 
   void close();
 
   /**
-   * Returns the api groups
+   * Returns the api groups. This does not include the core/legacy v1 apiVersion.
    *
    * @return the {@link APIGroupList} metadata
    */
@@ -108,6 +108,8 @@ public interface Client extends HttpClientAware, ConfigAware<Config>, Closeable 
 
   /**
    * Return the api resource metadata for the given groupVersion
+   * <p>
+   * Use v1 to indicate the core/legacy resources
    *
    * @param groupVersion the groupVersion - group/version
    * @return the {@link APIResourceList} for the groupVersion

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -207,6 +207,9 @@ public abstract class BaseClient implements Client {
 
   @Override
   public APIResourceList getApiResources(String groupVersion) {
+    if ("v1".equals(groupVersion)) {
+      return getOperationSupport().restCall(APIResourceList.class, "api", "v1");
+    }
     return getOperationSupport().restCall(APIResourceList.class, APIS, groupVersion);
   }
 

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ApiGroupResourceListsIT.java
@@ -53,5 +53,9 @@ class ApiGroupResourceListsIT {
     APIResourceList list = client.getApiResources("apps/v1");
 
     assertTrue(list.getResources().stream().anyMatch(r -> "deployments".equals(r.getName())));
+
+    list = client.getApiResources("v1");
+
+    assertTrue(list.getResources().stream().anyMatch(r -> "configmaps".equals(r.getName())));
   }
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PluralizeIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PluralizeIT.java
@@ -19,11 +19,9 @@ import io.fabric8.jupiter.api.RequireK8sVersionAtLeast;
 import io.fabric8.kubernetes.api.Pluralize;
 import io.fabric8.kubernetes.api.model.APIGroup;
 import io.fabric8.kubernetes.api.model.APIResource;
-import io.fabric8.kubernetes.api.model.APIResourceList;
 import io.fabric8.kubernetes.api.model.GroupVersionForDiscovery;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,8 +51,7 @@ class PluralizeIT {
     final List<APIResource> testCases;
     try (KubernetesClient client = new KubernetesClientBuilder().build()) {
       // Core Resources
-      testCases = new ArrayList<>(new OperationSupport(client)
-          .restCall(APIResourceList.class, "api/v1").getResources());
+      testCases = new ArrayList<>(client.getApiResources("v1").getResources());
       // Additional groups
       for (APIGroup group : client.getApiGroups().getGroups()) {
         for (GroupVersionForDiscovery version : group.getVersions()) {


### PR DESCRIPTION
## Description
Fix #4065

Adds a way to get the core api resources, this will allow for implementation of things like: #887

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
