### PR TITLE
Update resource version when `replaceStatus()` is used with Mock Kubernetes Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.0-SNAPSHOT
 
 #### Bugs
+* Fix #4216: Update metadata when `replaceStatus()` is called
 
 #### Improvements
 * Fix #4006: Remove outdated shared test classes in `kubernetes-client/` and `openshift-client/` modules

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
@@ -250,7 +250,6 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Resetabl
         }
 
         setDefaultMetadata(updated, pathValues, source);
-
         String updatedAsString = Serialization.asJson(updated);
 
         return validateRequestBodyAndHandleRequest(updatedAsString, h -> {
@@ -414,8 +413,9 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Resetabl
           if (isStatusPath(path)) {
             JsonNode status = removeStatus(updated);
             // set the status on the existing node
-            updated = existingNode;
+            updated = existingNode.deepCopy();
             setStatus(updated, status);
+            setDefaultMetadata(updated, pathValues, existingNode);
           } else {
             // preserve status and generated fields
             if (statusSubresource) {


### PR DESCRIPTION
## Description

Fix #4216 

When the Kubernetes Mock Server is used in CRUD mode and a resource status is updated using the `replaceStatus()` method, it does not seem to dispatch the update to clients and thus it does not trigger the `waitUntilCondition(...)` or `scale(N, true)` methods waiting for them.

This seems to be caused by the resource version field in metadata not being updated. This PR uses the `deepCopy()` of the existing object (in order to be able to diff it against the updated one) and calls the `setDefaultMetadata(...)` method on it. This now causes the resource version to be updated and that triggers the dispatching of the events tot he clients even when status is updated with `replaceStatus()`

This should close close #4216.

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change