### PR TITLE
fix #4320 #4318: implementing release on cancel and fixing transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 * Fix #4256: crd-generator-apt pom.xml includes transitive dependencies
 * Fix #4294: crd-generator respects JsonIgnore annotations on enum properties
 * Fix #4247: NO_PROXY with invalid entries throws exception
+* Fix #4320: corrected leader transitions field on leader election leases
 
 #### Improvements
 * Fix #4041: adding Quantity.getNumericalAmount with an explanation about bytes and cores.
 * Fix #4241: added more context to informer logs with the endpoint path
 * Fix #4250: allowing for deserialization of polymorphic unwrapped fields
+* Fix #4318: implemented LeaderElection releaseOnCancel
 * Fix #4259: Java Generator's CR should have Lombok's `@EqualsAndHashCode` with `callSuper = true`
 
 #### Dependency Upgrade

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaderElectionRecord.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaderElectionRecord.java
@@ -30,7 +30,8 @@ import java.util.Objects;
  * This information should be used for observational purposes only and could be replaced
  * with a random string (e.g. UUID) with only slight modification of this code.
  *
- * @see <a href="https://github.com/kubernetes/client-go/blob/1aa326d7304eba6aedc8c89daad615cc7499d1f7/tools/leaderelection/resourcelock/interface.go">leaderelection/resourcelock/interface.go</a>
+ * @see <a href=
+ *      "https://github.com/kubernetes/client-go/blob/1aa326d7304eba6aedc8c89daad615cc7499d1f7/tools/leaderelection/resourcelock/interface.go">leaderelection/resourcelock/interface.go</a>
  */
 public class LeaderElectionRecord {
 
@@ -46,11 +47,11 @@ public class LeaderElectionRecord {
 
   @JsonCreator
   public LeaderElectionRecord(
-    @JsonProperty("holderIdentity") String holderIdentity, @JsonProperty("leaseDuration") Duration leaseDuration,
-    @JsonProperty("acquireTime") ZonedDateTime acquireTime, @JsonProperty("renewTime") ZonedDateTime renewTime,
-    @JsonProperty("leaderTransitions") int leaderTransitions) {
+      @JsonProperty("holderIdentity") String holderIdentity, @JsonProperty("leaseDuration") Duration leaseDuration,
+      @JsonProperty("acquireTime") ZonedDateTime acquireTime, @JsonProperty("renewTime") ZonedDateTime renewTime,
+      @JsonProperty("leaderTransitions") int leaderTransitions) {
 
-    this.holderIdentity = Objects.requireNonNull(holderIdentity, "holderIdentity is required");
+    this.holderIdentity = holderIdentity;
     this.leaseDuration = Objects.requireNonNull(leaseDuration, "leaseDuration is required");
     this.acquireTime = Objects.requireNonNull(acquireTime, "acquireTime is required");
     this.renewTime = Objects.requireNonNull(renewTime, "renewTime is required");
@@ -87,19 +88,22 @@ public class LeaderElectionRecord {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
     LeaderElectionRecord that = (LeaderElectionRecord) o;
     return leaderTransitions == that.leaderTransitions &&
-      Objects.equals(holderIdentity, that.holderIdentity) &&
-      Objects.equals(leaseDuration, that.leaseDuration) &&
-      Objects.equals(acquireTime, that.acquireTime) &&
-      Objects.equals(renewTime, that.renewTime) &&
-      Objects.equals(version, that.version);
+        Objects.equals(holderIdentity, that.holderIdentity) &&
+        Objects.equals(leaseDuration, that.leaseDuration) &&
+        Objects.equals(acquireTime, that.acquireTime) &&
+        Objects.equals(renewTime, that.renewTime) &&
+        Objects.equals(version, that.version);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(holderIdentity, leaseDuration, acquireTime, renewTime, leaderTransitions, version);
   }
+
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElectorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElectorTest.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.LeaderE
 import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.Lock;
 import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.LockException;
 import io.fabric8.kubernetes.client.utils.CommonThreadPool;
+import io.fabric8.kubernetes.client.utils.Utils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
@@ -130,7 +131,14 @@ class LeaderElectorTest {
     started.cancel(true);
 
     // Then
-    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> activeLer.get().getLeaseDuration().equals(Duration.ZERO));
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> Utils.isNullOrEmpty(activeLer.get().getHolderIdentity()));
+    assertEquals(0, activeLer.get().getLeaderTransitions());
+
+    // the leader is now empty/null, we should be able to re-acquire
+    assertTrue(leaderElector.tryAcquireOrRenew());
+
+    // there should be a transition
+    assertEquals(1, activeLer.get().getLeaderTransitions());
   }
 
   @Test
@@ -142,6 +150,20 @@ class LeaderElectorTest {
     when(ler.getHolderIdentity()).thenReturn("1337");
     // When
     final boolean result = new LeaderElector(mock(NamespacedKubernetesClient.class), lec, Runnable::run).isLeader(ler);
+    // Then
+    assertTrue(result);
+  }
+
+  @Test
+  void isLeaderTrueEmptyIdentity() {
+    // Given
+    final LeaderElectionConfig lec = mock(LeaderElectionConfig.class, Answers.RETURNS_DEEP_STUBS);
+    when(lec.getLock().identity()).thenReturn("1337");
+    when(lec.getLeaseDuration()).thenReturn(Duration.ofMinutes(59L));
+    final LeaderElectionRecord ler = mock(LeaderElectionRecord.class);
+    when(ler.getRenewTime()).thenReturn(ZonedDateTime.now(ZoneOffset.UTC));
+    // When
+    final boolean result = new LeaderElector(mock(NamespacedKubernetesClient.class), lec, Runnable::run).canBecomeLeader(ler);
     // Then
     assertTrue(result);
   }
@@ -165,6 +187,7 @@ class LeaderElectorTest {
     final LeaderElectionConfig lec = mock(LeaderElectionConfig.class);
     when(lec.getLeaseDuration()).thenReturn(Duration.ofMinutes(59L));
     final LeaderElectionRecord ler = mock(LeaderElectionRecord.class);
+    when(ler.getHolderIdentity()).thenReturn("someone");
     when(ler.getRenewTime()).thenReturn(ZonedDateTime.now(ZoneOffset.UTC).minusHours(1));
     // When
     final boolean result = new LeaderElector(mock(NamespacedKubernetesClient.class), lec, Runnable::run).canBecomeLeader(ler);
@@ -178,6 +201,7 @@ class LeaderElectorTest {
     final LeaderElectionConfig lec = mock(LeaderElectionConfig.class);
     when(lec.getLeaseDuration()).thenReturn(Duration.ofHours(1L));
     final LeaderElectionRecord ler = mock(LeaderElectionRecord.class);
+    when(ler.getHolderIdentity()).thenReturn("someone");
     when(ler.getRenewTime()).thenReturn(ZonedDateTime.now(ZoneOffset.UTC));
     // When
     final boolean result = new LeaderElector(mock(NamespacedKubernetesClient.class), lec, Runnable::run).canBecomeLeader(ler);


### PR DESCRIPTION
## Description
addresses #4320 #4318 for leader election.

@manusa @csviri in the previous refactoring I had already put in a call to onStopLeading when cancelled - however this is not strictly correct.  If you don't have release on cancel set you won't loose the leadership until after the duration has expired.  Should that be refined as well?

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
