### PR TITLE
feat: add annotation @PreserveUnknownFields for field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #4383: bump snakeyaml from 1.30 to 1.31
 
 #### New Features
+* Feat: add annotation @PreserveUnknownFields for generation field
 
 #### _**Note**_: Breaking changes in the API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix #4383: bump snakeyaml from 1.30 to 1.31
 
 #### New Features
-* Feat: add annotation @PreserveUnknownFields for generation field
+* Feat: add annotation @PreserveUnknownFields for marking generated field have `x-kubernetes-preserve-unknown-fields: true` defined
 
 #### _**Note**_: Breaking changes in the API
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -86,6 +86,7 @@ public abstract class AbstractJsonSchema<T, B> {
   public static final String ANNOTATION_REQUIRED = "io.fabric8.generator.annotation.Required";
   public static final String ANNOTATION_NOT_NULL = "javax.validation.constraints.NotNull";
   public static final String ANNOTATION_SCHEMA_FROM = "io.fabric8.crd.generator.annotation.SchemaFrom";
+  public static final String ANNOTATION_PERSERVE_UNKNOWN_FIELDS = "io.fabric8.crd.generator.annotation.PreserveUnknownFields";
   public static final String ANNOTATION_SCHEMA_SWAP = "io.fabric8.crd.generator.annotation.SchemaSwap";
 
   public static final String JSON_NODE_TYPE = "com.fasterxml.jackson.databind.JsonNode";
@@ -123,21 +124,25 @@ public abstract class AbstractJsonSchema<T, B> {
     final boolean nullable;
     final boolean required;
 
+    final boolean preserveUnknownFields;
+
     SchemaPropsOptions() {
       min = Optional.empty();
       max = Optional.empty();
       pattern = Optional.empty();
       nullable = false;
       required = false;
+      preserveUnknownFields = false;
     }
 
     public SchemaPropsOptions(Optional<Double> min, Optional<Double> max, Optional<String> pattern,
-        boolean nullable, boolean required) {
+        boolean nullable, boolean required, boolean preserveUnknownFields) {
       this.min = min;
       this.max = max;
       this.pattern = pattern;
       this.nullable = nullable;
       this.required = required;
+      this.preserveUnknownFields = preserveUnknownFields;
     }
 
     public Optional<Double> getMin() {
@@ -158,6 +163,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public boolean getRequired() {
       return nullable;
+    }
+
+    public boolean isPreserveUnknownFields() {
+      return preserveUnknownFields;
     }
   }
 
@@ -321,7 +330,8 @@ public abstract class AbstractJsonSchema<T, B> {
           facade.max,
           facade.pattern,
           facade.nullable,
-          facade.required);
+          facade.required,
+          facade.preserveSelfUnknownFields);
 
       addProperty(possiblyRenamedProperty, builder, possiblyUpdatedSchema, options);
     }
@@ -352,6 +362,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean required;
     private boolean ignored;
     private boolean preserveUnknownFields;
+    private boolean preserveSelfUnknownFields;
     private String description;
     private TypeRef schemaFrom;
 
@@ -416,6 +427,9 @@ public abstract class AbstractJsonSchema<T, B> {
           case ANNOTATION_JSON_ANY_SETTER:
             preserveUnknownFields = true;
             break;
+          case ANNOTATION_PERSERVE_UNKNOWN_FIELDS:
+            preserveSelfUnknownFields = true;
+            break;
           case ANNOTATION_SCHEMA_FROM:
             schemaFrom = extractClassRef(a.getParameters().get("type"));
             break;
@@ -453,6 +467,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public boolean isPreserveUnknownFields() {
       return preserveUnknownFields;
+    }
+
+    public boolean isPreserveSelfUnknownFields() {
+      return preserveSelfUnknownFields;
     }
 
     public String getDescription() {
@@ -494,6 +512,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean required;
     private boolean ignored;
     private boolean preserveUnknownFields;
+    private boolean preserveSelfUnknownFields;
     private final Property original;
     private String nameContributedBy;
     private String descriptionContributedBy;
@@ -581,6 +600,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
         if (p.isPreserveUnknownFields()) {
           preserveUnknownFields = true;
+        }
+
+        if (p.isPreserveSelfUnknownFields()) {
+          preserveSelfUnknownFields = true;
         }
 
         if (p.contributeSchemaFrom()) {

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
@@ -18,7 +18,7 @@ package io.fabric8.crd.generator.annotation;
 import java.lang.annotation.*;
 
 /*
- * Used to tweak the behavior of the crd-generator
+ * Used to emit 'x-kubernetes-preserve-unknown-fields'
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc.
+ * Copyright (C) 2022 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.crd.example.extraction;
+package io.fabric8.crd.generator.annotation;
 
-import io.fabric8.crd.generator.annotation.PreserveUnknownFields;
-import io.fabric8.crd.generator.annotation.SchemaFrom;
+import java.lang.annotation.*;
 
-public class ExtractionSpec {
-
-  @SchemaFrom(type = FooExtractor.class)
-  private Foo foo;
-
-  @PreserveUnknownFields
-  private Foo bar;
-
+/*
+ * Used to tweak the behavior of the crd-generator
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PreserveUnknownFields {
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -66,6 +66,10 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
         schema.setNullable(true);
       }
 
+      if (options.isPreserveUnknownFields()) {
+        schema.setXKubernetesPreserveUnknownFields(true);
+      }
+
       builder.addToProperties(property.getName(), schema);
     }
   }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -67,6 +67,10 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
         schema.setNullable(true);
       }
 
+      if (options.isPreserveUnknownFields()) {
+        schema.setXKubernetesPreserveUnknownFields(true);
+      }
+
       builder.addToProperties(property.getName(), schema);
     }
   }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -194,6 +194,7 @@ class JsonSchemaTest {
     JSONSchemaProps bar = spec.get("bar");
     Map<String, JSONSchemaProps> barProps = bar.getProperties();
     assertNotNull(barProps);
+    assertTrue(bar.getXKubernetesPreserveUnknownFields());
 
     // you can change everything
     assertEquals("integer", barProps.get("BAZ").getType());

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -381,19 +381,20 @@ will be generated as:
 
 ## Features cheatsheet
 
-| Annotation | Description |
-|-----------------------------------------------------------|---------------------------------------------------------------------------------------|
-| `com.fasterxml.jackson.annotation.JsonProperty`           | The field is named after the provided value instead of looking up the java field name |
-| `com.fasterxml.jackson.annotation.JsonPropertyDescription`| The provided text is be embedded in the `description` of the field                    |
-| `com.fasterxml.jackson.annotation.JsonIgnore`             | The field is ignored                                                                  |
-| `com.fasterxml.jackson.annotation.JsonAnyGetter`          | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
-| `com.fasterxml.jackson.annotation.JsonAnySetter`          | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
-| `io.fabric8.generator.annotation.Min`                     | The field defines a validation `min`                                                  |
-| `io.fabric8.generator.annotation.Max`                     | The field defines a validation `max`                                                  |
-| `io.fabric8.generator.annotation.Pattern`                 | The field defines a validation `pattern`                                              |
-| `io.fabric8.generator.annotation.Nullable`                | The field is marked as `nullable`                                                     |
-| `io.fabric8.generator.annotation.Required`                | The field is marked as `required`                                                     |
-| `io.fabric8.crd.generator.annotation.SchemaFrom`          | The field type for the generation is the one coming from the annotation               |
-| `io.fabric8.crd.generator.annotation.SchemaSwap`          | Same as SchemaFrom, but can be applied at any point in the class hierarchy            |
+| Annotation                                                   | Description                                                                           |
+|--------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `com.fasterxml.jackson.annotation.JsonProperty`              | The field is named after the provided value instead of looking up the java field name |
+| `com.fasterxml.jackson.annotation.JsonPropertyDescription`   | The provided text is be embedded in the `description` of the field                    |
+| `com.fasterxml.jackson.annotation.JsonIgnore`                | The field is ignored                                                                  |
+| `io.fabric8.crd.generator.annotation.PreserveUnknownFields`  | The field have `x-kubernetes-preserve-unknown-fields: true` defined                   |
+| `com.fasterxml.jackson.annotation.JsonAnyGetter`             | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
+| `com.fasterxml.jackson.annotation.JsonAnySetter`             | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
+| `io.fabric8.generator.annotation.Min`                        | The field defines a validation `min`                                                  |
+| `io.fabric8.generator.annotation.Max`                        | The field defines a validation `max`                                                  |
+| `io.fabric8.generator.annotation.Pattern`                    | The field defines a validation `pattern`                                              |
+| `io.fabric8.generator.annotation.Nullable`                   | The field is marked as `nullable`                                                     |
+| `io.fabric8.generator.annotation.Required`                   | The field is marked as `required`                                                     |
+| `io.fabric8.crd.generator.annotation.SchemaFrom`             | The field type for the generation is the one coming from the annotation               |
+| `io.fabric8.crd.generator.annotation.SchemaSwap`             | Same as SchemaFrom, but can be applied at any point in the class hierarchy            |
 
 A field of type `com.fasterxml.jackson.databind.JsonNode` is encoded as an empty object with `x-kubernetes-preserve-unknown-fields: true` defined.

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -357,6 +357,28 @@ Corresponding `x-kubernetes-preserve-unknown-fields: true` will be generated in 
             x-kubernetes-preserve-unknown-fields: true
 ```
 
+You can also annotation a field with @PreserveUnknownFields:
+
+```java
+interface ExampleInterface {}
+
+public class ExampleSpec {
+    @PreserveUnknownFields
+    ExampleInterface someValue;
+}
+```
+
+will be generated as:
+
+```yaml
+          spec:
+            properties:
+              someValue:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+```
+
 ## Features cheatsheet
 
 | Annotation | Description |

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -357,7 +357,7 @@ Corresponding `x-kubernetes-preserve-unknown-fields: true` will be generated in 
             x-kubernetes-preserve-unknown-fields: true
 ```
 
-You can also annotation a field with @PreserveUnknownFields:
+You can also annotate a field with `io.fabric8.crd.generator.annotation.PreserveUnknownFields`:
 
 ```java
 interface ExampleInterface {}


### PR DESCRIPTION
Signed-off-by: wineway <wangyuweihx@gmail.com>

## Description
like https://github.com/fabric8io/kubernetes-client/issues/4313, we need to use a sealed interface as a field type and offer multi implementations for this interface, it seems we can't and don't need to validate its fields in this situation, and we don't want to add something like @JsonAnyGetter might change its serialize behavior. so we think we can add a new annotation `@PreserveUnknownFields` for this scenario.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
