### PR TITLE
fix #4408: allowing for users to set the exception handling behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix #4365: The Watch retry logic will handle more cases, as well as perform an exceptional close for events that are not properly handled.  Informers can directly provide those exceptional outcomes via the SharedIndexInformer.stopped CompletableFuture.
 * Fix #4396: Provide more error context when @Group/@Version annotations are missing
 * Fix #4384: The Java generator now supports the generation of specific annotations (min, max, pattern, etc.), as defined by #4348
+* Fix #4408: Allowing informers started via the start() method to have configurable exception / retry handling.
 * Fix #3864: Change ManagedOpenShiftClient OSGi ConfigurationPolicy to REQUIRE
 
 #### Dependency Upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * Fix #3733: The authentication command from the .kube/config won't be discarded if no arguments are specified
 * Fix #4312: fix timestamp can't be deserialized for IstioCondition
 * Fix #4369: Informers will retry with a backoff on list/watch failure as they did in 5.12 and prior.
-* Fix #4426: [java-generator] Encode an `AnyType` instead of an Object if `x-kubernetes-preserve-unknown-fields` is present and the type is null.
+* Fix #4350: SchemaSwap annotation is now repeatable and is applied multiple times if classes are used more than once in the class hierarchy.
+* Fix #3733: The authentication command from the .kube/config won't be discarded if no arguments are specified
 * Fix #4441: corrected patch base handling for the patch methods available from a Resource - resource(item).patch() will be evaluated as resource(latest).patch(item).  Also undeprecated patch(item), which is consistent with leaving patch(context, item) undeprecated as well.  For consistency with the other operations (such as edit), patch(item) will use the context item as the base when available, or the server side item when not.  This means that patch(item) is only the same as resource(item).patch() when the patch(item) is called when the context item is missing or is the same as the latest.
 * Fix #4442: TokenRefreshInterceptor doesn't overwrite existing OAuth token with empty string
 * Fix #4350: SchemaSwap annotation is now repeatable and is applied multiple times if classes are used more than once in the class hierarchy.
@@ -45,6 +46,7 @@
 * Fix #3924: Extension Mock modules have been removed
 * Fix #4384: javax.validation.* annotations are no longer added by the Java generator.
 * Fix #3906: removed BaseKubernetesList, use KubernetesList instead
+* Fix #4408: deprecated SharedInformerFactory.addSharedInformerEventListener, instead use the SharedIndexInformer.stopped method.  Also the signature of SharedIndexInformer.start was changed to a CompletionStage rather than a CompletableFuture.
 
 ### 5.12.4 (2022-09-30)
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ExceptionHandler.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/ExceptionHandler.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.informers;
+
+import com.fasterxml.jackson.core.JacksonException;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+
+public interface ExceptionHandler {
+
+  /**
+   * Called to determine if the informer should continue to retry after the given exception.
+   * <p>
+   * See also {@link #isDeserializationException(Throwable)} that can help determine if the
+   * problem is a mismatch with the target client class.
+   *
+   * @param isStarted true if the informer had already successfully started
+   * @param t the non-http gone {@link WatcherException} from a
+   *        {@link Watcher#onClose(io.fabric8.kubernetes.client.WatcherException)}
+   *        or throwable from a list/watch call.
+   * @return true if the informer should continue to retry
+   */
+  boolean retryAfterException(boolean isStarted, Throwable t);
+
+  /**
+   * Check to see if the exception of it's cause is coming from what is likely a
+   * deserialization issue - either an exception from jackson or a class cast
+   *
+   * @param t
+   * @return
+   */
+  public static boolean isDeserializationException(Throwable t) {
+    while (!(t instanceof ClassCastException || t instanceof JacksonException)) {
+      Throwable cause = t.getCause();
+      if (cause == t || cause == null) {
+        return false;
+      }
+      t = cause;
+    }
+    return true;
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedIndexInformer.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedIndexInformer.java
@@ -175,7 +175,7 @@ public interface SharedIndexInformer<T> extends AutoCloseable {
 
   /**
    * Sets the {@link ExceptionHandler} for this informer. For example, exceptionHandler((b, t) -&gt; true)), will
-   * keep retying no matter what the exception is.
+   * keep retrying no matter what the exception is.
    * <p>
    * May only be called prior to the informer starting
    *

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedInformerFactory.java
@@ -81,6 +81,10 @@ public interface SharedInformerFactory {
    */
   void stopAllRegisteredInformers();
 
+  /**
+   * @deprecated use {@link SharedIndexInformer#stopped()} method to get notified when an informer stops.
+   */
+  @Deprecated
   void addSharedInformerEventListener(SharedInformerEventListener event);
 
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/ExceptionHandlerTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/ExceptionHandlerTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.informers;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import io.fabric8.kubernetes.client.WatcherException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExceptionHandlerTest {
+
+  @Test
+  void testDeserializationException() {
+    assertFalse(ExceptionHandler.isDeserializationException(new NullPointerException()));
+    assertTrue(
+        ExceptionHandler.isDeserializationException(new WatcherException("x", new JsonMappingException(() -> {
+        }, ""))));
+  }
+
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/SharedInformerFactoryImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/SharedInformerFactoryImpl.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 
@@ -106,11 +107,11 @@ public class SharedInformerFactoryImpl implements SharedInformerFactory {
 
   @Override
   public synchronized Future<Void> startAllRegisteredInformers() {
-    List<CompletableFuture<Void>> startInformerTasks = new ArrayList<>();
+    List<CompletionStage<Void>> startInformerTasks = new ArrayList<>();
 
     if (!informers.isEmpty()) {
       for (SharedIndexInformer<?> informer : informers) {
-        CompletableFuture<Void> future = informer.start();
+        CompletionStage<Void> future = informer.start();
         startInformerTasks.add(future);
         future.whenComplete((v, t) -> {
           if (t != null) {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
@@ -17,11 +17,15 @@ package io.fabric8.kubernetes.client.informers.impl;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.client.Watch;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +47,15 @@ class DefaultSharedIndexInformerResyncTest {
   private DefaultSharedIndexInformer<Pod, PodList> createDefaultSharedIndexInformer(long resyncPeriod) {
     defaultSharedIndexInformer = new DefaultSharedIndexInformer<>(Pod.class, listerWatcher, resyncPeriod, Runnable::run);
     return defaultSharedIndexInformer;
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    Mockito.when(listerWatcher.submitWatch(Mockito.any(), Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(Mockito.mock(Watch.class)));
+    PodList result = new PodListBuilder().withNewMetadata().endMetadata().build();
+    Mockito.when(listerWatcher.submitList(Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(result));
   }
 
   @AfterEach

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceInformerExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/CustomResourceInformerExample.java
@@ -56,8 +56,11 @@ public class CustomResourceInformerExample {
             }
           });
 
-      sharedInformerFactory
-          .addSharedInformerEventListener(ex -> logger.error("Exception occurred, but caught: {}", ex.getMessage()));
+      podInformer.stopped().whenComplete((v, t) -> {
+        if (t != null) {
+          logger.error("Exception occurred, caught: {}", t.getMessage());
+        }
+      });
 
       logger.info("Starting all registered informers");
       sharedInformerFactory.startAllRegisteredInformers();


### PR DESCRIPTION
## Description
Fix #4408 

cc @csviri 

I couldn't come up with a good way to deal with this all under the covers, so it seemed best to introduce an explicit handler with a signature that's sufficient to cover our default behavior.  This makes the final solution much closer to some of the earlier proposals.  For the method:

```
boolean retryAfterException(boolean isStarted, Throwable t);
```
our current behavior is:

```
(b, t) -> b && !(t instanceof WatcherException)
```
That is we'll retry once started and only if it's not a WatcherException.  

The expectation here is that if you use the runnableInformer method, you can change this behavior by calling something like exceptionHandler((b, t) -> true)

In reviewing the go implementation, I see the following differences:

- Their WatchErrorHandler is doc'd as only informational - however the reflector is passed in, so you can easily kill it if you wanted.
- They will always retry, so the WatchErrorHandler method does not return anything.
- The equivalent of a watch onClose exception is not passed to their WatchErrorHandler.  I think their assumption is that you'll immediately be trying a fresh list / watch and then you'll experience a problem with one of those calls if something is still wrong. 

I've added a helper method to ExceptionHandler to check for deserialization issues - but that is not currently used in any built-in way.   If you use something like exceptionHandler((b, t) -> true), but there is a jsonprocessing exception with the list call or with a watch event the result would be that you'll just keep retrying - a fresh list operation, then watch.  If you don't want to make an assumption that things will self heal (a missing conversion webhook is installed later), then ExceptionHandler.isDeserializationException could be used - exceptionHandler((b, t) -> !ExceptionHandler.isDeserializationException(t))

With a major release we can then determine if the default behavior should become more generally to just keep retrying.

Along with this is a small breaking change to make the return type for start and stopped to be a CompletionStage rather than a CompletableFuture - I realized that since we don't want the user completing and don't support canceling, we should be using the narrower type instead.  Since the stopped method was just introduced we may be able to change that one without too much concern (that would also need backported).  If anyone has any qualms with start changing as well, I'll revert that.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
