### PR TITLE
fix #2271: Refresh token every minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Fix #2271: Support periodic refresh of access tokens before they expire
 
 #### _**Note**_: Breaking changes in the API
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
@@ -52,7 +52,6 @@ public class TokenRefreshInterceptor implements Interceptor {
     }
   }
 
-
   @Override
   public CompletableFuture<Boolean> afterFailure(BasicBuilder headerBuilder, HttpResponse<?> response) {
     if (response.code() == HttpURLConnection.HTTP_UNAUTHORIZED) {
@@ -70,7 +69,7 @@ public class TokenRefreshInterceptor implements Interceptor {
     Config newestConfig = Config.autoConfigure(currentContextName);
     if (newestConfig.getAuthProvider() != null && newestConfig.getAuthProvider().getName().equalsIgnoreCase("oidc")) {
       newAccessToken = OpenIDConnectionUtils.resolveOIDCTokenFromAuthConfig(newestConfig.getAuthProvider().getConfig(),
-        factory.newBuilder());
+          factory.newBuilder());
     } else {
       newAccessToken = CompletableFuture.completedFuture(newestConfig.getOauthToken());
     }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
@@ -18,10 +18,13 @@ package io.fabric8.kubernetes.client.utils;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.http.BasicBuilder;
 import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.http.HttpHeaders;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.Interceptor;
 
 import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -34,40 +37,61 @@ public class TokenRefreshInterceptor implements Interceptor {
   private final Config config;
   private HttpClient.Factory factory;
 
+  private Instant lastRefresh;
+
   public TokenRefreshInterceptor(Config config, HttpClient.Factory factory) {
     this.config = config;
+    this.lastRefresh = Instant.now();
     this.factory = factory;
   }
 
   @Override
+  public void before(BasicBuilder headerBuilder, HttpHeaders headers) {
+    if (timeToRefresh()) {
+      refreshToken(headerBuilder);
+    }
+  }
+
+
+  @Override
   public CompletableFuture<Boolean> afterFailure(BasicBuilder headerBuilder, HttpResponse<?> response) {
     if (response.code() == HttpURLConnection.HTTP_UNAUTHORIZED) {
-      String currentContextName = null;
-      CompletableFuture<String> newAccessToken = null;
-
-      if (config.getCurrentContext() != null) {
-        currentContextName = config.getCurrentContext().getName();
-      }
-      Config newestConfig = Config.autoConfigure(currentContextName);
-      if (newestConfig.getAuthProvider() != null && newestConfig.getAuthProvider().getName().equalsIgnoreCase("oidc")) {
-        newAccessToken = OpenIDConnectionUtils.resolveOIDCTokenFromAuthConfig(newestConfig.getAuthProvider().getConfig(),
-            factory.newBuilder());
-      } else {
-        newAccessToken = CompletableFuture.completedFuture(newestConfig.getOauthToken());
-      }
-
-      return newAccessToken.thenApply(s -> {
-        if (s != null) {
-          // Delete old Authorization header and append new one
-          headerBuilder.setHeader("Authorization", "Bearer " + s);
-          config.setOauthToken(s);
-          return true;
-        }
-        return false;
-      });
-
+      return refreshToken(headerBuilder);
     }
     return CompletableFuture.completedFuture(false);
   }
 
+  private CompletableFuture<Boolean> refreshToken(BasicBuilder headerBuilder) {
+    String currentContextName = null;
+    if (config.getCurrentContext() != null) {
+      currentContextName = config.getCurrentContext().getName();
+    }
+    CompletableFuture<String> newAccessToken;
+    Config newestConfig = Config.autoConfigure(currentContextName);
+    if (newestConfig.getAuthProvider() != null && newestConfig.getAuthProvider().getName().equalsIgnoreCase("oidc")) {
+      newAccessToken = OpenIDConnectionUtils.resolveOIDCTokenFromAuthConfig(newestConfig.getAuthProvider().getConfig(),
+        factory.newBuilder());
+    } else {
+      newAccessToken = CompletableFuture.completedFuture(newestConfig.getOauthToken());
+    }
+    return newAccessToken.thenApply(s -> {
+      if (s != null) {
+        // Delete old Authorization header and append new one
+        headerBuilder.setHeader("Authorization", "Bearer " + s);
+        config.setOauthToken(s);
+        lastRefresh = Instant.now();
+        return true;
+      }
+      return false;
+    });
+  }
+
+  private boolean timeToRefresh() {
+    return lastRefresh.plus(1, ChronoUnit.MINUTES).isBefore(Instant.now());
+  }
+
+  // For testing only
+  void setLastRefresh(Instant lastRefresh) {
+    this.lastRefresh = lastRefresh;
+  }
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
@@ -19,8 +19,6 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.TestHttpResponse;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -28,6 +26,8 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_AUTH_SERVICEACCOUNT_TOKEN_FILE_SYSTEM_PROPERTY;
@@ -68,7 +68,7 @@ class TokenRefreshInterceptorTest {
       // Prepare kubeconfig for autoconfiguration
       File tempFile = Files.createTempFile("test", "kubeconfig").toFile();
       Files.copy(Objects.requireNonNull(getClass().getResourceAsStream("/token-refresh-interceptor/kubeconfig")),
-        Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
+          Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
       System.setProperty(KUBERNETES_KUBECONFIG_FILE, tempFile.getAbsolutePath());
 
       HttpRequest.Builder builder = Mockito.mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
@@ -77,7 +77,7 @@ class TokenRefreshInterceptorTest {
       TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(Config.autoConfigure(null), null);
       // Replace kubeconfig file
       Files.copy(Objects.requireNonNull(getClass().getResourceAsStream("/token-refresh-interceptor/kubeconfig.new")),
-        Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
+          Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
       tokenRefreshInterceptor.setLastRefresh(Instant.now().minus(61, ChronoUnit.SECONDS));
       tokenRefreshInterceptor.before(builder, null);
       Mockito.verify(builder).setHeader("Authorization", "Bearer new token");
@@ -86,8 +86,6 @@ class TokenRefreshInterceptorTest {
       System.clearProperty(KUBERNETES_KUBECONFIG_FILE);
     }
   }
-
-
 
   @Test
   void shouldReloadInClusterServiceAccount() throws Exception {

--- a/kubernetes-client-api/src/test/resources/token-refresh-interceptor/kubeconfig.new
+++ b/kubernetes-client-api/src/test/resources/token-refresh-interceptor/kubeconfig.new
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: testns/ca.pem
+    insecure-skip-tls-verify: true
+    server: https://172.28.128.4:8443
+  name: 172-28-128-4:8443
+contexts:
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: testns
+    user: user/172-28-128-4:8443
+  name: testns/172-28-128-4:8443/user
+current-context: testns/172-28-128-4:8443/user
+kind: Config
+preferences: {}
+users:
+- name: user/172-28-128-4:8443
+  user:
+    token: new token


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Should address #2271.
Platforms such as Amazon EKS since 1.21 rely on `BoundServiceAccountTokenVolume` to have time-limited access tokens. It is expected from kubernetes client implementations to refresh the configuration periodically to get a new token.

From [kubernetes 1.21 release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md?rgh-link-date=2021-05-18T09%3A11%3A56Z#changelog-since-v1200)
> Clients should reload the token from disk periodically (once per minute is recommended) to ensure they continue to use a valid token. k8s.io/client-go version v11.0.0+ and v0.15.0+ reload tokens automatically.

Prior work from #3105 addressed it once the token expired, however it doesn't address the current situation where the token is actually valid for 90 days, but expected to be refreshed at least every hour. This triggers audit logs events in AWS which can lead users to think their client will break once the token really expires.

This introduces a proactive aproach of refreshing the token from disk if the current token has been retrieved more than one minute ago.

For oidc implementation, I'm not knowledgeable enough to determine whether a more optimal solution could be implemented using some alternate validity timestamp.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
