### PR TITLE
fix #4365 correcting backoff interval

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientException.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientException.java
@@ -60,7 +60,7 @@ public class KubernetesClientException extends RuntimeException {
     super(message, t);
     this.code = code;
     this.status = status;
-    this.requestMetadata = requestMetadata;
+    this.requestMetadata = requestMetadata == null ? RequestMetadata.EMPTY : requestMetadata;
   }
 
   /**
@@ -229,5 +229,13 @@ public class KubernetesClientException extends RuntimeException {
           return EMPTY;
       }
     }
+  }
+
+  /**
+   * Create a new {@link KubernetesClientException} with this exception as the cause
+   */
+  public KubernetesClientException copyAsCause() {
+    return new KubernetesClientException(this.getMessage(), this, this.getCode(), this.getStatus(),
+        this.requestMetadata);
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -83,6 +83,7 @@ public class OperationSupport {
   protected String apiGroupVersion;
   protected boolean dryRun;
   private final int requestRetryBackoffLimit;
+  private final int requestRetryBackoffInterval;
 
   public OperationSupport(Client client) {
     this(new OperationContext().withClient(client));
@@ -106,8 +107,10 @@ public class OperationSupport {
     }
 
     if (ctx.getConfig() != null) {
+      requestRetryBackoffInterval = ctx.getConfig().getRequestRetryBackoffInterval();
       this.requestRetryBackoffLimit = ctx.getConfig().getRequestRetryBackoffLimit();
     } else {
+      requestRetryBackoffInterval = Config.DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL;
       this.requestRetryBackoffLimit = Config.DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
     }
   }
@@ -508,15 +511,14 @@ public class OperationSupport {
       if (e.getCause() != null) {
         t = e.getCause();
       }
+      // throw a new exception to preserve the calling stack trace
       if (t instanceof IOException) {
-        throw (IOException) t;
+        throw new IOException(t.getMessage(), t);
       }
-      if (t instanceof RuntimeException) {
-        throw (RuntimeException) t;
+      if (t instanceof KubernetesClientException) {
+        throw ((KubernetesClientException) t).copyAsCause();
       }
-      InterruptedIOException ie = new InterruptedIOException();
-      ie.initCause(e);
-      throw ie;
+      throw new KubernetesClientException(t.getMessage(), t);
     }
   }
 
@@ -568,7 +570,7 @@ public class OperationSupport {
     HttpRequest request = requestBuilder.build();
     CompletableFuture<HttpResponse<byte[]>> futureResponse = new CompletableFuture<>();
     retryWithExponentialBackoff(futureResponse,
-        new ExponentialBackoffIntervalCalculator(requestRetryBackoffLimit, MAX_RETRY_INTERVAL_EXPONENT),
+        new ExponentialBackoffIntervalCalculator(requestRetryBackoffInterval, MAX_RETRY_INTERVAL_EXPONENT),
         Utils.getNonNullOrElse(client, httpClient), request);
 
     return futureResponse.thenApply(response -> {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
@@ -296,6 +296,7 @@ class BaseOperationTest {
   void testHttpRetryWithMoreFailuresThanRetries() {
     final AtomicInteger httpExecutionCounter = new AtomicInteger(0);
     HttpClient mockClient = newHttpClientWithSomeFailures(httpExecutionCounter, 1000);
+    long start = System.currentTimeMillis();
     BaseOperation<Pod, PodList, Resource<Pod>> baseOp = new BaseOperation(new OperationContext()
         .withClient(mockClient(mockClient,
             new ConfigBuilder().withMasterUrl("https://172.17.0.2:8443").withNamespace("default")
@@ -309,7 +310,10 @@ class BaseOperationTest {
       Pod result = baseOp.get();
     });
 
+    long stop = System.currentTimeMillis();
+
     // Then
+    assertTrue(stop - start >= 700); //100+200+400
     assertTrue(exception.getMessage().contains("Internal Server Error"),
         "As the last failure, the 3rd one, is not an IOException the message expected to contain: 'Internal Server Error'!");
     assertEquals(4, httpExecutionCounter.get(), "Expected 4 calls: one normal try and 3 backoff retries!");


### PR DESCRIPTION
## Description
I introduced a regression in #4365 with the refactoring of the exponential backoff - the interval was not carried forward. 

Another, optional, change is to add exceptions that preserve for blocking request stacktraces - that seems better than just the underlying stacktrace which will just be from the httpclient layer.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
