### PR TITLE
fix (kubernetes-client-api) : Configure SnakeYaml to ignore converting timestamps to Date objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.1-SNAPSHOT
 
 #### Bugs
+* Configure SnakeYaml to ignore converting timestamps to Date objects
 
 #### Improvements
 * Fix #4041: adding Quantity.getNumericalAmount with an explanation about bytes and cores.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -26,8 +26,12 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.serialization.UnmatchedFieldTypeModule;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.resolver.Resolver;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -401,7 +405,7 @@ public class Serialization {
   }
 
   private static <T> T unmarshalYaml(InputStream is, TypeReference<T> type) throws JsonProcessingException {
-    final Yaml yaml = new Yaml(new SafeConstructor());
+    final Yaml yaml = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), new CustomYamlTagResolver());
     Map<String, Object> obj = yaml.load(is);
     String objAsJsonStr = JSON_MAPPER.writeValueAsString(obj);
     return unmarshalJsonStr(objAsJsonStr, type);
@@ -437,6 +441,19 @@ public class Serialization {
           });
     } catch (JsonProcessingException e) {
       throw new IllegalStateException(e);
+    }
+  }
+
+  private static class CustomYamlTagResolver extends Resolver {
+    @Override
+    public void addImplicitResolver(Tag tag, Pattern regexp, String first) {
+      if (tag == Tag.TIMESTAMP)
+        return;
+      if (tag.equals(Tag.BOOL)) {
+        regexp = Pattern.compile("^(?:true|True|TRUE|false|False|FALSE)$");
+        first = "tTfF";
+      }
+      super.addImplicitResolver(tag, regexp, first);
     }
   }
 }

--- a/kubernetes-client-api/src/test/resources/serialization/test-configmap-manifest-bool-dateformat.yml
+++ b/kubernetes-client-api/src/test/resources/serialization/test-configmap-manifest-bool-dateformat.yml
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-dateformat-bool
+data:
+  bool: NO
+  date: 2022-07-22

--- a/kubernetes-client-api/src/test/resources/serialization/test-lease-manifest-typed-fields.yml
+++ b/kubernetes-client-api/src/test/resources/serialization/test-lease-manifest-typed-fields.yml
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  generateName: test-typed
+  annotations:
+    creationTimestamp: 2022-07-22T10:42:02Z
+spec:
+  acquireTime: 2022-07-22T10:42:11.000001Z
+  leaseDurationSeconds: 2
+  leaseTransitions: 3

--- a/kubernetes-client-api/src/test/resources/serialization/test-pod-manifest-dateformat-annotation.yml
+++ b/kubernetes-client-api/src/test/resources/serialization/test-pod-manifest-dateformat-annotation.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: test-dateformat-annotation
+  annotations:
+    report_date: 2020-01-01
+spec:
+  shareProcessNamespace: false
+  terminationGracePeriodSeconds: 2
+  containers:
+    - name: test
+      image: test:latest
+      ports:
+        - containerPort: 80


### PR DESCRIPTION
## Description

Related to https://github.com/eclipse/jkube/issues/1647

+ Add custom Resolver for SnakeYaml which will ignore resolving tag if
  it's of type Timestamp.This solves some unexpected behavior that snakeyaml
  deserializes "2015-01-01 00:00:00" to `java.util.Date` but jackson
  serializes java.util.Date to an integer.
+ Also ignore all boolean values which are not `true` or `false`.
  Earlier SnakeYaml was also converting `No` to `false`.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
