### PR TITLE
Do not discard auth command if no args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #3745: the client will throw better exceptions when a namespace is not discernible for an operation
 * Fix #4106: removed listing from projectrequests
 * Fix #4081: moving Versionable.withResourceVersion to a method on WatchAndWaitable and removing Waitable from the return type
+* Fix #3733: The authentication command from the .kube/config won't be discarded if no arguments are specified
 
 #### Improvements
 * Remove `setIntVal`, `setStrVal`, `setKind` setters from `IntOrString` class to avoid invalid combinations

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -766,7 +766,7 @@ public class Config {
     List<String> argv = new ArrayList<>(Utils.getCommandPlatformPrefix());
     command = getCommandWithFullyQualifiedPath(command, systemPathValue);
     List<String> args = exec.getArgs();
-    if (args != null) {
+    if (args != null && !args.isEmpty()) {
       command += " " + String.join(" ", args);
     }
     argv.add(command);

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -767,8 +767,9 @@ public class Config {
     command = getCommandWithFullyQualifiedPath(command, systemPathValue);
     List<String> args = exec.getArgs();
     if (args != null) {
-      argv.add(command + " " + String.join(" ", args));
+      command += " " + String.join(" ", args);
     }
+    argv.add(command);
     return argv;
   }
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -591,6 +591,7 @@ public class ConfigTest {
       .withApiVersion("client.authentication.k8s.io/v1alpha1")
       .withCommand("/usr/local/bin/gke-gcloud-auth-plugin")
       .build();
+    // Simulate "user.exec.args: null" like e.g. in the configuration for the gke-gcloud-auth-plugin.
     execConfigNoArgs.setArgs(null);
 
     // When

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -586,24 +586,22 @@ public class ConfigTest {
   void testGetAuthenticatorCommandFromExecConfigNoArgs() throws IOException {
     // Given
     File commandFolder = Files.createTempDirectory("test").toFile();
-    File commandFile = new File(commandFolder, "aws");
-    boolean isNewFileCreated = commandFile.createNewFile();
     String systemPathValue = getTestPathValue(commandFolder);
     ExecConfig execConfigNoArgs = new ExecConfigBuilder()
-        .withApiVersion("client.authentication.k8s.io/v1alpha1")
-        .withCommand("gke-gcloud-auth-plugin")
-        .build();
+      .withApiVersion("client.authentication.k8s.io/v1alpha1")
+      .withCommand("/usr/local/bin/gke-gcloud-auth-plugin")
+      .build();
+    execConfigNoArgs.setArgs(null);
 
     // When
-    List<String> processBuilderArgs = Config.getAuthenticatorCommandFromExecConfig(execConfigNoArgs, new File("~/.kube/config"),
-        systemPathValue);
+    List<String> processBuilderArgs = Config.getAuthenticatorCommandFromExecConfig(
+      execConfigNoArgs, null, systemPathValue);
 
     // Then
-    assertTrue(isNewFileCreated);
     assertNotNull(processBuilderArgs);
     assertEquals(3, processBuilderArgs.size());
     assertPlatformPrefixes(processBuilderArgs);
-    assertEquals(commandFile.getAbsolutePath(), processBuilderArgs.get(2));
+    assertEquals("/usr/local/bin/gke-gcloud-auth-plugin", processBuilderArgs.get(2));
   }
 
   private void assertPlatformPrefixes(List<String> processBuilderArgs) {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -589,15 +589,15 @@ public class ConfigTest {
     File commandFile = new File(commandFolder, "gke-gcloud-auth-plugin");
     String systemPathValue = getTestPathValue(commandFolder);
     ExecConfig execConfigNoArgs = new ExecConfigBuilder()
-      .withApiVersion("client.authentication.k8s.io/v1alpha1")
-      .withCommand(commandFile.getPath())
-      .build();
+        .withApiVersion("client.authentication.k8s.io/v1alpha1")
+        .withCommand(commandFile.getPath())
+        .build();
     // Simulate "user.exec.args: null" like e.g. in the configuration for the gke-gcloud-auth-plugin.
     execConfigNoArgs.setArgs(null);
 
     // When
     List<String> processBuilderArgs = Config.getAuthenticatorCommandFromExecConfig(
-      execConfigNoArgs, null, systemPathValue);
+        execConfigNoArgs, null, systemPathValue);
 
     // Then
     assertNotNull(processBuilderArgs);

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -582,6 +582,30 @@ public class ConfigTest {
     assertEquals("api-eks.example.com", commandParts.get(6));
   }
 
+  @Test
+  void testGetAuthenticatorCommandFromExecConfigNoArgs() throws IOException {
+    // Given
+    File commandFolder = Files.createTempDirectory("test").toFile();
+    File commandFile = new File(commandFolder, "aws");
+    boolean isNewFileCreated = commandFile.createNewFile();
+    String systemPathValue = getTestPathValue(commandFolder);
+    ExecConfig execConfigNoArgs = new ExecConfigBuilder()
+        .withApiVersion("client.authentication.k8s.io/v1alpha1")
+        .withCommand("gke-gcloud-auth-plugin")
+        .build();
+
+    // When
+    List<String> processBuilderArgs = Config.getAuthenticatorCommandFromExecConfig(execConfigNoArgs, new File("~/.kube/config"),
+        systemPathValue);
+
+    // Then
+    assertTrue(isNewFileCreated);
+    assertNotNull(processBuilderArgs);
+    assertEquals(3, processBuilderArgs.size());
+    assertPlatformPrefixes(processBuilderArgs);
+    assertEquals(commandFile.getAbsolutePath(), processBuilderArgs.get(2));
+  }
+
   private void assertPlatformPrefixes(List<String> processBuilderArgs) {
     List<String> platformArgsExpected = Utils.getCommandPlatformPrefix();
     assertEquals(platformArgsExpected.get(0), processBuilderArgs.get(0));

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -583,13 +583,14 @@ public class ConfigTest {
   }
 
   @Test
-  void testGetAuthenticatorCommandFromExecConfigNoArgs() throws IOException {
+  void testGetAuthenticatorCommandFromExecConfigNullArgs() throws IOException {
     // Given
     File commandFolder = Files.createTempDirectory("test").toFile();
+    File commandFile = new File(commandFolder, "gke-gcloud-auth-plugin");
     String systemPathValue = getTestPathValue(commandFolder);
     ExecConfig execConfigNoArgs = new ExecConfigBuilder()
       .withApiVersion("client.authentication.k8s.io/v1alpha1")
-      .withCommand("/usr/local/bin/gke-gcloud-auth-plugin")
+      .withCommand(commandFile.getPath())
       .build();
     // Simulate "user.exec.args: null" like e.g. in the configuration for the gke-gcloud-auth-plugin.
     execConfigNoArgs.setArgs(null);
@@ -602,7 +603,7 @@ public class ConfigTest {
     assertNotNull(processBuilderArgs);
     assertEquals(3, processBuilderArgs.size());
     assertPlatformPrefixes(processBuilderArgs);
-    assertEquals("/usr/local/bin/gke-gcloud-auth-plugin", processBuilderArgs.get(2));
+    assertEquals(commandFile.getPath(), processBuilderArgs.get(2));
   }
 
   private void assertPlatformPrefixes(List<String> processBuilderArgs) {


### PR DESCRIPTION
## Description
The authentication command (`user.exec.args: command`) from the `.kube/config` won't be discarded if no arguments are specified (`user.exec.args: null`).

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->

Fixes https://github.com/fabric8io/kubernetes-client/issues/3733
Backport for the 5.12 branch: https://github.com/fabric8io/kubernetes-client/pull/4122