### PR TITLE
fix: Config client authentication exec command should not fail when args is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #4369: Informers will retry with a backoff on list/watch failure as they did in 5.12 and prior.
 * Fix #4350: SchemaSwap annotation is now repeatable and is applied multiple times if classes are used more than once in the class hierarchy.
+* Fix #3733: The authentication command from the .kube/config won't be discarded if no arguments are specified
 
 #### Improvements
 * Fix #4348: Introduce specific annotations for the generators

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -764,8 +764,9 @@ public class Config {
     command = getCommandWithFullyQualifiedPath(command, systemPathValue);
     List<String> args = exec.getArgs();
     if (args != null && !args.isEmpty()) {
-      argv.add(command + " " + String.join(" ", args));
+      command += " " + String.join(" ", args);
     }
+    argv.add(command);
     return argv;
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -763,7 +763,7 @@ public class Config {
     List<String> argv = new ArrayList<>(Utils.getCommandPlatformPrefix());
     command = getCommandWithFullyQualifiedPath(command, systemPathValue);
     List<String> args = exec.getArgs();
-    if (args != null) {
+    if (args != null && !args.isEmpty()) {
       argv.add(command + " " + String.join(" ", args));
     }
     return argv;

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -582,6 +582,30 @@ public class ConfigTest {
     assertEquals("api-eks.example.com", commandParts.get(6));
   }
 
+  @Test
+  void testGetAuthenticatorCommandFromExecConfigNullArgs() throws IOException {
+    // Given
+    File commandFolder = Files.createTempDirectory("test").toFile();
+    File commandFile = new File(commandFolder, "gke-gcloud-auth-plugin");
+    String systemPathValue = getTestPathValue(commandFolder);
+    ExecConfig execConfigNoArgs = new ExecConfigBuilder()
+        .withApiVersion("client.authentication.k8s.io/v1alpha1")
+        .withCommand(commandFile.getPath())
+        .build();
+    // Simulate "user.exec.args: null" like e.g. in the configuration for the gke-gcloud-auth-plugin.
+    execConfigNoArgs.setArgs(null);
+
+    // When
+    List<String> processBuilderArgs = Config.getAuthenticatorCommandFromExecConfig(
+        execConfigNoArgs, null, systemPathValue);
+
+    // Then
+    assertNotNull(processBuilderArgs);
+    assertEquals(3, processBuilderArgs.size());
+    assertPlatformPrefixes(processBuilderArgs);
+    assertEquals(commandFile.getPath(), processBuilderArgs.get(2));
+  }
+
   private void assertPlatformPrefixes(List<String> processBuilderArgs) {
     List<String> platformArgsExpected = Utils.getCommandPlatformPrefix();
     assertEquals(platformArgsExpected.get(0), processBuilderArgs.get(0));

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -57,6 +57,11 @@ public class ConfigTest {
   private static final String TEST_KUBECONFIG_EXEC_WIN_FILE = Utils
       .filePath(ConfigTest.class.getResource("/test-kubeconfig-exec-win"));
 
+  private static final String TEST_KUBECONFIG_EXEC_FILE_NULL_ARGS = Utils
+      .filePath(ConfigTest.class.getResource("/test-kubeconfig-exec-null-args"));
+  private static final String TEST_KUBECONFIG_EXEC_FILE_WIN_NULL_ARGS = Utils
+      .filePath(ConfigTest.class.getResource("/test-kubeconfig-exec-win-null-args"));
+
   private static final String TEST_KUBECONFIG_NO_CURRENT_CONTEXT_FILE = Utils
       .filePath(ConfigTest.class.getResource("/test-kubeconfig-nocurrentctxt.yml"));
 
@@ -444,6 +449,24 @@ public class ConfigTest {
     Config config = Config.autoConfigure(null);
     assertNotNull(config);
     assertEquals("HELLO WORLD", config.getOauthToken());
+  }
+
+  @Test
+  void should_accept_client_authentication_commands_with_null_args() throws Exception {
+    try {
+      if (FileSystem.getCurrent() == FileSystem.WINDOWS) {
+        System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_FILE_WIN_NULL_ARGS);
+      } else {
+        Files.setPosixFilePermissions(Paths.get(TEST_TOKEN_GENERATOR_FILE), PosixFilePermissions.fromString("rwxrwxr-x"));
+        System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, TEST_KUBECONFIG_EXEC_FILE_NULL_ARGS);
+      }
+
+      Config config = Config.autoConfigure(null);
+      assertNotNull(config);
+      assertEquals("HELLO", config.getOauthToken());
+    } finally {
+      System.clearProperty(Config.KUBERNETES_KUBECONFIG_FILE);
+    }
   }
 
   @Test

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-null-args
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-null-args
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://wherever
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      args: null
+      command: ./token-generator
+      env:
+      - name: PART1
+        value: hello

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-win-null-args
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-win-null-args
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://wherever
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      args: null
+      command: ".\\token-generator-win.bat"
+      env:
+      - name: PART1
+        value: hello

--- a/kubernetes-client-api/src/test/resources/token-generator-win.bat
+++ b/kubernetes-client-api/src/test/resources/token-generator-win.bat
@@ -15,7 +15,12 @@
 @REM
 
 @echo off
-SET token=%PART1% %1
+IF [%1]==[] (
+    SET token=%PART1%
+) ELSE (
+    SET token=%PART1% %1
+)
+
 CALL :upper token
 
 echo {
@@ -26,7 +31,7 @@ echo   "status": {
 echo     "token": "%token%"
 echo   }
 echo }
+GOTO :EOF
 
 :upper
 FOR %%a IN (A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) DO CALL SET "%1=%%%1:%%a=%%a%%%"
-GOTO :EOF


### PR DESCRIPTION
## Description
Fix https://github.com/fabric8io/kubernetes-client/issues/3733
Closes #4121 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
