### PR TITLE
adding a possibility to get a log as an InputStream from the Loggable resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 SharedIndexInformer allows for the addition and removal of indexes even after starting, and you can remove the default namespace index if you wish.
 And Store.getKey can be used rather than directly referencing static Cache functions.
 * Fix #4065: Client.getAPIResources("v1") can be used to obtain the core/legacy resources
+* Fix #4093: adding a possibility to get a log as an `InputStream` from the `Loggable` resources
 
 #### Dependency Upgrade
 * Fix #3788: Point CamelK Extension model to latest released version v1.8.0

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedOutputStream;
 import java.io.Reader;
@@ -46,6 +47,13 @@ public interface Loggable {
    * @return {@link Reader} log reader
    */
   Reader getLogReader();
+
+  /**
+   * Get a InputStream for reading logs
+   *
+   * @return {@link InputStream} log input stream
+   */
+  InputStream getLogInputStream();
 
   /**
    * Watch logs of a resource. Use {@link LogWatch#getOutput()} to obtain the stream

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.kubernetes.client.dsl.Loggable;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
@@ -37,14 +38,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -275,26 +272,33 @@ public class DeploymentOperationsImpl
    */
   @Override
   public Reader getLogReader() {
-    List<RollableScalableResource<ReplicaSet>> podResources = doGetLog();
-    if (!podResources.isEmpty()) {
-      if (podResources.size() > 1) {
-        LOG.debug("Found {} pods, Using first one to get log reader", podResources.size());
-      }
-      return podResources.get(0).getLogReader();
-    }
-    return null;
+    return findFirstPodResource().map(Loggable::getLogReader).orElse(null);
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return findFirstPodResource().map(Loggable::getLogInputStream).orElse(null);
   }
 
   @Override
   public LogWatch watchLog(OutputStream out) {
-    List<RollableScalableResource<ReplicaSet>> replicaSetResources = doGetLog();
-    if (!replicaSetResources.isEmpty()) {
-      if (replicaSetResources.size() > 1) {
-        LOG.debug("Found {} pods, Using first one to get logs", replicaSetResources.size());
+    return findFirstPodResource().map(it -> it.watchLog(out)).orElse(null);
+  }
+
+  private Optional<RollableScalableResource<ReplicaSet>> findFirstPodResource() {
+    List<RollableScalableResource<ReplicaSet>> podResources = doGetLog();
+    if (!podResources.isEmpty()) {
+      if (podResources.size() > 1) {
+        LOG.debug("Found {} pods, Using first one to get log", podResources.size());
       }
-      return replicaSetResources.get(0).watchLog(out);
+      return Optional.of(podResources.get(0));
     }
-    return null;
+    return Optional.empty();
   }
 
   private Deployment sendPatchedDeployment(Map<String, Object> patchedUpdate) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.RollingOperationContext;
 import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.util.Collections;
@@ -173,6 +174,16 @@ public class ReplicaSetOperationsImpl
   @Override
   public Reader getLogReader() {
     return PodOperationUtil.getLogReader(doGetLog(false));
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return PodOperationUtil.getLogInputStream(doGetLog(false));
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
@@ -35,6 +35,7 @@ import io.fabric8.kubernetes.client.dsl.internal.RollingOperationContext;
 import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.util.Collections;
@@ -158,6 +159,16 @@ public class StatefulSetOperationsImpl
   @Override
   public Reader getLogReader() {
     return PodOperationUtil.getLogReader(doGetLog(false));
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return PodOperationUtil.getLogInputStream(doGetLog(false));
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.util.HashMap;
@@ -140,6 +141,16 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
   @Override
   public Reader getLogReader() {
     return PodOperationUtil.getLogReader(doGetLog(false));
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return Reader
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return PodOperationUtil.getLogInputStream(doGetLog(false));
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -134,6 +134,16 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     return doGetLog(Reader.class);
   }
 
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return doGetLog(InputStream.class);
+  }
+
   @Override
   public String getLog(boolean isPretty) {
     return new PodOperationsImpl(getContext().withPrettyOutput(isPretty), context).getLog();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
@@ -33,6 +33,7 @@ import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollableScalableResourc
 import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
 import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.util.Collections;
@@ -156,6 +157,16 @@ public class ReplicationControllerOperationsImpl extends
   @Override
   public Reader getLogReader() {
     return PodOperationUtil.getLogReader(doGetLog(false));
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return PodOperationUtil.getLogInputStream(doGetLog(false));
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
@@ -33,6 +33,7 @@ import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollableScalableResourc
 import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
 import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.util.Collections;
@@ -180,6 +181,16 @@ public class ReplicaSetOperationsImpl
   @Override
   public Reader getLogReader() {
     return PodOperationUtil.getLogReader(doGetLog(false));
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return PodOperationUtil.getLogInputStream(doGetLog(false));
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
@@ -31,6 +31,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -163,6 +164,26 @@ class PodOperationUtilTest {
     assertThat(reader).isNotNull();
     verify(p1, times(1)).getLogReader();
     verify(p2, times(0)).getLogReader();
+  }
+
+  @Test
+  void testGetLogInputStreamEmptyPodResourceList() {
+    assertThat(PodOperationUtil.getLogInputStream(Collections.emptyList())).isNull();
+  }
+
+  @Test
+  void testGetLogInputStreamMultiplePodReplicasPicksFirstPod() {
+    // Given
+    PodResource p1 = mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+    PodResource p2 = mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
+
+    // When
+    InputStream inputStream = PodOperationUtil.getLogInputStream(createMockPodResourceList(p1, p2));
+
+    // Then
+    assertThat(inputStream).isNotNull();
+    verify(p1, times(1)).getLogInputStream();
+    verify(p2, times(0)).getLogInputStream();
   }
 
   @Test

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -36,6 +36,7 @@ import io.fabric8.openshift.client.dsl.DeployableScalableResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.net.MalformedURLException;
@@ -185,6 +186,16 @@ public class DeploymentConfigOperationsImpl
   @Override
   public Reader getLogReader() {
     return doGetLog(false, Reader.class);
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return doGetLog(false, InputStream.class);
   }
 
   @Override

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
@@ -36,6 +36,7 @@ import io.fabric8.openshift.client.dsl.BuildResource;
 import io.fabric8.openshift.client.dsl.internal.BuildOperationContext;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.net.URL;
@@ -141,6 +142,16 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
   @Override
   public Reader getLogReader() {
     return doGetLog(Reader.class);
+  }
+
+  /**
+   * Returns an unclosed InputStream. It's the caller responsibility to close it.
+   *
+   * @return InputStream
+   */
+  @Override
+  public InputStream getLogInputStream() {
+    return doGetLog(InputStream.class);
   }
 
   @Override


### PR DESCRIPTION
## Description

Fix #4093 
Exposing `getLogInputStream()` method to the `Loggable` interface to be able to stream resource log output.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->

Fixes #4093