### PR TITLE
feat: VersionInfo in KubernetesMockServer can be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix #1285: removed references to manually calling registerCustomKind
 * Fix #3334: adding basic support for server side apply.  Use patch(PatchContext.of(PatchType.SERVER_SIDE_APPLY), service), or new PatchContext.Builder().withPatchType(PatchType.SERVER_SIDE_APPLY).withForce(true).build() to override conflicts.
 * Fix #2207: added LeaderElector.start to provide a CompletableFuture for easy cancellation.
+* Fix #3758: VersionInfo in KubernetesMockServer can be overridden
 * Fix #3969: relist will not trigger sync events
 * Fix #4082: improving informOnCondition to test the initial list instead of individual add events
 * Fix #3968: SharedIndexInformer.initialState can be used to set the store state before the informer starts. 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.regex.Pattern;
 
@@ -49,9 +50,9 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
   private static final Context context = new Context(Serialization.jsonMapper());
 
   private final Map<ServerRequest, Queue<ServerResponse>> responses;
-  private final VersionInfo versionInfo;
   private final Dispatcher dispatcher;
-  private List<Pattern> unsupportedPatterns = Collections.emptyList();
+  private VersionInfo versionInfo;
+  private List<Pattern> unsupportedPatterns;
 
   public KubernetesMockServer() {
     this(true);
@@ -86,12 +87,13 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
     this.dispatcher = dispatcher;
     this.responses = responses;
     this.versionInfo = versionInfo;
+    unsupportedPatterns = Collections.emptyList();
   }
 
   @Override
   public void onStart() {
     expect().get().withPath("/").andReturn(200, new RootPathsBuilder().addToPaths(getRootPaths()).build()).always();
-    expect().get().withPath("/version").andReturn(200, versionInfo).always();
+    expect().get().withPath("/version").andReply(200, request -> versionInfo).always();
   }
 
   public void init() {
@@ -120,6 +122,15 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
     client.adapt(BaseClient.class)
         .setMatchingGroupPredicate(s -> unsupportedPatterns.stream().noneMatch(p -> p.matcher(s).find()));
     return client.adapt(NamespacedKubernetesClient.class);
+  }
+
+  /**
+   * Replace the current {@link VersionInfo} instance.
+   *
+   * @param versionInfo the new VersionInfo.
+   */
+  public final void setVersionInfo(VersionInfo versionInfo) {
+    this.versionInfo = Objects.requireNonNull(versionInfo);
   }
 
   /**

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerTest.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,6 +49,17 @@ class KubernetesMockServerTest {
     assertThat(client.getKubernetesVersion())
         .hasFieldOrPropertyWithValue("major", "0")
         .hasFieldOrPropertyWithValue("minor", "0");
+  }
+
+  @Test
+  @DisplayName("versionInfo can be modified after start")
+  void versionInfoModified() {
+    // When
+    server.setVersionInfo(new VersionInfo.Builder().withMajor("1").withMinor("337").build());
+    // Then
+    assertThat(client.getKubernetesVersion())
+        .hasFieldOrPropertyWithValue("major", "1")
+        .hasFieldOrPropertyWithValue("minor", "337");
   }
 
   @Test


### PR DESCRIPTION
## Description

Fix #3758

feat: VersionInfo in KubernetesMockServer can be overridden

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
