### PR TITLE
chore #3906: deprecating CustomResourceList

### DIFF
--- a/doc/MIGRATION-v6.md
+++ b/doc/MIGRATION-v6.md
@@ -244,9 +244,10 @@ We've removed setter methods `setIntVal`, `setKind`, `setStrVal` from the class.
 
 - DSL methods available off of a resource context involving a resource - `client.configMaps().withName("name").create(configMap)` - should instead use a no-argument method - `client.configMaps().resource(configMap).create()` or `client.resource(configMap).create()`.
 
-- DSL methods available off of a collection context involving a resource - `client.configMaps().create(configMap)` - should instead use a no-argument method - `client.configMaps().resource(configMap).create()` or `client.resource(configMap).create()`.
-
+- DSL methods available off of a collection context involving a resource - `client.configMaps().create(configMap)` - should instead use a no-argument method - `client.configMaps().resource(configMap).create()` or `client.resource(configMap).create()`.  
 The only exception to the above is `patch(PatchContext, item)` - it is valid to be called after withName. 
+
+- CustomResourceList was deprecated - use DefaultKubernetesResourceList instead.
 
 ## Object Sorting
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResourceList.java
@@ -18,5 +18,9 @@ package io.fabric8.kubernetes.client;
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
+/**
+ * @deprecated use DefaultKubernetesResourceList instead
+ */
+@Deprecated
 public class CustomResourceList<T extends HasMetadata> extends DefaultKubernetesResourceList<T> {
 }

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CRDExample.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
-import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -111,23 +110,23 @@ public class CRDExample {
         System.out.println("Found CRD: " + dummyCRD.getMetadata().getSelfLink());
       } else {
         dummyCRD = CustomResourceDefinitionContext.v1CRDFromCustomResourceType(Dummy.class)
-          .editSpec()
-          .editVersion(0)
-          .withNewSchema()
-          .withNewOpenAPIV3Schema()
-          .withTitle("dummy")
-          .withType("object")
-          .addToRequired("spec")
-          .addToProperties("spec", new JSONSchemaPropsBuilder()
+            .editSpec()
+            .editVersion(0)
+            .withNewSchema()
+            .withNewOpenAPIV3Schema()
+            .withTitle("dummy")
             .withType("object")
-            .addToProperties("foo", new JSONSchemaPropsBuilder().withType("string").build())
-            .addToProperties("bar", new JSONSchemaPropsBuilder().withType("string").build())
-            .build())
-          .endOpenAPIV3Schema()
-          .endSchema()
-          .endVersion()
-          .endSpec()
-          .build();
+            .addToRequired("spec")
+            .addToProperties("spec", new JSONSchemaPropsBuilder()
+                .withType("object")
+                .addToProperties("foo", new JSONSchemaPropsBuilder().withType("string").build())
+                .addToProperties("bar", new JSONSchemaPropsBuilder().withType("string").build())
+                .build())
+            .endOpenAPIV3Schema()
+            .endSchema()
+            .endVersion()
+            .endSpec()
+            .build();
 
         client.apiextensions().v1().customResourceDefinitions().create(dummyCRD);
         System.out.println("Created CRD " + dummyCRD.getMetadata().getName());
@@ -141,7 +140,7 @@ public class CRDExample {
       if (resourceNamespaced) {
         dummyClient = ((MixedOperation<Dummy, DummyList, Resource<Dummy>>) dummyClient).inNamespace(namespace);
       }
-      CustomResourceList<Dummy> dummyList = dummyClient.list();
+      DummyList dummyList = dummyClient.list();
       List<Dummy> items = dummyList.getItems();
       System.out.println("  found " + items.size() + " dummies");
       for (Dummy item : items) {

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceV1Example.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceV1Example.java
@@ -15,12 +15,12 @@
  */
 package io.fabric8.kubernetes.examples;
 
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
-import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
@@ -82,7 +82,7 @@ public class CustomResourceV1Example {
     }
   }
 
-  public static final class ShowList extends CustomResourceList<Show> {
+  public static final class ShowList extends DefaultKubernetesResourceList<Show> {
   }
 
   @SuppressWarnings("unused")

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummyList.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/crds/DummyList.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.examples.crds;
 
-import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 
-public class DummyList extends CustomResourceList<Dummy> {
+public class DummyList extends DefaultKubernetesResourceList<Dummy> {
 }


### PR DESCRIPTION
## Description
Partially addresses #3906 - by deprecating CustomResourceList as it provides no additional functionality.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
