### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ concurrency:
   group: ci-build-kubernetes-client-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Java ${{ matrix.java }} Maven

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ci-go-kubernetes-client-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Kubernetes Model Generator Build

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -30,6 +30,9 @@ concurrency:
   group: ci-docs-kubernetes-client-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   javadoc:
     name: JavaDocs

--- a/.github/workflows/release-snapshots.yaml
+++ b/.github/workflows/release-snapshots.yaml
@@ -28,6 +28,9 @@ on:
   schedule:
     - cron: '0 2 * * *' # Every day at 2am
 
+permissions:
+  contents: read
+
 jobs:
   release-snapshots:
     name: Release SNAPSHOT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,9 @@ on:
         required: true
         default: '8'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release ${{ github.event.inputs.tag }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,6 +30,9 @@ concurrency:
   group: ci-sonar-kubernetes-client-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     name: Sonar

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -30,6 +30,9 @@ concurrency:
   group: ci-license-kubernetes-client-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   style-check:
     name: License & Code Style Checks

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ci-win-kubernetes-client-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Java ${{ matrix.java }} Maven


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
