### PR TITLE
fix #4127 Change the visibility of Abstract class constructor to "protected".

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/decorator/NamedResourceDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/decorator/NamedResourceDecorator.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.utils.Utils;
+
 import java.util.Optional;
 
 public abstract class NamedResourceDecorator<T> extends Decorator<VisitableBuilder> {
@@ -36,15 +37,15 @@ public abstract class NamedResourceDecorator<T> extends Decorator<VisitableBuild
 
   private final ResourceVisitor visitor = new ResourceVisitor(null, null);
 
-  public NamedResourceDecorator() {
+  protected NamedResourceDecorator() {
     this(ANY, ANY);
   }
 
-  public NamedResourceDecorator(String name) {
+  protected NamedResourceDecorator(String name) {
     this(ANY, name);
   }
 
-  public NamedResourceDecorator(String kind, String name) {
+  protected NamedResourceDecorator(String kind, String name) {
     this.kind = kind;
     this.name = name;
   }
@@ -123,13 +124,13 @@ public abstract class NamedResourceDecorator<T> extends Decorator<VisitableBuild
 
     public Class<T> getType() {
       return (Class) Generics
-        .getTypeArguments(NamedResourceDecorator.class, NamedResourceDecorator.this.getClass())
-        .get(0);
+          .getTypeArguments(NamedResourceDecorator.class, NamedResourceDecorator.this.getClass())
+          .get(0);
     }
   }
 
   @Override
   public Class<? extends Decorator>[] after() {
-    return new Class[]{ ResourceProvidingDecorator.class };
+    return new Class[] { ResourceProvidingDecorator.class };
   }
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/CustomResourceDefinitionVersionDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/CustomResourceDefinitionVersionDecorator.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.crd.generator.v1beta1.decorator;
 
-import static io.fabric8.crd.generator.utils.Metadata.getMetadata;
-
 import io.fabric8.crd.generator.decorator.Decorator;
 import io.fabric8.crd.generator.utils.Generics;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
@@ -24,10 +22,13 @@ import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersionBuilder;
 import io.fabric8.kubernetes.client.utils.Utils;
+
 import java.util.Optional;
 
+import static io.fabric8.crd.generator.utils.Metadata.getMetadata;
+
 public abstract class CustomResourceDefinitionVersionDecorator<T> extends
-  Decorator<VisitableBuilder> {
+    Decorator<VisitableBuilder> {
 
   protected static final String ANY = null;
 
@@ -37,7 +38,7 @@ public abstract class CustomResourceDefinitionVersionDecorator<T> extends
   private final CustomResourceDefinitionVersionVisitor versionSelector = new CustomResourceDefinitionVersionVisitor();
   private final VersionVisitor versionVisitor = new VersionVisitor();
 
-  public CustomResourceDefinitionVersionDecorator(String name, String version) {
+  protected CustomResourceDefinitionVersionDecorator(String name, String version) {
     this.name = name;
     this.version = version;
   }
@@ -57,7 +58,7 @@ public abstract class CustomResourceDefinitionVersionDecorator<T> extends
       return;
     }
     if (Utils.isNullOrEmpty(name) || objectMeta.map(ObjectMeta::getName).filter(s -> s.equals(name))
-      .isPresent()) {
+        .isPresent()) {
       builder.accept(versionSelector);
     }
   }
@@ -65,7 +66,7 @@ public abstract class CustomResourceDefinitionVersionDecorator<T> extends
   public abstract void andThenVisit(T version);
 
   private class CustomResourceDefinitionVersionVisitor extends
-    TypedVisitor<CustomResourceDefinitionVersionBuilder> {
+      TypedVisitor<CustomResourceDefinitionVersionBuilder> {
 
     @Override
     public void visit(CustomResourceDefinitionVersionBuilder builder) {
@@ -84,22 +85,22 @@ public abstract class CustomResourceDefinitionVersionDecorator<T> extends
 
     public Class<T> getType() {
       return (Class) Generics
-        .getTypeArguments(CustomResourceDefinitionVersionDecorator.class,
-          CustomResourceDefinitionVersionDecorator.this.getClass())
-        .get(0);
+          .getTypeArguments(CustomResourceDefinitionVersionDecorator.class,
+              CustomResourceDefinitionVersionDecorator.this.getClass())
+          .get(0);
     }
   }
 
   @Override
   public Class<? extends Decorator>[] after() {
-    return new Class[]{
-      AddCustomResourceDefinitionResourceDecorator.class,
-      AddCustomResourceDefinitionVersionDecorator.class};
+    return new Class[] {
+        AddCustomResourceDefinitionResourceDecorator.class,
+        AddCustomResourceDefinitionVersionDecorator.class };
   }
 
   @Override
   public Class<? extends Decorator>[] before() {
-    return new Class[]{};
+    return new Class[] {};
   }
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -46,32 +46,31 @@ import static io.fabric8.kubernetes.client.utils.Utils.isNullOrEmpty;
  *
  * Properties are set up automatically as follows:
  * <ul>
- *   <li>group is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getGroup(Class)}</li>
- *   <li>version is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getVersion(Class)}</li>
- *   <li>singular is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getSingular(Class)}</li>
- *   <li>plural is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getPlural(Class)}</li>
- *   <li>computed CRD name using {@link CustomResource#getCRDName(Class)}</li>
+ * <li>group is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getGroup(Class)}</li>
+ * <li>version is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getVersion(Class)}</li>
+ * <li>singular is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getSingular(Class)}</li>
+ * <li>plural is set using {@link io.fabric8.kubernetes.api.model.HasMetadata#getPlural(Class)}</li>
+ * <li>computed CRD name using {@link CustomResource#getCRDName(Class)}</li>
  * </ul>
  *
- * In addition, {@link CustomResource#setApiVersion(String)} and {@link CustomResource#setKind(String)} are overridden to not do anything since these values
+ * In addition, {@link CustomResource#setApiVersion(String)} and {@link CustomResource#setKind(String)} are overridden to not do
+ * anything since these values
  * are set.
  *
  * @param <S> the class providing the {@code Spec} part of this CustomResource
  * @param <T> the class providing the {@code Status} part of this CustomResource
  */
-@JsonDeserialize(
-  using = JsonDeserializer.None.class
-)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 @JsonPropertyOrder({
-  "apiVersion",
-  "kind",
-  "metadata",
-  "spec",
-  "status"
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec",
+    "status"
 })
 @JsonInclude(Include.NON_NULL)
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
-  @BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
 })
 public abstract class CustomResource<S, T> implements HasMetadata {
   private static final Logger LOG = LoggerFactory.getLogger(CustomResource.class);
@@ -95,12 +94,12 @@ public abstract class CustomResource<S, T> implements HasMetadata {
   private final boolean served;
   private final boolean storage;
 
-  public CustomResource() {
+  protected CustomResource() {
     final String version = HasMetadata.super.getApiVersion();
     final Class<? extends CustomResource> clazz = getClass();
     if (isNullOrEmpty(version)) {
       throw new IllegalArgumentException(clazz.getName() + " CustomResource must provide an API version using @"
-        + Group.class.getName() + " and @" + Version.class.getName() + " annotations");
+          + Group.class.getName() + " and @" + Version.class.getName() + " annotations");
     }
     this.apiVersion = version;
     this.kind = HasMetadata.super.getKind();
@@ -126,7 +125,9 @@ public abstract class CustomResource<S, T> implements HasMetadata {
 
   /**
    * Override to provide your own Spec instance
-   * @return a new Spec instance or {@code null} if the responsibility of instantiating the Spec is left to users of this CustomResource
+   * 
+   * @return a new Spec instance or {@code null} if the responsibility of instantiating the Spec is left to users of this
+   *         CustomResource
    */
   protected S initSpec() {
     return null;
@@ -134,7 +135,9 @@ public abstract class CustomResource<S, T> implements HasMetadata {
 
   /**
    * Override to provide your own Status instance
-   * @return a new Status instance or {@code null} if the responsibility of instantiating the Status is left to users of this CustomResource
+   * 
+   * @return a new Status instance or {@code null} if the responsibility of instantiating the Status is left to users of this
+   *         CustomResource
    */
   protected T initStatus() {
     return null;
@@ -143,12 +146,12 @@ public abstract class CustomResource<S, T> implements HasMetadata {
   @Override
   public String toString() {
     return "CustomResource{" +
-      "kind='" + getKind() + '\'' +
-      ", apiVersion='" + getApiVersion() + '\'' +
-      ", metadata=" + metadata +
-      ", spec=" + spec +
-      ", status=" + status +
-      '}';
+        "kind='" + getKind() + '\'' +
+        ", apiVersion='" + getApiVersion() + '\'' +
+        ", metadata=" + metadata +
+        ", spec=" + spec +
+        ", status=" + status +
+        '}';
   }
 
   @Override
@@ -159,7 +162,8 @@ public abstract class CustomResource<S, T> implements HasMetadata {
   @Override
   public void setApiVersion(String version) {
     // already set in constructor
-    LOG.debug("Calling CustomResource#setApiVersion doesn't do anything because the API version is computed and shouldn't be changed");
+    LOG.debug(
+        "Calling CustomResource#setApiVersion doesn't do anything because the API version is computed and shouldn't be changed");
   }
 
   @Override
@@ -232,8 +236,8 @@ public abstract class CustomResource<S, T> implements HasMetadata {
    */
   public static String[] getShortNames(Class<? extends CustomResource> clazz) {
     return Optional.ofNullable(clazz.getAnnotation(ShortNames.class))
-      .map(ShortNames::value)
-      .orElse(new String[]{});
+        .map(ShortNames::value)
+        .orElse(new String[] {});
   }
 
   /**
@@ -284,21 +288,33 @@ public abstract class CustomResource<S, T> implements HasMetadata {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof CustomResource)) return false;
+    if (this == o)
+      return true;
+    if (!(o instanceof CustomResource))
+      return false;
 
     CustomResource<?, ?> that = (CustomResource<?, ?>) o;
 
-    if (served != that.served) return false;
-    if (storage != that.storage) return false;
-    if (!metadata.equals(that.metadata)) return false;
-    if (!Objects.equals(spec, that.spec)) return false;
-    if (!Objects.equals(status, that.status)) return false;
-    if (!singular.equals(that.singular)) return false;
-    if (!crdName.equals(that.crdName)) return false;
-    if (!kind.equals(that.kind)) return false;
-    if (!apiVersion.equals(that.apiVersion)) return false;
-    if (!scope.equals(that.scope)) return false;
+    if (served != that.served)
+      return false;
+    if (storage != that.storage)
+      return false;
+    if (!metadata.equals(that.metadata))
+      return false;
+    if (!Objects.equals(spec, that.spec))
+      return false;
+    if (!Objects.equals(status, that.status))
+      return false;
+    if (!singular.equals(that.singular))
+      return false;
+    if (!crdName.equals(that.crdName))
+      return false;
+    if (!kind.equals(that.kind))
+      return false;
+    if (!apiVersion.equals(that.apiVersion))
+      return false;
+    if (!scope.equals(that.scope))
+      return false;
     return plural.equals(that.plural);
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
@@ -33,7 +33,7 @@ public abstract class ExtensibleResourceAdapter<T> extends ResourceAdapter<T> im
   protected ExtensibleResource<T> resource;
   protected Client client;
 
-  public ExtensibleResourceAdapter() {
+  protected ExtensibleResourceAdapter() {
 
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/MetricOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/MetricOperationsImpl.java
@@ -18,8 +18,8 @@ package io.fabric8.kubernetes.client.dsl.internal;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MetricOperation;
 import io.fabric8.kubernetes.client.utils.URLUtils;
-import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.client.utils.URLUtils.URLBuilder;
+import io.fabric8.kubernetes.client.utils.Utils;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ public abstract class MetricOperationsImpl<T, L> extends OperationSupport implem
   private final Class<L> apiTypeListClass;
   private final Class<T> apiTypeClass;
 
-  public MetricOperationsImpl(OperationContext operationContext, Class<T> apiTypeClass, Class<L> apiTypeListClass) {
+  protected MetricOperationsImpl(OperationContext operationContext, Class<T> apiTypeClass, Class<L> apiTypeListClass) {
     super(operationContext);
     this.apiTypeClass = apiTypeClass;
     this.apiTypeListClass = apiTypeListClass;
@@ -107,11 +107,11 @@ public abstract class MetricOperationsImpl<T, L> extends OperationSupport implem
     URLBuilder httpUrlBuilder = new URLBuilder(baseUrl);
 
     StringBuilder sb = new StringBuilder();
-    for(Map.Entry<String, String> entry : labels.entrySet()) {
+    for (Map.Entry<String, String> entry : labels.entrySet()) {
       sb.append(entry.getKey()).append("=").append(entry.getValue()).append(",");
     }
     httpUrlBuilder.addQueryParameter("labelSelector", sb.substring(0, sb.toString().length() - 1));
     return httpUrlBuilder.toString();
   }
-  
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorListener.java
@@ -39,7 +39,7 @@ public class ProcessorListener<T> {
   private ZonedDateTime nextResync;
   private ResourceEventHandler<? super T> handler;
 
-  public ProcessorListener(ResourceEventHandler<? super T> handler, long resyncPeriodInMillis) {
+  protected ProcessorListener(ResourceEventHandler<? super T> handler, long resyncPeriodInMillis) {
     this.resyncPeriodInMillis = resyncPeriodInMillis;
     this.handler = handler;
 


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fix #4127 

Abstract classes should not have public constructors. Constructors of abstract classes can only be called in constructors of their subclasses. So there is no point in making them public. The protected modifier should be enough.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
