### PR TITLE
Making the calling of WebSocket.request consistent

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
@@ -48,11 +48,14 @@ class WatcherWebSocketListener<T extends HasMetadata> implements WebSocket.Liste
 
   @Override
   public void onMessage(WebSocket webSocket, String text) {
-    webSocket.request();
     // onMesssage and onClose are serialized, but it's not specified if onError
     // may occur simultaneous with onMessage.  So we prevent concurrent processing
-    synchronized (this) {
-      manager.onMessage(text);
+    try {
+      synchronized (this) {
+        manager.onMessage(text);
+      }
+    } finally {
+      webSocket.request();
     }
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -59,8 +59,12 @@ class WatchTest {
 
   @BeforeEach
   void setUp() {
-    pod1 = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
-      .withResourceVersion("1").endMetadata().build();
+    pod1 = new PodBuilder().withNewMetadata()
+        .withNamespace("test")
+        .withName("pod1")
+        .withResourceVersion("1")
+        .endMetadata()
+        .build();
   }
 
   @Test
@@ -68,10 +72,16 @@ class WatchTest {
   void testTryWithResourcesConnectsThenReceivesEvent() throws InterruptedException {
     // Given
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
-        .andUpgradeToWebSocket().open()
-        .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "DELETED"))
-        .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(outdatedEvent()).done().once();
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "DELETED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(outdatedEvent())
+        .done()
+        .once();
     final CountDownLatch deleteLatch = new CountDownLatch(1);
     final CountDownLatch closeLatch = new CountDownLatch(1);
     final Watcher<Pod> watcher = new Watcher<Pod>() {
@@ -104,8 +114,10 @@ class WatchTest {
     // Given
     final CountDownLatch closeLatch = new CountDownLatch(1);
     server.expect()
-      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
-      .andReturn(410, outdatedEvent()).once();
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andReturn(410, outdatedEvent())
+        .once();
     final Watcher<Pod> watcher = new Watcher<Pod>() {
       @Override
       public void eventReceived(Action action, Pod resource) {
@@ -139,20 +151,27 @@ class WatchTest {
   void testWithTimeoutSecondsShouldAddQueryParam() throws InterruptedException {
     // Given
     server.expect()
-      .withPath("/api/v1/namespaces/test/pods?timeoutSeconds=30&allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket().open()
-      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "DELETED"))
-      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(outdatedEvent()).done().once();
-
+        .withPath("/api/v1/namespaces/test/pods?timeoutSeconds=30&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "DELETED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(outdatedEvent())
+        .done()
+        .once();
 
     // When
     final CountDownLatch eventReceivedLatch = new CountDownLatch(1);
     Watch watch = client.pods().watch(new ListOptionsBuilder().withTimeoutSeconds(30L).build(), new Watcher<Pod>() {
       @Override
-      public void eventReceived(Action action, Pod resource) { eventReceivedLatch.countDown(); }
+      public void eventReceived(Action action, Pod resource) {
+        eventReceivedLatch.countDown();
+      }
 
       @Override
-      public void onClose(WatcherException cause) { }
+      public void onClose(WatcherException cause) {
+      }
     });
 
     // Then
@@ -171,7 +190,11 @@ class WatchTest {
     // accept watch and disconnect
     server.expect().withPath(path).andUpgradeToWebSocket().open().done().once();
     // refuse reconnect attempts 6 times
-    server.expect().withPath(path).andReturn(HttpURLConnection.HTTP_NOT_FOUND, new StatusBuilder().withCode(HttpURLConnection.HTTP_NOT_FOUND).build()).times(6);
+    server.expect()
+        .withPath(path)
+        .andReturn(HttpURLConnection.HTTP_NOT_FOUND,
+            new StatusBuilder().withCode(HttpURLConnection.HTTP_NOT_FOUND).build())
+        .times(6);
     // accept next reconnect and send outdated event to stop the watch
     server.expect().withPath(path).andUpgradeToWebSocket().open(outdatedEvent()).done().once();
     final CountDownLatch closeLatch = new CountDownLatch(1);
@@ -201,9 +224,16 @@ class WatchTest {
     final CountDownLatch closeLatch = new CountDownLatch(1);
 
     server.expect()
-      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket().open().waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "MODIFIED")).waitFor(EVENT_WAIT_PERIOD_MS)
-      .andEmit(new WatchEvent(pod1, "MODIFIED")).done().once();
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "MODIFIED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "MODIFIED"))
+        .done()
+        .once();
 
     Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
       @Override
@@ -231,30 +261,43 @@ class WatchTest {
   void testReconnectsWithLastResourceVersion() throws InterruptedException {
     final CountDownLatch eventLatch = new CountDownLatch(3);
 
-    final Pod pod1initial = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
-      .withResourceVersion("9").endMetadata().build();
+    final Pod pod1initial = new PodBuilder().withNewMetadata()
+        .withNamespace("test")
+        .withName("pod1")
+        .withResourceVersion("9")
+        .endMetadata()
+        .build();
 
-
-    final Pod pod1update = new PodBuilder().withNewMetadata().withNamespace("test").withName("pod1")
-      .withResourceVersion("10").endMetadata().build();
+    final Pod pod1update = new PodBuilder().withNewMetadata()
+        .withNamespace("test")
+        .withName("pod1")
+        .withResourceVersion("10")
+        .endMetadata()
+        .build();
 
     final String path = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true";
 
     server.expect()
-      .withPath(path)
-      .andUpgradeToWebSocket().open()
-      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1initial, "MODIFIED"))
-      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1update, "MODIFIED"))
-      .done().once();
+        .withPath(path)
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1initial, "MODIFIED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1update, "MODIFIED"))
+        .done()
+        .once();
 
     final String reconnectPath = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=10&allowWatchBookmarks=true&watch=true";
 
     server.expect()
-      .withPath(reconnectPath)
-      .andUpgradeToWebSocket().open()
-      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1update, "MODIFIED"))
-      .done().once();
-
+        .withPath(reconnectPath)
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1update, "MODIFIED"))
+        .done()
+        .once();
 
     Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new Watcher<Pod>() {
       @Override
@@ -273,22 +316,28 @@ class WatchTest {
 
   private static WatchEvent outdatedEvent() {
     return new WatchEventBuilder().withStatusObject(
-      new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
-        .withMessage(
-        "410: The event in requested index is outdated and cleared (the requested history has been cleared [3/1]) [2]")
-      .build()).build();
+        new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
+            .withMessage(
+                "410: The event in requested index is outdated and cleared (the requested history has been cleared [3/1]) [2]")
+            .build())
+        .build();
   }
-
 
   @Test
   @DisplayName("TryWithResources, connects and receives event then receives GONE, should receive first event and then close")
   void testTryWithResourcesConnectsThenReceivesEventBookmark() throws InterruptedException {
     // Given
     server.expect()
-      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket().open()
-      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(new WatchEvent(pod1, "BOOKMARK"))
-      .waitFor(EVENT_WAIT_PERIOD_MS).andEmit(outdatedEvent()).done().once();
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "BOOKMARK"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(outdatedEvent())
+        .done()
+        .once();
     final CountDownLatch bookmarkLatch = new CountDownLatch(1);
     final CountDownLatch closeLatch = new CountDownLatch(1);
     final Watcher<Pod> watcher = new Watcher<Pod>() {
@@ -307,7 +356,10 @@ class WatchTest {
       }
     };
     // When
-    try (Watch watch = client.pods().withName("pod1").withResourceVersion("1").watch(new ListOptionsBuilder().withAllowWatchBookmarks(true).build(), watcher)) {
+    try (Watch watch = client.pods()
+        .withName("pod1")
+        .withResourceVersion("1")
+        .watch(new ListOptionsBuilder().withAllowWatchBookmarks(true).build(), watcher)) {
       // Then
       assertNotNull(watch);
       assertTrue(bookmarkLatch.await(10, TimeUnit.SECONDS));
@@ -332,9 +384,45 @@ class WatchTest {
 
       @Override
       public void onClose(WatcherException cause) {
-      }});
+      }
+    });
 
     // initial failure, then the http retry
     Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> server.getRequestCount() == 2);
+  }
+
+  @Test
+  void testWatcherException() throws InterruptedException {
+    // Given
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "MODIFIED"))
+        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .andEmit(new WatchEvent(pod1, "MODIFIED"))
+        .done()
+        .once();
+
+    CountDownLatch latch = new CountDownLatch(2);
+
+    client.pods().watch(new Watcher<Pod>() {
+
+      @Override
+      public void eventReceived(Action action, Pod resource) {
+        latch.countDown();
+        if (latch.getCount() == 1) {
+          throw new RuntimeException();
+        }
+      }
+
+      @Override
+      public void onClose(WatcherException cause) {
+      }
+    });
+
+    // ensure that the exception does not inhibit further message processing
+    assertTrue(latch.await(5, TimeUnit.SECONDS));
   }
 }


### PR DESCRIPTION
## Description
I should have noticed this with #4163, but for consistency request should be called after the message is processed. Also adding a test to make sure that an exception won't cause message processing to stop - it won't because it's being caught and the call to request is in a finally block just in case.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
