### PR TITLE
Backport of #4461

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * * Fix #4206: KubernetesDeserializer can now handle any valid object. If the object lacks type information, it will be deserialized as a GenericKubernetesResource.
 * Fix #4365: backport of stopped future for informers to obtain the termination exception
 * Fix #4383: bump snakeyaml from 1.28 to 1.33
+* Fix #4442: TokenRefreshInterceptor doesn't overwrite existing OAuth token with empty string
 
 #### _**Note**_: Behavior changes
 * Fix #4206: The Serialization utility class will throw an Exception, instead of returning null, if an untyped unmarshall method is used on something that lacks type information

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
@@ -74,7 +74,7 @@ public class TokenRefreshInterceptor implements Interceptor {
       newAccessToken = newestConfig.getOauthToken();
     }
 
-    if (newAccessToken != null) {
+    if (Utils.isNotNullOrEmpty(newAccessToken)) {
       // Delete old Authorization header and append new one
       headerBuilder
         .setHeader("Authorization", "Bearer " + newAccessToken);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
@@ -16,9 +16,14 @@
 package io.fabric8.kubernetes.client.utils;
 
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.http.BasicBuilder;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -35,7 +40,13 @@ import static io.fabric8.kubernetes.client.Config.KUBERNETES_AUTH_SERVICEACCOUNT
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY;
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_KUBECONFIG_FILE;
 import static io.fabric8.kubernetes.client.MockHttpClientUtils.buildResponse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 /**
  * Ignoring for now - the token refresh should be based upon the java 11 client or the provided client library and not okhttp
@@ -50,7 +61,7 @@ public class TokenRefreshInterceptorTest {
       Files.copy(Objects.requireNonNull(getClass().getResourceAsStream("/test-kubeconfig-tokeninterceptor")), Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
       System.setProperty(KUBERNETES_KUBECONFIG_FILE, tempFile.getAbsolutePath());
 
-      HttpRequest.Builder builder = Mockito.mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
+      HttpRequest.Builder builder = mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
 
       // Call
       boolean reissue = new TokenRefreshInterceptor(Config.autoConfigure(null), null).afterFailure(builder, buildResponse(HttpURLConnection.HTTP_UNAUTHORIZED, "foo"));
@@ -71,7 +82,7 @@ public class TokenRefreshInterceptorTest {
         Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
       System.setProperty(KUBERNETES_KUBECONFIG_FILE, tempFile.getAbsolutePath());
 
-      HttpRequest.Builder builder = Mockito.mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
+      HttpRequest.Builder builder = mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
 
       // Call
       TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(Config.autoConfigure(null), null);
@@ -88,6 +99,54 @@ public class TokenRefreshInterceptorTest {
   }
 
   @Test
+  @DisplayName("#4442 token auto refresh should not overwrite existing token when not applicable")
+  void refreshShouldNotOverwriteExistingToken() throws Exception {
+    try (MockedStatic<Config> configMock = mockStatic(Config.class, CALLS_REAL_METHODS)) {
+      // Given
+      final Config autoConfig = new ConfigBuilder(Config.empty())
+          .withOauthToken("") // empty token
+          .build();
+      configMock.when(() -> Config.autoConfigure(any())).thenReturn(autoConfig);
+      final Config config = new ConfigBuilder(Config.empty())
+          .withOauthToken("existing-token")
+          .build();
+      final TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(config, null);
+      tokenRefreshInterceptor.setLastRefresh(Instant.now().minusSeconds(61));
+      final HttpResponse<String> response = mock(HttpResponse.class);
+      when(response.code()).thenReturn(401);
+      // When
+      final boolean result = tokenRefreshInterceptor.afterFailure(mock(BasicBuilder.class), response);
+      // Then
+      assertThat(result).isFalse();
+      assertThat(config).hasFieldOrPropertyWithValue("oauthToken", "existing-token");
+    }
+  }
+
+  @Test
+  @DisplayName("#4442 token auto refresh should  overwrite existing token when applicable")
+  void refreshShouldOverwriteExistingToken() throws Exception {
+    try (MockedStatic<Config> configMock = mockStatic(Config.class, CALLS_REAL_METHODS)) {
+      // Given
+      final Config autoConfig = new ConfigBuilder(Config.empty())
+          .withOauthToken("new-token")
+          .build();
+      configMock.when(() -> Config.autoConfigure(any())).thenReturn(autoConfig);
+      final Config config = new ConfigBuilder(Config.empty())
+          .withOauthToken("existing-token")
+          .build();
+      final TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(config, null);
+      tokenRefreshInterceptor.setLastRefresh(Instant.now().minusSeconds(61));
+      final HttpResponse<String> response = mock(HttpResponse.class);
+      when(response.code()).thenReturn(401);
+      // When
+      final boolean result = tokenRefreshInterceptor.afterFailure(mock(BasicBuilder.class), response);
+      // Then
+      assertThat(result).isTrue();
+      assertThat(config).hasFieldOrPropertyWithValue("oauthToken", "new-token");
+    }
+  }
+
+  @Test
   void shouldReloadInClusterServiceAccount() throws IOException {
     try {
       // Write service account token file with value "expired" in it,
@@ -97,7 +156,7 @@ public class TokenRefreshInterceptorTest {
       System.setProperty(KUBERNETES_AUTH_SERVICEACCOUNT_TOKEN_FILE_SYSTEM_PROPERTY, tokenFile.getAbsolutePath());
       System.setProperty(KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
 
-      HttpRequest.Builder builder = Mockito.mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
+      HttpRequest.Builder builder = mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
 
       // The expired token will be read at auto configure.
       TokenRefreshInterceptor interceptor = new TokenRefreshInterceptor(Config.autoConfigure(null), null);
@@ -126,7 +185,7 @@ public class TokenRefreshInterceptorTest {
       System.setProperty(KUBERNETES_KUBECONFIG_FILE, tempFile.getAbsolutePath());
 
       // Prepare HTTP call that will fail with 401 Unauthorized to trigger OIDC token renewal.
-      HttpRequest.Builder builder = Mockito.mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
+      HttpRequest.Builder builder = mock(HttpRequest.Builder.class, Mockito.RETURNS_SELF);
 
       // Loads the initial kubeconfig, including initial token value.
       Config config = Config.autoConfigure(null);
@@ -140,7 +199,7 @@ public class TokenRefreshInterceptorTest {
       Files.copy(Objects.requireNonNull(getClass().getResourceAsStream("/test-kubeconfig-tokeninterceptor-oidc")),
           Paths.get(tempFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
 
-      TokenRefreshInterceptor interceptor = new TokenRefreshInterceptor(config, Mockito.mock(HttpClient.Factory.class));
+      TokenRefreshInterceptor interceptor = new TokenRefreshInterceptor(config, mock(HttpClient.Factory.class));
       boolean reissue = interceptor.afterFailure(builder, buildResponse(HttpURLConnection.HTTP_UNAUTHORIZED, "foo"));
 
       // Make the call and check that renewed token was read at 401 Unauthorized.


### PR DESCRIPTION
## Description
fix(kubernetes-client-api): TokenRefreshInterceptor doesn't overwrite existing OAuth token with empty string

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
