### PR TITLE
fix (kubernetes-client) : Approve/Reject API should also be available in v1beta1 CertificateSigningRequest DSL (#2811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.0-SNAPSHOT
 
 #### Bugs
+* Fix #2811: Approve/Reject CSR not supported in v1beta1 CertificateSigningRequest API
 * Fix #4216: Update metadata when `replaceStatus()` is called
 
 #### Improvements

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1CertificateSigningRequestResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1CertificateSigningRequestResource.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestCondition;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestConditionBuilder;
+
+public interface V1beta1CertificateSigningRequestResource<T> extends Resource<T> {
+
+  /**
+   * Deny a given CertificateSigningRequest.
+   *
+   * Creates an opinionated CertificateSigningRequestCondition while denying
+   * provided CertificateSigningRequest
+   *
+   * @return updated CertificateSigningRequest from Kubernetes ApiServer
+   */
+  default T deny() {
+    return deny(new CertificateSigningRequestConditionBuilder()
+        .withType("Denied")
+        .withStatus("True")
+        .withReason("DeniedViaRESTApi")
+        .withMessage("Denied by REST API /approval endpoint.")
+        .build());
+  }
+
+  /**
+   * Reject a given CertificateSigningRequest.
+   *
+   * @param certificateSigningRequestCondition a condition of a CertificateSigningRequest object
+   * @return updated CertificateSigningRequest from Kubernetes ApiServer
+   */
+  T deny(CertificateSigningRequestCondition certificateSigningRequestCondition);
+
+  /**
+   * Approve a given CertificateSigningRequest.
+   *
+   * @param certificateSigningRequestCondition a condition of a CertificateSigningRequest object
+   * @return updated CertificateSigningRequest from Kubernetes ApiServer
+   */
+  T approve(CertificateSigningRequestCondition certificateSigningRequestCondition);
+
+  /**
+   * Approve a given CertificateSigningRequest.
+   *
+   * Creates an opinionated CertificateSigningRequestCondition while approving
+   * provided CertificateSigningRequest
+   *
+   * @return updated CertificateSigningRequest from Kubernetes ApiServer
+   */
+  default T approve() {
+    return approve(new CertificateSigningRequestConditionBuilder()
+        .withType("Approved")
+        .withStatus("True")
+        .withReason("ApprovedViaRESTApi")
+        .withMessage("Approved by REST API /approval endpoint.")
+        .build());
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1CertificatesAPIGroupDSL.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/V1beta1CertificatesAPIGroupDSL.java
@@ -20,5 +20,5 @@ import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRe
 import io.fabric8.kubernetes.client.Client;
 
 public interface V1beta1CertificatesAPIGroupDSL extends Client {
-  NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests();
+  NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, V1beta1CertificateSigningRequestResource<CertificateSigningRequest>> certificateSigningRequests();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/DefaultKubernetesClient.java
@@ -219,6 +219,8 @@ public class DefaultKubernetesClient extends BaseClient implements NamespacedKub
     this.getHandlers().register(StatefulSet.class, StatefulSetOperationsImpl::new);
     this.getHandlers().register(io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest.class,
         CertificateSigningRequestOperationsImpl::new);
+    this.getHandlers().register(io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest.class,
+        io.fabric8.kubernetes.client.dsl.internal.certificates.v1beta1.CertificateSigningRequestOperationsImpl::new);
   }
 
   protected DefaultKubernetesClient(Config config, BaseClient client) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1CertificatesAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V1beta1CertificatesAPIGroupClient.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client;
 import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
 import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestList;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.V1beta1CertificateSigningRequestResource;
 import io.fabric8.kubernetes.client.dsl.V1beta1CertificatesAPIGroupDSL;
 import io.fabric8.kubernetes.client.extension.ClientAdapter;
 
@@ -26,8 +26,10 @@ public class V1beta1CertificatesAPIGroupClient extends ClientAdapter<V1beta1Cert
     implements V1beta1CertificatesAPIGroupDSL {
 
   @Override
-  public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, Resource<CertificateSigningRequest>> certificateSigningRequests() {
-    return resources(CertificateSigningRequest.class, CertificateSigningRequestList.class);
+  public NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, V1beta1CertificateSigningRequestResource<CertificateSigningRequest>> certificateSigningRequests() {
+    return (NonNamespaceOperation<CertificateSigningRequest, CertificateSigningRequestList, V1beta1CertificateSigningRequestResource<CertificateSigningRequest>>) resources(
+        CertificateSigningRequest.class, CertificateSigningRequestList.class,
+        V1beta1CertificateSigningRequestResource.class);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -26,6 +26,8 @@ import io.fabric8.kubernetes.api.model.Preconditions;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestCondition;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
@@ -458,6 +460,13 @@ public class OperationSupport {
 
   protected Map<String, String> getParameters() {
     return Collections.emptyMap();
+  }
+
+  protected <T extends HasMetadata> T handleApproveOrDeny(T csr, Class<T> type) throws IOException, InterruptedException {
+    String uri = URLUtils.join(getResourceUrl(null, csr.getMetadata().getName(), false).toString(), "approval");
+    HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
+        .put(JSON, JSON_MAPPER.writeValueAsString(csr)).uri(uri);
+    return handleResponse(requestBuilder, type);
   }
 
   /**

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/certificates/v1beta1/CertificateSigningRequestOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/certificates/v1beta1/CertificateSigningRequestOperationsImpl.java
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package io.fabric8.kubernetes.client.dsl.internal.certificates.v1;
+package io.fabric8.kubernetes.client.dsl.internal.certificates.v1beta1;
 
-import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequest;
-import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestCondition;
-import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestList;
-import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestStatus;
-import io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestStatusBuilder;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestCondition;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestList;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestStatus;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestStatusBuilder;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.CertificateSigningRequestResource;
+import io.fabric8.kubernetes.client.dsl.V1beta1CertificateSigningRequestResource;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
@@ -31,15 +31,15 @@ import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
 import java.io.IOException;
 
 public class CertificateSigningRequestOperationsImpl extends
-    HasMetadataOperation<CertificateSigningRequest, CertificateSigningRequestList, CertificateSigningRequestResource<CertificateSigningRequest>>
-    implements CertificateSigningRequestResource<CertificateSigningRequest> {
+    HasMetadataOperation<CertificateSigningRequest, CertificateSigningRequestList, V1beta1CertificateSigningRequestResource<CertificateSigningRequest>>
+    implements V1beta1CertificateSigningRequestResource<CertificateSigningRequest> {
   public CertificateSigningRequestOperationsImpl(Client client) {
     this(HasMetadataOperationsImpl.defaultContext(client));
   }
 
   CertificateSigningRequestOperationsImpl(OperationContext context) {
     super(context.withApiGroupName("certificates.k8s.io")
-        .withApiGroupVersion("v1")
+        .withApiGroupVersion("v1beta1")
         .withPlural("certificatesigningrequests"), CertificateSigningRequest.class, CertificateSigningRequestList.class);
   }
 
@@ -58,6 +58,13 @@ public class CertificateSigningRequestOperationsImpl extends
     return addStatusToCSRAndSubmit(certificateSigningRequestCondition);
   }
 
+  private CertificateSigningRequestStatus createCertificateSigningRequestStatus(
+      CertificateSigningRequestCondition certificateSigningRequestCondition) {
+    return new CertificateSigningRequestStatusBuilder()
+        .addToConditions(certificateSigningRequestCondition)
+        .build();
+  }
+
   private CertificateSigningRequest addStatusToCSRAndSubmit(
       CertificateSigningRequestCondition certificateSigningRequestCondition) {
     try {
@@ -70,12 +77,5 @@ public class CertificateSigningRequestOperationsImpl extends
     } catch (IOException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("approval " + type), e);
     }
-  }
-
-  private CertificateSigningRequestStatus createCertificateSigningRequestStatus(
-      CertificateSigningRequestCondition certificateSigningRequestCondition) {
-    return new CertificateSigningRequestStatusBuilder()
-        .addToConditions(certificateSigningRequestCondition)
-        .build();
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CertificateSigningRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CertificateSigningRequestTest.java
@@ -18,13 +18,18 @@ package io.fabric8.kubernetes.client.mock;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequest;
 import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestBuilder;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestStatus;
+import io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestStatusBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Test;
+
 import java.net.HttpURLConnection;
 import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,16 +55,17 @@ class CertificateSigningRequestTest {
   void testCreate() {
     // Given
     CertificateSigningRequest csr = new CertificateSigningRequestBuilder()
-      .withNewMetadata().withName("test-k8s-csr").endMetadata()
-      .withNewSpec()
-      .addToGroups("system:authenticated")
-      .withRequest("RSBSRVFVRVNULS0tLS0KTUlJRWJqQ0NBbFlDQVFBd0tURVBNQTBHQTFVRUF3d0dhMmxrYjI1bk1SWXdGQVlEVlFRS0RBMWtZWFJoTFdWdQpaMmx1WldWeU1JSUNJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBc2dVZXl0S0F6ZDkyClN1S2pZL1RqbmRsZ0lkSFVVYWFxbHJIVW1nbTloKzY2RTJCNGs0TSt6Q0tOQmovemlMdWV6NFNUeHJ6SFk3RlUKNGUxWElBU3lMS0dmRGNPaks5NThURThwcXBRM21VdlpWMmxnK25BTVF5dlZUYWdZSmFId2JWUzVlNHgvRmpKcQoxTWpQZ1VoSGFXeEdIYTQrQnZYQU9Kdk5BdnV4alpZaVJET251dGxHVzloQkRKRlhoUk5jOGFKNnFiZWVBWnNiCmozWUFMaUcydWp1VmhoTUVRNEJxdFVHVGZCMzBQNGhRK2t2bWVKc2ZUU3Vsb2xiWFdIdVZGWnh1d0FJek5RbmQKMTd4VHd2cU04OGZFb3ZJazBJV0ZCWTk2aHRvaUVNdThZUms4SEZ6QkJralhsZGlkbVNNSHkwK0plcFRONmdQTQpEYVVsd1cxS0lCcW9TbnZNcjY4cFRVWEVhZVRjc040anMxTUIwK3FwR0JBS1puWWVxM0JmMkxVVFBNaG1VZ2VVCmFUTFlqODI2WVorZjJrOWJ1cngwK1NOSmVZbWoxVTl0N3A2YWM0dDIzZHVYQ1BzYkNrUFNKeGtrU3dudUlVVzkKdmJVVGtJNGtVMlFVMnE0NzRaMW1uMlkvejF2TEdQdEpsTDFYUVFVNEdsb2hrQkVkM1BsUTRtOGU1WGZSRkV6ZgpYZnhMRXFRczFTeEg1ekhjcnVaOWxJdnBkeEw5Tkc5WlR6M0tmT0tIbCtSUzdxMGdKaExac0RubUJKNXZab3p4CldXci9IRW9PamFYbGh0VitDN3M4TUg5Y0lKZENZNnpjcFVrZis1NmZ0Z1FuN0YrT1RYdDI0UVJQYWNFZnRFOTkKVERPb2luTGtOMm1kckxiMTgxQUZNUWJ0bTFLc1k2MENBd0VBQWFBQU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQwpBUUNQYU1WdDd4YWhkZlF1L1BySFVTTW5LK2I0SlJScEdEYlpWUXk4aUtkSmdHM0VrYnNBZ21qQmN4Q1IvL2t1CkVhU0plSGNWK20xVlFUTEp1ZFU3ZHFUeFBLOVFCNlB2aHlBbCttNnFaQkt1Q25VM1BKc2k5azBYSE5GWXBqRmYKVFNwTlpJSnRuanVEQWVtT05kcjJYMm1rODZmSmpWTEUvYnA1KzM5dFBkN0xjL3dZR2JoRU0xcExtUGpQK0Z6eQpzZnBiYW5PcmZFSG5NMmlsRFpGZURVSEpYL3F5Ykt1RC9BRmdoZk1Ua0x3ODNLNkNRdCtDQm05djRCeEtCS2xqCkdBWEQyUEhUTWlzektUbGpBM3czYUphanZzU0FwQXFCWnFocjB3QzdOb1dYM1h6S0p3ck9MaWVxemo3SXlpUGEKTEI5SmJveFpOQTdBSU5ucEdsa1hDZlRGT2RManZtQkVRQXV5Ym9wLzdqV2RiSzJHRkZKS2UwdlVlbWNUeGdHVwp5c0ZyV2pqMUlvdVBVNFZ6ck82QVBVQnZCZUFtdU1Bbm9yVng5emc4akhlT1pkd2RWdFRnOUwrK0VnWjlxK0htCjVtUlJGVHlZOWo4WVVvd2J6TzRlRUZnaVN0di84T1p0YmtOeDFROWFQWHJ3VUV1Q1I0SUthWG0wNlJUYXJOYXUKTWFsbk5oZm9WYi9Bc1R5d1ArNlc1dGErcTBpckR5cnVkZk5pRkFWbkRMZEU5a2hWZzVrU0lPRzhYbEZUMklwSQpkdVNpcUl0NlNUTlY3UmdaRzBGTFN5akxoc3laWnY2bitpUzl3Ky9OOFpoUzgvalViUUVidG1VTnNJU3Z5WS9JCmZqcHNZQUdleExvVW5mN2pDaUhkbTVhSnJ5SU1kdmZ2akJsMDhIVk5nWG1McVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K")
-      .addToUsages("client auth")
-      .endSpec()
-      .build();
+        .withNewMetadata().withName("test-k8s-csr").endMetadata()
+        .withNewSpec()
+        .addToGroups("system:authenticated")
+        .withRequest(
+            "RSBSRVFVRVNULS0tLS0KTUlJRWJqQ0NBbFlDQVFBd0tURVBNQTBHQTFVRUF3d0dhMmxrYjI1bk1SWXdGQVlEVlFRS0RBMWtZWFJoTFdWdQpaMmx1WldWeU1JSUNJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBc2dVZXl0S0F6ZDkyClN1S2pZL1RqbmRsZ0lkSFVVYWFxbHJIVW1nbTloKzY2RTJCNGs0TSt6Q0tOQmovemlMdWV6NFNUeHJ6SFk3RlUKNGUxWElBU3lMS0dmRGNPaks5NThURThwcXBRM21VdlpWMmxnK25BTVF5dlZUYWdZSmFId2JWUzVlNHgvRmpKcQoxTWpQZ1VoSGFXeEdIYTQrQnZYQU9Kdk5BdnV4alpZaVJET251dGxHVzloQkRKRlhoUk5jOGFKNnFiZWVBWnNiCmozWUFMaUcydWp1VmhoTUVRNEJxdFVHVGZCMzBQNGhRK2t2bWVKc2ZUU3Vsb2xiWFdIdVZGWnh1d0FJek5RbmQKMTd4VHd2cU04OGZFb3ZJazBJV0ZCWTk2aHRvaUVNdThZUms4SEZ6QkJralhsZGlkbVNNSHkwK0plcFRONmdQTQpEYVVsd1cxS0lCcW9TbnZNcjY4cFRVWEVhZVRjc040anMxTUIwK3FwR0JBS1puWWVxM0JmMkxVVFBNaG1VZ2VVCmFUTFlqODI2WVorZjJrOWJ1cngwK1NOSmVZbWoxVTl0N3A2YWM0dDIzZHVYQ1BzYkNrUFNKeGtrU3dudUlVVzkKdmJVVGtJNGtVMlFVMnE0NzRaMW1uMlkvejF2TEdQdEpsTDFYUVFVNEdsb2hrQkVkM1BsUTRtOGU1WGZSRkV6ZgpYZnhMRXFRczFTeEg1ekhjcnVaOWxJdnBkeEw5Tkc5WlR6M0tmT0tIbCtSUzdxMGdKaExac0RubUJKNXZab3p4CldXci9IRW9PamFYbGh0VitDN3M4TUg5Y0lKZENZNnpjcFVrZis1NmZ0Z1FuN0YrT1RYdDI0UVJQYWNFZnRFOTkKVERPb2luTGtOMm1kckxiMTgxQUZNUWJ0bTFLc1k2MENBd0VBQWFBQU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQwpBUUNQYU1WdDd4YWhkZlF1L1BySFVTTW5LK2I0SlJScEdEYlpWUXk4aUtkSmdHM0VrYnNBZ21qQmN4Q1IvL2t1CkVhU0plSGNWK20xVlFUTEp1ZFU3ZHFUeFBLOVFCNlB2aHlBbCttNnFaQkt1Q25VM1BKc2k5azBYSE5GWXBqRmYKVFNwTlpJSnRuanVEQWVtT05kcjJYMm1rODZmSmpWTEUvYnA1KzM5dFBkN0xjL3dZR2JoRU0xcExtUGpQK0Z6eQpzZnBiYW5PcmZFSG5NMmlsRFpGZURVSEpYL3F5Ykt1RC9BRmdoZk1Ua0x3ODNLNkNRdCtDQm05djRCeEtCS2xqCkdBWEQyUEhUTWlzektUbGpBM3czYUphanZzU0FwQXFCWnFocjB3QzdOb1dYM1h6S0p3ck9MaWVxemo3SXlpUGEKTEI5SmJveFpOQTdBSU5ucEdsa1hDZlRGT2RManZtQkVRQXV5Ym9wLzdqV2RiSzJHRkZKS2UwdlVlbWNUeGdHVwp5c0ZyV2pqMUlvdVBVNFZ6ck82QVBVQnZCZUFtdU1Bbm9yVng5emc4akhlT1pkd2RWdFRnOUwrK0VnWjlxK0htCjVtUlJGVHlZOWo4WVVvd2J6TzRlRUZnaVN0di84T1p0YmtOeDFROWFQWHJ3VUV1Q1I0SUthWG0wNlJUYXJOYXUKTWFsbk5oZm9WYi9Bc1R5d1ArNlc1dGErcTBpckR5cnVkZk5pRkFWbkRMZEU5a2hWZzVrU0lPRzhYbEZUMklwSQpkdVNpcUl0NlNUTlY3UmdaRzBGTFN5akxoc3laWnY2bitpUzl3Ky9OOFpoUzgvalViUUVidG1VTnNJU3Z5WS9JCmZqcHNZQUdleExvVW5mN2pDaUhkbTVhSnJ5SU1kdmZ2akJsMDhIVk5nWG1McVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K")
+        .addToUsages("client auth")
+        .endSpec()
+        .build();
     server.expect().post().withPath("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests")
-      .andReturn(HttpURLConnection.HTTP_OK, csr)
-      .once();
+        .andReturn(HttpURLConnection.HTTP_OK, csr)
+        .once();
 
     // When
     csr = client.certificates().v1beta1().certificateSigningRequests().create(csr);
@@ -67,5 +73,73 @@ class CertificateSigningRequestTest {
     // Then
     assertNotNull(csr);
     assertEquals("test-k8s-csr", csr.getMetadata().getName());
+  }
+
+  @Test
+  void testApprove() {
+    // Given
+    server.expect().get().withPath("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/my-cert")
+        .andReturn(HttpURLConnection.HTTP_OK, createCertificateSigningRequest().build())
+        .once();
+
+    server.expect().put().withPath("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/my-cert/approval")
+        .andReturn(HttpURLConnection.HTTP_OK, createCertificateSigningRequest()
+            .withStatus(createCertificateSigningRequestStatus("Approved")).build())
+        .once();
+
+    // When
+    CertificateSigningRequest updatedCsr = client.certificates().v1beta1().certificateSigningRequests().withName("my-cert")
+        .approve();
+
+    // Then
+    assertNotNull(updatedCsr);
+    assertFalse(updatedCsr.getStatus().getConditions().isEmpty());
+    assertEquals("Approved", updatedCsr.getStatus().getConditions().get(0).getType());
+  }
+
+  @Test
+  void testDeny() {
+    // Given
+    server.expect().get().withPath("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/my-cert")
+        .andReturn(HttpURLConnection.HTTP_OK, createCertificateSigningRequest().build())
+        .once();
+
+    server.expect().put().withPath("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/my-cert/approval")
+        .andReturn(HttpURLConnection.HTTP_OK,
+            createCertificateSigningRequest().withStatus(createCertificateSigningRequestStatus("Denied")).build())
+        .once();
+
+    // When
+    CertificateSigningRequest updatedCsr = client.certificates().v1beta1().certificateSigningRequests().withName("my-cert")
+        .deny();
+
+    // Then
+    assertNotNull(updatedCsr);
+    assertFalse(updatedCsr.getStatus().getConditions().isEmpty());
+    assertEquals("Denied", updatedCsr.getStatus().getConditions().get(0).getType());
+  }
+
+  private CertificateSigningRequestBuilder createCertificateSigningRequest() {
+    return new CertificateSigningRequestBuilder()
+        .withNewMetadata().withName("my-cert").endMetadata()
+        .withNewSpec()
+        .withSignerName("fabric8io.com/kubernetes-java-client")
+        .addToGroups("system:authenticated")
+        .withRequest(
+            "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJRWJqQ0NBbFlDQVFBd0tURVBNQTBHQTFVRUF3d0dhMmxrYjI1bk1SWXdGQVlEVlFRS0RBMWtZWFJoTFdWdQpaMmx1WldWeU1JSUNJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBc2dVZXl0S0F6ZDkyClN1S2pZL1RqbmRsZ0lkSFVVYWFxbHJIVW1nbTloKzY2RTJCNGs0TSt6Q0tOQmovemlMdWV6NFNUeHJ6SFk3RlUKNGUxWElBU3lMS0dmRGNPaks5NThURThwcXBRM21VdlpWMmxnK25BTVF5dlZUYWdZSmFId2JWUzVlNHgvRmpKcQoxTWpQZ1VoSGFXeEdIYTQrQnZYQU9Kdk5BdnV4alpZaVJET251dGxHVzloQkRKRlhoUk5jOGFKNnFiZWVBWnNiCmozWUFMaUcydWp1VmhoTUVRNEJxdFVHVGZCMzBQNGhRK2t2bWVKc2ZUU3Vsb2xiWFdIdVZGWnh1d0FJek5RbmQKMTd4VHd2cU04OGZFb3ZJazBJV0ZCWTk2aHRvaUVNdThZUms4SEZ6QkJralhsZGlkbVNNSHkwK0plcFRONmdQTQpEYVVsd1cxS0lCcW9TbnZNcjY4cFRVWEVhZVRjc040anMxTUIwK3FwR0JBS1puWWVxM0JmMkxVVFBNaG1VZ2VVCmFUTFlqODI2WVorZjJrOWJ1cngwK1NOSmVZbWoxVTl0N3A2YWM0dDIzZHVYQ1BzYkNrUFNKeGtrU3dudUlVVzkKdmJVVGtJNGtVMlFVMnE0NzRaMW1uMlkvejF2TEdQdEpsTDFYUVFVNEdsb2hrQkVkM1BsUTRtOGU1WGZSRkV6ZgpYZnhMRXFRczFTeEg1ekhjcnVaOWxJdnBkeEw5Tkc5WlR6M0tmT0tIbCtSUzdxMGdKaExac0RubUJKNXZab3p4CldXci9IRW9PamFYbGh0VitDN3M4TUg5Y0lKZENZNnpjcFVrZis1NmZ0Z1FuN0YrT1RYdDI0UVJQYWNFZnRFOTkKVERPb2luTGtOMm1kckxiMTgxQUZNUWJ0bTFLc1k2MENBd0VBQWFBQU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQwpBUUNQYU1WdDd4YWhkZlF1L1BySFVTTW5LK2I0SlJScEdEYlpWUXk4aUtkSmdHM0VrYnNBZ21qQmN4Q1IvL2t1CkVhU0plSGNWK20xVlFUTEp1ZFU3ZHFUeFBLOVFCNlB2aHlBbCttNnFaQkt1Q25VM1BKc2k5azBYSE5GWXBqRmYKVFNwTlpJSnRuanVEQWVtT05kcjJYMm1rODZmSmpWTEUvYnA1KzM5dFBkN0xjL3dZR2JoRU0xcExtUGpQK0Z6eQpzZnBiYW5PcmZFSG5NMmlsRFpGZURVSEpYL3F5Ykt1RC9BRmdoZk1Ua0x3ODNLNkNRdCtDQm05djRCeEtCS2xqCkdBWEQyUEhUTWlzektUbGpBM3czYUphanZzU0FwQXFCWnFocjB3QzdOb1dYM1h6S0p3ck9MaWVxemo3SXlpUGEKTEI5SmJveFpOQTdBSU5ucEdsa1hDZlRGT2RManZtQkVRQXV5Ym9wLzdqV2RiSzJHRkZKS2UwdlVlbWNUeGdHVwp5c0ZyV2pqMUlvdVBVNFZ6ck82QVBVQnZCZUFtdU1Bbm9yVng5emc4akhlT1pkd2RWdFRnOUwrK0VnWjlxK0htCjVtUlJGVHlZOWo4WVVvd2J6TzRlRUZnaVN0di84T1p0YmtOeDFROWFQWHJ3VUV1Q1I0SUthWG0wNlJUYXJOYXUKTWFsbk5oZm9WYi9Bc1R5d1ArNlc1dGErcTBpckR5cnVkZk5pRkFWbkRMZEU5a2hWZzVrU0lPRzhYbEZUMklwSQpkdVNpcUl0NlNUTlY3UmdaRzBGTFN5akxoc3laWnY2bitpUzl3Ky9OOFpoUzgvalViUUVidG1VTnNJU3Z5WS9JCmZqcHNZQUdleExvVW5mN2pDaUhkbTVhSnJ5SU1kdmZ2akJsMDhIVk5nWG1McVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K")
+        .withExpirationSeconds(86400)
+        .addToUsages("client auth")
+        .endSpec();
+  }
+
+  private CertificateSigningRequestStatus createCertificateSigningRequestStatus(String type) {
+    return new CertificateSigningRequestStatusBuilder()
+        .addNewCondition()
+        .withType(type)
+        .withStatus("True")
+        .withReason(type + "ViaRESTApi")
+        .withMessage("This CSR was denied by REST API /approval endpoint.")
+        .endCondition()
+        .build();
   }
 }


### PR DESCRIPTION
## Description

Fix #2811

Port `approve()`, `deny()` methods to `client.certificates().v1beta1()` DSL

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
