### PR TITLE
fix #4142: additional patch methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 SharedIndexInformer allows for the addition and removal of indexes even after starting, and you can remove the default namespace index if you wish.
 And Store.getKey can be used rather than directly referencing static Cache functions.
 * Fix #4065: Client.getAPIResources("v1") can be used to obtain the core/legacy resources
+* Fix #4142: Added patch() and patch(PatchContext) methods for use with resource and load
 * Fix #4093: adding a possibility to get a log as an `InputStream` from the `Loggable` resources
 
 #### Dependency Upgrade

--- a/doc/MIGRATION-v6.md
+++ b/doc/MIGRATION-v6.md
@@ -215,6 +215,8 @@ Client.adapt will no longer perform the isAdaptable check - that is you may free
 
 - DSL methods available off of a collection context involving a resource - client.configMaps().create(configMap) - should instead use a no-argument method - client.configMaps().resource(configMap).create() or client.resource(configMap).create().
 
+The only exception to the above is patch(PatchContext, item) - it is valid to be called after withName. 
+
 ## Object Sorting
 
 KubernetesList and Template will no longer automatically sort their objects by default.  You may use the HasMetadataComparator to sort the items as needed.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
@@ -64,17 +64,19 @@ public interface EditReplacePatchable<T>
 
   /**
    * Update field(s) of a resource using a JSON patch.
-   *
-   * <br>
+   * <p>
    * It is the same as calling {@link #patch(PatchContext, Object)} with {@link PatchType#JSON} specified.
-   *
+   * <p>
    * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected
    * way.
-   * Consider using edit instead or ensure you have called load or resource to define the base of your patch
+   * <p>
+   * Consider using edit, which allows for a known base, and a builder instead.
    *
    * @param item to be patched with patched values
    * @return returns deserialized version of api server response
+   * @deprecated use resource(item).patch() or edit instead
    */
+  @Deprecated
   default T patch(T item) {
     return patch(PatchContext.of(PatchType.JSON), item);
   }
@@ -83,8 +85,7 @@ public interface EditReplacePatchable<T>
    * Update field(s) of a resource using type specified in {@link PatchContext}(defaults to strategic merge if not specified).
    *
    * <ul>
-   * <li>{@link PatchType#JSON} - will create a JSON patch against the current item. See the note in {@link #patch(Object)}
-   * about what is used for the base object.
+   * <li>{@link PatchType#JSON} - will create a JSON patch against the latest server state
    * <li>{@link PatchType#JSON_MERGE} - will send the serialization of the item as a JSON MERGE patch.
    * Set the resourceVersion to null to prevent optimistic locking.
    * <li>{@link PatchType#STRATEGIC_MERGE} - will send the serialization of the item as a STRATEGIC MERGE patch.
@@ -137,4 +138,40 @@ public interface EditReplacePatchable<T>
    * @return updated object
    */
   T patchStatus();
+
+  /**
+   * Update field(s) of a resource using a JSON patch.
+   * <p>
+   * It is the same as calling {@link #patch(PatchContext, Object)} with {@link PatchType#JSON} specified.
+   * <p>
+   * WARNING: This may overwrite concurrent changes (between when you obtained your item and the current state) in an unexpected
+   * way.
+   * <p>
+   * Consider using edit instead.
+   *
+   * @return returns deserialized version of api server response
+   */
+  T patch();
+
+  /**
+   * Update field(s) of a resource using type specified in {@link PatchContext}(defaults to strategic merge if not specified).
+   * <p>
+   * For use when you are providing a complete object to be patched:
+   * resource(item).patch(PatchContext.of(PatchType.SERVER_SIDE_APPLY))
+   *
+   * <ul>
+   * <li>{@link PatchType#JSON} - will create a JSON patch against the latest server state
+   * <li>{@link PatchType#JSON_MERGE} - will send the serialization of the item as a JSON MERGE patch.
+   * Set the resourceVersion to null to prevent optimistic locking.
+   * <li>{@link PatchType#STRATEGIC_MERGE} - will send the serialization of the item as a STRATEGIC MERGE patch.
+   * Set the resourceVersion to null to prevent optimistic locking.
+   * <li>{@link PatchType#SERVER_SIDE_APPLY} - will send the serialization of the item as a SERVER SIDE APPLY patch.
+   * You may explicitly set the {@link PatchContext#getFieldManager()} as well to override the default.
+   * </ul>
+   *
+   * @param patchContext {@link PatchContext} for patch request
+   * @return returns deserialized version of api server response
+   */
+  T patch(PatchContext patchContext);
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -291,4 +291,14 @@ public class ResourceAdapter<T> implements Resource<T> {
     return resource.patchStatus();
   }
 
+  @Override
+  public T patch() {
+    return resource.patch();
+  }
+
+  @Override
+  public T patch(PatchContext patchContext) {
+    return resource.patch(patchContext);
+  }
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -142,6 +142,7 @@ public class ResourceAdapter<T> implements Resource<T> {
   }
 
   @Override
+  @Deprecated
   public T patch(T item) {
     return resource.patch(item);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -516,7 +516,25 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public T patchStatus() {
-    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
+    return patchStatus(getNonNullItem());
+  }
+
+  @Override
+  public T patch() {
+    return patch(getNonNullItem());
+  }
+
+  @Override
+  public T patch(PatchContext patchContext) {
+    return patch(patchContext, getNonNullItem());
+  }
+
+  protected T getNonNullItem() {
+    T result = getItem();
+    if (result == null) {
+      throw new KubernetesClientException("item required");
+    }
+    return result;
   }
 
   @Override
@@ -1045,7 +1063,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public ExtensibleResource<T> lockResourceVersion() {
-    return lockResourceVersion(KubernetesResourceUtil.getResourceVersion(getItem()));
+    return lockResourceVersion(KubernetesResourceUtil.getResourceVersion(getNonNullItem()));
   }
 
   @Override
@@ -1055,7 +1073,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public T create() {
-    return create(getItem());
+    return create(getNonNullItem());
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
@@ -142,8 +142,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
     }
     if (!status) {
       try {
-        ObjectMeta metadata = item.getMetadata();
-        item = modifyItemForReplaceOrPatch(() -> requireFromServer(), item);
+        item = modifyItemForReplaceOrPatch(this::requireFromServer, item);
       } catch (Exception e) {
         throw KubernetesClientException.launderThrowable(forOperationType(REPLACE_OPERATION), e);
       }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
@@ -116,6 +116,31 @@ class ConfigMapCrudTest {
   }
 
   @Test
+  void testPatchBase() {
+    ConfigMap configmap2 = new ConfigMapBuilder()
+        .withNewMetadata()
+        .addToLabels("foo", "bar")
+        .withName("configmap2")
+        .endMetadata()
+        .addToData("two", "2")
+        .build();
+    ConfigMap configmap2a = new ConfigMapBuilder()
+        .withNewMetadata()
+        .addToLabels("foo", "bar")
+        .withName("configmap2")
+        .endMetadata()
+        .addToData("three", "3")
+        .build();
+
+    client.configMaps().inNamespace("ns1").resource(configmap2).create();
+    client.configMaps().inNamespace("ns1").resource(configmap2a).replace();
+
+    // should still diff to latest
+    ConfigMap result = client.configMaps().inNamespace("ns1").resource(configmap2).patch(configmap2);
+    assertEquals(Collections.singletonMap("three", "3"), result.getData());
+  }
+
+  @Test
   @DisplayName("edit, should add and remove data entries")
   void edit() {
     // Given


### PR DESCRIPTION
## Description
fix #4142: additional patch methods

also correcting the javadocs wrt the patch base item.

removing logic that infers from the passed in item as the context will
already have the necessary information

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
