### PR TITLE
fix #4478: status handling was inserting an explicit missing node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,18 @@
 ### 6.2-SNAPSHOT
 
 #### Bugs
+* Fix #3733: The authentication command from the .kube/config won't be discarded if no arguments are specified
 * Fix #4312: fix timestamp can't be deserialized for IstioCondition
 * Fix #4369: Informers will retry with a backoff on list/watch failure as they did in 5.12 and prior.
-* Fix #4350: SchemaSwap annotation is now repeatable and is applied multiple times if classes are used more than once in the class hierarchy.
-* Fix #3733: The authentication command from the .kube/config won't be discarded if no arguments are specified
-* Fix #4460: removing split packages.  Converting Default clients into adapters rather than real instances.
+* Fix #4426: [java-generator] Encode an `AnyType` instead of an Object if `x-kubernetes-preserve-unknown-fields` is present and the type is null.
 * Fix #4441: corrected patch base handling for the patch methods available from a Resource - resource(item).patch() will be evaluated as resource(latest).patch(item).  Also undeprecated patch(item), which is consistent with leaving patch(context, item) undeprecated as well.  For consistency with the other operations (such as edit), patch(item) will use the context item as the base when available, or the server side item when not.  This means that patch(item) is only the same as resource(item).patch() when the patch(item) is called when the context item is missing or is the same as the latest.
 * Fix #4442: TokenRefreshInterceptor doesn't overwrite existing OAuth token with empty string
+* Fix #4350: SchemaSwap annotation is now repeatable and is applied multiple times if classes are used more than once in the class hierarchy.
 * Fix #4459: Fixed OSGi startup exceptions while using KubernetesClient/OpenShiftClient
-* Fix #4482: Fixing blocking behavior of okhttp log watch
+* Fix #4460: removing split packages.  Converting Default clients into adapters rather than real instances.
 * Fix #4473: Fix regression in backoff interval introduced in #4365
-* Fix #4426: [java-generator] Encode an `AnyType` instead of an Object if `x-kubernetes-preserve-unknown-fields` is present and the type is null.
+* Fix #4478: Removing the resourceVersion bump with null status
+* Fix #4482: Fixing blocking behavior of okhttp log watch
 
 #### Improvements
 * Fix #4471: Adding KubernetesClientBuilder.withHttpClientBuilderConsumer to further customize the HttpClient for any implementation.

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PatchHandler.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PatchHandler.java
@@ -67,7 +67,7 @@ public class PatchHandler implements KubernetesCrudDispatcherHandler {
     final JsonNode updatedResource;
     if (isStatusPath(path)) {
       updatedResource = currentResource.deepCopy();
-      setStatus(updatedResource, fullPatch.path(STATUS));
+      setStatus(updatedResource, fullPatch.get(STATUS));
     } else {
       updatedResource = fullPatch;
       // preserve original status (PATCH requests to the custom resource ignore changes to the status stanza)

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PutHandler.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PutHandler.java
@@ -48,12 +48,12 @@ public class PutHandler implements KubernetesCrudDispatcherHandler {
     final JsonNode updatedResource;
     if (isStatusPath(path)) {
       updatedResource = currentResource.deepCopy();
-      setStatus(updatedResource, persistence.asNode(requestBody).path(STATUS));
+      setStatus(updatedResource, persistence.asNode(requestBody).get(STATUS));
     } else {
       updatedResource = persistence.asNode(requestBody);
       // preserve original status (PUT requests to the custom resource ignore changes to the status stanza)
       if (persistence.isStatusSubresourceEnabledForResource(path)) {
-        setStatus(updatedResource, currentResource.path(STATUS));
+        setStatus(updatedResource, currentResource.get(STATUS));
       }
     }
     validatePath(attributes, updatedResource);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -195,6 +195,30 @@ class CustomResourceCrudTest {
     assertNotNull(result.getStatus());
   }
 
+  @Test
+  void testNullStatus() {
+    CronTab cronTab = createCronTab("my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
+
+    NonNamespaceOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
+        .resources(CronTab.class).inNamespace("test-ns");
+
+    CronTab result = cronTabClient.resource(cronTab).create();
+
+    // should be null after create
+    assertNull(result.getStatus());
+    String resourceVersion = result.getMetadata().getResourceVersion();
+
+    // should be a no-op
+    result = cronTabClient.resource(result).patchStatus();
+    assertNull(result.getStatus());
+    assertEquals(resourceVersion, result.getMetadata().getResourceVersion());
+
+    // should be a no-op
+    result = cronTabClient.resource(result).replace();
+    assertNull(result.getStatus());
+    assertEquals(resourceVersion, result.getMetadata().getResourceVersion());
+  }
+
   void assertCronTab(CronTab cronTab, String name, String cronTabSpec, int replicas, String image) {
     assertEquals(name, cronTab.getMetadata().getName());
     assertEquals(cronTabSpec, cronTab.getSpec().getCronSpec());


### PR DESCRIPTION
## Description

Fix #4478 

Fix for #4478 - the mock server patch / put handling usage of the path method inserted an explicit Missing node, which then caused a diff.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
