### PR TITLE
updating deprecated direct constructor usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ This client provides access to the full [Kubernetes](http://kubernetes.io/) &
 The easiest way to create a client is:
 
 ```java
-KubernetesClient client = new DefaultKubernetesClient();
+KubernetesClient client = new KubernetesClientBuilder().build();
 ```
 
 `DefaultOpenShiftClient` implements both the `KubernetesClient` & `OpenShiftClient` interface so if you need the
 OpenShift extensions, such as `Build`s, etc then simply do:
 
 ```java
-OpenShiftClient osClient = new DefaultOpenShiftClient();
+OpenShiftClient osClient = new KubernetesClientBuilder().build().adapt(OpenShiftClient.class);
 ```
 
 ### Configuring the client
@@ -121,7 +121,7 @@ Alternatively you can use the `ConfigBuilder` to create a config object for the 
 
 ```java
 Config config = new ConfigBuilder().withMasterUrl("https://mymaster.com").build();
-KubernetesClient client = new DefaultKubernetesClient(config);
+KubernetesClient client = new KubernetesClientBuilder().withConfig(config).build();
 ```
 
 ###
@@ -264,7 +264,7 @@ which allows adapting an existing [KubernetesClient](kubernetes-client-api/src/m
  For example:
 
 ```java
-KubernetesClient client = new DefaultKubernetesClient();
+KubernetesClient client = new KubernetesClientBuilder().build();
 
 OpenShiftClient oClient = client.adapt(OpenShiftClient.class);
 ```
@@ -272,7 +272,7 @@ OpenShiftClient oClient = client.adapt(OpenShiftClient.class);
 The client also support the isAdaptable() method which checks if the adaptation is possible and returns true if it does.
 
 ```java
-KubernetesClient client = new DefaultKubernetesClient();
+KubernetesClient client = new KubernetesClientBuilder().build();
 if (client.isAdaptable(OpenShiftClient.class)) {
     OpenShiftClient oClient = client.adapt(OpenShiftClient.class);
 } else {


### PR DESCRIPTION
## Description
Removing references to Default Kubernetes/OpenShift contructors.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
