### PR TITLE
fix: IntOrString supports null values

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/IntOrString.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/IntOrString.java
@@ -49,12 +49,13 @@ public class IntOrString implements Serializable {
 
   private Object value;
 
-  public IntOrString() { }
+  public IntOrString() {
+  }
 
   //Builders are generated for the first non-empty constructor found.
-  @Buildable(editableEnabled = false, generateBuilderPackage=true, builderPackage = "io.fabric8.kubernetes.api.builder")
+  @Buildable(editableEnabled = false, generateBuilderPackage = true, builderPackage = "io.fabric8.kubernetes.api.builder")
   public IntOrString(Object value) {
-    if (value instanceof Integer || value instanceof String) {
+    if (value == null || value instanceof Integer || value instanceof String) {
       this.value = value;
     } else {
       throw new IllegalArgumentException("Either integer or string value needs to be provided");

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/IntOrStringTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/IntOrStringTest.java
@@ -73,7 +73,7 @@ class IntOrStringTest {
 
     // Then
     assertThat(intOrString)
-      .hasFieldOrPropertyWithValue("value", 89);
+        .hasFieldOrPropertyWithValue("value", 89);
   }
 
   @Test
@@ -83,19 +83,28 @@ class IntOrStringTest {
 
     // Then
     assertThat(intOrString)
-      .hasFieldOrPropertyWithValue("value", "89");
+        .hasFieldOrPropertyWithValue("value", "89");
   }
 
   @Test
-  void builder_withEmpty_shouldThrowException() {
+  void builder_withEmpty_shouldSetNullValue() {
     // Given
     IntOrStringBuilder intOrStringBuilder = new IntOrStringBuilder();
+    // When
+    final IntOrString result = intOrStringBuilder.build();
+    // Then
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("value", null);
+  }
 
+  @Test
+  void builder_withBoolean_shouldThrowException() {
+    // Given
+    IntOrStringBuilder intOrStringBuilder = new IntOrStringBuilder().withValue(true);
     // When
     IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, intOrStringBuilder::build);
-
     // Then
     assertThat(illegalArgumentException)
-      .hasMessage("Either integer or string value needs to be provided");
+        .hasMessage("Either integer or string value needs to be provided");
   }
 }


### PR DESCRIPTION
## Description
fix: IntOrString supports null values

- For backwards compatibility, IntOrString should still support
null values.

Relates to:
- #3806 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
