### PR TITLE
fix (openshift-client) : Change ManagedOpenShiftClient OSGi ConfigurationPolicy to REQUIRE (#3864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix #4365: The Watch retry logic will handle more cases, as well as perform an exceptional close for events that are not properly handled.  Informers can directly provide those exceptional outcomes via the SharedIndexInformer.stopped CompletableFuture.
 * Fix #4396: Provide more error context when @Group/@Version annotations are missing
 * Fix #4384: The Java generator now supports the generation of specific annotations (min, max, pattern, etc.), as defined by #4348
+* Fix #3864: Change ManagedOpenShiftClient OSGi ConfigurationPolicy to REQUIRE
 
 #### Dependency Upgrade
 * Fix #4243: Update Tekton pipeline model to v0.39.0
@@ -26,6 +27,7 @@
 * Fix #4350: SchemaSwap's fieldName parameter now expects a field name only, not a method or a constructor.
 * Module `io.fabric8:tekton-model-triggers` which contained Tekton triggers v1alpha1 model has been removed. We have introduced separate modules `io.fabric8:tekton-model-v1alpha1` and `io.fabric8:tekton-model-v1beta1` for Tekton triggers v1alpha1 and v1beta1 apigroups respectively. Users who are using `io.fabric8:tekton-client` dependency directly should be unaffected by this change.
 * Fix #4384: javax.validation.* annotations are no longer added by the Java generator.
+* Fix #3864: Now it's compulsory to provide `etc/io.fabric8.openshift.client.cfg` file in order to load ManagedOpenShiftClient in OSGi environment.
 
 ### 6.1.1 (2022-09-01)
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -49,3 +49,37 @@ Finally the fabric8 client will use 1 thread per PortForward and an additional t
 Like many java application the Fabric8 Client utilizes [slf4j](https://www.slf4j.org/).  You may configure support for whatever underlying logging framework suits your needs.  The logging contexts for the Fabric8 Client follow the standard convention of the package structure - everything from within the client will be rooted at the io.fabric8 context.  Third-party dependencies, including the chosen HTTP client implementation, will have different root contexts.
 
 If you are using pod exec, which can occur indirectly via pod operations like copying files, and not seeing the expected behavior - please enable debug logging for the io.fabric8.kubernetes.client.dsl.internal context.  That will provide the stdErr and stdOut as debug logs to further diagnose what is occurring.
+
+### How to use KubernetesClient in OSGi?
+
+Fabric8 Kubernetes Client provides ManagedKubernetesClient and ManagedOpenShiftClient as [OSGi Declarative Service](https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.component.html). In order to use it, you must have [Service Component Runtime (SCR)](https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.component.html#service.component-service.component.runtime) feature enabled in your OSGi runtime. In [Apache Karaf](https://karaf.apache.org/), you can add this to Karaf Maven Plugin configuration:
+```xml
+<plugin>
+  <groupId>org.apache.karaf.tooling</groupId>
+  <artifactId>karaf-maven-plugin</artifactId>
+  <version>${karaf.version}</version>
+  <configuration>
+    <startupFeatures>
+      <feature>scr</feature>
+    </startupFeatures>
+  </configuration>
+</plugin>
+```
+
+You would need to provide component configuration files for the client you're using. For example, in case of [Apache Karaf](https://karaf.apache.org/), place configuration files in this directory:
+```
+src/
+└── main
+    └── resources
+        ├── assembly
+        │ └── etc
+        │     ├── io.fabric8.kubernetes.client.cfg
+        │     ├── io.fabric8.openshift.client.cfg
+```
+
+Once added KubernetesClient declarative services would be exposed automatically on startup. Then you can inject it in your project. Here is an example using Apache camel's `@BeanInject` annotation:
+
+```java
+  @BeanInject
+  private KubernetesClient kubernetesClient
+```

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -183,7 +183,7 @@ import static io.fabric8.openshift.client.OpenShiftConfig.DEFAULT_BUILD_TIMEOUT;
 import static io.fabric8.openshift.client.OpenShiftConfig.OPENSHIFT_BUILD_TIMEOUT_SYSTEM_PROPERTY;
 import static io.fabric8.openshift.client.OpenShiftConfig.OPENSHIFT_URL_SYSTEM_PROPERTY;
 
-@Component(configurationPid = "io.fabric8.openshift.client", policy = ConfigurationPolicy.OPTIONAL)
+@Component(configurationPid = "io.fabric8.openshift.client", policy = ConfigurationPolicy.REQUIRE)
 @Service({ OpenShiftClient.class, NamespacedOpenShiftClient.class })
 public class ManagedOpenShiftClient extends NamespacedKubernetesClientAdapter<NamespacedOpenShiftClient>
     implements NamespacedOpenShiftClient {

--- a/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
+++ b/platforms/karaf/itests/src/test/java/io/fabric8/kubernetes/karaf/itests/TestBase.java
@@ -56,6 +56,8 @@ public class TestBase {
           editConfigurationFileExtend(
               "etc/io.fabric8.kubernetes.client.cfg", "junit", "ignored"),
           editConfigurationFileExtend(
+              "etc/io.fabric8.openshift.client.cfg", "junit", "ignored"),
+          editConfigurationFileExtend(
               "etc/org.ops4j.pax.url.mvn.cfg",
               "org.ops4j.pax.url.mvn.repositories",
               "https://repo1.maven.org/maven2/"),
@@ -94,6 +96,8 @@ public class TestBase {
           features,
           editConfigurationFileExtend(
               "etc/io.fabric8.kubernetes.client.cfg", "junit", "ignored"),
+          editConfigurationFileExtend(
+              "etc/io.fabric8.openshift.client.cfg", "junit", "ignored"),
           editConfigurationFileExtend(
               "etc/org.ops4j.pax.url.mvn.cfg",
               "org.ops4j.pax.url.mvn.repositories",


### PR DESCRIPTION
## Description
Fix #3864

Just like ManagedKubernetesClient, ManagedOpenShiftClient also doesn't handle `activate()` being called with null properties. Setting Component configuration policy to REQUIRE which would make having configuration object for ManagedOpenShiftClient (i.e. `src/main/resources/assembly/etc/io.fabric8.openshift.client.cfg`) compulsory.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
