### PR TITLE
fix #4206: ensuring null won't be returned from kubernetesdeserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Fix #4294: crd-generator respects JsonIgnore annotations on enum properties
 * Fix #4247: NO_PROXY with invalid entries throws exception
 * Fix #4320: corrected leader transitions field on leader election leases
+* Fix #4206: KubernetesDeserializer can now handle any valid object. If the object lacks type information, it will be deserialized as a GenericKubernetesResource.
+
 
 #### Improvements
 * Fix #4254: adding debug logging for exec stream messages
@@ -23,6 +25,7 @@
 * Fix #2271: Support periodic refresh of access tokens before they expire
 
 #### _**Note**_: Breaking changes in the API
+* Fix #4206: The Serialization utility class will throw an Exception, instead of returning null, if an untyped unmarshall method is used on something that lacks type information
 
 ### 5.12.3 (2022-07-27)
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import io.fabric8.kubernetes.api.model.Config;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesList;
@@ -41,6 +42,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
 import io.fabric8.kubernetes.api.model.coordination.v1.LeaseSpec;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -240,13 +242,10 @@ class SerializationTest {
   }
 
   @Test
-  @DisplayName("unmarshal, with invalid YAML resource, should return null")
-  void unmarshalWithInvalidResourceShouldReturnNull() {
-    // When
-    final KubernetesResource result = Serialization.unmarshal(
-        SerializationTest.class.getResourceAsStream("/serialization/invalid-resource.yml"));
-    // Then
-    assertThat(result).isNull();
+  @DisplayName("unmarshal, with invalid YAML resource, should throw exception")
+  void unmarshalWithInvalidResourceShouldThrowException() {
+    InputStream is = SerializationTest.class.getResourceAsStream("/serialization/invalid-resource.yml");
+    assertThrows(KubernetesClientException.class, () -> Serialization.unmarshal(is));
   }
 
   @Test
@@ -330,6 +329,24 @@ class SerializationTest {
   void quantityQuoting() {
     Quantity quantity = Serialization.unmarshal("amount: \"2\"\nformat: \"Gi\"", Quantity.class);
     assertThat(Serialization.asYaml(quantity)).isEqualTo("--- \"2Gi\"\n");
+  }
+
+  @Test
+  void parseConfigWithRaw() {
+    Config config = Serialization.unmarshal("extensions: \n"
+        + "- name: foo\n"
+        + "  extension:\n"
+        + "    not: kubernetesresource", Config.class);
+
+    // ensure that the extenion is preserved
+    assertThat(Serialization.asYaml(config)).isEqualTo("---\n"
+        + "clusters: []\n"
+        + "contexts: []\n"
+        + "extensions:\n"
+        + "- extension:\n"
+        + "    not: \"kubernetesresource\"\n"
+        + "  name: \"foo\"\n"
+        + "users: []\n");
   }
 
   @JsonTypeResolver(io.fabric8.kubernetes.model.jackson.UnwrappedTypeResolverBuilder.class)

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DryRunTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/DryRunTest.java
@@ -55,7 +55,8 @@ class DryRunTest {
     this.mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
     Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
     when(mockClient.sendAsync(any(), Mockito.eq(byte[].class)))
-        .thenReturn(CompletableFuture.completedFuture(TestHttpResponse.from(200, "{}")));
+        .thenReturn(CompletableFuture.completedFuture(TestHttpResponse.from(200,
+            "{\"kind\":\"Pod\", \"apiVersion\":\"v1\"}")));
     kubernetesClient = new DefaultKubernetesClient(mockClient, config);
     Mockito.when(mockClient.newHttpRequestBuilder()).thenAnswer(answer -> {
       HttpRequest.Builder result = Mockito.mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.internal;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.kubernetes.api.KubernetesResourceMappingProvider;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
@@ -116,26 +117,26 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
 
   private static KubernetesResource fromObjectNode(JsonParser jp, JsonNode node) throws IOException {
     TypeKey key = getKey(node);
-    if (key != null) {
-      Class<? extends KubernetesResource> resourceType = mapping.getForKey(key);
-      if (resourceType == null) {
-        return jp.getCodec().treeToValue(node, GenericKubernetesResource.class);
-      } else if (KubernetesResource.class.isAssignableFrom(resourceType)) {
-        boolean inTemplate = false;
-        if (TEMPLATE_CLASS_NAME.equals(resourceType.getName())) {
-          inTemplate = true;
-          IN_TEMPLATE.set(true);
-        }
-        try {
-          return jp.getCodec().treeToValue(node, resourceType);
-        } finally {
-          if (inTemplate) {
-            IN_TEMPLATE.remove();
-          }
+    Class<? extends KubernetesResource> resourceType = mapping.getForKey(key);
+    if (resourceType == null) {
+      return jp.getCodec().treeToValue(node, GenericKubernetesResource.class);
+    } else if (KubernetesResource.class.isAssignableFrom(resourceType)) {
+      boolean inTemplate = false;
+      if (TEMPLATE_CLASS_NAME.equals(resourceType.getName())) {
+        inTemplate = true;
+        IN_TEMPLATE.set(true);
+      }
+      try {
+        return jp.getCodec().treeToValue(node, resourceType);
+      } finally {
+        if (inTemplate) {
+          IN_TEMPLATE.remove();
         }
       }
     }
-    return null;
+    throw new JsonMappingException(jp, String.format(
+        "There's a class loading issue, %s is registered as a KubernetesResource, but is not an instance of KubernetesResource",
+        resourceType.getName()));
   }
 
   /**


### PR DESCRIPTION
## Description
This is to address #4206.  We cannot throw an exception as it appears that the Config parsing has embedded HasMetadata (extensions) references, which lack type information.  So instead we'll return a generic resource - that should ensure round-trip parse/serialization is also correct.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
