### PR TITLE
fix #4107: removing excessive generics

### DIFF
--- a/doc/MIGRATION-v6.md
+++ b/doc/MIGRATION-v6.md
@@ -224,8 +224,8 @@ KubernetesList and Template will no longer automatically sort their objects by d
 
 - WatchListDeletable now takes three type parameters to include the Resource type.
 
-- PodResource is no longer generic.
-- 
+- PodResource, BuildResource, and interfaces related to containers and logging are no longer generic.
+
 - SharedInformer was removed, there is now only SharedIndexInformer
 
 - The following interfaces were removed: 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/BytesLimitTerminateTimeTailPrettyLoggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/BytesLimitTerminateTimeTailPrettyLoggable.java
@@ -16,20 +16,20 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-public interface BytesLimitTerminateTimeTailPrettyLoggable<W> extends TimeTailPrettyLoggable<W> {
+public interface BytesLimitTerminateTimeTailPrettyLoggable extends TimeTailPrettyLoggable {
 
   /**
    * Configure Maximum bytes of logs to return. Defaults to no limit.
-   * 
+   *
    * @param limitBytes number of bytes
    * @return returns pod log operation with specified PodLogOption configured
    */
-  TimeTailPrettyLoggable<W> limitBytes(int limitBytes);
+  TimeTailPrettyLoggable limitBytes(int limitBytes);
 
   /**
    * Get logs for the previous instance of the container in a pod if it exists:
    *
    * @return returns pod log operation with specified PodLogOption configured
    */
-  TimeTailPrettyLoggable<W> terminated();
+  TimeTailPrettyLoggable terminated();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
@@ -15,19 +15,22 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface ContainerResource<W, I, PI, O, PO, X, T, IS>
-    extends TtyExecOutputErrorable<X, O, PO, T>,
-    TimestampBytesLimitTerminateTimeTailPrettyLoggable<W> {
+import java.io.InputStream;
+import java.io.PipedOutputStream;
 
-  TtyExecOutputErrorable<X, O, PO, T> readingInput(I in);
+public interface ContainerResource
+    extends TtyExecOutputErrorable,
+    TimestampBytesLimitTerminateTimeTailPrettyLoggable {
 
-  TtyExecOutputErrorable<X, O, PO, T> writingInput(PI in);
+  TtyExecOutputErrorable readingInput(InputStream in);
 
-  TtyExecOutputErrorable<X, O, PO, T> redirectingInput();
+  TtyExecOutputErrorable writingInput(PipedOutputStream in);
 
-  TtyExecOutputErrorable<X, O, PO, T> redirectingInput(Integer bufferSize);
+  TtyExecOutputErrorable redirectingInput();
 
-  CopyOrReadable<IS> file(String path);
+  TtyExecOutputErrorable redirectingInput(Integer bufferSize);
 
-  CopyOrReadable<IS> dir(String path);
+  CopyOrReadable file(String path);
+
+  CopyOrReadable dir(String path);
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CopyOrReadable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CopyOrReadable.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.dsl;
 import java.io.InputStream;
 import java.nio.file.Path;
 
-public interface CopyOrReadable<I> {
+public interface CopyOrReadable {
 
   /**
    * Upload file located at specified {@link Path} to Pod
@@ -36,7 +36,7 @@ public interface CopyOrReadable<I> {
    */
   boolean upload(InputStream inputStream);
 
-  I read();
+  InputStream read();
 
   boolean copy(Path destination);
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ExecListenable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ExecListenable.java
@@ -16,13 +16,8 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-/**
- *
- * @param <I> The exec input.
- * @param <T> The exec output.
- */
-public interface ExecListenable<I, T> extends
-    Execable<I, T> {
+public interface ExecListenable extends
+    Execable {
 
-  Execable<I, T> usingListener(ExecListener listener);
+  Execable usingListener(ExecListener listener);
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Execable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Execable.java
@@ -16,12 +16,8 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-/**
- * @param <X>   The exec input
- * @param <T>   The exec output
- */
-public interface Execable<X, T> {
+public interface Execable {
 
-    T exec(X... input);
+  ExecWatch exec(String... input);
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
@@ -21,10 +21,8 @@ import java.io.Reader;
 
 /**
  * Loggable interface for all resources which produce logs
- *
- * @param <W> returns a LogWatch for watching logs
  */
-public interface Loggable<W> {
+public interface Loggable {
 
   /**
    * Get logs of a resource
@@ -53,16 +51,17 @@ public interface Loggable<W> {
    *
    * @return returns a Closeable interface for log watch
    */
-  W watchLog();
+  LogWatch watchLog();
 
   /**
    * Watch logs of resource and put them inside OutputStream inside
-   * <br>if the OutputStream is a PipedOutputStream, it will be closed when the Watch terminates
+   * <br>
+   * if the OutputStream is a PipedOutputStream, it will be closed when the Watch terminates
    *
    * @param out {@link OutputStream} for storing logs
    * @return returns a Closeable interface for log watch
    */
-  W watchLog(OutputStream out);
+  LogWatch watchLog(OutputStream out);
 
   /**
    * While waiting for Pod logs, how long shall we wait until a Pod
@@ -71,6 +70,6 @@ public interface Loggable<W> {
    * @param logWaitTimeout timeout in milliseconds
    * @return {@link Loggable} for fetching logs
    */
-  Loggable<W> withLogWaitTimeout(Integer logWaitTimeout);
+  Loggable withLogWaitTimeout(Integer logWaitTimeout);
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
@@ -20,22 +20,18 @@ import io.fabric8.kubernetes.api.model.policy.v1.Eviction;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.PortForward;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
 public interface PodResource extends Resource<Pod>,
-    Loggable<LogWatch>,
-    Containerable<String, ContainerResource<LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, InputStream>>,
-    ContainerResource<LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, InputStream>,
+    Loggable,
+    Containerable<String, ContainerResource>,
+    ContainerResource,
     PortForwardable<PortForward, LocalPortForward, ReadableByteChannel, WritableByteChannel> {
 
   /**
    * Evicts resource, respecting {@link io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget}
-   * 
+   *
    * @return value indicating object was evicted or not
    * @throws io.fabric8.kubernetes.client.KubernetesClientException if an error occurs, including if the Pod is not found.
    */

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PrettyLoggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PrettyLoggable.java
@@ -16,12 +16,12 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-public interface PrettyLoggable<W> extends Loggable<W> {
+public interface PrettyLoggable extends Loggable {
 
   /**
    * Get logs with pretty output
-   * 
+   *
    * @return returns pod log operation with specified PodLogOption configured
    */
-  Loggable<W> withPrettyOutput();
+  Loggable withPrettyOutput();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ScalableResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ScalableResource.java
@@ -18,12 +18,12 @@ package io.fabric8.kubernetes.client.dsl;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
 
 public interface ScalableResource<T> extends Resource<T>,
-    Loggable<LogWatch>,
-    Containerable<String, Loggable<LogWatch>> {
+    Loggable,
+    Containerable<String, Loggable> {
 
   /**
    * Scale the resource to given count
-   * 
+   *
    * @param count the desired instance count
    * @return the resource
    */
@@ -31,7 +31,7 @@ public interface ScalableResource<T> extends Resource<T>,
 
   /**
    * Scale the resource to given count
-   * 
+   *
    * @param count the desired instance count
    * @param wait if true, wait for the number of instances to exist - no guarantee is made
    *        as to readiness

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TailPrettyLoggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TailPrettyLoggable.java
@@ -16,13 +16,13 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-public interface TailPrettyLoggable<W> extends PrettyLoggable<W> {
+public interface TailPrettyLoggable extends PrettyLoggable {
 
   /**
    * Get logs lines of recent log file to display.
-   * 
+   *
    * @param lines number of lines to tail
    * @return returns pod log operation with specified PodLogOption configured
    */
-  PrettyLoggable<W> tailingLines(int lines);
+  PrettyLoggable tailingLines(int lines);
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TimeTailPrettyLoggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TimeTailPrettyLoggable.java
@@ -16,7 +16,7 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-public interface TimeTailPrettyLoggable<W> extends TailPrettyLoggable<W> {
+public interface TimeTailPrettyLoggable extends TailPrettyLoggable {
 
   /**
    * Only return logs after a specific date (RFC3339)
@@ -24,13 +24,13 @@ public interface TimeTailPrettyLoggable<W> extends TailPrettyLoggable<W> {
    * @param timestamp timestamp as string
    * @return log operation with PodLogOptions configured
    */
-  TailPrettyLoggable<W> sinceTime(String timestamp);
+  TailPrettyLoggable sinceTime(String timestamp);
 
   /**
    * Get logs after a duration of seconds:
-   * 
+   *
    * @param seconds number of seconds
    * @return log operation with PodLogOptions configured
    */
-  TailPrettyLoggable<W> sinceSeconds(int seconds);
+  TailPrettyLoggable sinceSeconds(int seconds);
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TimestampBytesLimitTerminateTimeTailPrettyLoggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TimestampBytesLimitTerminateTimeTailPrettyLoggable.java
@@ -16,12 +16,12 @@
 
 package io.fabric8.kubernetes.client.dsl;
 
-public interface TimestampBytesLimitTerminateTimeTailPrettyLoggable<W> extends BytesLimitTerminateTimeTailPrettyLoggable<W> {
+public interface TimestampBytesLimitTerminateTimeTailPrettyLoggable extends BytesLimitTerminateTimeTailPrettyLoggable {
 
   /**
    * Include timestamps on each line in the log output
-   * 
+   *
    * @return returns pod log operation with specified PodLogOption configured
    */
-  BytesLimitTerminateTimeTailPrettyLoggable<W> usingTimestamps();
+  BytesLimitTerminateTimeTailPrettyLoggable usingTimestamps();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecErrorChannelable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecErrorChannelable.java
@@ -15,18 +15,15 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-/**
- * @param <X> The exec input.
- * @param <O> Where to write err channel to.
- * @param <P> Where to read err channel from.
- * @param <T> The exec output.
- */
-public interface TtyExecErrorChannelable<X, O, P, T> extends
-    TtyExecable<X, T> {
+import java.io.OutputStream;
+import java.io.PipedInputStream;
 
-  TtyExecable<X, T> writingErrorChannel(O in);
+public interface TtyExecErrorChannelable extends
+    TtyExecable {
 
-  TtyExecable<X, T> readingErrorChannel(P in);
+  TtyExecable writingErrorChannel(OutputStream in);
 
-  TtyExecable<X, T> redirectingErrorChannel();
+  TtyExecable readingErrorChannel(PipedInputStream in);
+
+  TtyExecable redirectingErrorChannel();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecErrorable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecErrorable.java
@@ -15,19 +15,16 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-/**
- * @param <X> The exec input.
- * @param <O> Where to write err to.
- * @param <P> Where to read err from.
- * @param <T> The exec output.
- */
-public interface TtyExecErrorable<X, O, P, T> extends
-    TtyExecErrorChannelable<X, O, P, T> {
+import java.io.OutputStream;
+import java.io.PipedInputStream;
 
-  TtyExecErrorChannelable<X, O, P, T> writingError(O in);
+public interface TtyExecErrorable extends
+    TtyExecErrorChannelable {
 
-  TtyExecErrorChannelable<X, O, P, T> readingError(P in);
+  TtyExecErrorChannelable writingError(OutputStream in);
 
-  TtyExecErrorChannelable<X, O, P, T> redirectingError();
+  TtyExecErrorChannelable readingError(PipedInputStream in);
+
+  TtyExecErrorChannelable redirectingError();
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecOutputErrorable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecOutputErrorable.java
@@ -15,18 +15,15 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-/**
- * @param <X> The exec input.
- * @param <O> Where to write err to.
- * @param <P> Where to read err from.
- * @param <T> The exec output.
- */
-public interface TtyExecOutputErrorable<X, O, P, T> extends
-    TtyExecErrorable<X, O, P, T> {
+import java.io.OutputStream;
+import java.io.PipedInputStream;
 
-  TtyExecErrorable<X, O, P, T> writingOutput(O in);
+public interface TtyExecOutputErrorable extends
+    TtyExecErrorable {
 
-  TtyExecErrorable<X, O, P, T> readingOutput(P in);
+  TtyExecErrorable writingOutput(OutputStream in);
 
-  TtyExecErrorable<X, O, P, T> redirectingOutput();
+  TtyExecErrorable readingOutput(PipedInputStream in);
+
+  TtyExecErrorable redirectingOutput();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TtyExecable.java
@@ -15,14 +15,9 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-/**
- *
- * @param <I> The exec input.
- * @param <T> The exec output.
- */
-public interface TtyExecable<I, T> extends
-    ExecListenable<I, T> {
+public interface TtyExecable extends
+    ExecListenable {
 
-  ExecListenable<I, T> withTTY();
+  ExecListenable withTTY();
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
@@ -134,7 +134,7 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
 
   /**
    * Returns an unclosed Reader. It's the caller responsibility to close it.
-   * 
+   *
    * @return Reader
    */
   @Override
@@ -153,7 +153,7 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
   }
 
   @Override
-  public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
+  public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
     return new JobOperationsImpl(podControllerOperationContext.withLogWaitTimout(logWaitTimeout), context);
   }
 
@@ -180,7 +180,7 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
   }
 
   @Override
-  public Loggable<LogWatch> inContainer(String id) {
+  public Loggable inContainer(String id) {
     return new JobOperationsImpl(podControllerOperationContext.withContainerId(id), context);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -85,7 +85,7 @@ import java.util.concurrent.TimeUnit;
 import static io.fabric8.kubernetes.client.utils.internal.OptionalDependencyWrapper.wrapRunWithOptionalDependency;
 
 public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodResource>
-    implements PodResource, CopyOrReadable<InputStream> {
+    implements PodResource, CopyOrReadable {
 
   public static final int HTTP_TOO_MANY_REQUESTS = 429;
   private static final Integer DEFAULT_POD_LOG_WAIT_TIMEOUT = 5;
@@ -226,7 +226,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
-  public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
+  public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
     return new PodOperationsImpl(getContext().withLogWaitTimeout(logWaitTimeout), context);
   }
 
@@ -311,7 +311,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
-  public ContainerResource<LogWatch, InputStream, PipedOutputStream, OutputStream, PipedInputStream, String, ExecWatch, InputStream> inContainer(
+  public ContainerResource inContainer(
       String containerId) {
     return new PodOperationsImpl(getContext().withContainerId(containerId), context);
   }
@@ -368,12 +368,12 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
-  public CopyOrReadable<InputStream> file(String file) {
+  public CopyOrReadable file(String file) {
     return new PodOperationsImpl(getContext().withFile(file), context);
   }
 
   @Override
-  public CopyOrReadable<InputStream> dir(String dir) {
+  public CopyOrReadable dir(String dir) {
     return new PodOperationsImpl(getContext().withDir(dir), context);
   }
 
@@ -568,112 +568,112 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
-  public TtyExecOutputErrorable<String, OutputStream, PipedInputStream, ExecWatch> readingInput(InputStream in) {
+  public TtyExecOutputErrorable readingInput(InputStream in) {
     return new PodOperationsImpl(getContext().withIn(in), context);
   }
 
   @Override
-  public TtyExecOutputErrorable<String, OutputStream, PipedInputStream, ExecWatch> writingInput(PipedOutputStream inPipe) {
+  public TtyExecOutputErrorable writingInput(PipedOutputStream inPipe) {
     return new PodOperationsImpl(getContext().withInPipe(inPipe), context);
   }
 
   @Override
-  public TtyExecOutputErrorable<String, OutputStream, PipedInputStream, ExecWatch> redirectingInput() {
+  public TtyExecOutputErrorable redirectingInput() {
     return redirectingInput(null);
   }
 
   @Override
-  public TtyExecOutputErrorable<String, OutputStream, PipedInputStream, ExecWatch> redirectingInput(Integer bufferSize) {
+  public TtyExecOutputErrorable redirectingInput(Integer bufferSize) {
     return new PodOperationsImpl(getContext().withInPipe(new PipedOutputStream()).withBufferSize(bufferSize), context);
   }
 
   @Override
-  public TtyExecErrorable<String, OutputStream, PipedInputStream, ExecWatch> writingOutput(OutputStream out) {
+  public TtyExecErrorable writingOutput(OutputStream out) {
     return new PodOperationsImpl(getContext().withOut(out), context);
   }
 
   @Override
-  public TtyExecErrorable<String, OutputStream, PipedInputStream, ExecWatch> readingOutput(PipedInputStream outPipe) {
+  public TtyExecErrorable readingOutput(PipedInputStream outPipe) {
     return new PodOperationsImpl(getContext().withOutPipe(outPipe), context);
   }
 
   @Override
-  public TtyExecErrorable<String, OutputStream, PipedInputStream, ExecWatch> redirectingOutput() {
+  public TtyExecErrorable redirectingOutput() {
     return readingOutput(new PipedInputStream());
   }
 
   @Override
-  public TtyExecErrorChannelable<String, OutputStream, PipedInputStream, ExecWatch> writingError(OutputStream err) {
+  public TtyExecErrorChannelable writingError(OutputStream err) {
     return new PodOperationsImpl(getContext().withErr(err), context);
   }
 
   @Override
-  public TtyExecErrorChannelable<String, OutputStream, PipedInputStream, ExecWatch> readingError(PipedInputStream errPipe) {
+  public TtyExecErrorChannelable readingError(PipedInputStream errPipe) {
     return new PodOperationsImpl(getContext().withErrPipe(errPipe), context);
   }
 
   @Override
-  public TtyExecErrorChannelable<String, OutputStream, PipedInputStream, ExecWatch> redirectingError() {
+  public TtyExecErrorChannelable redirectingError() {
     return readingError(new PipedInputStream());
   }
 
   @Override
-  public TtyExecable<String, ExecWatch> writingErrorChannel(OutputStream errChannel) {
+  public TtyExecable writingErrorChannel(OutputStream errChannel) {
     return new PodOperationsImpl(getContext().withErrChannel(errChannel), context);
   }
 
   @Override
-  public TtyExecable<String, ExecWatch> readingErrorChannel(PipedInputStream errChannelPipe) {
+  public TtyExecable readingErrorChannel(PipedInputStream errChannelPipe) {
     return new PodOperationsImpl(getContext().withErrChannelPipe(errChannelPipe), context);
   }
 
   @Override
-  public TtyExecable<String, ExecWatch> redirectingErrorChannel() {
+  public TtyExecable redirectingErrorChannel() {
     return readingErrorChannel(new PipedInputStream());
   }
 
   @Override
-  public ExecListenable<String, ExecWatch> withTTY() {
+  public ExecListenable withTTY() {
     return new PodOperationsImpl(getContext().withTty(true), context);
   }
 
   @Override
-  public Loggable<LogWatch> withPrettyOutput() {
+  public Loggable withPrettyOutput() {
     return new PodOperationsImpl(getContext().withPrettyOutput(true), context);
   }
 
   @Override
-  public PrettyLoggable<LogWatch> tailingLines(int withTailingLines) {
+  public PrettyLoggable tailingLines(int withTailingLines) {
     return new PodOperationsImpl(getContext().withTailingLines(withTailingLines), context);
   }
 
   @Override
-  public TailPrettyLoggable<LogWatch> sinceTime(String sinceTimestamp) {
+  public TailPrettyLoggable sinceTime(String sinceTimestamp) {
     return new PodOperationsImpl(getContext().withSinceTimestamp(sinceTimestamp), context);
   }
 
   @Override
-  public TailPrettyLoggable<LogWatch> sinceSeconds(int sinceSeconds) {
+  public TailPrettyLoggable sinceSeconds(int sinceSeconds) {
     return new PodOperationsImpl(getContext().withSinceSeconds(sinceSeconds), context);
   }
 
   @Override
-  public TimeTailPrettyLoggable<LogWatch> terminated() {
+  public TimeTailPrettyLoggable terminated() {
     return new PodOperationsImpl(getContext().withTerminatedStatus(true), context);
   }
 
   @Override
-  public Execable<String, ExecWatch> usingListener(ExecListener execListener) {
+  public Execable usingListener(ExecListener execListener) {
     return new PodOperationsImpl(getContext().withExecListener(execListener), context);
   }
 
   @Override
-  public BytesLimitTerminateTimeTailPrettyLoggable<LogWatch> limitBytes(int limitBytes) {
+  public BytesLimitTerminateTimeTailPrettyLoggable limitBytes(int limitBytes) {
     return new PodOperationsImpl(getContext().withLimitBytes(limitBytes), context);
   }
 
   @Override
-  public BytesLimitTerminateTimeTailPrettyLoggable<LogWatch> usingTimestamps() {
+  public BytesLimitTerminateTimeTailPrettyLoggable usingTimestamps() {
     return new PodOperationsImpl(getContext().withTimestamps(true), context);
   }
 

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftClient.java
@@ -231,7 +231,7 @@ public interface OpenShiftClient extends KubernetesClient, SupportTestingClient 
    *
    * @return MixedOperation instance for Build object
    */
-  MixedOperation<Build, BuildList, BuildResource<Build, LogWatch>> builds();
+  MixedOperation<Build, BuildList, BuildResource> builds();
 
   /**
    * API entrypoint for handling BuildConfig(build.openshift.io/v1)
@@ -578,7 +578,7 @@ public interface OpenShiftClient extends KubernetesClient, SupportTestingClient 
 
   /**
    * Returns the current logged in user details similar to the `oc whoami` command.
-   * 
+   *
    * @return User as currently logged in user
    */
   User currentUser();

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/dsl/BuildResource.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/dsl/BuildResource.java
@@ -18,7 +18,8 @@ package io.fabric8.openshift.client.dsl;
 
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.TimestampBytesLimitTerminateTimeTailPrettyLoggable;
+import io.fabric8.openshift.api.model.Build;
 
-public interface BuildResource<T, W> extends Resource<T>,
-  TimestampBytesLimitTerminateTimeTailPrettyLoggable<W> {
+public interface BuildResource extends Resource<Build>,
+    TimestampBytesLimitTerminateTimeTailPrettyLoggable {
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -287,7 +287,7 @@ public class DefaultOpenShiftClient extends DefaultKubernetesClient
   }
 
   @Override
-  public MixedOperation<Build, BuildList, BuildResource<Build, LogWatch>> builds() {
+  public MixedOperation<Build, BuildList, BuildResource> builds() {
     return new BuildOperationsImpl(this);
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -221,7 +221,7 @@ public class DeploymentConfigOperationsImpl
   }
 
   @Override
-  public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
+  public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
     return new DeploymentConfigOperationsImpl(rollingOperationContext.withLogWaitTimout(logWaitTimeout), context);
   }
 
@@ -249,7 +249,7 @@ public class DeploymentConfigOperationsImpl
   }
 
   @Override
-  public Loggable<LogWatch> inContainer(String id) {
+  public Loggable inContainer(String id) {
     return new DeploymentConfigOperationsImpl(rollingOperationContext.withContainerId(id), context);
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.openshift.client.dsl.internal.build;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.BytesLimitTerminateTimeTailPrettyLoggable;
@@ -46,8 +45,8 @@ import java.util.Map;
 
 import static io.fabric8.openshift.client.OpenShiftAPIGroups.BUILD;
 
-public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, BuildResource<Build, LogWatch>> implements
-    BuildResource<Build, LogWatch> {
+public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, BuildResource> implements
+    BuildResource {
 
   public static final String OPENSHIFT_IO_BUILD_NAME = "openshift.io/build.name";
   private final boolean withTerminatedStatus;
@@ -163,44 +162,44 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
   }
 
   @Override
-  public Loggable<LogWatch> withLogWaitTimeout(Integer logWaitTimeout) {
+  public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
     BuildOperationsImpl result = newInstance(context);
     result.podLogWaitTimeout = logWaitTimeout;
     return result;
   }
 
   @Override
-  public Loggable<LogWatch> withPrettyOutput() {
+  public Loggable withPrettyOutput() {
     return new BuildOperationsImpl(getContext().withPrettyOutput(true), context);
   }
 
   @Override
-  public PrettyLoggable<LogWatch> tailingLines(int tailingLines) {
+  public PrettyLoggable tailingLines(int tailingLines) {
     return new BuildOperationsImpl(getContext().withTailingLines(tailingLines), context);
   }
 
   @Override
-  public TimeTailPrettyLoggable<LogWatch> terminated() {
+  public TimeTailPrettyLoggable terminated() {
     return new BuildOperationsImpl(getContext().withTerminatedStatus(true), context);
   }
 
   @Override
-  public TailPrettyLoggable<LogWatch> sinceTime(String sinceTimestamp) {
+  public TailPrettyLoggable sinceTime(String sinceTimestamp) {
     return new BuildOperationsImpl(getContext().withSinceTimestamp(sinceTimestamp), context);
   }
 
   @Override
-  public TailPrettyLoggable<LogWatch> sinceSeconds(int sinceSeconds) {
+  public TailPrettyLoggable sinceSeconds(int sinceSeconds) {
     return new BuildOperationsImpl(getContext().withSinceSeconds(sinceSeconds), context);
   }
 
   @Override
-  public BytesLimitTerminateTimeTailPrettyLoggable<LogWatch> limitBytes(int limitBytes) {
+  public BytesLimitTerminateTimeTailPrettyLoggable limitBytes(int limitBytes) {
     return new BuildOperationsImpl(getContext().withLimitBytes(limitBytes), context);
   }
 
   @Override
-  public BytesLimitTerminateTimeTailPrettyLoggable<LogWatch> usingTimestamps() {
+  public BytesLimitTerminateTimeTailPrettyLoggable usingTimestamps() {
     return new BuildOperationsImpl(getContext().withTimestamps(true), context);
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -323,7 +323,7 @@ public class ManagedOpenShiftClient extends NamespacedKubernetesClientAdapter<Na
   }
 
   @Override
-  public MixedOperation<Build, BuildList, BuildResource<Build, LogWatch>> builds() {
+  public MixedOperation<Build, BuildList, BuildResource> builds() {
     return getClient().builds();
   }
 


### PR DESCRIPTION
## Description
Addresses #4107 - removing generics from interfaces that only have a single implementation

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
