### PR TITLE
fix #3969 #4222: deferring add events until cache is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 5.12.3
+* Fix #3969: relist will not trigger sync events
+* Fix #4222: backport of #4082 - to not process events until the cache is complete
+
 ### 5.12.2 (2022-04-06)
 * Fix #3582: SSL truststore can be loaded in FIPS enabled environments
 * Fix #3797: Implement SchemaSwap; generate CRD from model not owned

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -70,7 +70,11 @@ class ResourceTest {
   void testCreateOrReplace() {
     // Given
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect()
+        .post()
+        .withPath("/api/v1/namespaces/test/pods")
+        .andReturn(HttpURLConnection.HTTP_CREATED, pod1)
+        .once();
 
     // When
     HasMetadata response = client.resource(pod1).createOrReplace();
@@ -78,12 +82,16 @@ class ResourceTest {
     // Then
     assertEquals(pod1, response);
   }
-  
+
   @Test
   void testCreateOrReplaceString() {
     // Given
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect()
+        .post()
+        .withPath("/api/v1/namespaces/test/pods")
+        .andReturn(HttpURLConnection.HTTP_CREATED, pod1)
+        .once();
 
     // When
     HasMetadata response = client.resource(Serialization.asYaml(pod1)).createOrReplace();
@@ -94,17 +102,22 @@ class ResourceTest {
 
   @Test
   void testGenericResourceFails() {
-    assertThrows(KubernetesClientException.class, () -> client.resource(Serialization.unmarshal("apiVersion: example.io/v1\n"
-        + "kind: GenericThatFails\n"
-        + "metadata:\n"
-        + "  name: failure\n", GenericKubernetesResource.class)));
+    assertThrows(KubernetesClientException.class,
+        () -> client.resource(Serialization.unmarshal("apiVersion: example.io/v1\n"
+            + "kind: GenericThatFails\n"
+            + "metadata:\n"
+            + "  name: failure\n", GenericKubernetesResource.class)));
   }
 
   @Test
   void testCreateOrReplaceWhenCreateFails() {
     // Given
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
-    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_BAD_REQUEST, pod1).once();
+    server.expect()
+        .post()
+        .withPath("/api/v1/namespaces/test/pods")
+        .andReturn(HttpURLConnection.HTTP_BAD_REQUEST, pod1)
+        .once();
 
     NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicable<Pod> podOperation = client.resource(pod1);
 
@@ -112,31 +125,35 @@ class ResourceTest {
     assertThrows(KubernetesClientException.class, podOperation::createOrReplace);
   }
 
-    @Test
-    void testCreateWithExplicitNamespace() {
-      Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+  @Test
+  void testCreateWithExplicitNamespace() {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-      server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect()
+        .post()
+        .withPath("/api/v1/namespaces/ns1/pods")
+        .andReturn(HttpURLConnection.HTTP_CREATED, pod1)
+        .once();
 
-      HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
-      assertEquals(pod1, response);
-    }
+    HasMetadata response = client.resource(pod1).inNamespace("ns1").createOrReplace();
+    assertEquals(pod1, response);
+  }
 
-    @Test
-    void testCreateOrReplaceWithDeleteExisting() throws Exception {
-      Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
+  @Test
+  void testCreateOrReplaceWithDeleteExisting() throws Exception {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
 
-      server.expect().delete().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
-      server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
+    server.expect().delete().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_OK, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/ns1/pods").andReturn(HttpURLConnection.HTTP_CREATED, pod1).once();
 
-      HasMetadata response = client.resource(pod1).inNamespace("ns1").deletingExisting().createOrReplace();
-      assertEquals(pod1, response);
+    HasMetadata response = client.resource(pod1).inNamespace("ns1").deletingExisting().createOrReplace();
+    assertEquals(pod1, response);
 
-      RecordedRequest request = server.getLastRequest();
-      assertEquals(2, server.getRequestCount());
-      assertEquals("/api/v1/namespaces/ns1/pods", request.getPath());
-      assertEquals("POST", request.getMethod());
-    }
+    RecordedRequest request = server.getLastRequest();
+    assertEquals(2, server.getRequestCount());
+    assertEquals("/api/v1/namespaces/ns1/pods", request.getPath());
+    assertEquals("POST", request.getMethod());
+  }
 
   @Test
   void itPassesPropagationPolicyWithDeleteExisting() throws InterruptedException {
@@ -174,13 +191,17 @@ class ResourceTest {
     assertThrows(KubernetesClientException.class, podOperation::createOrReplace);
   }
 
-    @Test
-    void testRequire() {
-      server.expect().get().withPath("/api/v1/namespaces/ns1/pods/pod1").andReturn(HttpURLConnection.HTTP_NOT_FOUND, "").once();
-      PodResource<Pod> podOp = client.pods().inNamespace("ns1").withName("pod1");
+  @Test
+  void testRequire() {
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/ns1/pods/pod1")
+        .andReturn(HttpURLConnection.HTTP_NOT_FOUND, "")
+        .once();
+    PodResource podOp = client.pods().inNamespace("ns1").withName("pod1");
 
-      Assertions.assertThrows(ResourceNotFoundException.class, podOp::require);
-    }
+    Assertions.assertThrows(ResourceNotFoundException.class, podOp::require);
+  }
 
   @Test
   void testDelete() {
@@ -200,22 +221,27 @@ class ResourceTest {
     assertFalse(deleted);
   }
 
-
   @Test
   void testWatch() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
         .withName("pod1")
         .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withNamespace("test")
+        .and()
+        .build();
 
-      server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pod1).once();
-      server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, pod1).once();
+    server.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pod1).once();
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, pod1).once();
 
-     server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
         .open()
-          .waitFor(1000).andEmit(new WatchEvent(pod1, "DELETED"))
+        .waitFor(1000)
+        .andEmit(new WatchEvent(pod1, "DELETED"))
         .done()
-      .always();
+        .always();
 
     final CountDownLatch latch = new CountDownLatch(1);
 
@@ -234,25 +260,30 @@ class ResourceTest {
     watch.close();
   }
 
-
   @Test
   void testWaitUntilReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500)
+        .andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -265,7 +296,8 @@ class ResourceTest {
   static void list(KubernetesMockServer server, Pod pod) {
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/"+pod.getMetadata().getNamespace()+"/pods?fieldSelector=metadata.name%3D"+pod.getMetadata().getName())
+        .withPath("/api/v1/namespaces/" + pod.getMetadata().getNamespace() + "/pods?fieldSelector=metadata.name%3D"
+            + pod.getMetadata().getName())
         .andReturn(200,
             new PodListBuilder().withItems(pod).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
@@ -274,22 +306,32 @@ class ResourceTest {
   @Test
   void testWaitUntilExistsThenReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "1");
+    Pod ready = createReadyFrom(pod1, "True", "2");
 
     // and again so that "periodicWatchUntilReady" successfully begins
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, noReady).times(2);
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .andReturn(200, noReady)
+        .times(2);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(100).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(100)
+        .andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.pods().withName("pod1").waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -298,84 +340,108 @@ class ResourceTest {
   @Test
   void testWaitUntilCondition() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "1");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
-    Pod withConditionBeingFalse = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .addNewCondition()
-      .withType("dummy")
-      .withStatus("False")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod withConditionBeingFalse = new PodBuilder(pod1).editMetadata()
+        .withResourceVersion("2")
+        .endMetadata()
+        .withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .addNewCondition()
+        .withType("dummy")
+        .withStatus("False")
+        .endCondition()
+        .endStatus()
+        .build();
 
-    Pod withConditionBeingTrue = new PodBuilder(pod1).withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .addNewCondition()
-      .withType("Dummy")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+    Pod withConditionBeingTrue = new PodBuilder(pod1).editMetadata()
+        .withResourceVersion("4")
+        .endMetadata()
+        .withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .addNewCondition()
+        .withType("Dummy")
+        .withStatus("True")
+        .endCondition()
+        .endStatus()
+        .build();
 
     // at first the pod is non-ready
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .waitFor(2000).andEmit(new WatchEvent(withConditionBeingFalse, "MODIFIED"))
-      .waitFor(2500).andEmit(new WatchEvent(withConditionBeingTrue, "MODIFIED"))
-      .done()
-      .always();
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000)
+        .andEmit(new WatchEvent(ready, "MODIFIED"))
+        .waitFor(2000)
+        .andEmit(new WatchEvent(withConditionBeingFalse, "MODIFIED"))
+        .waitFor(2500)
+        .andEmit(new WatchEvent(withConditionBeingTrue, "MODIFIED"))
+        .done()
+        .always();
 
-
-    Pod p = client.pods().withName("pod1").waitUntilCondition(
-      r -> r.getStatus().getConditions()
-            .stream()
-            .anyMatch(c -> "Dummy".equals(c.getType()) && "True".equals(c.getStatus())),
-      8, SECONDS
-    );
+    Pod p = client.pods()
+        .withName("pod1")
+        .waitUntilCondition(
+            r -> r.getStatus()
+                .getConditions()
+                .stream()
+                .anyMatch(c -> "Dummy".equals(c.getType()) && "True".equals(c.getStatus())),
+            8, SECONDS);
 
     assertThat(p.getStatus().getConditions())
-      .extracting("type", "status")
-      .containsExactly(tuple("Ready", "True"), tuple("Dummy", "True"));
+        .extracting("type", "status")
+        .containsExactly(tuple("Ready", "True"), tuple("Dummy", "True"));
   }
 
   @Test
   void tesErrorEventDuringWaitReturnFromAPIIfMatch() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     Status status = new StatusBuilder()
-      .withCode(HttpURLConnection.HTTP_FORBIDDEN)
-      .build();
+        .withCode(HttpURLConnection.HTTP_FORBIDDEN)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .once();
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500)
+        .andEmit(new WatchEvent(status, "ERROR"))
+        .waitFor(500)
+        .andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .once();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -384,32 +450,43 @@ class ResourceTest {
   @Test
   void testRetryOnErrorEventDuringWait() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     Status status = new StatusBuilder()
-      .withCode(HttpURLConnection.HTTP_FORBIDDEN)
-      .build();
+        .withCode(HttpURLConnection.HTTP_FORBIDDEN)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .done()
-      .once();
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500)
+        .andEmit(new WatchEvent(status, "ERROR"))
+        .done()
+        .once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .once();
-
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500)
+        .andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .once();
 
     Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -418,12 +495,14 @@ class ResourceTest {
   @Test
   void testSkipWatchIfAlreadyMatchingCondition() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     // once not ready, to begin watch
     list(ready);
@@ -437,23 +516,30 @@ class ResourceTest {
     Pod pod1 = new PodBuilder().withNewMetadata()
         .withName("pod1")
         .withResourceVersion("1")
-        .withNamespace("test").and().build();
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     Status status = new StatusBuilder()
-      .withCode(HTTP_GONE)
-      .build();
+        .withCode(HTTP_GONE)
+        .build();
 
     // once not ready, to begin watch
     list(noReady);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(500).andEmit(new WatchEvent(status, "ERROR"))
-      .done()
-      .once();
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(500)
+        .andEmit(new WatchEvent(status, "ERROR"))
+        .done()
+        .once();
 
     list(ready);
 
@@ -463,48 +549,60 @@ class ResourceTest {
   @Test
   void testWaitOnConditionDeleted() throws InterruptedException {
     Pod ready = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().withNewStatus()
-      .addNewCondition()
-      .withType("Ready")
-      .withStatus("True")
-      .endCondition()
-      .endStatus()
-      .build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .withNewStatus()
+        .addNewCondition()
+        .withType("Ready")
+        .withStatus("True")
+        .endCondition()
+        .endStatus()
+        .build();
 
     list(ready);
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "DELETED"))
-      .done()
-      .once();
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000)
+        .andEmit(new WatchEvent(ready, "DELETED"))
+        .done()
+        .once();
 
-
-    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull,8, SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 8, SECONDS);
     assertNull(p);
   }
 
   @Test
   void testCreateAndWaitUntilReady() throws InterruptedException {
     Pod pod1 = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withResourceVersion("1")
-      .withNamespace("test").and().build();
+        .withName("pod1")
+        .withResourceVersion("1")
+        .withNamespace("test")
+        .and()
+        .build();
 
-    Pod noReady = createReadyFrom(pod1, "False");
-    Pod ready = createReadyFrom(pod1, "True");
+    Pod noReady = createReadyFrom(pod1, "False", "2");
+    Pod ready = createReadyFrom(pod1, "True", "3");
 
     list(noReady);
     server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(201, noReady).once();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true").andUpgradeToWebSocket()
-      .open()
-      .waitFor(1000).andEmit(new WatchEvent(ready, "MODIFIED"))
-      .done()
-      .always();
-
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(1000)
+        .andEmit(new WatchEvent(ready, "MODIFIED"))
+        .done()
+        .always();
 
     Pod p = client.resource(noReady).createOrReplaceAnd().waitUntilReady(10, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
@@ -513,14 +611,13 @@ class ResourceTest {
   @Test
   void testFromServerGet() {
     Pod pod = new PodBuilder().withNewMetadata()
-      .withName("pod1")
-      .withNamespace("test")
-      .withResourceVersion("1")
-      .and()
-      .build();
+        .withName("pod1")
+        .withNamespace("test")
+        .withResourceVersion("1")
+        .and()
+        .build();
 
     server.expect().get().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod).once();
-
 
     HasMetadata response = client.resource(pod).fromServer().get();
     assertEquals(pod, response);
@@ -531,28 +628,36 @@ class ResourceTest {
   void testFromServerWaitUntilConditionAlwaysGetsResourceFromServer() throws Exception {
     // Given
     final Pod conditionNotMetPod = new PodBuilder().withNewMetadata()
-      .withName("pod")
-      .withNamespace("test")
-      .addToLabels("CONDITION", "NOT_MET")
-      .endMetadata().build();
+        .withName("pod")
+        .withNamespace("test")
+        .withResourceVersion("1")
+        .addToLabels("CONDITION", "NOT_MET")
+        .endMetadata()
+        .build();
     final Pod conditionMetPod = new PodBuilder().withNewMetadata()
-      .withName("pod")
-      .withNamespace("test")
-      .withResourceVersion("1")
-      .addToLabels("CONDITION", "MET")
-      .endMetadata()
-      .build();
+        .withName("pod")
+        .withNamespace("test")
+        .withResourceVersion("2")
+        .addToLabels("CONDITION", "MET")
+        .endMetadata()
+        .build();
     list(conditionNotMetPod);
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket().open()
-      .immediately().andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
-      .waitFor(10).andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
-      .done()
-      .once();
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .immediately()
+        .andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
+        .waitFor(10)
+        .andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
+        .done()
+        .once();
     // When
     HasMetadata response = client
-      .resource(new PodBuilder(conditionMetPod).build())
-      .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
+        .resource(new PodBuilder(conditionMetPod).build())
+        .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
     // Then
     assertEquals(conditionMetPod, response);
     assertEquals(2, server.getRequestCount());
@@ -561,25 +666,27 @@ class ResourceTest {
   @Test
   void testWaitNullDoesntExist() throws InterruptedException {
     server.expect()
-      .get()
-      .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
-      .andReturn(200,
-        new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
-      .once();
+        .get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .andReturn(200,
+            new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
+        .once();
 
     Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 1, SECONDS);
     assertNull(p);
   }
 
-  private static Pod createReadyFrom(Pod pod, String status) {
+  static Pod createReadyFrom(Pod pod, String status, String resourceVersion) {
     return new PodBuilder(pod)
-      .withNewStatus()
+        .editMetadata()
+        .withResourceVersion(resourceVersion)
+        .endMetadata()
+        .withNewStatus()
         .addNewCondition()
-          .withType("Ready")
-          .withStatus(status)
+        .withType("Ready")
+        .withStatus(status)
         .endCondition()
-      .endStatus()
-      .build();
+        .endStatus()
+        .build();
   }
 }
-


### PR DESCRIPTION
## Description
fix #3969 #4222: deferring add events until cache is complete - it was easiest to also keep the change to omit resync events on relist

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
