### PR TITLE
Fix #4312: fix timestamp can't be deserialized for IstioCondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.2-SNAPSHOT
 
 #### Bugs
+* Fix #4312: fix timestamp can't be deserialized for IstioCondition
 * Fix #4369: Informers will retry with a backoff on list/watch failure as they did in 5.12 and prior.
 * Fix #4350: SchemaSwap annotation is now repeatable and is applied multiple times if classes are used more than once in the class hierarchy.
 * Fix #3733: The authentication command from the .kube/config won't be discarded if no arguments are specified

--- a/extensions/istio/generator-v1alpha3/cmd/generate/generate.go
+++ b/extensions/istio/generator-v1alpha3/cmd/generate/generate.go
@@ -85,7 +85,7 @@ func main() {
 		reflect.TypeOf(types.BoolValue{}):   "java.lang.Boolean",
 		reflect.TypeOf(types.DoubleValue{}): "java.lang.Double",
 		reflect.TypeOf(types.Duration{}):    "java.lang.String",
-		reflect.TypeOf(types.Timestamp{}):   "java.lang.Long",
+		reflect.TypeOf(types.Timestamp{}):   "java.lang.String",
 		reflect.TypeOf(types.Int32Value{}):  "java.lang.Integer",
 		reflect.TypeOf(types.UInt32Value{}): "java.lang.Integer",
 		reflect.TypeOf(types.Struct{}):      "java.util.Map<String, Object>",

--- a/extensions/istio/generator-v1beta1/cmd/generate/generate.go
+++ b/extensions/istio/generator-v1beta1/cmd/generate/generate.go
@@ -91,7 +91,7 @@ func main() {
 		reflect.TypeOf(types.BoolValue{}):   "java.lang.Boolean",
 		reflect.TypeOf(types.DoubleValue{}): "java.lang.Double",
 		reflect.TypeOf(types.Duration{}):    "java.lang.String",
-		reflect.TypeOf(types.Timestamp{}):   "java.lang.Long",
+		reflect.TypeOf(types.Timestamp{}):   "java.lang.String",
 		reflect.TypeOf(types.Int32Value{}):  "java.lang.Integer",
 		reflect.TypeOf(types.UInt32Value{}): "java.lang.Integer",
 	}

--- a/extensions/istio/model-v1alpha3/src/generated/java/io/fabric8/istio/api/meta/v1alpha1/IstioCondition.java
+++ b/extensions/istio/model-v1alpha3/src/generated/java/io/fabric8/istio/api/meta/v1alpha1/IstioCondition.java
@@ -70,9 +70,9 @@ public class IstioCondition implements KubernetesResource
 {
 
     @JsonProperty("lastProbeTime")
-    private Long lastProbeTime;
+    private String lastProbeTime;
     @JsonProperty("lastTransitionTime")
-    private Long lastTransitionTime;
+    private String lastTransitionTime;
     @JsonProperty("message")
     private String message;
     @JsonProperty("reason")
@@ -100,7 +100,7 @@ public class IstioCondition implements KubernetesResource
      * @param lastProbeTime
      * @param status
      */
-    public IstioCondition(Long lastProbeTime, Long lastTransitionTime, String message, String reason, String status, String type) {
+    public IstioCondition(String lastProbeTime, String lastTransitionTime, String message, String reason, String status, String type) {
         super();
         this.lastProbeTime = lastProbeTime;
         this.lastTransitionTime = lastTransitionTime;
@@ -111,22 +111,22 @@ public class IstioCondition implements KubernetesResource
     }
 
     @JsonProperty("lastProbeTime")
-    public Long getLastProbeTime() {
+    public String getLastProbeTime() {
         return lastProbeTime;
     }
 
     @JsonProperty("lastProbeTime")
-    public void setLastProbeTime(Long lastProbeTime) {
+    public void setLastProbeTime(String lastProbeTime) {
         this.lastProbeTime = lastProbeTime;
     }
 
     @JsonProperty("lastTransitionTime")
-    public Long getLastTransitionTime() {
+    public String getLastTransitionTime() {
         return lastTransitionTime;
     }
 
     @JsonProperty("lastTransitionTime")
-    public void setLastTransitionTime(Long lastTransitionTime) {
+    public void setLastTransitionTime(String lastTransitionTime) {
         this.lastTransitionTime = lastTransitionTime;
     }
 

--- a/extensions/istio/model-v1alpha3/src/main/resources/schema/istio-schema.json
+++ b/extensions/istio/model-v1alpha3/src/main/resources/schema/istio-schema.json
@@ -193,10 +193,10 @@
       "type": "object",
       "properties": {
         "lastProbeTime": {
-          "existingJavaType": "java.lang.Long"
+          "existingJavaType": "java.lang.String"
         },
         "lastTransitionTime": {
-          "existingJavaType": "java.lang.Long"
+          "existingJavaType": "java.lang.String"
         },
         "message": {
           "type": "string"

--- a/extensions/istio/model-v1beta1/src/generated/java/io/fabric8/istio/api/meta/v1alpha1/IstioCondition.java
+++ b/extensions/istio/model-v1beta1/src/generated/java/io/fabric8/istio/api/meta/v1alpha1/IstioCondition.java
@@ -70,9 +70,9 @@ public class IstioCondition implements KubernetesResource
 {
 
     @JsonProperty("lastProbeTime")
-    private Long lastProbeTime;
+    private String lastProbeTime;
     @JsonProperty("lastTransitionTime")
-    private Long lastTransitionTime;
+    private String lastTransitionTime;
     @JsonProperty("message")
     private String message;
     @JsonProperty("reason")
@@ -100,7 +100,7 @@ public class IstioCondition implements KubernetesResource
      * @param lastProbeTime
      * @param status
      */
-    public IstioCondition(Long lastProbeTime, Long lastTransitionTime, String message, String reason, String status, String type) {
+    public IstioCondition(String lastProbeTime, String lastTransitionTime, String message, String reason, String status, String type) {
         super();
         this.lastProbeTime = lastProbeTime;
         this.lastTransitionTime = lastTransitionTime;
@@ -111,22 +111,22 @@ public class IstioCondition implements KubernetesResource
     }
 
     @JsonProperty("lastProbeTime")
-    public Long getLastProbeTime() {
+    public String getLastProbeTime() {
         return lastProbeTime;
     }
 
     @JsonProperty("lastProbeTime")
-    public void setLastProbeTime(Long lastProbeTime) {
+    public void setLastProbeTime(String lastProbeTime) {
         this.lastProbeTime = lastProbeTime;
     }
 
     @JsonProperty("lastTransitionTime")
-    public Long getLastTransitionTime() {
+    public String getLastTransitionTime() {
         return lastTransitionTime;
     }
 
     @JsonProperty("lastTransitionTime")
-    public void setLastTransitionTime(Long lastTransitionTime) {
+    public void setLastTransitionTime(String lastTransitionTime) {
         this.lastTransitionTime = lastTransitionTime;
     }
 

--- a/extensions/istio/model-v1beta1/src/main/resources/schema/istio-schema.json
+++ b/extensions/istio/model-v1beta1/src/main/resources/schema/istio-schema.json
@@ -65,10 +65,10 @@
       "type": "object",
       "properties": {
         "lastProbeTime": {
-          "existingJavaType": "java.lang.Long"
+          "existingJavaType": "java.lang.String"
         },
         "lastTransitionTime": {
-          "existingJavaType": "java.lang.Long"
+          "existingJavaType": "java.lang.String"
         },
         "message": {
           "type": "string"


### PR DESCRIPTION
## Description
Fix #4312

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
