### PR TITLE
[java-gen] Preserve unknown without type should translate to AnyType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix #4459: Fixed OSGi startup exceptions while using KubernetesClient/OpenShiftClient
 * Fix #4482: Fixing blocking behavior of okhttp log watch
 * Fix #4473: Fix regression in backoff interval introduced in #4365
-* Fix #4426: [java-generator] Encode a `JsonNode` instead of an Object if `x-kubernetes-preserve-unknown-fields` is present and the type is null.
+* Fix #4426: [java-generator] Encode an `AnyType` instead of an Object if `x-kubernetes-preserve-unknown-fields` is present and the type is null.
 
 #### Improvements
 * Fix #4348: Introduce specific annotations for the generators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #4459: Fixed OSGi startup exceptions while using KubernetesClient/OpenShiftClient
 * Fix #4482: Fixing blocking behavior of okhttp log watch
 * Fix #4473: Fix regression in backoff interval introduced in #4365
+* Fix #4426: [java-generator] Encode a `JsonNode` instead of an Object if `x-kubernetes-preserve-unknown-fields` is present and the type is null.
 
 #### Improvements
 * Fix #4348: Introduce specific annotations for the generators

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -239,14 +239,17 @@ public abstract class AbstractJsonSchema<T, B> {
   }
 
   private T internalFromImpl(TypeDef definition, Set<String> visited, InternalSchemaSwaps schemaSwaps, String... ignore) {
-    final B builder = newBuilder();
     Set<String> ignores = ignore.length > 0 ? new LinkedHashSet<>(Arrays.asList(ignore))
         : Collections
             .emptySet();
     List<String> required = new ArrayList<>();
 
-    boolean preserveUnknownFields = (definition.getFullyQualifiedName() != null &&
+    final boolean isJsonNode = (definition.getFullyQualifiedName() != null &&
         definition.getFullyQualifiedName().equals(JSON_NODE_TYPE));
+
+    final B builder = (isJsonNode) ? newBuilder(null) : newBuilder();
+
+    boolean preserveUnknownFields = isJsonNode;
 
     definition.getAnnotations().forEach(annotation -> extractSchemaSwaps(definition.toReference(), annotation, schemaSwaps));
 
@@ -578,6 +581,14 @@ public abstract class AbstractJsonSchema<T, B> {
    * @return a new builder object specific to the CRD generation version
    */
   public abstract B newBuilder();
+
+  /**
+   * Creates a new specific builder object.
+   *
+   * @param type the type to be used
+   * @return a new builder object specific to the CRD generation version
+   */
+  public abstract B newBuilder(String type);
 
   /**
    * Adds the specified property to the specified builder, calling {@link #internalFrom(String, TypeRef)}

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -92,6 +92,7 @@ public abstract class AbstractJsonSchema<T, B> {
   public static final String ANNOTATION_SCHEMA_SWAPS = "io.fabric8.crd.generator.annotation.SchemaSwaps";
 
   public static final String JSON_NODE_TYPE = "com.fasterxml.jackson.databind.JsonNode";
+  public static final String ANY_TYPE = "io.fabric8.kubernetes.api.model.AnyType";
 
   static {
     COMMON_MAPPINGS.put(STRING_REF, STRING_MARKER);
@@ -245,7 +246,8 @@ public abstract class AbstractJsonSchema<T, B> {
     List<String> required = new ArrayList<>();
 
     final boolean isJsonNode = (definition.getFullyQualifiedName() != null &&
-        definition.getFullyQualifiedName().equals(JSON_NODE_TYPE));
+        (definition.getFullyQualifiedName().equals(JSON_NODE_TYPE)
+            || definition.getFullyQualifiedName().equals(ANY_TYPE)));
 
     final B builder = (isJsonNode) ? newBuilder(null) : newBuilder();
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -49,8 +49,13 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
 
   @Override
   public JSONSchemaPropsBuilder newBuilder() {
+    return newBuilder("object");
+  }
+
+  @Override
+  public JSONSchemaPropsBuilder newBuilder(String type) {
     final JSONSchemaPropsBuilder builder = new JSONSchemaPropsBuilder();
-    builder.withType("object");
+    builder.withType(type);
     return builder;
   }
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -50,8 +50,13 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
 
   @Override
   public JSONSchemaPropsBuilder newBuilder() {
+    return newBuilder("object");
+  }
+
+  @Override
+  public JSONSchemaPropsBuilder newBuilder(String type) {
     final JSONSchemaPropsBuilder builder = new JSONSchemaPropsBuilder();
-    builder.withType("object");
+    builder.withType(type);
     return builder;
   }
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -152,16 +152,19 @@ class JsonSchemaTest {
     assertTrue(spec.containsKey("free"));
     JSONSchemaProps freeField = spec.get("free");
 
+    assertNull(freeField.getType());
     assertTrue(freeField.getXKubernetesPreserveUnknownFields());
 
     assertTrue(spec.containsKey("field"));
     JSONSchemaProps field = spec.get("field");
 
+    assertEquals("integer", field.getType());
     assertNull(field.getXKubernetesPreserveUnknownFields());
 
     assertTrue(spec.containsKey("foo"));
     JSONSchemaProps fooField = spec.get("foo");
 
+    assertEquals("object", fooField.getType());
     assertTrue(fooField.getXKubernetesPreserveUnknownFields());
   }
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -148,7 +148,7 @@ public abstract class AbstractJSONSchema2Pojo {
       return fromJsonSchema.apply(JPrimitiveNameAndType.INT_OR_STRING);
     } else if (type == null
         && Boolean.TRUE.equals(prop.getXKubernetesPreserveUnknownFields())) {
-      return fromJsonSchema.apply(JPrimitiveNameAndType.JSON_NODE);
+      return fromJsonSchema.apply(JPrimitiveNameAndType.ANY_TYPE);
     } else if (prop.getEnum() != null && prop.getEnum().size() > 0) {
       return fromJsonSchema.apply(new JEnumNameAndType(key));
     } else {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -148,7 +148,7 @@ public abstract class AbstractJSONSchema2Pojo {
       return fromJsonSchema.apply(JPrimitiveNameAndType.INT_OR_STRING);
     } else if (type == null
         && Boolean.TRUE.equals(prop.getXKubernetesPreserveUnknownFields())) {
-      return fromJsonSchema.apply(new JObjectNameAndType(key));
+      return fromJsonSchema.apply(JPrimitiveNameAndType.JSON_NODE);
     } else if (prop.getEnum() != null && prop.getEnum().size() > 0) {
       return fromJsonSchema.apply(new JEnumNameAndType(key));
     } else {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitiveNameAndType.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitiveNameAndType.java
@@ -23,6 +23,7 @@ public class JPrimitiveNameAndType extends JavaNameAndType {
   static final JPrimitiveNameAndType FLOAT = new JPrimitiveNameAndType("Float");
   static final JPrimitiveNameAndType DOUBLE = new JPrimitiveNameAndType("Double");
   static final JPrimitiveNameAndType STRING = new JPrimitiveNameAndType("String");
+  static final JPrimitiveNameAndType JSON_NODE = new JPrimitiveNameAndType("com.fasterxml.jackson.databind.JsonNode");
 
   public JPrimitiveNameAndType(String name) {
     super(name, JavaType.PRIMITIVE);

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitiveNameAndType.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitiveNameAndType.java
@@ -23,7 +23,7 @@ public class JPrimitiveNameAndType extends JavaNameAndType {
   static final JPrimitiveNameAndType FLOAT = new JPrimitiveNameAndType("Float");
   static final JPrimitiveNameAndType DOUBLE = new JPrimitiveNameAndType("Double");
   static final JPrimitiveNameAndType STRING = new JPrimitiveNameAndType("String");
-  static final JPrimitiveNameAndType JSON_NODE = new JPrimitiveNameAndType("com.fasterxml.jackson.databind.JsonNode");
+  static final JPrimitiveNameAndType ANY_TYPE = new JPrimitiveNameAndType("io.fabric8.kubernetes.api.model.AnyType");
 
   public JPrimitiveNameAndType(String name) {
     super(name, JavaType.PRIMITIVE);

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -209,7 +209,7 @@ class CompilationTest {
 
     // Assert
     assertTrue(compilation.errors().isEmpty());
-    assertEquals(15, compilation.sourceFiles().size());
+    assertEquals(13, compilation.sourceFiles().size());
     assertEquals(Compilation.Status.SUCCESS, compilation.status());
   }
 

--- a/java-generator/it/src/it/extensions/pom.xml
+++ b/java-generator/it/src/it/extensions/pom.xml
@@ -107,6 +107,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M7</version>
         <configuration>
           <useFile>false</useFile>
           <trimStackTrace>false</trimStackTrace>

--- a/java-generator/it/src/it/preserve-unknown-objects/invoker.properties
+++ b/java-generator/it/src/it/preserve-unknown-objects/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=test

--- a/java-generator/it/src/it/preserve-unknown-objects/pom.xml
+++ b/java-generator/it/src/it/preserve-unknown-objects/pom.xml
@@ -20,7 +20,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>cert-manager-enum-ser-deser</artifactId>
+  <artifactId>preserve-unknown-objects</artifactId>
   <groupId>io.fabric8.it</groupId>
   <version>0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -31,24 +31,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>io.sundr</groupId>
-      <artifactId>sundr-adapter-reflect</artifactId>
-      <version>@sundrio.version@</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.sundr</groupId>
-      <artifactId>builder-annotations</artifactId>
-      <version>@sundrio.version@</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>@lombok.version@</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>java-generator-integration-tests</artifactId>
@@ -87,8 +69,7 @@
           </execution>
         </executions>
         <configuration>
-          <source>src/test/resources/cert-manager.crds.1.7.1.yaml</source>
-          <generatedAnnotations>false</generatedAnnotations>
+          <source>src/test/resources/dapr-components-crd.yaml</source>
         </configuration>
       </plugin>
       <plugin>

--- a/java-generator/it/src/it/preserve-unknown-objects/pom.xml
+++ b/java-generator/it/src/it/preserve-unknown-objects/pom.xml
@@ -70,6 +70,7 @@
         </executions>
         <configuration>
           <source>src/test/resources/dapr-components-crd.yaml</source>
+          <generatedAnnotations>false</generatedAnnotations>
         </configuration>
       </plugin>
       <plugin>

--- a/java-generator/it/src/it/preserve-unknown-objects/src/test/java/io/fabric8/it/certmanager/TestPreserveUnkonwnUsability.java
+++ b/java-generator/it/src/it/preserve-unknown-objects/src/test/java/io/fabric8/it/certmanager/TestPreserveUnkonwnUsability.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.it.certmanager;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.dapr.v1alpha1.Component;
+import io.dapr.v1alpha1.ComponentSpec;
+import io.dapr.v1alpha1.componentspec.Metadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.jupiter.api.Test;
+import io.fabric8.java.generator.testing.KubernetesResourceDiff;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestPreserveUnknownUsability {
+
+  @Test
+  void testDeserialization() {
+    // Arrange
+    Component sample =
+      Serialization.unmarshal(getClass().getResourceAsStream("/sample.yaml"), Component.class);
+
+    // Act
+    List<Metadata> metadataList = sample.getSpec().getMetadata();
+
+    // Assert
+    assertEquals(5, metadataList.size());
+  }
+
+  private Component createSampleComponent() throws Exception {
+    Component component = new Component();
+    ComponentSpec spec = new ComponentSpec();
+    spec.setType("pubsub.mqtt");
+    spec.setVersion("v1");
+
+    Metadata meta1 = new Metadata();
+    meta1.setName("consumerID");
+    meta1.setValue(new TextNode("{uuid}"));
+
+    Metadata meta2 = new Metadata();
+    meta2.setName("url");
+    meta2.setValue(new TextNode("tcp://admin:public@localhost:1883"));
+
+    Metadata meta3 = new Metadata();
+    meta3.setName("qos");
+    meta3.setValue(new IntNode(1));
+
+    Metadata meta4 = new Metadata();
+    meta4.setName("anArray");
+    meta4.setValue(Serialization.jsonMapper().readTree("[1,2,3]"));
+
+    Metadata meta5 = new Metadata();
+    meta5.setName("anObject");
+    meta5.setValue(Serialization.jsonMapper().readTree("{ \"ONE\": 1, \"TWO\": 2 }"));
+
+    List<Metadata> lst = new ArrayList();
+    lst.add(meta1);
+    lst.add(meta2);
+    lst.add(meta3);
+    lst.add(meta4);
+    lst.add(meta5);
+    spec.setMetadata(lst);
+
+    component.setSpec(spec);
+    ObjectMeta om = new ObjectMeta();
+    om.setName("messagebus");
+    component.setMetadata(om);
+
+    return component;
+  }
+
+  @Test
+  void testAgainstSample() throws Exception {
+    // Arrange
+    Path resPath = Paths.get(getClass().getResource("/sample.yaml").toURI());
+    String yamlContent = new String(Files.readAllBytes(resPath), "UTF8");
+    Component sample = createSampleComponent();
+    KubernetesResourceDiff diff = new KubernetesResourceDiff(yamlContent, Serialization.asYaml(sample));
+
+    // Act
+    List<JsonNode> aggregatedDiffs = diff.getListOfDiffs();
+
+    // Assert
+    assertEquals(0, aggregatedDiffs.size());
+  }
+}

--- a/java-generator/it/src/it/preserve-unknown-objects/src/test/java/io/fabric8/it/certmanager/TestPreserveUnkonwnUsability.java
+++ b/java-generator/it/src/it/preserve-unknown-objects/src/test/java/io/fabric8/it/certmanager/TestPreserveUnkonwnUsability.java
@@ -16,11 +16,10 @@
 package io.fabric8.it.certmanager;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import io.dapr.v1alpha1.Component;
 import io.dapr.v1alpha1.ComponentSpec;
 import io.dapr.v1alpha1.componentspec.Metadata;
+import io.fabric8.kubernetes.api.model.AnyType;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.junit.jupiter.api.Test;
@@ -30,6 +29,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,23 +58,26 @@ class TestPreserveUnknownUsability {
 
     Metadata meta1 = new Metadata();
     meta1.setName("consumerID");
-    meta1.setValue(new TextNode("{uuid}"));
+    meta1.setValue(new AnyType("{uuid}"));
 
     Metadata meta2 = new Metadata();
     meta2.setName("url");
-    meta2.setValue(new TextNode("tcp://admin:public@localhost:1883"));
+    meta2.setValue(new AnyType("tcp://admin:public@localhost:1883"));
 
     Metadata meta3 = new Metadata();
     meta3.setName("qos");
-    meta3.setValue(new IntNode(1));
+    meta3.setValue(new AnyType(1));
 
     Metadata meta4 = new Metadata();
     meta4.setName("anArray");
-    meta4.setValue(Serialization.jsonMapper().readTree("[1,2,3]"));
+    meta4.setValue(new AnyType(new int[]{1, 2, 3}));
 
     Metadata meta5 = new Metadata();
     meta5.setName("anObject");
-    meta5.setValue(Serialization.jsonMapper().readTree("{ \"ONE\": 1, \"TWO\": 2 }"));
+    Map<String, Object> obj = new HashMap();
+    obj.put("ONE", 1);
+    obj.put("TWO", 2);
+    meta5.setValue(new AnyType(obj));
 
     List<Metadata> lst = new ArrayList();
     lst.add(meta1);

--- a/java-generator/it/src/it/preserve-unknown-objects/src/test/resources/dapr-components-crd.yaml
+++ b/java-generator/it/src/it/preserve-unknown-objects/src/test/resources/dapr-components-crd.yaml
@@ -1,0 +1,104 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: components.dapr.io
+spec:
+  group: dapr.io
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Component describes an Dapr component type
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          auth:
+            description: Auth represents authentication details for the component
+            properties:
+              secretStore:
+                type: string
+            required:
+            - secretStore
+            type: object
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          scopes:
+            items:
+              type: string
+            type: array
+          spec:
+            description: ComponentSpec is the spec for a component
+            properties:
+              initTimeout:
+                type: string
+              ignoreErrors:
+                type: boolean
+              metadata:
+                items:
+                  description: MetadataItem is a name/value pair for a metadata
+                  properties:
+                    name:
+                      type: string
+                    secretKeyRef:
+                      description: SecretKeyRef is a reference to a secret holding
+                        the value for the metadata item. Name is the secret name,
+                        and key is the field in the secret.
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    value:
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - name
+                  type: object
+                type: array
+              type:
+                type: string
+              version:
+                type: string
+            required:
+            - metadata
+            - type
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+  names:
+    kind: Component
+    plural: components
+    singular: component
+    categories:
+    - all
+    - dapr
+  scope: Namespaced

--- a/java-generator/it/src/it/preserve-unknown-objects/src/test/resources/sample.yaml
+++ b/java-generator/it/src/it/preserve-unknown-objects/src/test/resources/sample.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.mqtt
+  version: v1
+  metadata:
+    - name: consumerID
+      value: "{uuid}"
+    - name: url
+      value: "tcp://admin:public@localhost:1883"
+    - name: qos
+      value: 1
+    - name: anArray
+      value:
+        - 1
+        - 2
+        - 3
+    - name: anObject
+      value:
+        ONE: 1
+        TWO: 2


### PR DESCRIPTION
## Description
Resolves #4426 

The new encoding seems to be better aligned with the rules:
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
