### PR TITLE
fix (osgi) : Fix OSGi startup exceptions while using KubernetesClient/OpenShiftClient

### DIFF
--- a/extensions/camel-k/client/pom.xml
+++ b/extensions/camel-k/client/pom.xml
@@ -33,6 +33,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.camelk.client.*,

--- a/extensions/certmanager/client/pom.xml
+++ b/extensions/certmanager/client/pom.xml
@@ -34,6 +34,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.certmanager.client.*,

--- a/extensions/chaosmesh/client/pom.xml
+++ b/extensions/chaosmesh/client/pom.xml
@@ -35,6 +35,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.chaosmesh.client.*,

--- a/extensions/istio/client/pom.xml
+++ b/extensions/istio/client/pom.xml
@@ -29,6 +29,14 @@
   <name>Fabric8 :: Istio :: Client</name>
 
   <properties>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)"
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.istio.client.*,

--- a/extensions/knative/client/pom.xml
+++ b/extensions/knative/client/pom.xml
@@ -29,6 +29,14 @@
   <name>Fabric8 :: Knative :: Client</name>
 
   <properties>
+    <osgi.require-capability>
+      osgi.extender;
+      filter:="(osgi.extender=osgi.serviceloader.registrar)"
+    </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.knative.client.*,

--- a/extensions/open-cluster-management/client/pom.xml
+++ b/extensions/open-cluster-management/client/pom.xml
@@ -35,6 +35,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.openclustermanagement.client.*,

--- a/extensions/service-catalog/client/pom.xml
+++ b/extensions/service-catalog/client/pom.xml
@@ -34,6 +34,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.servicecatalog.client.*,

--- a/extensions/tekton/client/pom.xml
+++ b/extensions/tekton/client/pom.xml
@@ -33,6 +33,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.tekton.client.*,

--- a/extensions/verticalpodautoscaler/client/pom.xml
+++ b/extensions/verticalpodautoscaler/client/pom.xml
@@ -34,6 +34,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.verticalpodautoscaler.client.*,

--- a/extensions/volcano/client/pom.xml
+++ b/extensions/volcano/client/pom.xml
@@ -34,6 +34,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.volcano.client.*,

--- a/extensions/volumesnapshot/client/pom.xml
+++ b/extensions/volumesnapshot/client/pom.xml
@@ -35,6 +35,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter
+    </osgi.provide-capability>
     <osgi.import>
       io.fabric8.kubernetes.api.builder,
       !io.fabric8.volumesnapshot.client.*,

--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -34,6 +34,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.http.HttpClient$Factory
+    </osgi.provide-capability>
     <osgi.import>
       !android.util*,
       *,

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -34,6 +34,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.http.HttpClient$Factory
+    </osgi.provide-capability>
     <osgi.import>
       !android.util*,
       *,

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -33,6 +33,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.http.HttpClient$Factory
+    </osgi.provide-capability>
     <osgi.import>
       !android.util*,
       *,

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -33,6 +33,10 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.processor)",
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.ServiceToURLProvider
+    </osgi.provide-capability>
     <osgi.import>
       !android.util*,
       *,

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.OAuthTokenProvider;
 import io.fabric8.kubernetes.client.ResourceHandler;
-import io.fabric8.kubernetes.client.extension.ExtensionAdapter;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
@@ -66,7 +65,6 @@ import static io.fabric8.kubernetes.client.Config.KUBERNETES_WEBSOCKET_TIMEOUT_S
 @Service({ KubernetesClient.class, NamespacedKubernetesClient.class })
 @References({
     @Reference(referenceInterface = io.fabric8.kubernetes.client.ResourceHandler.class, cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE, policy = ReferencePolicy.DYNAMIC, bind = "bindResourceHandler", unbind = "unbindResourceHandler"),
-    @Reference(referenceInterface = ExtensionAdapter.class, cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE, policy = ReferencePolicy.DYNAMIC, bind = "bindExtensionAdapter", unbind = "unbindExtensionAdapter"),
     @Reference(referenceInterface = OAuthTokenProvider.class, cardinality = ReferenceCardinality.OPTIONAL_UNARY, policyOption = ReferencePolicyOption.GREEDY, bind = "bindOAuthTokenProvider", unbind = "unbindOAuthTokenProvider")
 })
 public class ManagedKubernetesClient extends NamespacedKubernetesClientAdapter<DefaultKubernetesClient> {
@@ -189,14 +187,6 @@ public class ManagedKubernetesClient extends NamespacedKubernetesClientAdapter<D
   @Deprecated
   public void unbindResourceHandler(ResourceHandler resourceHandler) {
     // not used
-  }
-
-  public void bindExtensionAdapter(ExtensionAdapter adapter) {
-    getClient().getAdapters().register(adapter);
-  }
-
-  public void unbindExtensionAdapter(ExtensionAdapter adapter) {
-    getClient().getAdapters().unregister(adapter);
   }
 
   public void bindOAuthTokenProvider(OAuthTokenProvider provider) {

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -33,6 +33,11 @@
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)"
     </osgi.require-capability>
+    <osgi.provide-capability>
+      osgi.serviceloader;
+      osgi.serviceloader=io.fabric8.kubernetes.client.extension.ExtensionAdapter,
+      io.fabric8.kubernetes.client.ServiceToURLProvider
+    </osgi.provide-capability>
     <osgi.import>
       !org.junit*,
       *


### PR DESCRIPTION
## Description

- Remove ExtensionAdapter reference from ManagedKubernetesClient, no provider is exposed for ExtensionAdapter interface in kubernetes-client module. `bindExtensionAdapter` and `bindExtensionAdapter` are throwing `NullPointerException` during startup.
- Add `Provide-Capability` field in `openshift-client` and other extensions bundle configurations in order to resolve SPIFly related `NPE` (reported in #3890)

### See also
- https://aries.apache.org/documentation/modules/spi-fly.html ([#providers](https://aries.apache.org/documentation/modules/spi-fly.html#_providers))

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift


