### PR TITLE
feat: Jetty HttpClient implementation

### DIFF
--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes: [v1.24.0,v1.23.3, v1.12.10]
-        httpclient: [jdk]
+        httpclient: [jdk,jetty]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         openshift: [v3.11.0, v3.10.0]
-        httpclient: [jdk]
+        httpclient: [jdk,jetty]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release-snapshots.yaml
+++ b/.github/workflows/release-snapshots.yaml
@@ -84,4 +84,4 @@ jobs:
           gpg-private-key: ${{ secrets.SIGNINGKEY }}
           gpg-passphrase: SIGNINGPASSWORD
       - name: Build and release Java 11 modules
-        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} -pl "httpclient-jdk" clean deploy
+        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} -pl "httpclient-jdk" -pl "httpclient-jetty" clean deploy

--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -26,7 +26,7 @@
 
   <artifactId>kubernetes-httpclient-jdk</artifactId>
   <packaging>jar</packaging>
-  <name>Fabric8 :: Kubernetes :: JDK HttpClient</name>
+  <name>Fabric8 :: Kubernetes :: HttpClient :: JDK</name>
 
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
@@ -49,6 +49,28 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
@@ -181,7 +181,7 @@ class JdkHttpClientBuilderImpl implements Builder {
   }
 
   @Override
-  public Builder tlsVersions(TlsVersion[] tlsVersions) {
+  public Builder tlsVersions(TlsVersion... tlsVersions) {
     this.tlsVersions = tlsVersions;
     return this;
   }
@@ -192,7 +192,6 @@ class JdkHttpClientBuilderImpl implements Builder {
     copy.readTimeout = this.readTimeout;
     copy.sslContext = this.sslContext;
     copy.interceptors = new LinkedHashMap<>(this.interceptors);
-    copy.followRedirects = this.followRedirects;
     copy.proxyAddress = this.proxyAddress;
     copy.proxyAuthorization = this.proxyAuthorization;
     copy.tlsVersions = this.tlsVersions;

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpRequestImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpRequestImpl.java
@@ -26,11 +26,12 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Flow.Subscriber;
 
-class JdkHttpRequestImpl implements HttpRequest {
+import static io.fabric8.kubernetes.client.http.StandardHttpHeaders.CONTENT_TYPE;
 
-  private static final String CONTENT_TYPE = "Content-Type";
+class JdkHttpRequestImpl implements HttpRequest {
 
   public static class BuilderImpl implements Builder {
 
@@ -139,6 +140,11 @@ class JdkHttpRequestImpl implements HttpRequest {
   @Override
   public List<String> headers(String key) {
     return request.headers().allValues(key);
+  }
+
+  @Override
+  public Map<String, List<String>> headers() {
+    return request.headers().map();
   }
 
   @Override

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientAsyncBodyTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientAsyncBodyTest.java
@@ -17,34 +17,12 @@ package io.fabric8.kubernetes.client.jdkhttp;
 
 import io.fabric8.kubernetes.client.http.AbstractAsyncBodyTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
-import org.junit.jupiter.api.Disabled;
-
 
 @SuppressWarnings("java:S2187")
-public class JdkHttpClientAsyncBodyTest  extends AbstractAsyncBodyTest {
+public class JdkHttpClientAsyncBodyTest extends AbstractAsyncBodyTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new JdkHttpClientFactory();
   }
 
-  // TODO: Check tests validate expected behavior
-  @Disabled("TODO: Check tests validate expected behavior")
-  @Override
-  public void consumeLinesProcessedAfterConsume() throws Exception {
-    super.consumeLinesProcessedAfterConsume();
-  }
-
-  // TODO: Check tests validate expected behavior
-  @Disabled("TODO: Check tests validate expected behavior")
-  @Override
-  public void consumeLinesNotProcessedIfCancelled() throws Exception {
-    super.consumeLinesNotProcessedIfCancelled();
-  }
-
-  // TODO: Check tests validate expected behavior
-  @Disabled("TODO: Check tests validate expected behavior")
-  @Override
-  public void consumeByteBufferLinesProcessedAfterConsume() throws Exception {
-    super.consumeByteBufferLinesProcessedAfterConsume();
-  }
 }

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientAsyncBodyTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientAsyncBodyTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractAsyncBodyTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import org.junit.jupiter.api.Disabled;
+
+
+@SuppressWarnings("java:S2187")
+public class JdkHttpClientAsyncBodyTest  extends AbstractAsyncBodyTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JdkHttpClientFactory();
+  }
+
+  // TODO: Check tests validate expected behavior
+  @Disabled("TODO: Check tests validate expected behavior")
+  @Override
+  public void consumeLinesProcessedAfterConsume() throws Exception {
+    super.consumeLinesProcessedAfterConsume();
+  }
+
+  // TODO: Check tests validate expected behavior
+  @Disabled("TODO: Check tests validate expected behavior")
+  @Override
+  public void consumeLinesNotProcessedIfCancelled() throws Exception {
+    super.consumeLinesNotProcessedIfCancelled();
+  }
+
+  // TODO: Check tests validate expected behavior
+  @Disabled("TODO: Check tests validate expected behavior")
+  @Override
+  public void consumeByteBufferLinesProcessedAfterConsume() throws Exception {
+    super.consumeByteBufferLinesProcessedAfterConsume();
+  }
+}

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientInterceptorTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientInterceptorTest.java
@@ -17,7 +17,6 @@ package io.fabric8.kubernetes.client.jdkhttp;
 
 import io.fabric8.kubernetes.client.http.AbstractInterceptorTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
-import org.junit.jupiter.api.Disabled;
 
 @SuppressWarnings("java:S2187")
 public class JdkHttpClientInterceptorTest extends AbstractInterceptorTest {
@@ -26,15 +25,4 @@ public class JdkHttpClientInterceptorTest extends AbstractInterceptorTest {
     return new JdkHttpClientFactory();
   }
 
-  // TODO: Check implementation
-  @Disabled("TODO: Check implementation")
-  @Override
-  public void afterHttpFailureReplacesResponseInConsumeLines() {
-  }
-
-  // TODO: Check implementation
-  @Disabled("TODO: Check implementation")
-  @Override
-  public void afterHttpFailureReplacesResponseInConsumeBytes() {
-  }
 }

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientInterceptorTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientInterceptorTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractInterceptorTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import org.junit.jupiter.api.Disabled;
+
+@SuppressWarnings("java:S2187")
+public class JdkHttpClientInterceptorTest extends AbstractInterceptorTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JdkHttpClientFactory();
+  }
+
+  // TODO: Check implementation
+  @Disabled("TODO: Check implementation")
+  @Override
+  public void afterHttpFailureReplacesResponseInConsumeLines() {
+  }
+
+  // TODO: Check implementation
+  @Disabled("TODO: Check implementation")
+  @Override
+  public void afterHttpFailureReplacesResponseInConsumeBytes() {
+  }
+}

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPostTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPostTest.java
@@ -19,7 +19,7 @@ import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("java:S2187")
-public class JdkHttpClientPostTest  extends AbstractHttpPostTest {
+public class JdkHttpClientPostTest extends AbstractHttpPostTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new JdkHttpClientFactory();

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPostTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPostTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JdkHttpClientPostTest  extends AbstractHttpPostTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JdkHttpClientFactory();
+  }
+}

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientProxyTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientProxyTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JdkHttpClientProxyTest extends AbstractHttpClientProxyTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JdkHttpClientFactory();
+  }
+}

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientWebSocketSendTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientWebSocketSendTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractWebSocketSendTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JdkHttpClientWebSocketSendTest extends AbstractWebSocketSendTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JdkHttpClientFactory();
+  }
+}

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>kubernetes-client-project</artifactId>
+    <groupId>io.fabric8</groupId>
+    <version>6.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kubernetes-httpclient-jetty</artifactId>
+  <packaging>jar</packaging>
+  <name>Fabric8 :: Kubernetes :: HttpClient :: Jetty</name>
+
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)",
+    </osgi.require-capability>
+    <osgi.import>
+      !android.util*,
+      *,
+    </osgi.import>
+    <osgi.export>
+      io.fabric8.kubernetes.client.jetty*;-noimport:=true,
+    </osgi.export>
+    <osgi.private>
+    </osgi.private>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-http-client-transport</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-jetty-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
+          <environmentVariables>
+            <KUBERNETES_MASTER />
+            <KUBERNETES_API_VERSION />
+            <KUBERNETES_TRUST_CERTIFICATES />
+            <KUBERNETES_CERTS_CA_FILE />
+            <KUBERNETES_CERTS_CA_DATA />
+            <KUBERNETES_CERTS_CLIENT_FILE />
+            <KUBERNETES_CERTS_CLIENT_DATA />
+            <KUBERNETES_CERTS_CLIENT_KEY_FILE />
+            <KUBERNETES_CERTS_CLIENT_KEY_DATA />
+            <KUBERNETES_CERTS_CLIENT_KEY_ALGO />
+            <KUBERNETES_CERTS_CLIENT_KEY_PASSPHRASE />
+            <KUBERNETES_AUTH_BASIC_USERNAME />
+            <KUBERNETES_AUTH_BASIC_PASSWORD />
+            <KUBERNETES_AUTH_TRYKUBECONFIG />
+            <KUBERNETES_AUTH_TRYSERVICEACCOUNT />
+            <KUBERNETES_AUTH_TOKEN />
+            <KUBERNETES_WATCH_RECONNECTINTERVAL />
+            <KUBERNETES_WATCH_RECONNECTLIMIT />
+            <KUBERNETES_REQUEST_TIMEOUT />
+            <KUBERNETES_NAMESPACE />
+            <KUBERNETES_TLS_VERSIONS>TLSv1.2,TLSv1.1,TLSv1</KUBERNETES_TLS_VERSIONS>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <classpathScope>test</classpathScope>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>${maven.bundle.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Bundle-Name>${project.name}</Bundle-Name>
+                <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                <Export-Package>${osgi.export}</Export-Package>
+                <Import-Package>${osgi.import}</Import-Package>
+                <DynamicImport-Package>${osgi.dynamic.import}</DynamicImport-Package>
+                <Require-Capability>${osgi.require-capability}</Require-Capability>
+                <Provide-Capability>${osgi.provide-capability}</Provide-Capability>
+                <Private-Package>${osgi.private}</Private-Package>
+                <Require-Bundle>${osgi.bundles}</Require-Bundle>
+                <Bundle-Activator>${osgi.activator}</Bundle-Activator>
+                <Export-Service>${osgi.export.service}</Export-Service>
+                <Include-Resource>
+                  /META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory=target/classes/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory,
+                </Include-Resource>
+              </instructions>
+              <classifier>bundle</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/DerivedJettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/DerivedJettyHttpClientBuilder.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.http.Interceptor;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings("unchecked")
+public abstract class DerivedJettyHttpClientBuilder<T extends HttpClient.DerivedClientBuilder> implements HttpClient.DerivedClientBuilder {
+
+  final JettyHttpClientFactory factory;
+  Duration readTimeout = Duration.ZERO;
+  Duration writeTimeout = Duration.ZERO;
+  final Map<String, Interceptor> interceptors;
+
+  DerivedJettyHttpClientBuilder(JettyHttpClientFactory factory) {
+    this.factory = factory;
+    interceptors = new LinkedHashMap<>();
+  }
+
+  @Override
+  public final T readTimeout(long readTimeout, TimeUnit unit) {
+    this.readTimeout = Duration.ofNanos(unit.toNanos(readTimeout));
+    return (T) this;
+  }
+
+  @Override
+  public T writeTimeout(long writeTimeout, TimeUnit unit) {
+    this.writeTimeout = Duration.ofNanos(unit.toNanos(writeTimeout));
+    return (T) this;
+  }
+
+  @Override
+  public T forStreaming() {
+    // NO OP
+    return (T) this;
+  }
+
+  @Override
+  public T authenticatorNone() {
+    // NO OP
+    return (T) this;
+  }
+
+  @Override
+  public T addOrReplaceInterceptor(String name, Interceptor interceptor) {
+    interceptors.put(name, interceptor);
+    return (T) this;
+  }
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/DerivedJettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/DerivedJettyHttpClientBuilder.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("unchecked")
-public abstract class DerivedJettyHttpClientBuilder<T extends HttpClient.DerivedClientBuilder> implements HttpClient.DerivedClientBuilder {
+public abstract class DerivedJettyHttpClientBuilder<T extends HttpClient.DerivedClientBuilder>
+    implements HttpClient.DerivedClientBuilder {
 
   final JettyHttpClientFactory factory;
   Duration readTimeout = Duration.ZERO;

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+public abstract class JettyAsyncResponseListener<T> extends Response.Listener.Adapter implements HttpClient.AsyncBody {
+
+  private final HttpRequest httpRequest;
+  private final HttpClient.BodyConsumer<T> bodyConsumer;
+  private final CompletableFuture<HttpResponse<HttpClient.AsyncBody>> asyncResponse;
+  private final CompletableFuture<Void> asyncBodyDone;
+  private final CountDownLatch consumeLock;
+
+  JettyAsyncResponseListener(HttpRequest httpRequest, HttpClient.BodyConsumer<T> bodyConsumer) {
+    this.httpRequest = httpRequest;
+    this.bodyConsumer = bodyConsumer;
+    asyncResponse = new CompletableFuture<>();
+    asyncBodyDone = new CompletableFuture<>();
+    consumeLock = new CountDownLatch(1);
+  }
+
+  @Override
+  public void consume() {
+    consumeLock.countDown();
+  }
+
+  @Override
+  public CompletableFuture<Void> done() {
+    return asyncBodyDone;
+  }
+
+  @Override
+  public void cancel() {
+    asyncBodyDone.cancel(false);
+  }
+
+  @Override
+  public void onBegin(Response response) {
+    asyncResponse.complete(new JettyHttpResponse<>(httpRequest, response, this));
+  }
+
+  @Override
+  public void onComplete(Result result) {
+    asyncBodyDone.complete(null);
+  }
+
+  public CompletableFuture<HttpResponse<HttpClient.AsyncBody>> listen(Request request) {
+    request.send(this);
+    return asyncResponse;
+  }
+
+  @Override
+  public void onContent(Response response, ByteBuffer content) {
+    try {
+      consumeLock.await();
+      if (!asyncBodyDone.isCancelled()) {
+        bodyConsumer.consume(process(response, content), this);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw KubernetesClientException.launderThrowable(e);
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  protected abstract T process(Response response, ByteBuffer content);
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.kubernetes.client.http.Interceptor;
+import io.fabric8.kubernetes.client.http.StandardHttpRequest;
+import io.fabric8.kubernetes.client.http.WebSocket;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.util.BufferingResponseListener;
+import org.eclipse.jetty.client.util.InputStreamRequestContent;
+import org.eclipse.jetty.client.util.StringRequestContent;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static io.fabric8.kubernetes.client.http.StandardMediaTypes.APPLICATION_OCTET_STREAM;
+import static io.fabric8.kubernetes.client.http.StandardMediaTypes.TEXT_PLAIN;
+import static org.eclipse.jetty.util.BufferUtil.toArray;
+
+public class JettyHttpClient implements io.fabric8.kubernetes.client.http.HttpClient {
+
+  private final HttpClient jetty;
+  private final WebSocketClient jettyWs;
+  private final Collection<Interceptor> interceptors;
+  private final JettyHttpClientBuilder builder;
+  private final JettyHttpClientFactory factory;
+
+  public JettyHttpClient(JettyHttpClientBuilder builder, HttpClient httpClient, WebSocketClient webSocketClient,
+      Collection<Interceptor> interceptors, JettyHttpClientFactory jettyHttpClientFactory) {
+    this.builder = builder;
+    this.jetty = httpClient;
+    this.jettyWs = webSocketClient;
+    this.interceptors = interceptors;
+    this.factory = jettyHttpClientFactory;
+  }
+
+  @Override
+  public void close() {
+    try {
+      jetty.stop();
+      jettyWs.stop();
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  @Override
+  public DerivedClientBuilder newBuilder() {
+    return builder.copy();
+  }
+
+  @Override
+  public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest originalRequest, Class<T> type) {
+    final var supportedResponse = JettyHttpResponse.SupportedResponse.from(type);
+    final var request = toStandardHttpRequest(originalRequest);
+    final CompletableFuture<HttpResponse<T>> future = new CompletableFuture<>();
+    newRequest(request).send(new BufferingResponseListener() {
+
+      // TODO: Long Term Refactor - This Listener blocks until the full response is read and keeps it in memory.
+      //       Find a way to stream the response body without completing the future
+      //       We need two signals, one when the response is received, and one when the body is completely
+      //       read.
+      //       Should this method be completely replaced by consumeXxx()?
+      @Override
+      public void onComplete(Result result) {
+        future.complete(new JettyHttpResponse<>(
+            request, result.getResponse(), supportedResponse.process(result.getResponse(), getContent(), type)));
+      }
+    });
+    return interceptResponse(request.toBuilder(), future, r -> sendAsync(r, type));
+  }
+
+  @Override
+  public CompletableFuture<HttpResponse<AsyncBody>> consumeLines(
+      HttpRequest originalRequest, BodyConsumer<String> consumer) {
+    final var request = toStandardHttpRequest(originalRequest);
+    final var future = new JettyAsyncResponseListener<>(request, consumer) {
+
+      @Override
+      protected String process(Response response, ByteBuffer content) {
+        return JettyHttpResponse.SupportedResponse.TEXT.process(response, toArray(content), String.class);
+      }
+    }.listen(newRequest(request));
+    return interceptResponse(request.toBuilder(), future, r -> consumeLines(r, consumer));
+  }
+
+  @Override
+  public CompletableFuture<HttpResponse<AsyncBody>> consumeBytes(
+      HttpRequest originalRequest, BodyConsumer<List<ByteBuffer>> consumer) {
+    final var request = toStandardHttpRequest(originalRequest);
+    final var future = new JettyAsyncResponseListener<>(request, consumer) {
+
+      @Override
+      protected List<ByteBuffer> process(Response response, ByteBuffer content) {
+        return Collections.singletonList(content);
+      }
+    }.listen(newRequest(request));
+    return interceptResponse(request.toBuilder(), future, r -> consumeBytes(r, consumer));
+  }
+
+  @Override
+  public WebSocket.Builder newWebSocketBuilder() {
+    return new JettyWebSocketBuilder(jettyWs, builder.readTimeout);
+  }
+
+  @Override
+  public HttpRequest.Builder newHttpRequestBuilder() {
+    return new StandardHttpRequest.Builder();
+  }
+
+  @Override
+  public Factory getFactory() {
+    return factory;
+  }
+
+  private Request newRequest(StandardHttpRequest originalRequest) {
+    try {
+      jetty.start();
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+    final var requestBuilder = originalRequest.toBuilder();
+    interceptors.forEach(i -> i.before(requestBuilder, originalRequest));
+    final var request = requestBuilder.build();
+
+    var jettyRequest = jetty.newRequest(request.uri()).method(request.method());
+    jettyRequest.timeout(builder.readTimeout.toMillis() + builder.writeTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    jettyRequest.headers(m -> request.headers().forEach((k, l) -> l.forEach(v -> m.add(k, v))));
+
+    final var contentType = request.headers("Content-Type").stream().findAny();
+    if (request.bodyString() != null) {
+      jettyRequest.body(new StringRequestContent(contentType.orElse(TEXT_PLAIN), request.bodyString()));
+    } else if (request.bodyStream() != null) {
+      jettyRequest.body(new InputStreamRequestContent(contentType.orElse(APPLICATION_OCTET_STREAM), request.bodyStream()));
+    }
+    return jettyRequest;
+  }
+
+  private <T> CompletableFuture<HttpResponse<T>> interceptResponse(
+      StandardHttpRequest.Builder builder, CompletableFuture<HttpResponse<T>> originalResponse,
+      Function<HttpRequest, CompletableFuture<HttpResponse<T>>> function) {
+    for (var interceptor : interceptors) {
+      originalResponse = originalResponse.thenCompose(r -> {
+        if (!r.isSuccessful()) {
+          return interceptor.afterFailure(builder, r)
+              .thenCompose(b -> {
+                if (Boolean.TRUE.equals(b)) {
+                  return function.apply(builder.build());
+                }
+                return CompletableFuture.completedFuture(r);
+              });
+        }
+        return CompletableFuture.completedFuture(r);
+      });
+    }
+    return originalResponse;
+  }
+
+  private static StandardHttpRequest toStandardHttpRequest(HttpRequest request) {
+    if (!(request instanceof StandardHttpRequest)) {
+      throw new IllegalArgumentException("Only StandardHttpRequest is supported");
+    }
+    return (StandardHttpRequest) request;
+  }
+
+  HttpClient getJetty() {
+    return jetty;
+  }
+
+  WebSocketClient getJettyWs() {
+    return jettyWs;
+  }
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.HttpClient.Builder;
+import io.fabric8.kubernetes.client.http.TlsVersion;
+import io.fabric8.kubernetes.client.internal.SSLUtils;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.Origin;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.dynamic.HttpClientTransportDynamic;
+import org.eclipse.jetty.client.http.HttpClientConnectionFactory;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.ClientConnectionFactoryOverHTTP2;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+public class JettyHttpClientBuilder extends DerivedJettyHttpClientBuilder<JettyHttpClientBuilder>
+  implements Builder {
+
+  private Duration connectTimeout;
+  private SSLContext sslContext;
+  private boolean followAllRedirects;
+  private Origin.Address proxyAddress;
+  private String proxyAuthorization;
+  private TlsVersion[] tlsVersions;
+  // TODO: HTTP2 disabled, MockWebServer support is limited and requires changes
+  // Enable (preferHttp11->false) the feature after fixing MockWebServer
+  private boolean preferHttp11 = true;
+  private HttpClient sharedHttpClient;
+  private WebSocketClient sharedWebSocketClient;
+
+  public JettyHttpClientBuilder(JettyHttpClientFactory factory) {
+    super(factory);
+  }
+
+  @Override
+  public JettyHttpClient build() {
+    if (sharedHttpClient != null) {
+      return new JettyHttpClient(this, sharedHttpClient, sharedWebSocketClient, interceptors.values(), factory);
+    }
+    final var sslContextFactory = new SslContextFactory.Client();
+    if (sslContext != null) {
+      sslContextFactory.setSslContext(sslContext);
+    }
+    if (tlsVersions != null && tlsVersions.length > 0) {
+      sslContextFactory.setIncludeProtocols(Stream.of(tlsVersions).map(TlsVersion::javaName).toArray(String[]::new));
+    }
+    sharedHttpClient = new HttpClient(newTransport(sslContextFactory, preferHttp11));
+    sharedWebSocketClient = new WebSocketClient(new HttpClient(newTransport(sslContextFactory, preferHttp11)));
+    sharedWebSocketClient.setIdleTimeout(Duration.ZERO);
+    if (connectTimeout != null) {
+      sharedHttpClient.setConnectTimeout(connectTimeout.toMillis());
+      sharedWebSocketClient.setConnectTimeout(connectTimeout.toMillis());
+    }
+    sharedHttpClient.setFollowRedirects(followAllRedirects);
+    if (proxyAddress != null) {
+      sharedHttpClient.getProxyConfiguration().getProxies().add(new HttpProxy(proxyAddress, false));
+    }
+    if (proxyAddress != null && proxyAuthorization != null) {
+      sharedHttpClient.getRequestListeners().add(new Request.Listener.Adapter() {
+        @Override
+        public void onBegin(Request request) {
+          request.headers(h -> h.put("Proxy-Authorization", proxyAuthorization));
+        }
+      });
+    }
+    return new JettyHttpClient(this, sharedHttpClient, sharedWebSocketClient, interceptors.values(), factory);
+  }
+
+  @Override
+  public JettyHttpClientBuilder connectTimeout(long connectTimeout, TimeUnit unit) {
+    this.connectTimeout = Duration.ofNanos(unit.toNanos(connectTimeout));
+    return this;
+  }
+
+  @Override
+  public JettyHttpClientBuilder sslContext(KeyManager[] keyManagers, TrustManager[] trustManagers) {
+    this.sslContext = SSLUtils.sslContext(keyManagers, trustManagers);
+    return this;
+  }
+
+  @Override
+  public JettyHttpClientBuilder followAllRedirects() {
+    followAllRedirects = true;
+    return this;
+  }
+
+  @Override
+  public JettyHttpClientBuilder proxyAddress(InetSocketAddress proxyAddress) {
+    if (proxyAddress == null) {
+      this.proxyAddress = null;
+    } else {
+      this.proxyAddress = new Origin.Address(proxyAddress.getHostString(), proxyAddress.getPort());
+    }
+    return this;
+  }
+
+  @Override
+  public JettyHttpClientBuilder proxyAuthorization(String credentials) {
+    proxyAuthorization = credentials;
+    return this;
+  }
+
+  @Override
+  public JettyHttpClientBuilder tlsVersions(TlsVersion... tlsVersions) {
+    this.tlsVersions = tlsVersions;
+    return this;
+  }
+
+  @Override
+  public JettyHttpClientBuilder preferHttp11() {
+    preferHttp11 = true;
+    return this;
+  }
+
+  public Builder copy() {
+    final var ret = new JettyHttpClientBuilder(factory);
+    ret.sharedHttpClient = sharedHttpClient;
+    ret.sharedWebSocketClient = sharedWebSocketClient;
+    ret.readTimeout = readTimeout;
+    ret.writeTimeout = writeTimeout;
+    ret.interceptors.putAll(interceptors);
+    ret.connectTimeout = connectTimeout;
+    ret.sslContext = sslContext;
+    ret.followAllRedirects = followAllRedirects;
+    ret.proxyAddress = proxyAddress;
+    ret.proxyAuthorization = proxyAuthorization;
+    ret.tlsVersions = tlsVersions;
+    ret.preferHttp11 = preferHttp11;
+    return ret;
+  }
+
+  private static HttpClientTransport newTransport(SslContextFactory.Client sslContextFactory, boolean preferHttp11) {
+    final var clientConnector = new ClientConnector();
+    clientConnector.setSslContextFactory(sslContextFactory);
+    final HttpClientTransport transport;
+    if (preferHttp11) {
+      transport = new HttpClientTransportOverHTTP(clientConnector);
+    } else {
+      var http2 = new ClientConnectionFactoryOverHTTP2.HTTP2(new HTTP2Client(clientConnector));
+      transport = new HttpClientTransportDynamic(clientConnector, http2, HttpClientConnectionFactory.HTTP11);
+    }
+    return transport;
+  }
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -42,7 +42,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
 public class JettyHttpClientBuilder extends DerivedJettyHttpClientBuilder<JettyHttpClientBuilder>
-  implements Builder {
+    implements Builder {
 
   private Duration connectTimeout;
   private SSLContext sslContext;

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientFactory.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientFactory.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.applyCommonConfiguration;
+
+public class JettyHttpClientFactory implements HttpClient.Factory {
+
+  @Override
+  public HttpClient createHttpClient(Config config) {
+    final var builder = newBuilder();
+    applyCommonConfiguration(config, builder, this);
+    return builder.build();
+  }
+
+  @Override
+  public JettyHttpClientBuilder newBuilder() {
+    return new JettyHttpClientBuilder(this);
+  }
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpResponse.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpResponse.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.kubernetes.client.utils.Utils;
+import org.eclipse.jetty.client.api.Response;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public class JettyHttpResponse<T> implements HttpResponse<T> {
+
+  private final HttpRequest request;
+  private final Response response;
+  private final T body;
+
+  public JettyHttpResponse(HttpRequest request, Response response, T body) {
+    this.request = request;
+    this.response = response;
+    this.body = body;
+  }
+
+  @Override
+  public List<String> headers(String key) {
+    return response.getHeaders().getValuesList(key);
+  }
+
+  @Override
+  public Map<String, List<String>> headers() {
+    return response.getHeaders().stream().reduce(new HashMap<>(), (m, e) -> {
+      m.compute(e.getName(), (k, v) -> {
+        if (v == null) {
+          v = new ArrayList<>();
+        }
+        v.add(e.getValue());
+        return v;
+      });
+      return m;
+    }, (m1, m2) -> m1);
+  }
+
+  @Override
+  public int code() {
+    return response.getStatus();
+  }
+
+  @Override
+  public T body() {
+    return body;
+  }
+
+  @Override
+  public HttpRequest request() {
+    return request;
+  }
+
+  @Override
+  public Optional<HttpResponse<?>> previousResponse() {
+    return Optional.empty();
+  }
+
+  enum SupportedResponse {
+
+    TEXT(String.class, (r, bytes) -> new String(bytes, responseCharset(r))),
+    INPUT_STREAM(ByteArrayInputStream.class, (r, bytes) -> new ByteArrayInputStream(bytes)),
+    READER(InputStreamReader.class, (r, bytes) -> new InputStreamReader(new ByteArrayInputStream(bytes), responseCharset(r))),
+    BYTE_ARRAY(byte[].class, (r, bytes) -> bytes);
+
+    private final Class<?> type;
+    private final BiFunction<Response, byte[], Object> processor;
+
+    SupportedResponse(Class<?> type, BiFunction<Response, byte[], Object> processor) {
+      this.type = type;
+      this.processor = processor;
+    }
+
+    public <T> T process(Response response, byte[] bytes, Class<T> type) {
+      return type.cast(processor.apply(response, bytes));
+    }
+
+    static SupportedResponse from(Class<?> type) {
+      for (SupportedResponse sr : SupportedResponse.values()) {
+        if (type.isAssignableFrom(sr.type)) {
+          return sr;
+        }
+      }
+      throw new IllegalArgumentException("Unsupported response type: " + type.getName());
+    }
+
+    private static Charset responseCharset(Response response) {
+      var responseCharset = StandardCharsets.UTF_8;
+      final var responseEncoding = response.getHeaders().get("Content-Encoding");
+      if (Utils.isNotNullOrEmpty(responseEncoding)) {
+        try {
+          responseCharset = Charset.forName(responseEncoding);
+        } catch (Exception e) {
+          // ignored
+        }
+      }
+      return responseCharset;
+    }
+  }
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.http.WebSocket;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.eclipse.jetty.websocket.api.WriteCallback;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class JettyWebSocket implements WebSocket, WebSocketListener {
+  private final WebSocket.Listener listener;
+  private final AtomicLong sendQueue;
+  private final Lock lock;
+  private final Condition backPressure;
+  private final AtomicBoolean closed;
+  private boolean moreMessages;
+  private Session webSocketSession;
+
+  public JettyWebSocket(WebSocket.Listener listener) {
+    this.listener = listener;
+    sendQueue = new AtomicLong();
+    lock = new ReentrantLock();
+    backPressure = lock.newCondition();
+    closed = new AtomicBoolean();
+    moreMessages = true;
+  }
+
+  @Override
+  public boolean send(ByteBuffer buffer) {
+    if (closed.get() || !webSocketSession.isOpen()) {
+      return false;
+    }
+    final int size = buffer.remaining();
+    sendQueue.addAndGet(size);
+    webSocketSession.getRemote().sendBytes(buffer, new WriteCallback() {
+      @Override
+      public void writeFailed(Throwable x) {
+        sendQueue.addAndGet(-size);
+      }
+
+      @Override
+      public void writeSuccess() {
+        sendQueue.addAndGet(-size);
+      }
+    });
+    return true;
+  }
+
+  @Override
+  public boolean sendClose(int code, String reason) {
+    if (webSocketSession.isOpen() && !closed.getAndSet(true)) {
+      webSocketSession.close(code, reason);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public long queueSize() {
+    return sendQueue.get();
+  }
+
+  @Override
+  public void request() {
+    try {
+      lock.lock();
+      moreMessages = true;
+      backPressure.signalAll();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void onWebSocketBinary(byte[] payload, int offset, int len) {
+    backPressure();
+    final var buffer = ByteBuffer.allocate(len);
+    buffer.put(payload, offset, len).rewind();
+    listener.onMessage(this, buffer.asReadOnlyBuffer());
+  }
+
+  @Override
+  public void onWebSocketText(String message) {
+    backPressure();
+    listener.onMessage(this, message);
+  }
+
+  @Override
+  public void onWebSocketClose(int statusCode, String reason) {
+    closed.set(true);
+    listener.onClose(this, statusCode, reason);
+  }
+
+  @Override
+  public void onWebSocketConnect(Session session) {
+    listener.onOpen(this);
+  }
+
+  @Override
+  public void onWebSocketError(Throwable cause) {
+    if (cause instanceof ClosedChannelException && closed.get()) {
+      // TODO: Check better
+      //  It appears to be a race condition in Jetty:
+      // - The server sends a close frame (but we haven't received it)
+      // - Client enqueues a sendClose -> webSocketSession.close(code, reason)
+      // - Jetty/client receives the  remote close -> onWebSocketClose
+      // - Jetty sends the enqueued close frame, but the socket was already closed in the previous step
+      // - Jetty throws a ClosedChannelException
+      return;
+    }
+    listener.onError(this, cause);
+  }
+
+  public JettyWebSocket setWebSocketSession(Session webSocketSession) {
+    this.webSocketSession = webSocketSession;
+    return this;
+  }
+
+  private void backPressure() {
+    try {
+      lock.lock();
+      while (!moreMessages) {
+        backPressure.await();
+      }
+      moreMessages = false;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw KubernetesClientException.launderThrowable(e);
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketBuilder.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.http.AbstractBasicBuilder;
+import io.fabric8.kubernetes.client.http.StandardHttpRequest;
+import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
+import io.fabric8.kubernetes.client.utils.Utils;
+import org.eclipse.jetty.client.HttpResponse;
+import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+
+public class JettyWebSocketBuilder extends AbstractBasicBuilder<JettyWebSocketBuilder> implements WebSocket.Builder {
+
+  private final WebSocketClient webSocketClient;
+  private final Duration handshakeTimeout;
+  private String subprotocol;
+
+  public JettyWebSocketBuilder(WebSocketClient webSocketClient, Duration handshakeTimeout) {
+    this.webSocketClient = webSocketClient;
+    this.handshakeTimeout = handshakeTimeout;
+  }
+
+  @Override
+  public CompletableFuture<WebSocket> buildAsync(WebSocket.Listener listener) {
+    try {
+      webSocketClient.start();
+      final ClientUpgradeRequest cur = new ClientUpgradeRequest();
+      if (Utils.isNotNullOrEmpty(subprotocol)) {
+        cur.setSubProtocols(subprotocol);
+      }
+      cur.setHeaders(getHeaders());
+      cur.setTimeout(handshakeTimeout.toMillis(), TimeUnit.MILLISECONDS);
+      // Extra-future required because we can't Map the UpgradeException to a WebSocketHandshakeException easily
+      final CompletableFuture<WebSocket> future = new CompletableFuture<>();
+      final var webSocket = new JettyWebSocket(listener);
+      return webSocketClient.connect(webSocket, Objects.requireNonNull(WebSocket.toWebSocketUri(getUri())), cur)
+          .thenApply(webSocket::setWebSocketSession)
+          .exceptionally(ex -> {
+            if (ex instanceof CompletionException && ex.getCause() instanceof UpgradeException) {
+              future.completeExceptionally(toHandshakeException((UpgradeException) ex.getCause()));
+            } else if (ex instanceof UpgradeException) {
+              future.completeExceptionally(toHandshakeException((UpgradeException) ex));
+            } else {
+              future.completeExceptionally(ex);
+            }
+            return null;
+          })
+          .thenCompose(ws -> {
+            future.complete(ws);
+            return future;
+          });
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
+    }
+  }
+
+  @Override
+  public JettyWebSocketBuilder subprotocol(String protocol) {
+    this.subprotocol = protocol;
+    return this;
+  }
+
+  private static WebSocketHandshakeException toHandshakeException(UpgradeException ex) {
+    return new WebSocketHandshakeException(new JettyHttpResponse<>(
+        new StandardHttpRequest.Builder().uri(ex.getRequestURI()).build(),
+        new HttpResponse(null, Collections.emptyList()).status(ex.getResponseStatusCode()),
+        null))
+            .initCause(ex);
+  }
+}

--- a/httpclient-jetty/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory
+++ b/httpclient-jetty/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.fabric8.kubernetes.client.jetty.JettyHttpClientFactory

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyAsyncBodyTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyAsyncBodyTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.AbstractAsyncBodyTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JettyAsyncBodyTest extends AbstractAsyncBodyTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilderTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilderTest.java
@@ -56,12 +56,11 @@ class JettyHttpClientBuilderTest {
   void underlyingHttpAndWsClientsDifferentTransports() {
     try (var client = factory.newBuilder().build()) {
       assertThat(client)
-        .satisfies(c -> assertThat(c.getJetty())
-          .isNotSameAs(c.getJettyWs().getHttpClient())
-          .returns(c.getJettyWs().getSslContextFactory(), HttpClient::getSslContextFactory)
-          .extracting(HttpClient::getTransport)
-          .isNotSameAs(c.getJettyWs().getHttpClient().getTransport())
-        );
+          .satisfies(c -> assertThat(c.getJetty())
+              .isNotSameAs(c.getJettyWs().getHttpClient())
+              .returns(c.getJettyWs().getSslContextFactory(), HttpClient::getSslContextFactory)
+              .extracting(HttpClient::getTransport)
+              .isNotSameAs(c.getJettyWs().getHttpClient().getTransport()));
     }
   }
 
@@ -70,9 +69,9 @@ class JettyHttpClientBuilderTest {
   void generatedWSClientHasDisabledIdleTimeout() {
     try (var client = factory.newBuilder().build()) {
       assertThat(client)
-        .extracting(JettyHttpClient::getJettyWs)
-        .extracting(WebSocketClient::getIdleTimeout)
-        .isEqualTo(Duration.ZERO);
+          .extracting(JettyHttpClient::getJettyWs)
+          .extracting(WebSocketClient::getIdleTimeout)
+          .isEqualTo(Duration.ZERO);
     }
   }
 
@@ -82,11 +81,11 @@ class JettyHttpClientBuilderTest {
     try (var client = factory.newBuilder().build()) {
       final var client2 = client.newBuilder().build();
       assertThat(client2)
-        .isInstanceOf(JettyHttpClient.class)
-        .asInstanceOf(InstanceOfAssertFactories.type(JettyHttpClient.class))
-        .isNotSameAs(client)
-        .returns(client.getJetty(), JettyHttpClient::getJetty)
-        .returns(client.getJettyWs(), JettyHttpClient::getJettyWs);
+          .isInstanceOf(JettyHttpClient.class)
+          .asInstanceOf(InstanceOfAssertFactories.type(JettyHttpClient.class))
+          .isNotSameAs(client)
+          .returns(client.getJetty(), JettyHttpClient::getJetty)
+          .returns(client.getJettyWs(), JettyHttpClient::getJettyWs);
     }
   }
 
@@ -95,8 +94,8 @@ class JettyHttpClientBuilderTest {
   void connectTimeout() {
     try (var client = factory.newBuilder().connectTimeout(1337, TimeUnit.MILLISECONDS).build()) {
       assertThat(client)
-        .returns(1337L, c -> c.getJetty().getConnectTimeout())
-        .returns(1337L, c -> c.getJettyWs().getConnectTimeout());
+          .returns(1337L, c -> c.getJetty().getConnectTimeout())
+          .returns(1337L, c -> c.getJettyWs().getConnectTimeout());
     }
   }
 
@@ -104,19 +103,19 @@ class JettyHttpClientBuilderTest {
   @DisplayName("followRedirects=false, no redirection")
   void followAllRedirectsDisabled() throws Exception {
     server.expect()
-      .withPath("/redirect-me")
-      .andReply(ResponseProviders.of(301, "", Collections.singletonMap("Location", "/new-location")))
-      .always();
+        .withPath("/redirect-me")
+        .andReply(ResponseProviders.of(301, "", Collections.singletonMap("Location", "/new-location")))
+        .always();
     server.expect()
-      .withPath("/new-location")
-      .andReturn(200, "You made it!")
-      .always();
+        .withPath("/new-location")
+        .andReturn(200, "You made it!")
+        .always();
     try (var client = factory.newBuilder().build()) {
       final var result = client
-        .sendAsync(client.newHttpRequestBuilder().uri(server.url("redirect-me")).build(), String.class)
+          .sendAsync(client.newHttpRequestBuilder().uri(server.url("redirect-me")).build(), String.class)
           .get(10, TimeUnit.SECONDS);
       assertThat(result)
-        .returns(301, HttpResponse::code);
+          .returns(301, HttpResponse::code);
     }
   }
 
@@ -124,26 +123,26 @@ class JettyHttpClientBuilderTest {
   @DisplayName("followAllRedirects=true, redirected")
   void followAllRedirectsEnabled() throws Exception {
     server.expect()
-      .withPath("/redirect-me")
-      .andReply(ResponseProviders.of(301, "", Collections.singletonMap("Location", "/new-location")))
-      .always();
+        .withPath("/redirect-me")
+        .andReply(ResponseProviders.of(301, "", Collections.singletonMap("Location", "/new-location")))
+        .always();
     server.expect()
-      .withPath("/new-location")
-      .andReturn(200, "You made it!")
-      .always();
+        .withPath("/new-location")
+        .andReturn(200, "You made it!")
+        .always();
     try (var client = factory.newBuilder().followAllRedirects().build()) {
       final var result = client
-        .sendAsync(client.newHttpRequestBuilder().uri(server.url("redirect-me")).build(), String.class)
+          .sendAsync(client.newHttpRequestBuilder().uri(server.url("redirect-me")).build(), String.class)
           .get(10, TimeUnit.SECONDS);
       assertThat(result)
-        .returns(200, HttpResponse::code)
-        .returns("You made it!", r -> {
-          try {
-            return r.bodyString();
-          } catch (IOException ignored) {
-            return null;
-          }
-        });
+          .returns(200, HttpResponse::code)
+          .returns("You made it!", r -> {
+            try {
+              return r.bodyString();
+            } catch (IOException ignored) {
+              return null;
+            }
+          });
     }
   }
 

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilderTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilderTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.mockwebserver.DefaultMockServer;
+import io.fabric8.mockwebserver.utils.ResponseProviders;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JettyHttpClientBuilderTest {
+
+  private static DefaultMockServer server;
+  private static JettyHttpClientFactory factory;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+    factory = new JettyHttpClientFactory();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    factory = null;
+    server.shutdown();
+  }
+
+  @Test
+  @DisplayName("build, creates a WS client and an HTTP client with different underlying connector instances")
+  void underlyingHttpAndWsClientsDifferentTransports() {
+    try (var client = factory.newBuilder().build()) {
+      assertThat(client)
+        .satisfies(c -> assertThat(c.getJetty())
+          .isNotSameAs(c.getJettyWs().getHttpClient())
+          .returns(c.getJettyWs().getSslContextFactory(), HttpClient::getSslContextFactory)
+          .extracting(HttpClient::getTransport)
+          .isNotSameAs(c.getJettyWs().getHttpClient().getTransport())
+        );
+    }
+  }
+
+  @Test
+  @DisplayName("build, creates a WS client with disabled Idle timeout")
+  void generatedWSClientHasDisabledIdleTimeout() {
+    try (var client = factory.newBuilder().build()) {
+      assertThat(client)
+        .extracting(JettyHttpClient::getJettyWs)
+        .extracting(WebSocketClient::getIdleTimeout)
+        .isEqualTo(Duration.ZERO);
+    }
+  }
+
+  @Test
+  @DisplayName("client.newBuilder().build(), reuses the jetty and jettyWS shared instances")
+  void buildClientBuilderBuildShareWsAndHttpClients() {
+    try (var client = factory.newBuilder().build()) {
+      final var client2 = client.newBuilder().build();
+      assertThat(client2)
+        .isInstanceOf(JettyHttpClient.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(JettyHttpClient.class))
+        .isNotSameAs(client)
+        .returns(client.getJetty(), JettyHttpClient::getJetty)
+        .returns(client.getJettyWs(), JettyHttpClient::getJettyWs);
+    }
+  }
+
+  @Test
+  @DisplayName("connectTimeout, sets connect timeout for underlying clients")
+  void connectTimeout() {
+    try (var client = factory.newBuilder().connectTimeout(1337, TimeUnit.MILLISECONDS).build()) {
+      assertThat(client)
+        .returns(1337L, c -> c.getJetty().getConnectTimeout())
+        .returns(1337L, c -> c.getJettyWs().getConnectTimeout());
+    }
+  }
+
+  @Test
+  @DisplayName("followRedirects=false, no redirection")
+  void followAllRedirectsDisabled() throws Exception {
+    server.expect()
+      .withPath("/redirect-me")
+      .andReply(ResponseProviders.of(301, "", Collections.singletonMap("Location", "/new-location")))
+      .always();
+    server.expect()
+      .withPath("/new-location")
+      .andReturn(200, "You made it!")
+      .always();
+    try (var client = factory.newBuilder().build()) {
+      final var result = client
+        .sendAsync(client.newHttpRequestBuilder().uri(server.url("redirect-me")).build(), String.class)
+          .get(10, TimeUnit.SECONDS);
+      assertThat(result)
+        .returns(301, HttpResponse::code);
+    }
+  }
+
+  @Test
+  @DisplayName("followAllRedirects=true, redirected")
+  void followAllRedirectsEnabled() throws Exception {
+    server.expect()
+      .withPath("/redirect-me")
+      .andReply(ResponseProviders.of(301, "", Collections.singletonMap("Location", "/new-location")))
+      .always();
+    server.expect()
+      .withPath("/new-location")
+      .andReturn(200, "You made it!")
+      .always();
+    try (var client = factory.newBuilder().followAllRedirects().build()) {
+      final var result = client
+        .sendAsync(client.newHttpRequestBuilder().uri(server.url("redirect-me")).build(), String.class)
+          .get(10, TimeUnit.SECONDS);
+      assertThat(result)
+        .returns(200, HttpResponse::code)
+        .returns("You made it!", r -> {
+          try {
+            return r.bodyString();
+          } catch (IOException ignored) {
+            return null;
+          }
+        });
+    }
+  }
+
+  @Test
+  @DisplayName("build, with preferHttp11, returns a client with an HTTP/1.1 transport")
+  void http11() throws Exception {
+    try (var client = factory.newBuilder().preferHttp11().build()) {
+      client.sendAsync(client.newHttpRequestBuilder().uri(server.url("/http-1-1")).build(), String.class).get();
+      assertThat(server.getLastRequest())
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("requestLine", "GET /http-1-1 HTTP/1.1");
+    }
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientFactoryTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientFactoryTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.Config;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JettyHttpClientFactoryTest {
+
+  @Test
+  @DisplayName("createHttpClient instantiates a JettyHttpClient")
+  void createHttpClientInstantiatesJettyHttpClient() {
+    // When
+    try (var result = new JettyHttpClientFactory().createHttpClient(Config.empty())) {
+      // Then
+      assertThat(result).isNotNull().isInstanceOf(JettyHttpClient.class);
+    }
+  }
+
+  @Test
+  @DisplayName("newBuilder instantiates a JettyHttpClientBuilder")
+  void newBuilderInstantiatesJettyHttpClientBuilder() {
+    // When
+    final var result = new JettyHttpClientFactory().newBuilder();
+    // Then
+    assertThat(result).isNotNull().isInstanceOf(JettyHttpClientBuilder.class);
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientProxyTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientProxyTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JettyHttpClientProxyTest extends AbstractHttpClientProxyTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.TestHttpRequest;
+import io.fabric8.kubernetes.client.http.TlsVersion;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JettyHttpClientTest {
+
+  private HttpClient httpClient;
+  private WebSocketClient webSocketClient;
+
+  @BeforeEach
+  void setUp() {
+    httpClient = new HttpClient();
+    webSocketClient = new WebSocketClient();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    webSocketClient.stop();
+    httpClient.stop();
+  }
+
+  @Test
+  @DisplayName("close, should close all underlying clients")
+  void closeShouldCloseClients() {
+    try (var jettyHttpClient = new JettyHttpClient(
+        null, httpClient, webSocketClient, Collections.emptyList(), null)) {
+      // When
+      jettyHttpClient.close();
+      // Then
+      assertThat(httpClient.isStopped()).isTrue();
+      assertThat(webSocketClient.isStopped()).isTrue();
+    }
+  }
+
+  @Test
+  @DisplayName("newBuilder instantiates a DerivedJettyHttpClientBuilder")
+  void newBuilderInstantiatesJettyHttpClientBuilderWithSameSettings() throws Exception {
+    // Given
+    final var originalBuilder = new JettyHttpClientBuilder(null);
+    originalBuilder
+        .connectTimeout(1337, TimeUnit.SECONDS)
+        .readTimeout(1337, TimeUnit.SECONDS)
+        .tlsVersions(TlsVersion.SSL_3_0)
+        .followAllRedirects();
+    try (var firstClient = new JettyHttpClient(
+        originalBuilder, httpClient, webSocketClient, Collections.emptyList(), null)) {
+      // When
+      final var result = firstClient.newBuilder()
+        .readTimeout(313373, TimeUnit.SECONDS);
+      // Then
+      assertThat(result)
+          .isNotNull()
+          .isInstanceOf(DerivedJettyHttpClientBuilder.class)
+          .isNotSameAs(originalBuilder);
+      final var expected = Map.of(
+          "tlsVersions", new TlsVersion[]{TlsVersion.SSL_3_0},
+          "followAllRedirects", true);
+      for (var entry : expected.entrySet()) {
+        final var field = JettyHttpClientBuilder.class.getDeclaredField(entry.getKey());
+        field.setAccessible(true);
+        assertThat(field.get(result))
+            .isEqualTo(field.get(originalBuilder))
+            .isEqualTo(entry.getValue());
+        field.setAccessible(false);
+      }
+      var readTimeout = DerivedJettyHttpClientBuilder.class.getDeclaredField("readTimeout");
+      readTimeout.setAccessible(true);
+      assertThat(readTimeout.get(result)).isEqualTo(Duration.ofSeconds(313373));
+      assertThat(readTimeout.get(originalBuilder)).isEqualTo(Duration.ofSeconds(1337));
+      readTimeout.setAccessible(false);
+    }
+  }
+
+  @Test
+  @DisplayName("sendAsync with unsupported type throws Exception")
+  void sendAsyncUnsupportedType() {
+    try (var jettyHttpClient = new JettyHttpClient(
+        null, httpClient, webSocketClient, Collections.emptyList(), null)) {
+      // When
+      final var result = assertThrows(IllegalArgumentException.class,
+          () -> jettyHttpClient.sendAsync(null, Integer.class));
+      // Then
+      assertThat(result).hasMessage("Unsupported response type: java.lang.Integer");
+    }
+  }
+
+  @Test
+  @DisplayName("sendAsync with unsupported HttpRequest throws Exception")
+  void sendAsyncUnsupportedHttpRequest() {
+    try (var jettyHttpClient = new JettyHttpClient(
+        new JettyHttpClientBuilder(null), httpClient, webSocketClient, Collections.emptyList(), null)) {
+      // When
+      final var request = new TestHttpRequest();
+      final var result = assertThrows(IllegalArgumentException.class,
+          () -> jettyHttpClient.sendAsync(request, String.class));
+      // Then
+      assertThat(result).hasMessage("Only StandardHttpRequest is supported");
+    }
+  }
+
+  @Test
+  @DisplayName("newWebSocketBuilder instantiates a JettyWebSocketBuilder")
+  void newWebSocketBuilderInstantiatesJettyWebSocketBuilder() {
+    try (var jettyHttpClient = new JettyHttpClient(
+      new JettyHttpClientBuilder(null), httpClient, webSocketClient, Collections.emptyList(), null)) {
+      // When
+      final var result = jettyHttpClient.newWebSocketBuilder();
+      // Then
+      assertThat(result).isNotNull().isInstanceOf(JettyWebSocketBuilder.class);
+    }
+  }
+
+  @Test
+  @DisplayName("getFactory returns original factory")
+  void getFactoryReturnsOriginal() {
+    // Given
+    final var factory = new JettyHttpClientFactory();
+    try (var jettyHttpClient = new JettyHttpClient(
+        null, httpClient, webSocketClient, Collections.emptyList(), factory)) {
+      // When
+      final var f1 = jettyHttpClient.getFactory();
+      final var f2 = jettyHttpClient.getFactory();
+      // Then
+      assertThat(f1).isSameAs(f2).isSameAs(factory);
+    }
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientTest.java
@@ -76,14 +76,14 @@ class JettyHttpClientTest {
         originalBuilder, httpClient, webSocketClient, Collections.emptyList(), null)) {
       // When
       final var result = firstClient.newBuilder()
-        .readTimeout(313373, TimeUnit.SECONDS);
+          .readTimeout(313373, TimeUnit.SECONDS);
       // Then
       assertThat(result)
           .isNotNull()
           .isInstanceOf(DerivedJettyHttpClientBuilder.class)
           .isNotSameAs(originalBuilder);
       final var expected = Map.of(
-          "tlsVersions", new TlsVersion[]{TlsVersion.SSL_3_0},
+          "tlsVersions", new TlsVersion[] { TlsVersion.SSL_3_0 },
           "followAllRedirects", true);
       for (var entry : expected.entrySet()) {
         final var field = JettyHttpClientBuilder.class.getDeclaredField(entry.getKey());
@@ -132,7 +132,7 @@ class JettyHttpClientTest {
   @DisplayName("newWebSocketBuilder instantiates a JettyWebSocketBuilder")
   void newWebSocketBuilderInstantiatesJettyWebSocketBuilder() {
     try (var jettyHttpClient = new JettyHttpClient(
-      new JettyHttpClientBuilder(null), httpClient, webSocketClient, Collections.emptyList(), null)) {
+        new JettyHttpClientBuilder(null), httpClient, webSocketClient, Collections.emptyList(), null)) {
       // When
       final var result = jettyHttpClient.newWebSocketBuilder();
       // Then

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpPostTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpPostTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JettyHttpPostTest extends AbstractHttpPostTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpResponseTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpResponseTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import org.eclipse.jetty.client.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class JettyHttpResponseTest {
+
+  @Test
+  void headersHandlesJettyHttpFields() {
+    // Given
+    final HttpResponse response = new HttpResponse(null, Collections.emptyList())
+        .headers(m -> m
+            .add("Content-Type", "text/plain")
+            .add("Content-Length", "1337")
+            .add("Via", "proxy-1")
+            .add("Via", "proxy-2"));
+    // When
+    final Map<String, List<String>> result = new JettyHttpResponse<>(null, response, null)
+        .headers();
+    // Then
+    assertThat(result)
+        .hasSize(3)
+        .containsEntry("Content-Type", Collections.singletonList("text/plain"))
+        .containsEntry("Content-Length", Collections.singletonList("1337"))
+        .containsEntry("Via", Arrays.asList("proxy-1", "proxy-2"));
+  }
+
+  @ParameterizedTest(name = "{index}: SupportedResponse: from type ''{0}'' is ''{1}''")
+  @MethodSource("supportedResponsesInput")
+  void supportedResponses(Class<?> type, JettyHttpResponse.SupportedResponse supportedResponse) {
+    // When
+    final var result = JettyHttpResponse.SupportedResponse.from(type);
+    // Then
+    assertThat(result).isEqualTo(supportedResponse);
+  }
+
+  static Stream<Arguments> supportedResponsesInput() {
+    return Stream.of(
+        arguments(String.class, JettyHttpResponse.SupportedResponse.TEXT),
+        arguments(InputStream.class, JettyHttpResponse.SupportedResponse.INPUT_STREAM),
+        arguments(ByteArrayInputStream.class, JettyHttpResponse.SupportedResponse.INPUT_STREAM),
+        arguments(Reader.class, JettyHttpResponse.SupportedResponse.READER),
+        arguments(InputStreamReader.class, JettyHttpResponse.SupportedResponse.READER),
+        arguments(byte[].class, JettyHttpResponse.SupportedResponse.BYTE_ARRAY));
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyInterceptorTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyInterceptorTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.AbstractInterceptorTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JettyInterceptorTest extends AbstractInterceptorTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketBuilderTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketBuilderTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
+import io.fabric8.mockwebserver.DefaultMockServer;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JettyWebSocketBuilderTest {
+
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  @Test
+  void buildAsyncConnectsAndUpgrades() throws Exception {
+    server.expect().withPath("/websocket-test")
+        .andUpgradeToWebSocket()
+        .open()
+        .done()
+        .always();
+    final var open = new AtomicBoolean(false);
+    new JettyWebSocketBuilder(new WebSocketClient(new HttpClient()), Duration.ZERO)
+        .uri(URI.create(server.url("/websocket-test")))
+        .buildAsync(new WebSocket.Listener() {
+          @Override
+          public void onOpen(WebSocket webSocket) {
+            open.set(true);
+          }
+        }).get(10L, TimeUnit.SECONDS);
+    assertThat(open).isTrue();
+  }
+
+  @Test
+  void buildAsyncCantUpgradeThrowsWebSocketHandshakeException() {
+    final var result = assertThrows(ExecutionException.class,
+        () -> new JettyWebSocketBuilder(new WebSocketClient(new HttpClient()), Duration.ZERO)
+            .uri(URI.create(server.url("/not-found")))
+            .buildAsync(new WebSocket.Listener() {
+            })
+            .get(10L, TimeUnit.SECONDS));
+    assertThat(result).cause().isInstanceOf(WebSocketHandshakeException.class);
+  }
+
+  @Test
+  void buildAsyncIncludesRequiredHeadersAndPropagatesConfigured() throws Exception {
+    server.expect().withPath("/websocket-headers-test")
+        .andUpgradeToWebSocket()
+        .open()
+        .done()
+        .always();
+    final var open = new AtomicBoolean(false);
+    new JettyWebSocketBuilder(new WebSocketClient(new HttpClient()), Duration.ZERO)
+        .header("A-Random-Header", "A-Random-Value")
+        .subprotocol("amqp")
+        .uri(URI.create(server.url("/websocket-headers-test")))
+        .buildAsync(new WebSocket.Listener() {
+          @Override
+          public void onOpen(WebSocket webSocket) {
+            open.set(true);
+          }
+        }).get(10L, TimeUnit.SECONDS);
+    assertThat(open).isTrue();
+    assertThat(server.getLastRequest().getHeaders().toMultimap())
+        .containsEntry("a-random-header", Collections.singletonList("A-Random-Value"))
+        .containsEntry("sec-websocket-protocol", Collections.singletonList("amqp"))
+        .containsEntry("connection", Collections.singletonList("Upgrade"))
+        .containsEntry("upgrade", Collections.singletonList("websocket"))
+        .containsEntry("sec-websocket-version", Collections.singletonList("13"))
+        .containsKey("sec-websocket-key");
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketSendTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketSendTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.AbstractWebSocketSendTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JettyWebSocketSendTest extends AbstractWebSocketSendTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
@@ -1,0 +1,265 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.WebSocket;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.websocket.api.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.LinkedHashMap;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JettyWebSocketTest {
+
+  @Test
+  @DisplayName("Remote WebSocket binary message, notifies first onMessage with no back pressure")
+  void webSocketBinaryNotifiesOnMessage() {
+    // Given
+    final var listener = new Listener();
+    // When
+    new JettyWebSocket(listener).onWebSocketBinary(new byte[] { 1, 3, 3, 7 }, 0, 4);
+    // Then
+    assertThat(listener.events)
+        .containsOnlyKeys("onMessage")
+        .extracting("onMessage", InstanceOfAssertFactories.type(Object[].class))
+        .extracting(o -> o[0], InstanceOfAssertFactories.type(ByteBuffer.class))
+        .extracting(BufferUtil::toArray, InstanceOfAssertFactories.type(byte[].class))
+        .isEqualTo(new byte[] { 1, 3, 3, 7 });
+  }
+
+  @Test
+  @DisplayName("Remote WebSocket text message, notifies first onMessage with no back pressure")
+  void webSocketTextNotifiesOnMessage() {
+    // Given
+    final var listener = new Listener();
+    // When
+    new JettyWebSocket(listener).onWebSocketText("the message");
+    // Then
+    assertThat(listener.events)
+        .containsOnlyKeys("onMessage")
+        .extracting("onMessage", InstanceOfAssertFactories.type(Object[].class))
+        .extracting(o -> o[0], InstanceOfAssertFactories.type(String.class))
+        .isEqualTo("the message");
+  }
+
+  @Test
+  @DisplayName("Remote WebSocket close, notifies onClose")
+  void webSocketCloseNotifiesOnClose() {
+    // Given
+    final var listener = new Listener();
+    // When
+    new JettyWebSocket(listener).onWebSocketClose(1337, "closed");
+    // Then
+    assertThat(listener.events)
+        .containsOnly(entry("onClose", new Object[] { 1337, "closed" }));
+  }
+
+  @Test
+  @DisplayName("Remote WebSocket connect, notifies onOpen")
+  void webSocketConnectNotifiesOnOpen() {
+    // Given
+    final var listener = new Listener();
+    // When
+    new JettyWebSocket(listener).onWebSocketConnect(null);
+    // Then
+    assertThat(listener.events).containsOnlyKeys("onOpen");
+  }
+
+  @Test
+  @DisplayName("Remote WebSocket error, notifies onError")
+  void webSocketErrorNotifiesOnError() {
+    // Given
+    final var listener = new Listener();
+    // When
+    new JettyWebSocket(listener).onWebSocketError(new Exception("WebSocket Error!"));
+    // Then
+    assertThat(listener.events)
+        .containsOnlyKeys("onError")
+        .extracting("onError", InstanceOfAssertFactories.type(Object[].class))
+        .extracting(o -> o[0], InstanceOfAssertFactories.throwable(Exception.class))
+        .hasMessage("WebSocket Error!");
+  }
+
+  @Test
+  @DisplayName("Remote WebSocket error, ignored if connection is already closed and is ClosedChannelException")
+  void webSocketErrorIgnoredWhenClosed() {
+    // Given
+    final var listener = new Listener();
+    final var jws = new JettyWebSocket(listener);
+    jws.onWebSocketClose(1000, "closed");
+    // When
+    jws.onWebSocketError(new ClosedChannelException());
+    // Then
+    assertThat(listener.events)
+        .containsOnlyKeys("onClose");
+  }
+
+  @Test
+  @DisplayName("Remote WebSocket error, notifies onClose if connection is already closed and is NOT ClosedChannelException")
+  void webSocketErrorNotifiesOnErrorWhenClosedAndNotClosedChannelException() {
+    // Given
+    final var listener = new Listener();
+    final var jws = new JettyWebSocket(listener);
+    jws.onWebSocketClose(1000, "closed");
+    // When
+    jws.onWebSocketError(new Exception("NOT ClosedChannelException"));
+    // Then
+    assertThat(listener.events)
+        .containsOnlyKeys("onClose", "onError")
+        .extracting("onError", InstanceOfAssertFactories.type(Object[].class))
+        .extracting(o -> o[0], InstanceOfAssertFactories.throwable(Exception.class))
+        .hasMessage("NOT ClosedChannelException");
+  }
+
+  @Test
+  @DisplayName("backPressure, onWebSocketText processes first frame and waits for request() call")
+  void backPressure() throws Exception {
+    final var executor = Executors.newSingleThreadExecutor();
+    try {
+      final var buffer = new StringBuffer();
+      final var messages = new String[] { "Hell", "o ", "World!" };
+      final BlockingQueue<String> lock = new ArrayBlockingQueue<>(3);
+      final var ws = new JettyWebSocket(new WebSocket.Listener() {
+        @Override
+        public void onMessage(WebSocket webSocket, String text) {
+          buffer.append(text);
+        }
+      });
+      executor.execute(() -> {
+        for (var m : messages) {
+          ws.onWebSocketText(m);
+          assertTrue(lock.offer(m));
+        }
+      });
+      lock.poll(1, TimeUnit.SECONDS);
+      assertThat(buffer).hasToString("Hell");
+      ws.request();
+      lock.poll(1, TimeUnit.SECONDS);
+      assertThat(buffer).hasToString("Hello ");
+      ws.request();
+      lock.poll(1, TimeUnit.SECONDS);
+      assertThat(buffer).hasToString("Hello World!");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  @DisplayName("sendClose, sends close message if connection is open")
+  void sendCloseWhenConnectionIsOpen() {
+    // Given
+    final var jws = new JettyWebSocket(new Listener());
+    final var session = mock(Session.class);
+    jws.setWebSocketSession(session);
+    when(session.isOpen()).thenReturn(true);
+    // When
+    jws.sendClose(1000, "Closing");
+    // Then
+    verify(session).close(1000, "Closing");
+  }
+
+  @Test
+  @DisplayName("sendClose, ignored if connection is closed")
+  void sendCloseIgnoredWhenConnectionIsClosed() {
+    // Given
+    final var jws = new JettyWebSocket(new Listener());
+    final var session = mock(Session.class);
+    jws.setWebSocketSession(session);
+    when(session.isOpen()).thenReturn(false);
+    // When
+    jws.sendClose(1000, "Closing");
+    // Then
+    verify(session, times(0)).close(anyInt(), anyString());
+  }
+
+  @Test
+  @DisplayName("sendClose, ignored if connection is already closed")
+  void sendCloseIgnoredWhenAlreadyClosed() {
+    // Given
+    final var jws = new JettyWebSocket(new Listener());
+    final var session = mock(Session.class);
+    jws.setWebSocketSession(session);
+    when(session.isOpen()).thenReturn(true);
+    jws.sendClose(1000, "Closing");
+    // When
+    jws.sendClose(1000, "Closing twice");
+    // Then
+    verify(session, times(1)).close(anyInt(), anyString());
+    verify(session).close(1000, "Closing");
+  }
+
+  @Test
+  @DisplayName("send increases queueSize")
+  void sendIncreasesQueueSize() {
+    // Given
+    final var jws = new JettyWebSocket(new Listener());
+    final var session = mock(Session.class, RETURNS_DEEP_STUBS);
+    jws.setWebSocketSession(session);
+    when(session.isOpen()).thenReturn(true);
+    // When
+    jws.send(ByteBuffer.wrap(new byte[] {1, 3, 3, 7}));
+    // Then
+    assertThat(jws.queueSize()).isEqualTo(4L);
+  }
+
+  private static final class Listener implements WebSocket.Listener {
+    private final LinkedHashMap<String, Object[]> events = new LinkedHashMap<>();
+
+    @Override
+    public void onOpen(WebSocket webSocket) {
+      events.put("onOpen", null);
+    }
+
+    @Override
+    public void onMessage(WebSocket webSocket, String text) {
+      events.put("onMessage", new Object[] { text });
+    }
+
+    @Override
+    public void onMessage(WebSocket webSocket, ByteBuffer bytes) {
+      events.put("onMessage", new Object[] { bytes });
+    }
+
+    @Override
+    public void onClose(WebSocket webSocket, int code, String reason) {
+      events.put("onClose", new Object[] { code, reason });
+    }
+
+    @Override
+    public void onError(WebSocket webSocket, Throwable error) {
+      events.put("onError", new Object[] { error });
+    }
+  }
+}

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
@@ -229,7 +229,7 @@ class JettyWebSocketTest {
     jws.setWebSocketSession(session);
     when(session.isOpen()).thenReturn(true);
     // When
-    jws.send(ByteBuffer.wrap(new byte[] {1, 3, 3, 7}));
+    jws.send(ByteBuffer.wrap(new byte[] { 1, 3, 3, 7 }));
     // Then
     assertThat(jws.queueSize()).isEqualTo(4L);
   }

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -26,8 +26,8 @@
 
   <artifactId>kubernetes-httpclient-okhttp</artifactId>
   <packaging>jar</packaging>
-  <name>Fabric8 :: Kubernetes :: OkHttp HttpClient</name>
-  
+  <name>Fabric8 :: Kubernetes :: HttpClient :: OkHttp</name>
+
   <properties>
     <osgi.require-capability>
       osgi.extender;
@@ -57,6 +57,28 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
       <version>${okhttp.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client-api</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
@@ -200,7 +200,7 @@ class OkHttpClientBuilderImpl implements Builder {
   }
 
   @Override
-  public Builder tlsVersions(TlsVersion[] tlsVersions) {
+  public Builder tlsVersions(TlsVersion... tlsVersions) {
     ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
         .tlsVersions(Arrays.asList(tlsVersions)
             .stream()

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -211,7 +211,7 @@ public class OkHttpClientImpl implements HttpClient {
     Function<BufferedSource, AsyncBody> handler = s -> new OkHttpAsyncBody<String>(consumer, s) {
       @Override
       protected String process(BufferedSource source) throws IOException {
-        return source.readUtf8LineStrict();
+        return source.readUtf8Line();
       }
     };
     return sendAsync(request, handler);

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -166,6 +166,11 @@ public class OkHttpClientImpl implements HttpClient {
       return response.headers(key);
     }
 
+    @Override
+    public Map<String, List<String>> headers() {
+      return response.headers().toMultimap();
+    }
+
   }
 
   private final okhttp3.OkHttpClient httpClient;

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpRequestImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpRequestImpl.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 class OkHttpRequestImpl implements HttpRequest {
 
@@ -154,6 +155,11 @@ class OkHttpRequestImpl implements HttpRequest {
   @Override
   public List<String> headers(String key) {
     return request.headers(key);
+  }
+
+  @Override
+  public Map<String, List<String>> headers() {
+    return request.headers().toMultimap();
   }
 
   @Override

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
 import io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl.OkHttpResponseImpl;
-import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -47,7 +46,7 @@ class OkHttpWebSocketImpl implements WebSocket {
 
     @Override
     public Builder uri(URI uri) {
-      builder.url(HttpUrl.get(uri));
+      builder.url(uri.toString());
       return this;
     }
 

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpAsyncBodyTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpAsyncBodyTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractAsyncBodyTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class OkHttpAsyncBodyTest extends AbstractAsyncBodyTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new OkHttpClientFactory();
+  }
+}

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpInterceptorTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpInterceptorTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractInterceptorTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import org.junit.jupiter.api.Disabled;
+
+@SuppressWarnings("java:S2187")
+public class OkHttpInterceptorTest extends AbstractInterceptorTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new OkHttpClientFactory();
+  }
+
+  // TODO: Check implementation
+  @Disabled("TODO: Check implementation")
+  @Override
+  public void afterHttpFailureReplacesResponseInConsumeLines() {
+  }
+
+  // TODO: Check implementation
+  @Disabled("TODO: Check implementation")
+  @Override
+  public void afterHttpFailureReplacesResponseInConsumeBytes() {
+  }
+}

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpInterceptorTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpInterceptorTest.java
@@ -17,24 +17,11 @@ package io.fabric8.kubernetes.client.okhttp;
 
 import io.fabric8.kubernetes.client.http.AbstractInterceptorTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
-import org.junit.jupiter.api.Disabled;
 
 @SuppressWarnings("java:S2187")
 public class OkHttpInterceptorTest extends AbstractInterceptorTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new OkHttpClientFactory();
-  }
-
-  // TODO: Check implementation
-  @Disabled("TODO: Check implementation")
-  @Override
-  public void afterHttpFailureReplacesResponseInConsumeLines() {
-  }
-
-  // TODO: Check implementation
-  @Disabled("TODO: Check implementation")
-  @Override
-  public void afterHttpFailureReplacesResponseInConsumeBytes() {
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPostTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPostTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class OkHttpPostTest extends AbstractHttpPostTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new OkHttpClientFactory();
+  }
+}

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketSendTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketSendTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractWebSocketSendTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class OkHttpWebSocketSendTest extends AbstractWebSocketSendTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new OkHttpClientFactory();
+  }
+}

--- a/httpclient-tests/pom.xml
+++ b/httpclient-tests/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-jetty</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
     </dependency>
     <dependency>
@@ -51,13 +55,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/JettyHttpClientTest.java
+++ b/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/JettyHttpClientTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.kubernetes.client.jetty.JettyHttpClientFactory;
+
+public class JettyHttpClientTest extends OkHttpClientTest {
+
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+
+}

--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -196,7 +196,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -207,6 +206,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/AbstractBasicBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/AbstractBasicBuilder.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractBasicBuilder<T extends BasicBuilder> implements BasicBuilder {
+
+  private URI uri;
+  private final Map<String, List<String>> headers = new HashMap<>();
+
+  @Override
+  public T uri(URI uri) {
+    this.uri = uri;
+    return (T) this;
+  }
+
+  @Override
+  public T header(String name, String value) {
+    headers.compute(name, (k, v) -> {
+      if (v == null) {
+        v = new ArrayList<>();
+      }
+      v.add(value);
+      return v;
+    });
+    return (T) this;
+  }
+
+  @Override
+  public T setHeader(String name, String value) {
+    headers.put(name, new ArrayList<>(Collections.singletonList(value)));
+    return (T) this;
+  }
+
+  protected final URI getUri() {
+    return uri;
+  }
+
+  protected final Map<String, List<String>> getHeaders() {
+    return headers;
+  }
+
+  protected final void setHeaders(Map<String, List<String>> headers) {
+    this.headers.clear();
+    this.headers.putAll(headers);
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
@@ -54,34 +54,65 @@ public interface HttpClient extends AutoCloseable {
 
     DerivedClientBuilder readTimeout(long readTimeout, TimeUnit unit);
 
+    DerivedClientBuilder writeTimeout(long writeTimeout, TimeUnit unit);
+
+    /**
+     * Sets the HttpClient to be used to perform HTTP requests whose responses
+     * will be streamed.
+     *
+     * @return this Builder instance.
+     */
     DerivedClientBuilder forStreaming();
 
-    DerivedClientBuilder authenticatorNone();
-
-    DerivedClientBuilder writeTimeout(long timeout, TimeUnit timeoutUnit);
-
     DerivedClientBuilder addOrReplaceInterceptor(String name, Interceptor interceptor);
+
+    /**
+     * Prevents any built-in authenticator to respond to challenges from origin server.
+     * <p>
+     * <i>OkHttp specific option.</i>
+     *
+     * @return this Builder instance.
+     */
+    DerivedClientBuilder authenticatorNone();
   }
 
   interface Builder extends DerivedClientBuilder {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     HttpClient build();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     Builder readTimeout(long readTimeout, TimeUnit unit);
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    Builder writeTimeout(long writeTimeout, TimeUnit unit);
+
     Builder connectTimeout(long connectTimeout, TimeUnit unit);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     Builder forStreaming();
 
-    @Override
-    Builder writeTimeout(long timeout, TimeUnit timeoutUnit);
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     Builder addOrReplaceInterceptor(String name, Interceptor interceptor);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     Builder authenticatorNone();
 
@@ -93,7 +124,7 @@ public interface HttpClient extends AutoCloseable {
 
     Builder proxyAuthorization(String credentials);
 
-    Builder tlsVersions(TlsVersion[] tlsVersions);
+    Builder tlsVersions(TlsVersion... tlsVersions);
 
     Builder preferHttp11();
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpHeaders.java
@@ -17,15 +17,23 @@
 package io.fabric8.kubernetes.client.http;
 
 import java.util.List;
+import java.util.Map;
 
 public interface HttpHeaders {
 
   /**
    * Returns a List of all the Header String values for the provided key/name.
-   * 
+   *
    * @param key The header key/name for which to provide the values.
    * @return the List of header values for the provided key.
    */
   List<String> headers(String key);
+
+  /**
+   * Returns a Map containing a list of String values for each Header.
+   *
+   * @return the Map of Headers and their list of values.
+   */
+  Map<String, List<String>> headers();
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class StandardHttpHeaders implements HttpHeaders {
+
+  public static final String CONTENT_TYPE = "Content-Type";
+  public static final String CONTENT_LENGTH = "Content-Length";
+  public static final String EXPECT = "Expect";
+  public static final String EXPECT_CONTINUE = "100-Continue";
+
+  private final Map<String, List<String>> headers;
+
+  public StandardHttpHeaders(Map<String, List<String>> headers) {
+    this.headers = headers;
+  }
+
+  @Override
+  public List<String> headers(String key) {
+    return Collections.unmodifiableList(headers.getOrDefault(key, Collections.emptyList()));
+  }
+
+  @Override
+  public Map<String, List<String>> headers() {
+    return Collections.unmodifiableMap(headers);
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpRequest.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpRequest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class StandardHttpRequest extends StandardHttpHeaders implements HttpRequest {
+
+  public static final String METHOD_POST = "POST";
+
+  private final URI uri;
+  private final String method;
+  private final String bodyString;
+  private final InputStream bodyStream;
+
+  public StandardHttpRequest(Map<String, List<String>> headers, URI uri, String method, String bodyString,
+      InputStream bodyStream) {
+    super(headers);
+    this.uri = uri;
+    this.method = method;
+    this.bodyString = bodyString;
+    this.bodyStream = bodyStream;
+  }
+
+  @Override
+  public URI uri() {
+    return uri;
+  }
+
+  @Override
+  public String method() {
+    return method;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String bodyString() {
+    return bodyString;
+  }
+
+  /**
+   * Return the body as a string, but only if one of the byte[] or InputStream valued {@link HttpRequest.Builder}
+   * methods were used otherwise null.
+   *
+   * @return the body as InputStream.
+   */
+  public InputStream bodyStream() {
+    return bodyStream;
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static final class Builder extends AbstractBasicBuilder<Builder> implements HttpRequest.Builder {
+
+    private String method = "GET";
+    private InputStream bodyAsStream;
+    private String bodyAsString;
+
+    public Builder() {
+    }
+
+    public Builder(StandardHttpRequest original) {
+      super.uri(original.uri());
+      super.setHeaders(original.headers());
+      method = original.method;
+      bodyAsString = original.bodyString;
+      bodyAsStream = original.bodyStream;
+    }
+
+    @Override
+    public StandardHttpRequest build() {
+      return new StandardHttpRequest(
+          getHeaders(), Objects.requireNonNull(getUri()), method, bodyAsString, bodyAsStream);
+    }
+
+    @Override
+    public HttpRequest.Builder uri(String uri) {
+      return super.uri(URI.create(uri));
+    }
+
+    @Override
+    public HttpRequest.Builder url(URL url) {
+      try {
+        return super.uri(url.toURI());
+      } catch (URISyntaxException e) {
+        throw KubernetesClientException.launderThrowable(e);
+      }
+    }
+
+    @Override
+    public HttpRequest.Builder post(String contentType, byte[] writeValueAsBytes) {
+      return post(contentType, new ByteArrayInputStream(writeValueAsBytes), writeValueAsBytes.length);
+    }
+
+    @Override
+    public HttpRequest.Builder post(String contentType, InputStream stream, long length) {
+      if (length >= 0) {
+        header(CONTENT_LENGTH, Long.toString(length));
+      }
+      method = METHOD_POST;
+      contentType(contentType);
+      bodyAsStream = stream;
+      return this;
+    }
+
+    @Override
+    public HttpRequest.Builder method(String method, String contentType, String body) {
+      this.method = method;
+      contentType(contentType);
+      this.bodyAsString = body;
+      return this;
+    }
+
+    private void contentType(String contentType) {
+      if (contentType != null) {
+        setHeader(CONTENT_TYPE, contentType);
+      }
+    }
+
+    @Override
+    public HttpRequest.Builder expectContinue() {
+      setHeader(EXPECT, EXPECT_CONTINUE);
+      return this;
+    }
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardMediaTypes.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardMediaTypes.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+public class StandardMediaTypes {
+
+  public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+  public static final String TEXT_PLAIN = "text/plain";
+
+  private StandardMediaTypes() {
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
@@ -74,6 +74,21 @@ public interface WebSocket {
      */
     CompletableFuture<WebSocket> buildAsync(Listener listener);
 
+    /**
+     * Protocol used for WebSocket message exchange.
+     *
+     * <blockquote>
+     * The client can request that the server use a specific subprotocol by
+     * including the |Sec-WebSocket-Protocol| field in its handshake. If it
+     * is specified, the server needs to include the same field and one of
+     * the selected subprotocol values in its response for the connection to
+     * be established.
+     * </blockquote>
+     * <i>RFC 6455: Section 1.9, Subprotocols Using the WebSocket Protocol</i>
+     *
+     * @param protocol the protocol to be used.
+     * @return this builder.
+     */
     Builder subprotocol(String protocol);
 
     @Override
@@ -121,5 +136,24 @@ public interface WebSocket {
    * of the current event.
    */
   void request();
+
+  /**
+   * Converts http or https URIs to ws or wss URIs.
+   * <p>
+   * Clients such as JDK or Jetty require URIs to be performed to the ws protocol, other clients perform
+   * this same transformation automatically.
+   *
+   * @param httpUri the original URI to transform.
+   * @return a new URI with the converted protocol (if applicable).
+   */
+  static URI toWebSocketUri(URI httpUri) {
+    if (httpUri != null && httpUri.getScheme().startsWith("http")) {
+      // the jdk logic expects a ws uri
+      // after the https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8245245 it just does the reverse of this
+      // to convert back to http(s) ...
+      return URI.create("ws" + httpUri.toString().substring(4));
+    }
+    return httpUri;
+  }
 
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.mockwebserver.DefaultMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public abstract class AbstractAsyncBodyTest {
+
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  @Test
+  @DisplayName("Lines are processed and consumed only after the consume() invocation")
+  public void consumeLinesProcessedAfterConsume() throws Exception {
+    try (final HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      server.expect().withPath("/consume-lines")
+          .andReturn(200, "This is the response body\n")
+          .always();
+      final StringBuffer responseText = new StringBuffer();
+      final HttpResponse<HttpClient.AsyncBody> asyncBodyResponse = client.consumeLines(
+          client.newHttpRequestBuilder().uri(server.url("/consume-lines")).build(),
+          (value, asyncBody) -> {
+            responseText.append(value);
+            asyncBody.done().complete(null); // OkHttp requires this, not sure if it should
+          })
+          .get(10L, TimeUnit.SECONDS);
+      assertThat(responseText).isEmpty();
+      asyncBodyResponse.body().consume();
+      asyncBodyResponse.body().done().get(10L, TimeUnit.SECONDS);
+      assertThat(responseText).contains("This is the response body");
+    }
+  }
+
+  @Test
+  @DisplayName("Lines are not processed when cancel() invocation")
+  public void consumeLinesNotProcessedIfCancelled() throws Exception {
+    try (final HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      server.expect().withPath("/cancel")
+          .andReturn(200, "This would be the response body")
+          .always();
+      final StringBuffer responseText = new StringBuffer();
+      final HttpResponse<HttpClient.AsyncBody> asyncBodyResponse = client
+          .consumeLines(client.newHttpRequestBuilder()
+              .uri(server.url("/cancel")).build(), (value, asyncBody) -> responseText.append(value))
+          .get(10L, TimeUnit.SECONDS);
+      asyncBodyResponse.body().cancel();
+      asyncBodyResponse.body().consume();
+      final CompletableFuture<Void> doneFuture = asyncBodyResponse.body().done();
+      assertThrows(CancellationException.class, () -> doneFuture.get(10L, TimeUnit.SECONDS));
+      assertThat(responseText).isEmpty();
+    }
+  }
+
+  @Test
+  @DisplayName("Bytes are processed and consumed only after the consume() invocation")
+  public void consumeByteBufferLinesProcessedAfterConsume() throws Exception {
+    try (final HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      server.expect().withPath("/consume-bytes")
+          .andReturn(200, "This is the response body as bytes")
+          .always();
+      final StringBuffer responseText = new StringBuffer();
+      final HttpResponse<HttpClient.AsyncBody> asyncBodyResponse = client.consumeBytes(
+          client.newHttpRequestBuilder().uri(server.url("/consume-bytes")).build(),
+          (value, asyncBody) -> {
+            responseText.append(value.stream().map(StandardCharsets.UTF_8::decode)
+                .map(CharBuffer::toString).collect(Collectors.joining()));
+            asyncBody.done().complete(null); // OkHttp requires this, not sure if it should
+          })
+          .get(10L, TimeUnit.SECONDS);
+      assertThat(responseText).isEmpty();
+      asyncBodyResponse.body().consume();
+      asyncBodyResponse.body().done().get(10L, TimeUnit.SECONDS);
+      assertThat(responseText).contains("This is the response body as bytes");
+    }
+  }
+
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
@@ -60,7 +60,7 @@ public abstract class AbstractAsyncBodyTest {
           client.newHttpRequestBuilder().uri(server.url("/consume-lines")).build(),
           (value, asyncBody) -> {
             responseText.append(value);
-            asyncBody.done().complete(null); // OkHttp requires this, not sure if it should
+            asyncBody.consume();
           })
           .get(10L, TimeUnit.SECONDS);
       assertThat(responseText).isEmpty();
@@ -80,7 +80,10 @@ public abstract class AbstractAsyncBodyTest {
       final StringBuffer responseText = new StringBuffer();
       final HttpResponse<HttpClient.AsyncBody> asyncBodyResponse = client
           .consumeLines(client.newHttpRequestBuilder()
-              .uri(server.url("/cancel")).build(), (value, asyncBody) -> responseText.append(value))
+              .uri(server.url("/cancel")).build(), (value, asyncBody) -> {
+                responseText.append(value);
+                asyncBody.consume();
+              })
           .get(10L, TimeUnit.SECONDS);
       asyncBodyResponse.body().cancel();
       asyncBodyResponse.body().consume();
@@ -103,7 +106,7 @@ public abstract class AbstractAsyncBodyTest {
           (value, asyncBody) -> {
             responseText.append(value.stream().map(StandardCharsets.UTF_8::decode)
                 .map(CharBuffer::toString).collect(Collectors.joining()));
-            asyncBody.done().complete(null); // OkHttp requires this, not sure if it should
+            asyncBody.consume();
           })
           .get(10L, TimeUnit.SECONDS);
       assertThat(responseText).isEmpty();

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientProxyTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientProxyTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.mockwebserver.DefaultMockServer;
+import okhttp3.Headers;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractHttpClientProxyTest {
+
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  @Test
+  @DisplayName("Proxied HttpClient adds required headers to the request")
+  void proxyConfigurationAddsRequiredHeaders() throws Exception {
+    // Given
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .proxyAddress(new InetSocketAddress("localhost", server.getPort()))
+        .proxyAuthorization("auth:cred");
+    try (HttpClient client = builder.build()) {
+      // When
+      client.sendAsync(client.newHttpRequestBuilder()
+          .uri(String.format("http://0.0.0.0:%s/not-found", server.getPort())).build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+      // Then
+      assertThat(server.getLastRequest())
+          .extracting(RecordedRequest::getHeaders)
+          .extracting(Headers::toMultimap)
+          .hasFieldOrPropertyWithValue("Host", Collections.singletonList("0.0.0.0:" + server.getPort()))
+          .hasFieldOrPropertyWithValue("Proxy-Authorization", Collections.singletonList("auth:cred"));
+    }
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.mockwebserver.DefaultMockServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractHttpPostTest {
+
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  @Test
+  @DisplayName("String body, should send a POST request with body")
+  public void postStringBody() throws Exception {
+    // When
+    try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      client
+          .sendAsync(client.newHttpRequestBuilder()
+              .uri(server.url("/post-string"))
+              .post("text/plain", "A string body")
+              .build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+    }
+    // Then
+    assertThat(server.getLastRequest())
+        .returns("POST", RecordedRequest::getMethod)
+        .returns("A string body", rr -> rr.getBody().readUtf8())
+        .extracting(rr -> rr.getHeader("Content-Type")).asString()
+        .startsWith("text/plain");
+  }
+
+  @Test
+  @DisplayName("InputStream body, should send a POST request with body")
+  public void postInputStreamBody() throws Exception {
+    // When
+    try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      client
+          .sendAsync(client.newHttpRequestBuilder()
+              .uri(server.url("/post-input-stream"))
+              .post("text/plain", new ByteArrayInputStream("A string body".getBytes(StandardCharsets.UTF_8)), -1)
+              .build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+    }
+    // Then
+    assertThat(server.getLastRequest())
+        .returns("POST", RecordedRequest::getMethod)
+        .returns("A string body", rr -> rr.getBody().readUtf8())
+        .extracting(rr -> rr.getHeader("Content-Type")).asString()
+        .startsWith("text/plain");
+  }
+
+  @Test
+  @DisplayName("byte[] body, should send a POST request with body")
+  public void postBytesBody() throws Exception {
+    // When
+    try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      client
+          .sendAsync(client.newHttpRequestBuilder()
+              .uri(server.url("/post-bytes"))
+              .post("text/plain", "A string body".getBytes(StandardCharsets.UTF_8))
+              .build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+    }
+    // Then
+    assertThat(server.getLastRequest())
+        .returns("POST", RecordedRequest::getMethod)
+        .returns("A string body", rr -> rr.getBody().readUtf8())
+        .extracting(rr -> rr.getHeader("Content-Type")).asString()
+        .startsWith("text/plain");
+  }
+
+  @Test
+  @DisplayName("FormData body, should send a POST request with body")
+  public void postFormDataBody() throws Exception {
+    // When
+    try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      client
+          .sendAsync(client.newHttpRequestBuilder()
+              .uri(server.url("/post-bytes"))
+              .post(Collections.singletonMap("field", "value"))
+              .build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+    }
+    // Then
+    assertThat(server.getLastRequest())
+        .returns("POST", RecordedRequest::getMethod)
+        .returns("field=value", rr -> rr.getBody().readUtf8())
+        .extracting(rr -> rr.getHeader("Content-Type")).asString()
+        .startsWith("application/x-www-form-urlencoded");
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.mockwebserver.DefaultMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractInterceptorTest {
+
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  @Test
+  @DisplayName("before, should add a header to the HTTP request")
+  public void beforeAddsHeaderToRequest() throws Exception {
+    // Given
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .addOrReplaceInterceptor("test", new Interceptor() {
+          @Override
+          public void before(BasicBuilder builder, HttpHeaders headers) {
+            builder.header("Test-Header", "Test-Value");
+          }
+        });
+    // When
+    try (HttpClient client = builder.build()) {
+      client.sendAsync(client.newHttpRequestBuilder().uri(server.url("/intercept-before")).build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+    }
+    // Then
+    assertThat(server.getLastRequest().getHeaders().toMultimap())
+        .containsEntry("test-header", Collections.singletonList("Test-Value"));
+  }
+
+  @Test
+  @DisplayName("afterFailure (HTTP), replaces the HttpResponse produced by HttpClient.sendAsync")
+  public void afterHttpFailureReplacesResponseInSendAsync() throws Exception {
+    // Given
+    server.expect().withPath("/intercepted-url").andReturn(200, "This works").always();
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .addOrReplaceInterceptor("test", new Interceptor() {
+          @Override
+          public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
+            builder.uri(URI.create(server.url("/intercepted-url")));
+            return CompletableFuture.completedFuture(true);
+          }
+        });
+    // When
+    try (HttpClient client = builder.build()) {
+      final HttpResponse<String> result = client
+          .sendAsync(client.newHttpRequestBuilder().uri(server.url("/not-found")).build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+      // Then
+      assertThat(result)
+          .returns("This works", HttpResponse::body)
+          .returns(200, HttpResponse::code);
+    }
+  }
+
+  @Test
+  @DisplayName("afterFailure (HTTP), replaces the HttpResponse produced by HttpClient.consumeLines")
+  public void afterHttpFailureReplacesResponseInConsumeLines() throws Exception {
+    // Given
+    server.expect().withPath("/intercepted-url").andReturn(200, "This works").always();
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .addOrReplaceInterceptor("test", new Interceptor() {
+          @Override
+          public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
+            builder.uri(URI.create(server.url("/intercepted-url")));
+            return CompletableFuture.completedFuture(true);
+          }
+        });
+    final AtomicReference<String> result = new AtomicReference<>();
+    // When
+    try (HttpClient client = builder.build()) {
+      final HttpResponse<HttpClient.AsyncBody> asyncR = client.consumeLines(
+          client.newHttpRequestBuilder().uri(server.url("/not-found")).build(), (s, ab) -> result.set(s))
+          .get(10L, TimeUnit.SECONDS);
+      asyncR.body().consume();
+      asyncR.body().done().get(10L, TimeUnit.SECONDS);
+      // Then
+      assertThat(result).hasValue("This works");
+    }
+  }
+
+  @Test
+  @DisplayName("afterFailure (HTTP), replaces the HttpResponse produced by HttpClient.consumeBytes")
+  public void afterHttpFailureReplacesResponseInConsumeBytes() throws Exception {
+    // Given
+    server.expect().withPath("/intercepted-url").andReturn(200, "This works").always();
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .addOrReplaceInterceptor("test", new Interceptor() {
+          @Override
+          public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
+            builder.uri(URI.create(server.url("/intercepted-url")));
+            return CompletableFuture.completedFuture(true);
+          }
+        });
+    final AtomicReference<String> result = new AtomicReference<>();
+    // When
+    try (HttpClient client = builder.build()) {
+      final HttpResponse<HttpClient.AsyncBody> asyncR = client.consumeBytes(
+          client.newHttpRequestBuilder().uri(server.url("/not-found")).build(),
+          (s, ab) -> result.set(StandardCharsets.UTF_8.decode(s.iterator().next()).toString()))
+          .get(10L, TimeUnit.SECONDS);
+      asyncR.body().consume();
+      asyncR.body().done().get(10L, TimeUnit.SECONDS);
+      // Then
+      assertThat(result).hasValue("This works");
+    }
+  }
+
+  @Test
+  @DisplayName("interceptors should be applied in the order they were added")
+  public void interceptorsAreAppliedInOrder() throws Exception {
+    // Given
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .addOrReplaceInterceptor("first", new Interceptor() {
+          @Override
+          public void before(BasicBuilder builder, HttpHeaders headers) {
+            builder.header("Test-Header", "Test-Value");
+          }
+        })
+        .addOrReplaceInterceptor("second", new Interceptor() {
+          @Override
+          public void before(BasicBuilder builder, HttpHeaders headers) {
+            builder.setHeader("Test-Header", "Test-Value-Override");
+          }
+        });
+    // When
+    try (HttpClient client = builder.build()) {
+      client.sendAsync(client.newHttpRequestBuilder().uri(server.url("/intercept-before")).build(), String.class)
+          .get(10L, TimeUnit.SECONDS);
+    }
+    // Then
+    assertThat(server.getLastRequest().getHeaders().toMultimap())
+        .containsEntry("test-header", Collections.singletonList("Test-Value-Override"));
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractWebSocketSendTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractWebSocketSendTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.mockwebserver.DefaultMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class AbstractWebSocketSendTest {
+
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  @Test
+  @DisplayName("send, emits a message to the server (the server responds to this message)")
+  void sendEmitsMessageToWebSocketServer() throws Exception {
+    try (final HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      // Given
+      server.expect().withPath("/send-text")
+          .andUpgradeToWebSocket()
+          .open()
+          .expect("GiveMeSomething")
+          .andEmit("received")
+          .always()
+          .done()
+          .always();
+      final BlockingQueue<String> receivedText = new ArrayBlockingQueue<>(1);
+      final WebSocket ws = client.newWebSocketBuilder()
+          // TODO: JDK HttpClient implementation doesn't work with ws URIs
+          // - Currently we are using an HttpRequest.Builder which is then
+          //   mapped to a WebSocket.Builder. We should probably user the WebSocket.Builder
+          //   directly
+          //.uri(URI.create(String.format("ws://%s:%s/send-text", server.getHostName(), server.getPort())))
+          .uri(URI.create(server.url("send-text")))
+          .buildAsync(new WebSocket.Listener() {
+            public void onMessage(WebSocket webSocket, String text) {
+              assertTrue(receivedText.offer(text));
+            }
+          }).get(10L, TimeUnit.SECONDS);
+      // When
+      ws.send(ByteBuffer.wrap("GiveMeSomething".getBytes(StandardCharsets.UTF_8)));
+      final String result = receivedText.poll(10L, TimeUnit.SECONDS);
+      // Then
+      assertThat(result).isEqualTo("received");
+    }
+  }
+
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpRequestTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpRequestTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.kubernetes.client.utils.IOHelpers;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+class StandardHttpRequestTest {
+
+  @Test
+  void builderMethod() {
+    // Given
+    final HttpRequest.Builder b = new StandardHttpRequest.Builder()
+        .header("h1", "v1")
+        .header("h1", "v2")
+        .uri("https://example.com/aitana")
+        .expectContinue()
+        .method("PUT", "application/json", "{\"v\":true}");
+    // When
+    final HttpRequest result = b.build();
+    // Then
+    assertThat(result)
+        .isInstanceOf(StandardHttpRequest.class)
+        .returns(URI.create("https://example.com/aitana"), HttpRequest::uri)
+        .returns("PUT", HttpRequest::method)
+        .returns("{\"v\":true}", HttpRequest::bodyString)
+        .extracting(HttpHeaders::headers, InstanceOfAssertFactories.map(String.class, List.class))
+        .containsOnly(
+            entry("h1", Arrays.asList("v1", "v2")),
+            entry("Content-Type", Collections.singletonList("application/json")),
+            entry("Expect", Collections.singletonList("100-Continue")));
+  }
+
+  @Test
+  void builderPostBytes() {
+    // Given
+    final HttpRequest.Builder b = new StandardHttpRequest.Builder()
+        .uri("https://example.com/alex")
+        .post("text/plain", "The bytes".getBytes(StandardCharsets.UTF_8));
+    // When
+    final HttpRequest result = b.build();
+    // Then
+    assertThat(result)
+        .isInstanceOf(StandardHttpRequest.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(StandardHttpRequest.class))
+        .returns(URI.create("https://example.com/alex"), HttpRequest::uri)
+        .returns("POST", HttpRequest::method)
+        .returns("The bytes", r -> toString(r.bodyStream()))
+        .extracting(HttpHeaders::headers, InstanceOfAssertFactories.map(String.class, List.class))
+        .containsOnly(
+            entry("Content-Type", Collections.singletonList("text/plain")),
+            entry("Content-Length", Collections.singletonList("9")));
+  }
+
+  @Test
+  void toBuilderReturnsNewBuilderWithPreservedSettings() {
+    // Given
+    final HttpRequest.Builder b = new StandardHttpRequest.Builder()
+        .header("h1", "v1")
+        .uri("https://example.com/julia");
+    // When
+    final HttpRequest.Builder result = ((StandardHttpRequest) b.build()).toBuilder();
+    // Then
+    assertThat(result)
+        .isNotSameAs(b)
+        .extracting(HttpRequest.Builder::build)
+        .isInstanceOf(StandardHttpRequest.class)
+        .returns(URI.create("https://example.com/julia"), HttpRequest::uri)
+        .returns("GET", HttpRequest::method)
+        .extracting(HttpHeaders::headers, InstanceOfAssertFactories.map(String.class, List.class))
+        .containsOnly(
+            entry("h1", Collections.singletonList("v1")));
+  }
+
+  static String toString(InputStream is) {
+    try {
+      return IOHelpers.readFully(is);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestHttpHeaders.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestHttpHeaders.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 /**
  * Basic {@link HttpHeaders} implementation to be used in tests instead of mocks or real headers.
- * 
+ *
  * @param <T> type for the return type of chained methods.
  */
 public class TestHttpHeaders<T extends HttpHeaders> implements HttpHeaders {
@@ -33,6 +33,11 @@ public class TestHttpHeaders<T extends HttpHeaders> implements HttpHeaders {
   @Override
   public List<String> headers(String key) {
     return headers.getOrDefault(key, Collections.emptyList());
+  }
+
+  @Override
+  public Map<String, List<String>> headers() {
+    return headers;
   }
 
   public T clearHeaders() {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/WebSocketTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/WebSocketTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import static io.fabric8.kubernetes.client.http.WebSocket.toWebSocketUri;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class WebSocketTest {
+
+  @ParameterizedTest(name = "{index}: toWebSocketUri: from ''{0}'' changes protocol to ''{1}''")
+  @MethodSource("toWebSocketUriInput")
+  void toWebSocketUriFromHttp(String uri, String expectedScheme) {
+    // When
+    final URI result = toWebSocketUri(URI.create(uri));
+    // Then
+    assertThat(result).hasScheme(expectedScheme);
+  }
+
+  static Stream<Arguments> toWebSocketUriInput() {
+    return Stream.of(
+        arguments("http://example.com", "ws"),
+        arguments("https://example.com", "wss"),
+        arguments("wss://example.com", "wss"),
+        arguments("ws://example.com", "ws"));
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/BaseClient.java
@@ -189,10 +189,14 @@ public abstract class BaseClient implements Client {
     if (Utils.isNullOrEmpty(typeApiVersion) || Utils.isNullOrEmpty(typeKind)) {
       return false;
     }
-    return getApiResources(ApiVersionUtil.joinApiGroupAndVersion(
-        HasMetadata.getGroup(type), HasMetadata.getVersion(type))).getResources()
-            .stream()
-            .anyMatch(r -> typeKind.equals(r.getKind()));
+    final APIResourceList apiResources = getApiResources(ApiVersionUtil.joinApiGroupAndVersion(
+        HasMetadata.getGroup(type), HasMetadata.getVersion(type)));
+    if (apiResources == null) {
+      return false;
+    }
+    return apiResources.getResources()
+        .stream()
+        .anyMatch(r -> typeKind.equals(r.getKind()));
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/BaseClientTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/BaseClientTest.java
@@ -98,6 +98,19 @@ class BaseClientTest {
   }
 
   @Test
+  @DisplayName("supports Ingress, with no group+version registered in server, should check API server and return false")
+  void supportsNetworkingApiNotFound() {
+    try (MockedConstruction<OperationSupport> ignore = mockConstruction(OperationSupport.class,
+        (mock, ctx) -> when(mock.restCall(APIResourceList.class, "/apis", "networking.k8s.io/v1"))
+            .thenReturn(null))) {
+      // When
+      final boolean result = baseClient.supports(Ingress.class);
+      // Then
+      assertThat(result).isFalse();
+    }
+  }
+
+  @Test
   @DisplayName("supports Ingress, with support in server, should check API server and return true")
   void supportsIngressInServer() {
     try (MockedConstruction<OperationSupport> ignore = mockConstruction(OperationSupport.class,

--- a/kubernetes-itests/pom.xml
+++ b/kubernetes-itests/pom.xml
@@ -89,5 +89,33 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>httpclient-jetty</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.fabric8</groupId>
+          <artifactId>openshift-client</artifactId>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>io.fabric8</groupId>
+              <artifactId>kubernetes-httpclient-okhttp</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>io.fabric8</groupId>
+          <artifactId>kubernetes-httpclient-jetty</artifactId>
+        </dependency>
+      </dependencies>
+      <repositories>
+        <repository>
+          <id>sonatype-snapshots</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <releases><enabled>false</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <okio.version>1.15.0</okio.version>
     <okio.bundle.version>1.15.0_1</okio.bundle.version>
     <jackson.version>2.13.3</jackson.version>
+    <jetty.version>11.0.9</jetty.version>
     <mockwebserver.version>0.2.2</mockwebserver.version>
     <maven-core.version>3.8.5</maven-core.version>
     <maven-plugin-annotations.version>3.6.4</maven-plugin-annotations.version>
@@ -94,24 +95,21 @@
     <jsr305.version>3.0.2</jsr305.version>
 
     <!-- Testing versions -->
+    <junit.version>5.8.2</junit.version>
     <assertj.core.version>3.23.1</assertj.core.version>
     <awaitility.version>4.2.0</awaitility.version>
     <approvaltests.version>15.6.0</approvaltests.version>
+    <mockito.version>4.6.1</mockito.version>
 
-    <retrofit.bundle.version>2.5.0_1</retrofit.bundle.version>
-    <conscrypt-openjdk-uber.version>1.4.2</conscrypt-openjdk-uber.version>
     <conscrypt-openjdk-uber.bundle.version>1.4.2_1</conscrypt-openjdk-uber.bundle.version>
     <generex.version>1.0.2</generex.version>
     <generex.bundle.version>1.0.1_1</generex.bundle.version>
-    <automaton.version>1.11-8</automaton.version>
     <automaton.bundle.version>1.11-8_1</automaton.bundle.version>
     <aries-spifly.bundle.version>1.3.0</aries-spifly.bundle.version>
     <asm.bundle.version>8.0.1</asm.bundle.version>
     <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
-    <junit.version>5.8.2</junit.version>
     <zjsonpatch.version>0.3.0</zjsonpatch.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <mockito.version>4.6.1</mockito.version>
     <lombok.version>1.18.24</lombok.version>
     <snakeyaml.version>1.30</snakeyaml.version>
     <bouncycastle.version>1.70</bouncycastle.version>
@@ -177,7 +175,7 @@
     <karaf.itest.skip>false</karaf.itest.skip>
     <project.build.outputTimestamp>2020-11-14T12:24:00Z</project.build.outputTimestamp>
     <validation-api.version>2.0.1.Final</validation-api.version>
-    
+
     <jsonschema2pojo.targetPackage>io.fabric8.kubernetes.api.model</jsonschema2pojo.targetPackage>
   </properties>
   <modules>
@@ -402,7 +400,7 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-httpclient-okhttp</artifactId>
-	    <version>${project.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
@@ -412,6 +410,11 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-httpclient-jdk</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-httpclient-jetty</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -755,6 +758,21 @@
         <optional>true</optional>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>http2-http-client-transport</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.websocket</groupId>
+        <artifactId>websocket-jetty-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
@@ -764,6 +782,12 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <!-- Testing and Mocking -->
@@ -1410,6 +1434,7 @@
       </activation>
       <modules>
         <module>httpclient-jdk</module>
+        <module>httpclient-jetty</module>
         <module>httpclient-tests</module>
       </modules>
     </profile>


### PR DESCRIPTION
 ## Description

feat: Jetty HttpClient implementation

- HttpClient Tests
  - Added HttpClient behavioral abstract tests that should be implemented for each of the HttpClient implementation modules (currently added implementations for OkHttp and Jetty).
- Jetty HttpClient implementation
  - Java 11 optional module
  - Should provide full-support for all HttpClient features

### Follow up tasks
- Enable HTTP/2 when MockWebServer provides adequate support
  #4193
- Refactor sendAsync for InputStream or Reader types so they don't read the full response in memory (easy refactor, but I prefer to do this separately ---> Not urgent)
- ~OkHttp & Jdk HttpClient failed response interceptors don't seem to work with `consumeLines` or `consumeBytes`~
  - ~`afterHttpFailureReplacesResponseInConsumeLines();`~
  - ~`afterHttpFailureReplacesResponseInConsumeBytes();`~
  - ~See `OkHttpInterceptorTest` & `JdkHttpClientInterceptorTest`~
- ~`AsyncBody.consume` has a confusing and inconsistent behavior~
  - ~https://github.com/fabric8io/kubernetes-client/pull/4180#discussion_r888543466~
  - ~`JdkHttpClientAsyncBodyTest` completely disabled due to non-compliance with prepared test cases~

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift


