### PR TITLE
Upgrade sundro to  0.91.1

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/PromoteSingleVersionAttributesDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/PromoteSingleVersionAttributesDecorator.java
@@ -23,20 +23,22 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefin
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersionBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresources;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceValidation;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class PromoteSingleVersionAttributesDecorator extends CustomResourceDefinitionDecorator<CustomResourceDefinitionSpecFluent<?>> {
+public class PromoteSingleVersionAttributesDecorator
+    extends CustomResourceDefinitionDecorator<CustomResourceDefinitionSpecFluent<?>> {
 
-	public PromoteSingleVersionAttributesDecorator(String name) {
-		super(name);
-	}
+  public PromoteSingleVersionAttributesDecorator(String name) {
+    super(name);
+  }
 
-	@Override
-	public void andThenVisit(CustomResourceDefinitionSpecFluent<?> spec, ObjectMeta resourceMeta) {
+  @Override
+  public void andThenVisit(CustomResourceDefinitionSpecFluent<?> spec, ObjectMeta resourceMeta) {
     List<CustomResourceDefinitionVersion> versions = spec.buildVersions();
 
     if (versions.size() == 1) {
@@ -44,7 +46,6 @@ public class PromoteSingleVersionAttributesDecorator extends CustomResourceDefin
       spec.withSubresources(version.getSubresources())
           .withValidation(version.getSchema())
           .withAdditionalPrinterColumns(version.getAdditionalPrinterColumns());
-        
 
       CustomResourceDefinitionVersion newVersion = new CustomResourceDefinitionVersionBuilder(version).build();
       newVersion.setSubresources(null);
@@ -54,14 +55,17 @@ public class PromoteSingleVersionAttributesDecorator extends CustomResourceDefin
       spec.removeAllFromVersions(versions);
       spec.withVersions(newVersion);
     } else {
-      Set<CustomResourceSubresources> subresources = versions.stream().map(CustomResourceDefinitionVersion::getSubresources).filter(o -> o != null).collect(Collectors.toSet());
-      Set<List<CustomResourceColumnDefinition>> additionalPrinterColumns = versions.stream().map(CustomResourceDefinitionVersion::getAdditionalPrinterColumns).filter(o -> o != null).collect(Collectors.toSet());
-      Set<CustomResourceValidation> schemas = versions.stream().map(CustomResourceDefinitionVersion::getSchema).filter(o -> o != null).collect(Collectors.toSet());
-      
+      Set<CustomResourceSubresources> subresources = versions.stream().map(CustomResourceDefinitionVersion::getSubresources)
+          .filter(o -> o != null).collect(Collectors.toSet());
+      Set<List<CustomResourceColumnDefinition>> additionalPrinterColumns = versions.stream()
+          .map(CustomResourceDefinitionVersion::getAdditionalPrinterColumns).filter(o -> o != null).collect(Collectors.toSet());
+      Set<CustomResourceValidation> schemas = versions.stream().map(CustomResourceDefinitionVersion::getSchema)
+          .filter(o -> o != null).collect(Collectors.toSet());
+
       boolean hasIdenticalSubresources = subresources.size() == 1;
       boolean hasIdenticalAdditionalPrinterColumns = additionalPrinterColumns.size() == 1;
       boolean hasIdenticalSchemas = schemas.size() == 1;
-      
+
       if (hasIdenticalSchemas) {
         spec.withValidation(schemas.iterator().next());
       }
@@ -92,17 +96,17 @@ public class PromoteSingleVersionAttributesDecorator extends CustomResourceDefin
 
       spec.withVersions(newVersions);
     }
-	}
+  }
 
-	@Override
-	public Class<? extends Decorator>[] after() {
-    return new Class[]{
-      AddCustomResourceDefinitionResourceDecorator.class,
-      AddCustomResourceDefinitionVersionDecorator.class,
-      CustomResourceDefinitionVersionDecorator.class,
-      AddSchemaToCustomResourceDefinitionVersionDecorator.class,
-      AddSubresourcesDecorator.class, AddStatusSubresourceDecorator.class,
-      AddStatusReplicasPathDecorator.class, AddSpecReplicasPathDecorator.class,
-      AddLabelSelectorPathDecorator.class};
-	}
+  @Override
+  public Class<? extends Decorator>[] after() {
+    return new Class[] {
+        AddCustomResourceDefinitionResourceDecorator.class,
+        AddCustomResourceDefinitionVersionDecorator.class,
+        CustomResourceDefinitionVersionDecorator.class,
+        AddSchemaToCustomResourceDefinitionVersionDecorator.class,
+        AddSubresourcesDecorator.class, AddStatusSubresourceDecorator.class,
+        AddStatusReplicasPathDecorator.class, AddSpecReplicasPathDecorator.class,
+        AddLabelSelectorPathDecorator.class };
+  }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -339,7 +339,6 @@ public class Config {
       String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras,
       OAuthTokenProvider oauthTokenProvider, Map<String, String> customHeaders, int requestRetryBackoffLimit,
       int requestRetryBackoffInterval, int uploadConnectionTimeout, int uploadRequestTimeout) {
-    this.masterUrl = masterUrl;
     this.apiVersion = apiVersion;
     this.namespace = namespace;
     this.trustCerts = trustCerts;
@@ -370,22 +369,17 @@ public class Config {
     this.errorMessages = errorMessages;
     this.userAgent = userAgent;
     this.tlsVersions = tlsVersions;
-
-    if (!this.masterUrl.toLowerCase(Locale.ROOT).startsWith(HTTP_PROTOCOL_PREFIX)
-        && !this.masterUrl.startsWith(HTTPS_PROTOCOL_PREFIX)) {
-      this.masterUrl = (SSLUtils.isHttpsAvailable(this) ? HTTPS_PROTOCOL_PREFIX : HTTP_PROTOCOL_PREFIX) + this.masterUrl;
-    }
-
-    if (!this.masterUrl.endsWith("/")) {
-      this.masterUrl = this.masterUrl + "/";
-    }
-
     this.trustStoreFile = trustStoreFile;
     this.trustStorePassphrase = trustStorePassphrase;
     this.keyStoreFile = keyStoreFile;
     this.keyStorePassphrase = keyStorePassphrase;
     this.oauthTokenProvider = oauthTokenProvider;
     this.customHeaders = customHeaders;
+
+    //We need to keep this after ssl configuration & masterUrl
+    //We set the masterUrl because it's needed by ensureHttps
+    this.masterUrl = masterUrl;
+    this.masterUrl = ensureEndsWithSlash(ensureHttps(masterUrl, this));
   }
 
   public static void configFromSysPropsOrEnvVars(Config config) {
@@ -1063,7 +1057,9 @@ public class Config {
   }
 
   public void setMasterUrl(String masterUrl) {
+    //We set the masterUrl because it's needed by ensureHttps
     this.masterUrl = masterUrl;
+    this.masterUrl = ensureEndsWithSlash(ensureHttps(masterUrl, this));
   }
 
   @JsonProperty("trustCerts")

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -51,10 +51,13 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(allowGetters = true, allowSetters = true)
@@ -420,8 +423,7 @@ public class Config {
     config.setImpersonateUsername(
         Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_USERNAME, config.getImpersonateUsername()));
 
-    String configuredImpersonateGroups = Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_GROUP,
-        config.getImpersonateGroup());
+    String configuredImpersonateGroups = Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_GROUP, Arrays.stream(Optional.ofNullable(config.getImpersonateGroups()).orElse(new String[0])).collect(Collectors.joining(",")));
     if (configuredImpersonateGroups != null) {
       config.setImpersonateGroups(configuredImpersonateGroups.split(","));
     }
@@ -939,25 +941,6 @@ public class Config {
   }
 
   public void setImpersonateGroups(String... impersonateGroup) {
-    this.requestConfig.setImpersonateGroups(impersonateGroup);
-  }
-
-  /**
-   * @deprecated Use {@link #getImpersonateGroups()} instead
-   * @return returns string of impersonate group
-   */
-  @Deprecated
-  @JsonProperty("impersonateGroup")
-  public String getImpersonateGroup() {
-    return getRequestConfig().getImpersonateGroup();
-  }
-
-  /**
-   * @param impersonateGroup ImpersonateGroup string
-   * @deprecated Use {@link #setImpersonateGroups(String...)} instead
-   */
-  @Deprecated
-  public void setImpersonateGroup(String impersonateGroup) {
     this.requestConfig.setImpersonateGroups(impersonateGroup);
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -423,7 +423,8 @@ public class Config {
     config.setImpersonateUsername(
         Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_USERNAME, config.getImpersonateUsername()));
 
-    String configuredImpersonateGroups = Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_GROUP, Arrays.stream(Optional.ofNullable(config.getImpersonateGroups()).orElse(new String[0])).collect(Collectors.joining(",")));
+    String configuredImpersonateGroups = Utils.getSystemPropertyOrEnvVar(KUBERNETES_IMPERSONATE_GROUP, Arrays
+        .stream(Optional.ofNullable(config.getImpersonateGroups()).orElse(new String[0])).collect(Collectors.joining(",")));
     if (configuredImpersonateGroups != null) {
       config.setImpersonateGroups(configuredImpersonateGroups.split(","));
     }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -284,28 +284,6 @@ public class RequestConfig {
     return impersonateUsername;
   }
 
-  /**
-   * Method to set Impersonate Group
-   *
-   * @param impersonateGroup impersonate group string
-   * @deprecated Use {@link #setImpersonateGroups(String...)} instead
-   */
-  @Deprecated
-  public void setImpersonateGroup(String impersonateGroup) {
-    setImpersonateGroups(impersonateGroup);
-  }
-
-  /**
-   * Method for getting Impersonate Groups
-   *
-   * @return Impersonate group string
-   * @deprecated Use {@link #getImpersonateGroups()} instead
-   */
-  @Deprecated
-  public String getImpersonateGroup() {
-    return (impersonateGroups == null || impersonateGroups.length == 0) ? null : impersonateGroups[0];
-  }
-
   public void setImpersonateGroups(String... impersonateGroups) {
     this.impersonateGroups = impersonateGroups == null ? new String[0] : Arrays.copyOf(impersonateGroups, impersonateGroups.length);
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_LOGGING_INTERVAL;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_MAX_CONCURRENT_REQUESTS;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST;
-import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL;
+import static io.fabric8.kubernetes.client.Config.DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_ROLLING_TIMEOUT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_SCALE_TIMEOUT;
 import static io.fabric8.kubernetes.client.Config.DEFAULT_UPLOAD_CONNECTION_TIMEOUT;
@@ -84,22 +84,24 @@ public class RequestConfig {
    */
   @Deprecated
   public RequestConfig(String username, String password, String oauthToken,
-                       int watchReconnectLimit, int watchReconnectInterval,
-                       int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
-                       long websocketTimeout, long websocketPingInterval,
-                       int maxConcurrentRequests, int maxConcurrentRequestsPerHost) {
-    this(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout, requestTimeout, scaleTimeout, loggingInterval,
-         websocketTimeout,  websocketPingInterval,maxConcurrentRequests, maxConcurrentRequestsPerHost, null, DEFAULT_REQUEST_RETRY_BACKOFFLIMIT, DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL,
-         DEFAULT_UPLOAD_CONNECTION_TIMEOUT, DEFAULT_UPLOAD_REQUEST_TIMEOUT);
+      int watchReconnectLimit, int watchReconnectInterval,
+      int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
+      long websocketTimeout, long websocketPingInterval,
+      int maxConcurrentRequests, int maxConcurrentRequestsPerHost) {
+    this(username, password, oauthToken, watchReconnectLimit, watchReconnectInterval, connectionTimeout, rollingTimeout,
+        requestTimeout, scaleTimeout, loggingInterval,
+        websocketTimeout, websocketPingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, null,
+        DEFAULT_REQUEST_RETRY_BACKOFFLIMIT, DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL,
+        DEFAULT_UPLOAD_CONNECTION_TIMEOUT, DEFAULT_UPLOAD_REQUEST_TIMEOUT);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
   public RequestConfig(String username, String password, String oauthToken,
-                       int watchReconnectLimit, int watchReconnectInterval,
-                       int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
-                       long websocketTimeout, long websocketPingInterval,
-                       int maxConcurrentRequests, int maxConcurrentRequestsPerHost, OAuthTokenProvider oauthTokenProvider,
-                       int requestRetryBackoffLimit, int requestRetryBackoffInterval, int uploadConnectionTimeout, int uploadRequestTimeout) {
+      int watchReconnectLimit, int watchReconnectInterval,
+      int connectionTimeout, long rollingTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
+      long websocketTimeout, long websocketPingInterval,
+      int maxConcurrentRequests, int maxConcurrentRequestsPerHost, OAuthTokenProvider oauthTokenProvider,
+      int requestRetryBackoffLimit, int requestRetryBackoffInterval, int uploadConnectionTimeout, int uploadRequestTimeout) {
     this.username = username;
     this.oauthToken = oauthToken;
     this.password = password;
@@ -285,7 +287,8 @@ public class RequestConfig {
   }
 
   public void setImpersonateGroups(String... impersonateGroups) {
-    this.impersonateGroups = impersonateGroups == null ? new String[0] : Arrays.copyOf(impersonateGroups, impersonateGroups.length);
+    this.impersonateGroups = impersonateGroups == null ? new String[0]
+        : Arrays.copyOf(impersonateGroups, impersonateGroups.length);
   }
 
   public String[] getImpersonateGroups() {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -322,7 +322,7 @@ public class ConfigTest {
     File configFile = new File(TEST_KUBECONFIG_FILE);
     final String configYAML = String.join("\n", Files.readAllLines(configFile.toPath()));
     final Config config = Config.fromKubeconfig(configYAML);
-    assertEquals("https://172.28.128.4:8443", config.getMasterUrl());
+    assertEquals("https://172.28.128.4:8443/", config.getMasterUrl());
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DefaultKubernetesClientTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DefaultKubernetesClientTest.java
@@ -109,7 +109,7 @@ class DefaultKubernetesClientTest {
     File configYml = new File(TEST_CONFIG_YML_FILE);
     try (InputStream is = new FileInputStream(configYml)){
       KubernetesClient client = DefaultKubernetesClient.fromConfig(is);
-      assertEquals("http://some.url", client.getMasterUrl().toString());
+      assertEquals("http://some.url/", client.getMasterUrl().toString());
     } catch (Exception e) {
       fail();
     }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DefaultKubernetesClientTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DefaultKubernetesClientTest.java
@@ -49,8 +49,9 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author wangyushuai2@jd.com
  */
 class DefaultKubernetesClientTest {
-  
-  private static final String TEST_CONFIG_YML_FILE = Utils.filePath(DefaultKubernetesClientTest.class.getResource("/test-config.yml"));
+
+  private static final String TEST_CONFIG_YML_FILE = Utils
+      .filePath(DefaultKubernetesClientTest.class.getResource("/test-config.yml"));
 
   private DefaultKubernetesClient defaultKubernetesClient;
 
@@ -73,16 +74,18 @@ class DefaultKubernetesClientTest {
     final Config configWithCustomerHeaders = new ConfigBuilder().withCustomHeaders(customHeaders).build();
 
     BasicBuilder basicBuilder = Mockito.mock(BasicBuilder.class);
-    HttpClientUtils.createApplicableInterceptors(configWithCustomerHeaders, null).get(HttpClientUtils.HEADER_INTERCEPTOR).before(basicBuilder, Mockito.mock(HttpHeaders.class));
+    HttpClientUtils.createApplicableInterceptors(configWithCustomerHeaders, null).get(HttpClientUtils.HEADER_INTERCEPTOR)
+        .before(basicBuilder, Mockito.mock(HttpHeaders.class));
     Mockito.verify(basicBuilder, Mockito.times(1)).header("user-id", "test-user");
   }
 
   @Test
   void testInitClientWithDefaultConfiguration() {
-    final Config defaultEmptyConfig =  new ConfigBuilder().build();
+    final Config defaultEmptyConfig = new ConfigBuilder().build();
 
     BasicBuilder basicBuilder = Mockito.mock(BasicBuilder.class);
-    HttpClientUtils.createApplicableInterceptors(defaultEmptyConfig, null).get(HttpClientUtils.HEADER_INTERCEPTOR).before(basicBuilder, Mockito.mock(HttpHeaders.class));
+    HttpClientUtils.createApplicableInterceptors(defaultEmptyConfig, null).get(HttpClientUtils.HEADER_INTERCEPTOR)
+        .before(basicBuilder, Mockito.mock(HttpHeaders.class));
 
     Mockito.verify(basicBuilder, Mockito.never()).header("user-id", "test-user");
   }
@@ -92,22 +95,22 @@ class DefaultKubernetesClientTest {
   void loadWithWindowsLineSeparatorsString() throws Exception {
     // Given
     final List<String> fileLines = Files.readAllLines(
-      new File(DefaultKubernetesClientTest.class.getResource("/test-list.yml").getFile()).toPath(), StandardCharsets.UTF_8);
+        new File(DefaultKubernetesClientTest.class.getResource("/test-list.yml").getFile()).toPath(), StandardCharsets.UTF_8);
     final String crlfFile = String.join(" \r\n", fileLines);
     // When
     final List<HasMetadata> result = new DefaultKubernetesClient()
-      .load(new ByteArrayInputStream(crlfFile.getBytes(StandardCharsets.UTF_8))).get();
+        .load(new ByteArrayInputStream(crlfFile.getBytes(StandardCharsets.UTF_8))).get();
     // Then
     assertThat(result)
-      .hasSize(2)
-      .hasAtLeastOneElementOfType(Service.class)
-      .hasAtLeastOneElementOfType(Deployment.class);
+        .hasSize(2)
+        .hasAtLeastOneElementOfType(Service.class)
+        .hasAtLeastOneElementOfType(Deployment.class);
   }
-  
+
   @Test
   void shouldInstantiateClientUsingYaml() {
     File configYml = new File(TEST_CONFIG_YML_FILE);
-    try (InputStream is = new FileInputStream(configYml)){
+    try (InputStream is = new FileInputStream(configYml)) {
       KubernetesClient client = DefaultKubernetesClient.fromConfig(is);
       assertEquals("http://some.url/", client.getMasterUrl().toString());
     } catch (Exception e) {
@@ -135,16 +138,16 @@ class DefaultKubernetesClientTest {
     extras.put("c", Collections.singletonList("d"));
 
     final Config config = new ConfigBuilder()
-      .withImpersonateUsername("a")
-      .withImpersonateGroups("b")
-      .withImpersonateExtras(extras)
-      .build();
+        .withImpersonateUsername("a")
+        .withImpersonateGroups("b")
+        .withImpersonateExtras(extras)
+        .build();
 
     final DefaultKubernetesClient client = new DefaultKubernetesClient(config);
     final Config currentConfig = client.getConfiguration();
 
     assertEquals("a", currentConfig.getImpersonateUsername());
-    assertArrayEquals(new String[]{"b"}, currentConfig.getImpersonateGroups());
+    assertArrayEquals(new String[] { "b" }, currentConfig.getImpersonateGroups());
     assertEquals(Collections.singletonList("d"), currentConfig.getImpersonateExtras().get("c"));
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DefaultKubernetesClientTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DefaultKubernetesClientTest.java
@@ -136,7 +136,7 @@ class DefaultKubernetesClientTest {
 
     final Config config = new ConfigBuilder()
       .withImpersonateUsername("a")
-      .withImpersonateGroup("b")
+      .withImpersonateGroups("b")
       .withImpersonateExtras(extras)
       .build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Core versions -->
-    <sundrio.version>0.90.5</sundrio.version>
+    <sundrio.version>0.91.1</sundrio.version>
     <okhttp.version>3.12.12</okhttp.version>
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
The pull request is mostly bumping sundrio to 0.91.1 and fixing some issues that manifest after this change:

- Drop deprecated code that was internally abusing setters, making them order sensitive.
- Fix incosistent handling of `masterUrl` in Config, so that settings via constructor or setters works the same.
- Fix crd generator issues that occur after fixing handling of `withXXX(null)`.