### PR TITLE
fix #4491: adding a more explicit shutdown exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.3-SNAPSHOT
 
 #### Bugs
+* Fix #4491: added a more explicit shutdown exception for okhttp
 * Fix #4534: Java Generator CLI default handling of skipGeneratedAnnotations
 * Fix #4535: The shell command string will now have single quotes sanitized
 * Fix #4547: preventing timing issues with leader election cancel

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -17,6 +17,7 @@
 package io.fabric8.kubernetes.client.okhttp;
 
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
@@ -42,6 +43,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Function;
 
 public class OkHttpClientImpl implements HttpClient {
@@ -242,22 +244,28 @@ public class OkHttpClientImpl implements HttpClient {
       Function<BufferedSource, AsyncBody> handler) {
     CompletableFuture<HttpResponse<AsyncBody>> future = new CompletableFuture<>();
     Call call = httpClient.newCall(((OkHttpRequestImpl) request).getRequest());
-    call.enqueue(new Callback() {
+    try {
+      call.enqueue(new Callback() {
 
-      @Override
-      public void onResponse(Call call, Response response) throws IOException {
-        BufferedSource source = response.body().source();
+        @Override
+        public void onResponse(Call call, Response response) throws IOException {
+          BufferedSource source = response.body().source();
 
-        AsyncBody asyncBody = handler.apply(source);
+          AsyncBody asyncBody = handler.apply(source);
 
-        future.complete(new OkHttpResponseImpl<>(response, asyncBody));
-      }
+          future.complete(new OkHttpResponseImpl<>(response, asyncBody));
+        }
 
-      @Override
-      public void onFailure(Call call, IOException e) {
-        future.completeExceptionally(e);
-      }
-    });
+        @Override
+        public void onFailure(Call call, IOException e) {
+          future.completeExceptionally(e);
+        }
+      });
+    } catch (RejectedExecutionException e) {
+      throw new KubernetesClientException("The okhttp client executor has been shutdown.  "
+          + "More than likely this is because the KubernetesClient.close method has been called "
+          + "- please ensure that is intentional.", e);
+    }
     future.whenComplete((r, t) -> {
       if (future.isCancelled()) {
         call.cancel();


### PR DESCRIPTION
## Description
Fixes #4491 - since this has come up a couple of times we probably need a more explicit message for a RejectedExecutionException from down in okhttp.  Assuming #4430 is committed, this change only needs applied to a single okhttp method.

It's also possible to handle this more generally with a proxied httpclient with close checking, but I don't think that is needed as the other clients either already do that check or provide a better exception.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
