### PR TITLE
fix (kubernetes-client) : Throw exception when `HasMetadata` is used in `resources(...)` API (#3990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Bugs
 * Fix #3832 #1883: simplifying the isHttpsAvailable check
 * Fix #3745: the client will throw better exceptions when a namespace is not discernible for an operation
+* Fix #3990: Throw exception when `HasMetadata` is used in `resources(...)` API
 * Fix #4106: removed listing from projectrequests
 * Fix #4140: changed StatefulSet rolling pause / resume to unsupported.  Also relying on default rolling logic to Deployments and StatefulSets
 * Fix #4081: moving Versionable.withResourceVersion to a method on WatchAndWaitable and removing Waitable from the return type

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -229,6 +229,9 @@ public abstract class BaseClient implements Client {
     if (GenericKubernetesResource.class.equals(resourceType)) {
       throw new KubernetesClientException("resources cannot be called with a generic type");
     }
+    if (resourceType.isInterface()) {
+      throw new IllegalArgumentException("resources cannot be called with an interface");
+    }
     try {
       // TODO: check the Resource class type
       return handlers.getOperation(resourceType, listClass, this);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedResourcesApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedResourcesApiTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@EnableKubernetesMockClient
+class TypedResourcesApiTest {
+  KubernetesClient client;
+
+  @Test
+  void resources_whenUsedWithGenericKubernetesResource_shouldThrowException() {
+    // Given + When
+    KubernetesClientException kubernetesClientException = assertThrows(KubernetesClientException.class,
+        () -> client.resources(GenericKubernetesResource.class));
+
+    // Then
+    assertThat(kubernetesClientException)
+        .hasMessage("resources cannot be called with a generic type");
+  }
+
+  @Test
+  void resources_whenUsedWithHasMetadata_shouldThrowException() {
+    // Given + When
+    IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class,
+        () -> client.resources(HasMetadata.class));
+
+    // Then
+    assertThat(illegalArgumentException)
+        .hasMessage("resources cannot be called with an interface");
+  }
+}


### PR DESCRIPTION
## Description
Fix #3990

Access to `resources(...)` DSL method with generic HasMetadata interface
shouldn't be allowed.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
