### PR TITLE
fix: status changes don't increment metadata.generation field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix #4106: removed listing from projectrequests
 * Fix #4140: changed StatefulSet rolling pause / resume to unsupported.  Also relying on default rolling logic to Deployments and StatefulSets
 * Fix #4081: moving Versionable.withResourceVersion to a method on WatchAndWaitable and removing Waitable from the return type
+* Fix #4139: status changes don't increment metadata.generation field
 * Fix #4149: port forwarding can accept both blocking and non-blocking channels
 * Fix #4171: allowing any object in clone
 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -46,8 +46,6 @@ import java.util.regex.Pattern;
 
 public class KubernetesMockServer extends DefaultMockServer implements Resetable {
 
-  private static final Context context = new Context(Serialization.jsonMapper());
-
   private final Map<ServerRequest, Queue<ServerResponse>> responses;
   private final VersionInfo versionInfo;
   private final Dispatcher dispatcher;
@@ -63,7 +61,7 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
 
   public KubernetesMockServer(MockWebServer server, Map<ServerRequest, Queue<ServerResponse>> responses,
       boolean useHttps) {
-    this(context, server, responses, useHttps);
+    this(new Context(Serialization.jsonMapper()), server, responses, useHttps);
   }
 
   public KubernetesMockServer(Context context, MockWebServer server,

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcherPatchTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcherPatchTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.mockwebserver.Context;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KubernetesCrudDispatcherPatchTest {
+
+  private KubernetesMockServer server;
+  private KubernetesClient client;
+
+  @BeforeEach
+  void setUp() {
+    server = new KubernetesMockServer(new Context(Serialization.jsonMapper()),
+        new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), false);
+    server.start();
+    client = server.createClient();
+  }
+
+  @AfterEach
+  void tearDown() {
+    client.close();
+    server.shutdown();
+  }
+
+  @Test
+  @DisplayName("editStatus, updates status values ignoring other fields and leaving generation unchanged")
+  void editStatusUpdatesOnlyStatusWithNoGenerationIncrement() {
+    // Given
+    final Pod created = client.resources(Pod.class)
+        .resource(new PodBuilder()
+            .withNewSpec().withDnsPolicy("always-dns").endSpec()
+            .withNewMetadata().withName("foo").addToLabels("app", "bar").endMetadata()
+            .build())
+        .create();
+    // When
+    final Pod patched = client.resources(Pod.class).withName("foo").editStatus(p -> new PodBuilder(p)
+        .editOrNewSpec().withDnsPolicy("come-on").endSpec()
+        .withNewStatus().withMessage("changed").endStatus()
+        .build());
+    // Then
+    assertThat(patched)
+        .returns(created.getMetadata().getGeneration(), p -> p.getMetadata().getGeneration())
+        .hasFieldOrPropertyWithValue("spec.dnsPolicy", "always-dns");
+  }
+}


### PR DESCRIPTION
## Description

Fix #4139

Relates to: https://github.com/java-operator-sdk/java-operator-sdk/pull/1280

fix: status changes don't increment metadata.generation field

/cc @csviri

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
