### PR TITLE
[java gen] - Support generated annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix #4348: Introduce specific annotations for the generators
 * Fix #4365: The Watch retry logic will handle more cases, as well as perform an exceptional close for events that are not properly handled.  Informers can directly provide those exceptional outcomes via the SharedIndexInformer.stopped CompletableFuture.
 * Fix #4396: Provide more error context when @Group/@Version annotations are missing
+* Fix #4384: The Java generator now supports the generation of specific annotations (min, max, pattern, etc.), as defined by #4348
 
 #### Dependency Upgrade
 * Fix #4243: Update Tekton pipeline model to v0.39.0
@@ -21,6 +22,7 @@
 #### _**Note**_: Breaking changes in the API
 * Fix #4350: SchemaSwap's fieldName parameter now expects a field name only, not a method or a constructor.
 * Module `io.fabric8:tekton-model-triggers` which contained Tekton triggers v1alpha1 model has been removed. We have introduced separate modules `io.fabric8:tekton-model-v1alpha1` and `io.fabric8:tekton-model-v1beta1` for Tekton triggers v1alpha1 and v1beta1 apigroups respectively. Users who are using `io.fabric8:tekton-client` dependency directly should be unaffected by this change.
+* Fix #4384: javax.validation.* annotations are no longer added by the Java generator.
 
 ### 6.1.1 (2022-09-01)
 

--- a/doc/java-generation-from-CRD.md
+++ b/doc/java-generation-from-CRD.md
@@ -101,10 +101,8 @@ The generated code depends on a few dependencies to succesfully compile:
   <artifactId>kubernetes-client</artifactId>
 </dependency>
 <dependency>
-  <groupId>javax.validation</groupId>
-  <artifactId>validation-api</artifactId>
-  <version>2.0.1.Final</version>
-  <scope>provided</scope>
+  <groupId>io.fabric8</groupId>
+  <artifactId>generator-annotations</artifactId>
 </dependency>
 ```
 

--- a/java-generator/core/pom.xml
+++ b/java-generator/core/pom.xml
@@ -68,9 +68,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <scope>provided</scope>
+      <groupId>io.fabric8</groupId>
+      <artifactId>generator-annotations</artifactId>
     </dependency>
 
     <!-- Testing -->

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JArray.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JArray.java
@@ -28,7 +28,7 @@ public class JArray extends AbstractJSONSchema2Pojo {
 
   public JArray(AbstractJSONSchema2Pojo nested, Config config, String description, final boolean isNullable,
       JsonNode defaultValue) {
-    super(config, description, isNullable, defaultValue);
+    super(config, description, isNullable, defaultValue, null);
     this.type = new ClassOrInterfaceType()
         .setName(JAVA_UTIL_LIST)
         .setTypeArguments(new ClassOrInterfaceType().setName(nested.getType()))

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -53,7 +53,7 @@ public class JCRObject extends AbstractJSONSchema2Pojo implements JObjectExtraAn
       boolean storage,
       boolean served,
       Config config) {
-    super(config, null, false, null);
+    super(config, null, false, null, null);
 
     this.pkg = (pkg == null) ? "" : pkg.trim();
     this.type = (this.pkg.isEmpty()) ? type : pkg + "." + type;

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JEnum.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JEnum.java
@@ -40,7 +40,7 @@ public class JEnum extends AbstractJSONSchema2Pojo {
 
   public JEnum(String type, List<JsonNode> values, Config config, String description, final boolean isNullable,
       JsonNode defaultValue) {
-    super(config, description, isNullable, defaultValue);
+    super(config, description, isNullable, defaultValue, null);
     this.type = AbstractJSONSchema2Pojo.sanitizeString(
         type.substring(0, 1).toUpperCase() + type.substring(1));
     this.values = values.stream().map(JsonNode::asText).collect(Collectors.toList());

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JMap.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JMap.java
@@ -31,7 +31,7 @@ public class JMap extends AbstractJSONSchema2Pojo {
 
   public JMap(AbstractJSONSchema2Pojo nested, Config config, String description, final boolean isNullable,
       JsonNode defaultValue) {
-    super(config, description, isNullable, defaultValue);
+    super(config, description, isNullable, defaultValue, null);
     this.type = new ClassOrInterfaceType()
         .setName(JAVA_UTIL_MAP)
         .setTypeArguments(

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -32,7 +32,6 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 
-import java.io.InputStream;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -66,7 +65,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
       Config config,
       String description,
       final boolean isNullable, JsonNode defaultValue) {
-    super(config, description, isNullable, defaultValue);
+    super(config, description, isNullable, defaultValue, null);
     this.required = new HashSet<>(Optional.ofNullable(required).orElse(Collections.emptyList()));
     this.fields = new HashMap<>();
     this.preserveUnknownFields = preserveUnknownFields;
@@ -197,7 +196,25 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
                 new StringLiteralExpr(originalFieldName)));
 
         if (isRequired) {
-          objField.addAnnotation("javax.validation.constraints.NotNull");
+          objField.addAnnotation("io.fabric8.generator.annotation.Required");
+        }
+        if (prop.getMaximum() != null) {
+          objField.addAnnotation(
+              new SingleMemberAnnotationExpr(
+                  new Name("io.fabric8.generator.annotation.Max"),
+                  new DoubleLiteralExpr(prop.getMaximum())));
+        }
+        if (prop.getMinimum() != null) {
+          objField.addAnnotation(
+              new SingleMemberAnnotationExpr(
+                  new Name("io.fabric8.generator.annotation.Min"),
+                  new DoubleLiteralExpr(prop.getMinimum())));
+        }
+        if (prop.getPattern() != null) {
+          objField.addAnnotation(
+              new SingleMemberAnnotationExpr(
+                  new Name("io.fabric8.generator.annotation.Pattern"),
+                  new StringLiteralExpr(StringEscapeUtils.escapeJava(prop.getPattern()))));
         }
 
         objField.createGetter();
@@ -229,6 +246,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
               new SingleMemberAnnotationExpr(
                   new Name("com.fasterxml.jackson.annotation.JsonSetter"),
                   new NameExpr("nulls = com.fasterxml.jackson.annotation.Nulls.SET")));
+          objField.addAnnotation("io.fabric8.generator.annotation.Nullable");
         }
 
         if (prop.getDefaultValue() != null) {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitive.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitive.java
@@ -25,8 +25,9 @@ public class JPrimitive extends AbstractJSONSchema2Pojo {
 
   private static final GeneratorResult empty = new GeneratorResult(new ArrayList<>(), new ArrayList<>());
 
-  public JPrimitive(String type, Config config, String description, final boolean isNullable, JsonNode defaultValue) {
-    super(config, description, isNullable, defaultValue);
+  public JPrimitive(String type, Config config, String description, final boolean isNullable, JsonNode defaultValue,
+      final ValidationProperties validationProperties) {
+    super(config, description, isNullable, defaultValue, validationProperties);
     this.type = type;
   }
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/ValidationProperties.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/ValidationProperties.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.java.generator.nodes;
+
+/**
+ * This class instances store the values for a generic JSON schema validation related properties, like `minimum`,
+ * `maximum`, etc.
+ */
+public class ValidationProperties {
+  private final Double maximum;
+  private final Double minimum;
+  private final String pattern;
+
+  private ValidationProperties(final Double maximum, final Double minimum, final String pattern) {
+    this.maximum = maximum;
+    this.minimum = minimum;
+    this.pattern = pattern;
+  }
+
+  public Double getMaximum() {
+    return maximum;
+  }
+
+  public Double getMinimum() {
+    return minimum;
+  }
+
+  public String getPattern() {
+    return pattern;
+  }
+
+  public static final class Builder {
+    private Double maximum;
+    private Double minimum;
+    private String pattern;
+
+    private Builder() {
+    }
+
+    public static Builder getInstance() {
+      return new Builder();
+    }
+
+    public Builder withMaximum(final Double maximum) {
+      this.maximum = maximum;
+      return this;
+    }
+
+    public Builder withMinimum(final Double minimum) {
+      this.minimum = minimum;
+      return this;
+    }
+
+    public Builder withPattern(final String pattern) {
+      this.pattern = pattern;
+      return this;
+    }
+
+    public ValidationProperties build() {
+      return new ValidationProperties(maximum, minimum, pattern);
+    }
+  }
+}

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GeneratorTest {
@@ -108,7 +109,13 @@ class GeneratorTest {
   @Test
   void testPrimitive() {
     // Arrange
-    JPrimitive primitive = new JPrimitive("test", defaultConfig, null, Boolean.FALSE, null);
+    JPrimitive primitive = new JPrimitive(
+        "test",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null,
+        null);
 
     // Act
     GeneratorResult res = primitive.generateJava();
@@ -119,10 +126,76 @@ class GeneratorTest {
   }
 
   @Test
+  void testPrimitiveWithNumericValidationConstraints() {
+    // Arrange
+    final Double expectedMaximum = 3.14;
+    final Double expectedMinimum = 0.0;
+    ValidationProperties validationProperties = ValidationProperties.Builder
+        .getInstance()
+        .withMaximum(expectedMaximum)
+        .withMinimum(expectedMinimum)
+        .build();
+    JPrimitive primitive = new JPrimitive(
+        "test",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null,
+        validationProperties);
+
+    // Act
+    GeneratorResult res = primitive.generateJava();
+
+    // Assert
+    assertEquals("test", primitive.getType());
+    assertEquals(0, res.getTopLevelClasses().size());
+    assertEquals(expectedMaximum, primitive.getMaximum());
+    assertEquals(expectedMinimum, primitive.getMinimum());
+    assertNull(primitive.getPattern());
+  }
+
+  @Test
+  void testPrimitiveWithAlphanumericValidationConstraints() {
+    // Arrange
+    final String expectedPattern = ".*whatever.*";
+    ValidationProperties validationProperties = ValidationProperties.Builder
+        .getInstance()
+        .withPattern(expectedPattern)
+        .build();
+    JPrimitive primitive = new JPrimitive(
+        "test",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null,
+        validationProperties);
+
+    // Act
+    GeneratorResult res = primitive.generateJava();
+
+    // Assert
+    assertEquals("test", primitive.getType());
+    assertEquals(0, res.getTopLevelClasses().size());
+    assertEquals(expectedPattern, primitive.getPattern());
+    assertNull(primitive.getMaximum());
+    assertNull(primitive.getMinimum());
+  }
+
+  @Test
   void testArrayOfPrimitives() {
     // Arrange
-    JArray array = new JArray(new JPrimitive("primitive", defaultConfig, null, Boolean.FALSE, null), defaultConfig, null,
-        Boolean.FALSE, null);
+    JArray array = new JArray(
+        new JPrimitive(
+            "primitive",
+            defaultConfig,
+            null,
+            Boolean.FALSE,
+            null,
+            null),
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = array.generateJava();
@@ -136,7 +209,13 @@ class GeneratorTest {
   void testMapOfPrimitives() {
     // Arrange
     JMap map = new JMap(
-        new JPrimitive("primitive", defaultConfig, null, Boolean.FALSE, null),
+        new JPrimitive(
+            "primitive",
+            defaultConfig,
+            null,
+            Boolean.FALSE,
+            null,
+            null),
         defaultConfig,
         null,
         Boolean.FALSE,
@@ -153,7 +232,17 @@ class GeneratorTest {
   @Test
   void testEmptyObject() {
     // Arrange
-    JObject obj = new JObject("v1alpha1", "t", null, null, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        "v1alpha1",
+        "t",
+        null,
+        null,
+        false,
+        "",
+        "", defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -168,7 +257,18 @@ class GeneratorTest {
   void testEmptyObjectWithSuffix() {
     // Arrange
     Config config = new Config(null, null, Config.Suffix.ALWAYS, null, null, null);
-    JObject obj = new JObject("v1alpha1", "t", null, null, false, "", "MySuffix", config, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        "v1alpha1",
+        "t",
+        null,
+        null,
+        false,
+        "",
+        "MySuffix",
+        config,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -182,7 +282,18 @@ class GeneratorTest {
   @Test
   void testEmptyObjectWithoutNamespace() {
     // Arrange
-    JObject obj = new JObject(null, "t", null, null, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        null,
+        "t",
+        null,
+        null,
+        false,
+        "",
+        "",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -200,7 +311,18 @@ class GeneratorTest {
     JSONSchemaProps newBool = new JSONSchemaProps();
     newBool.setType("boolean");
     props.put("o1", newBool);
-    JObject obj = new JObject("v1alpha1", "t", props, null, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        "v1alpha1",
+        "t",
+        props,
+        null,
+        false,
+        "",
+        "",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -225,14 +347,25 @@ class GeneratorTest {
     props.put("o1", newBool);
     List<String> req = new ArrayList<>(1);
     req.add("o1");
-    JObject obj = new JObject("v1alpha1", "t", props, req, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        "v1alpha1",
+        "t",
+        props,
+        req,
+        false,
+        "",
+        "",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
 
     // Assert
     Optional<ClassOrInterfaceDeclaration> clz = res.getTopLevelClasses().get(0).getCompilationUnit().getClassByName("T");
-    assertTrue(clz.get().getFieldByName("o1").get().getAnnotationByName("NotNull").isPresent());
+    assertTrue(clz.get().getFieldByName("o1").get().getAnnotationByName("Required").isPresent());
   }
 
   @Test
@@ -246,7 +379,13 @@ class GeneratorTest {
     enumValues.add(new TextNode("bar"));
     enumValues.add(new TextNode("baz"));
     props.put("e1", newEnum);
-    JEnum enu = new JEnum("t", enumValues, defaultConfig, null, Boolean.FALSE, null);
+    JEnum enu = new JEnum(
+        "t",
+        enumValues,
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = enu.generateJava();
@@ -276,7 +415,13 @@ class GeneratorTest {
     enumValues.add(new TextNode("bar"));
     enumValues.add(new TextNode("baz"));
     props.put("e1", newEnum);
-    JEnum enu = new JEnum("t", enumValues, new Config(false, null, null, null, null, null), null, Boolean.FALSE, null);
+    JEnum enu = new JEnum(
+        "t",
+        enumValues,
+        new Config(false, null, null, null, null, null),
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = enu.generateJava();
@@ -298,9 +443,22 @@ class GeneratorTest {
   void testArrayOfObjects() {
     // Arrange
     JArray array = new JArray(
-        new JObject(null, "t", null, null, false, "", "", defaultConfig, null, Boolean.FALSE, null),
+        new JObject(
+            null,
+            "t",
+            null,
+            null,
+            false,
+            "",
+            "",
+            defaultConfig,
+            null,
+            Boolean.FALSE,
+            null),
         defaultConfig,
-        null, false, null);
+        null,
+        false,
+        null);
 
     // Act
     GeneratorResult res = array.generateJava();
@@ -315,9 +473,22 @@ class GeneratorTest {
   void testMapOfObjects() {
     // Arrange
     JMap map = new JMap(
-        new JObject(null, "t", null, null, false, "", "", defaultConfig, null, Boolean.FALSE, null),
+        new JObject(
+            null,
+            "t",
+            null,
+            null,
+            false,
+            "",
+            "",
+            defaultConfig,
+            null,
+            Boolean.FALSE,
+            null),
         defaultConfig,
-        null, Boolean.FALSE, null);
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = map.generateJava();
@@ -335,7 +506,18 @@ class GeneratorTest {
     JSONSchemaProps newObj = new JSONSchemaProps();
     newObj.setType("object");
     props.put("o1", newObj);
-    JObject obj = new JObject(null, "t", props, null, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        null,
+        "t",
+        props,
+        null,
+        false,
+        "",
+        "",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -361,7 +543,18 @@ class GeneratorTest {
     JSONSchemaProps newObj = new JSONSchemaProps();
     newObj.setType("object");
     props.put("o1", newObj);
-    JObject obj = new JObject(null, "t", props, null, false, "My", "", config, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        null,
+        "t",
+        props,
+        null,
+        false,
+        "My",
+        "",
+        config,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -380,7 +573,18 @@ class GeneratorTest {
     JSONSchemaProps newObj = new JSONSchemaProps();
     newObj.setType("object");
     props.put("o1", newObj);
-    JObject obj = new JObject(null, "t", props, null, false, "My", "", config, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        null,
+        "t",
+        props,
+        null,
+        false,
+        "My",
+        "",
+        config,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -394,7 +598,18 @@ class GeneratorTest {
   @Test
   void testObjectWithPreservedFields() {
     // Arrange
-    JObject obj = new JObject(null, "t", null, null, true, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(
+        null,
+        "t",
+        null,
+        null,
+        true,
+        "",
+        "",
+        defaultConfig,
+        null,
+        Boolean.FALSE,
+        null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -439,20 +654,22 @@ class GeneratorTest {
     Optional<FieldDeclaration> o1Field = clzT.get().getFieldByName("o1");
     assertTrue(o1Field.isPresent());
     FieldDeclaration actualO1Field = o1Field.get();
-    Optional<AnnotationExpr> nullableAnnotation = actualO1Field
+    Optional<AnnotationExpr> nullableJacksonBasedAnnotation = actualO1Field
         .getAnnotationByName("com.fasterxml.jackson.annotation.JsonSetter");
-    assertTrue(nullableAnnotation.isPresent());
-    assertInstanceOf(SingleMemberAnnotationExpr.class, nullableAnnotation.get());
-    SingleMemberAnnotationExpr actualNullableAnnotation = (SingleMemberAnnotationExpr) nullableAnnotation.get();
+    assertTrue(nullableJacksonBasedAnnotation.isPresent());
+    assertInstanceOf(SingleMemberAnnotationExpr.class, nullableJacksonBasedAnnotation.get());
+    SingleMemberAnnotationExpr actualNullableAnnotation = (SingleMemberAnnotationExpr) nullableJacksonBasedAnnotation.get();
     assertEquals("nulls = com.fasterxml.jackson.annotation.Nulls.SET", actualNullableAnnotation.getMemberValue().toString());
+    Optional<AnnotationExpr> nullableFabric8BasedAnnotation = actualO1Field.getAnnotationByName("Nullable");
+    assertTrue(nullableFabric8BasedAnnotation.isPresent());
 
     Optional<FieldDeclaration> o2Field = clzT.get().getFieldByName("o2");
     assertTrue(o2Field.isPresent());
     FieldDeclaration actualO2Field = o2Field.get();
-    nullableAnnotation = actualO2Field.getAnnotationByName("com.fasterxml.jackson.annotation.JsonSetter");
-    assertTrue(nullableAnnotation.isPresent());
-    assertInstanceOf(SingleMemberAnnotationExpr.class, nullableAnnotation.get());
-    actualNullableAnnotation = (SingleMemberAnnotationExpr) nullableAnnotation.get();
+    nullableJacksonBasedAnnotation = actualO2Field.getAnnotationByName("com.fasterxml.jackson.annotation.JsonSetter");
+    assertTrue(nullableJacksonBasedAnnotation.isPresent());
+    assertInstanceOf(SingleMemberAnnotationExpr.class, nullableJacksonBasedAnnotation.get());
+    actualNullableAnnotation = (SingleMemberAnnotationExpr) nullableJacksonBasedAnnotation.get();
     assertEquals("nulls = com.fasterxml.jackson.annotation.Nulls.SKIP", actualNullableAnnotation.getMemberValue().toString());
 
     Optional<ClassOrInterfaceDeclaration> clzO1 = res.getTopLevelClasses().get(0).getCompilationUnit().getClassByName("O1");

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
@@ -16,6 +16,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
      * Akka Management (Cluster Bootstrap) HTTP port in the range 1024 - 65535. Can be disabled with "off". This port is exposed as HTTP_MGMT_PORT environment variable if it is enabled.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("akkaManagementPort")
+    @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Akka Management (Cluster Bootstrap) HTTP port in the range 1024 - 65535. Can be disabled with \"off\". This port is exposed as HTTP_MGMT_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String akkaManagementPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"8558\"", String.class);
@@ -180,6 +181,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
      * gRPC port in the range 1024 - 65535. Can be disabled with "off". This port is exposed as GRPC_PORT environment variable if it is enabled.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("grpcPort")
+    @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("gRPC port in the range 1024 - 65535. Can be disabled with \"off\". This port is exposed as GRPC_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String grpcPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"8101\"", String.class);
@@ -212,6 +214,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
      * HTTP port in the range 1024 - 65535. Disabled by default. This port is exposed as HTTP_PORT environment variable if it is enabled.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("httpPort")
+    @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("HTTP port in the range 1024 - 65535. Disabled by default. This port is exposed as HTTP_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String httpPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"off\"", String.class);
@@ -228,7 +231,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
      * Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
      */
     @com.fasterxml.jackson.annotation.JsonProperty("image")
-    @javax.validation.constraints.NotNull()
+    @io.fabric8.generator.annotation.Required()
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String image;
@@ -245,6 +248,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
      * Image pull policy. One of Always, Never, IfNotPresent. No setting falls back to the container default. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
      */
     @com.fasterxml.jackson.annotation.JsonProperty("imagePullPolicy")
+    @io.fabric8.generator.annotation.Pattern("^Always$|^Never$|^IfNotPresent$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Image pull policy. One of Always, Never, IfNotPresent. No setting falls back to the container default. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String imagePullPolicy;
@@ -389,6 +393,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
      * HTTP port to expose metrics for Prometheus to scrape. Must be  in the range 1024 - 65535. Disabled by default. This port is exposed as HTTP_PROMETHEUS_PORT environment variable if it is enabled.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("prometheusPort")
+    @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("HTTP port to expose metrics for Prometheus to scrape. Must be  in the range 1024 - 65535. Disabled by default. This port is exposed as HTTP_PROMETHEUS_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String prometheusPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"off\"", String.class);
@@ -421,6 +426,8 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
      * Number of desired pods.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("replicas")
+    @io.fabric8.generator.annotation.Max(1000.0)
+    @io.fabric8.generator.annotation.Min(0.0)
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Number of desired pods.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private Long replicas = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("1", Long.class);

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testKeycloakCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testKeycloakCrd.approved.txt
@@ -235,7 +235,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * The secret where the admin credentials are to be found.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("credentialSecret")
-    @javax.validation.constraints.NotNull()
+    @io.fabric8.generator.annotation.Required()
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("The secret where the admin credentials are to be found.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String credentialSecret;
@@ -268,7 +268,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * An internal URL (service name) to be used by the admin client.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("internalURL")
-    @javax.validation.constraints.NotNull()
+    @io.fabric8.generator.annotation.Required()
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("An internal URL (service name) to be used by the admin client.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String internalURL;
@@ -285,7 +285,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * Human-readable message indicating details about current operator phase or error.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("message")
-    @javax.validation.constraints.NotNull()
+    @io.fabric8.generator.annotation.Required()
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Human-readable message indicating details about current operator phase or error.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String message;
@@ -302,7 +302,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * Current phase of the operator.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("phase")
-    @javax.validation.constraints.NotNull()
+    @io.fabric8.generator.annotation.Required()
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Current phase of the operator.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String phase;
@@ -319,7 +319,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * True if all resources are in a ready state and all work is done.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("ready")
-    @javax.validation.constraints.NotNull()
+    @io.fabric8.generator.annotation.Required()
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if all resources are in a ready state and all work is done.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private Boolean ready;
@@ -352,7 +352,7 @@ public class KeycloakStatus implements io.fabric8.kubernetes.api.model.Kubernete
      * Version of Keycloak or RHSSO running on the cluster.
      */
     @com.fasterxml.jackson.annotation.JsonProperty("version")
-    @javax.validation.constraints.NotNull()
+    @io.fabric8.generator.annotation.Required()
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Version of Keycloak or RHSSO running on the cluster.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String version;

--- a/java-generator/it/pom.xml
+++ b/java-generator/it/pom.xml
@@ -44,11 +44,6 @@
       <version>4.12</version>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
       <scope>provided</scope>

--- a/java-generator/it/src/it/cert-manager/pom.xml
+++ b/java-generator/it/src/it/cert-manager/pom.xml
@@ -50,14 +50,13 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>@validation-api.version@</version>
-      <scope>provided</scope>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <version>@project.version@</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
+      <artifactId>generator-annotations</artifactId>
       <version>@project.version@</version>
     </dependency>
   </dependencies>

--- a/java-generator/it/src/it/enum-ser-deser/pom.xml
+++ b/java-generator/it/src/it/enum-ser-deser/pom.xml
@@ -50,14 +50,13 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>@validation-api.version@</version>
-      <scope>provided</scope>
+      <groupId>io.fabric8</groupId>
+      <artifactId>java-generator-integration-tests</artifactId>
+      <version>@project.version@</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>java-generator-integration-tests</artifactId>
+      <artifactId>generator-annotations</artifactId>
       <version>@project.version@</version>
     </dependency>
     <dependency>

--- a/java-generator/it/src/it/extensions/pom.xml
+++ b/java-generator/it/src/it/extensions/pom.xml
@@ -50,21 +50,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>@validation-api.version@</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>java-generator-integration-tests</artifactId>
       <version>@project.version@</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>@validation-api.version@</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>
@@ -77,6 +65,11 @@
       <artifactId>lombok</artifactId>
       <version>@lombok.version@</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>generator-annotations</artifactId>
+      <version>@project.version@</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Description

The changes are related to those in https://github.com/fabric8io/kubernetes-client/pull/4348 
The generator will now generate the expected annotations, i.e. those defined in `io.fabric8.generator.annotation`, the same ones that a reverse CRD generation from the Java model take into account.

Fix #4384 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->

I can suash the commits as soon as this is ready for merge or even earlier in case we agree on it. 
FYI @andreaTP, CC  @manusa 