### PR TITLE
adding more javadocs on the websocket methods

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
@@ -22,20 +22,42 @@ import java.util.concurrent.CompletableFuture;
 
 public interface WebSocket {
 
+  /**
+   * Callback methods for websocket events. The methods are
+   * guaranteed to be called serially - except for {@link #onError(WebSocket, Throwable)}
+   */
   interface Listener {
 
     default void onOpen(WebSocket webSocket) {
     }
 
+    /**
+     * Called once the full text message has been built. {@link WebSocket#request()} must
+     * be called to receive more messages or onClose.
+     */
     default void onMessage(WebSocket webSocket, String text) {
+      webSocket.request();
     }
 
+    /**
+     * Called once the full binary message has been built. {@link WebSocket#request()} must
+     * be called to receive more messages or onClose.
+     */
     default void onMessage(WebSocket webSocket, ByteBuffer bytes) {
+      webSocket.request();
     }
 
+    /**
+     * Called when the remote input closes. It's a terminal event, calls to {@link WebSocket#request()}
+     * do nothing after this.
+     */
     default void onClose(WebSocket webSocket, int code, String reason) {
     }
 
+    /**
+     * Called when an error has occurred. It's a terminal event, calls to {@link WebSocket#request()}
+     * do nothing after this.
+     */
     default void onError(WebSocket webSocket, Throwable error) {
     }
 
@@ -93,6 +115,10 @@ public interface WebSocket {
    * received
    * <p>
    * request is implicitly called by {@link Listener#onOpen(WebSocket)}
+   * <p>
+   * depending on the websocket implementation request may trigger immediate / concurrent delivery
+   * of the close event - this means you'll generally want to call this method once you've completed the consumption
+   * of the current event.
    */
   void request();
 


### PR DESCRIPTION
## Description
adding more javadocs on the websocket methods

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
