### PR TITLE
fix: Stack overflow on multi maps (and other non-trivial generic clas…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #4473: Fix regression in backoff interval introduced in #4365
 * Fix #4478: Removing the resourceVersion bump with null status
 * Fix #4482: Fixing blocking behavior of okhttp log watch
+* Fix #4487: Schema for multimaps is now generated correctly
 
 #### Improvements
 * Fix #4471: Adding KubernetesClientBuilder.withHttpClientBuilderConsumer to further customize the HttpClient for any implementation.
@@ -30,6 +31,7 @@
 * Fix #4243: Update Tekton triggers model to v0.20.2
 * Fix #4383: bump snakeyaml from 1.30 to 1.31
 * Fix #4347: Update Kubernetes Model to v1.25.0
+* Fix #4413: Update sundrio to 0.93.1
 
 #### New Features
 * Fix #4398: add annotation @PreserveUnknownFields for marking generated field have `x-kubernetes-preserve-unknown-fields: true` defined

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -137,9 +137,9 @@ class CRDGeneratorTest {
     assertEquals(0, generator.detailedGenerate().numberOfGeneratedCRDs());
 
     final CRDGenerationInfo info = generator
-      .customResourceClasses(Simplest.class, Child.class, Joke.class, JokeRequest.class)
-      .forCRDVersions("v1", "v1beta1")
-      .withOutput(output).detailedGenerate();
+        .customResourceClasses(Simplest.class, Child.class, Joke.class, JokeRequest.class)
+        .forCRDVersions("v1", "v1beta1")
+        .withOutput(output).detailedGenerate();
 
     assertEquals(4 * 2, info.numberOfGeneratedCRDs());
     final Map<String, Map<String, CRDInfo>> details = info.getCRDDetailsPerNameAndVersion();
@@ -160,9 +160,9 @@ class CRDGeneratorTest {
     CRDGenerator generator = new CRDGenerator();
     final String specVersion = "v1beta1";
     final CRDGenerationInfo info = generator
-      .customResourceClasses(Multiple.class, io.fabric8.crd.example.multiple.v2.Multiple.class)
-      .forCRDVersions(specVersion)
-      .withOutput(output).detailedGenerate();
+        .customResourceClasses(Multiple.class, io.fabric8.crd.example.multiple.v2.Multiple.class)
+        .forCRDVersions(specVersion)
+        .withOutput(output).detailedGenerate();
 
     assertEquals(1, info.numberOfGeneratedCRDs());
     final Map<String, Map<String, CRDInfo>> details = info.getCRDDetailsPerNameAndVersion();
@@ -185,13 +185,15 @@ class CRDGeneratorTest {
     assertTrue(versions.stream().filter(v -> v.getName().equals("v1")).count() == 1);
     assertTrue(versions.stream().filter(v -> v.getName().equals("v2")).count() == 1);
 
-
-    Class<?>[] mustContainTraversedClasses = {Multiple.class, MultipleSpec.class, io.fabric8.crd.example.multiple.v2.Multiple.class, io.fabric8.crd.example.multiple.v2.MultipleSpec.class};
+    Class<?>[] mustContainTraversedClasses = { Multiple.class, MultipleSpec.class,
+        io.fabric8.crd.example.multiple.v2.Multiple.class, io.fabric8.crd.example.multiple.v2.MultipleSpec.class };
     final Set<String> dependentClassNames = infos.get(specVersion).getDependentClassNames();
-    Arrays.stream(mustContainTraversedClasses).map(Class::getCanonicalName).forEach(c -> assertTrue(dependentClassNames.contains(c), "should contain " + c));
+    Arrays.stream(mustContainTraversedClasses).map(Class::getCanonicalName)
+        .forEach(c -> assertTrue(dependentClassNames.contains(c), "should contain " + c));
   }
 
-  @Test void notDefiningOutputShouldNotGenerateAnything() {
+  @Test
+  void notDefiningOutputShouldNotGenerateAnything() {
     CRDGenerator generator = new CRDGenerator();
     assertEquals(0, generator.generate());
 
@@ -201,24 +203,25 @@ class CRDGeneratorTest {
     assertEquals(0, generator.generate());
   }
 
-  @Test void generatingACycleShouldFail() {
+  @Test
+  void generatingACycleShouldFail() {
     final CRDGenerator generator = new CRDGenerator()
-      .customResourceClasses(Cyclic.class)
-      .forCRDVersions("v1", "v1beta1")
-      .withOutput(output);
+        .customResourceClasses(Cyclic.class)
+        .forCRDVersions("v1", "v1beta1")
+        .withOutput(output);
 
     assertThrows(
-      IllegalArgumentException.class,
-      () -> generator.detailedGenerate(),
-      "An IllegalArgument Exception hasn't been thrown when generating a CRD with cyclic references"
-    );
+        IllegalArgumentException.class,
+        () -> generator.detailedGenerate(),
+        "An IllegalArgument Exception hasn't been thrown when generating a CRD with cyclic references");
   }
 
-  @Test void notGeneratingACycleShouldSucceed() {
+  @Test
+  void notGeneratingACycleShouldSucceed() {
     final CRDGenerator generator = new CRDGenerator()
-      .customResourceClasses(NoCyclic.class)
-      .forCRDVersions("v1", "v1beta1")
-      .withOutput(output);
+        .customResourceClasses(NoCyclic.class)
+        .forCRDVersions("v1", "v1beta1")
+        .withOutput(output);
 
     CRDGenerationInfo info = generator.detailedGenerate();
     assertEquals(2, info.numberOfGeneratedCRDs());
@@ -239,11 +242,12 @@ class CRDGeneratorTest {
       throw e;
     }
   }
+
   @Test
   void simplestCRDShouldWork() {
     outputCRDIfFailed(Simplest.class, (customResource) -> {
       final CustomResourceDefinitionVersion version = checkCRD(customResource, "Simplest", "simplests",
-        Scope.CLUSTER, SimplestSpec.class, SimplestStatus.class);
+          Scope.CLUSTER, SimplestSpec.class, SimplestStatus.class);
       assertNotNull(version.getSubresources());
     });
 
@@ -253,10 +257,10 @@ class CRDGeneratorTest {
   void inheritedCRDShouldWork() {
     outputCRDIfFailed(Child.class, (customResource) -> {
       final CustomResourceDefinitionVersion version = checkCRD(customResource, "Child", "children",
-        Scope.NAMESPACED, ChildSpec.class, ChildStatus.class, BaseSpec.class, BaseStatus.class);
+          Scope.NAMESPACED, ChildSpec.class, ChildStatus.class, BaseSpec.class, BaseStatus.class);
       assertNotNull(version.getSubresources());
       final Map<String, JSONSchemaProps> specProps = version.getSchema().getOpenAPIV3Schema()
-        .getProperties().get("spec").getProperties();
+          .getProperties().get("spec").getProperties();
       assertEquals(4, specProps.size());
       assertEquals("integer", specProps.get("baseInt").getType());
       checkMapProp(specProps, "unsupported", "object");
@@ -269,38 +273,45 @@ class CRDGeneratorTest {
   void mapPropertyShouldHaveCorrectValueType() {
     outputCRDIfFailed(ContainingMaps.class, (customResource) -> {
       final CustomResourceDefinitionVersion version = checkCRD(customResource, "ContainingMaps", "containingmaps",
-        Scope.CLUSTER, ContainingMapsSpec.class);
+          Scope.CLUSTER, ContainingMapsSpec.class);
       assertNotNull(version.getSchema());
 
       final Map<String, JSONSchemaProps> specProps = version.getSchema().getOpenAPIV3Schema()
-        .getProperties().get("spec").getProperties();
+          .getProperties().get("spec").getProperties();
 
-      assertEquals(2, specProps.size());
+      assertEquals(9, specProps.size());
 
-      checkMapProp(specProps, "test", "array");
-      String arrayType = specProps.get("test").getAdditionalProperties().getSchema().getItems().getSchema().getType();
-      assertEquals("string", arrayType);
+      JSONSchemaProps testSchema = checkMapProp(specProps, "test", "array");
+      assertEquals("string", testSchema.getItems().getSchema().getType());
 
-      checkMapProp(specProps, "test2", "object");
-      JSONSchemaProps valueSchema = specProps.get("test2").getAdditionalProperties().getSchema().getAdditionalProperties().getSchema();
+      JSONSchemaProps test2Schema = checkMapProp(specProps, "test2", "object");
+      JSONSchemaProps valueSchema = test2Schema.getAdditionalProperties().getSchema();
       String valueType = valueSchema.getType();
       assertEquals("array", valueType);
-
       assertEquals("boolean", valueSchema.getItems().getSchema().getType());
+
+      for (int i = 1; i <= 7; i++) {
+        String name = "stringToIntMultiMap" + i;
+        JSONSchemaProps schema = checkMapProp(specProps, name, "array");
+        assertEquals("integer", schema.getItems().getSchema().getType(), name + "'s array item type should be integer");
+      }
     });
   }
 
-  private void checkMapProp(Map<String, JSONSchemaProps> specProps, String name, String valueType) {
+  private JSONSchemaProps checkMapProp(Map<String, JSONSchemaProps> specProps, String name, String valueType) {
     final JSONSchemaProps props = specProps.get(name);
-    assertEquals("object", props.getType());
-    assertEquals(valueType, props.getAdditionalProperties().getSchema().getType());
+    assertNotNull(props, name + " should be contained in spec");
+    assertEquals("object", props.getType(), name + "'s type should be object");
+    assertEquals(valueType, props.getAdditionalProperties().getSchema().getType(),
+        name + "'s value type should be " + valueType);
+    return props.getAdditionalProperties().getSchema();
   }
 
   @Test
   void jokeCRDShouldWork() {
     outputCRDIfFailed(Joke.class, (customResource) -> {
       CustomResourceDefinitionVersion version = checkCRD(Joke.class, "Joke", "jokes",
-        Scope.NAMESPACED);
+          Scope.NAMESPACED);
       assertNull(version.getSubresources());
     });
   }
@@ -309,10 +320,11 @@ class CRDGeneratorTest {
   void jokerequestCRDShouldWork() {
     outputCRDIfFailed(JokeRequest.class, (customResource) -> {
       final CustomResourceDefinitionSpec spec = checkSpec(customResource, Scope.NAMESPACED,
-        JokeRequestSpec.class, JokeRequestStatus.class, JokeRequestSpec.Category.class, JokeRequestSpec.ExcludedTopic.class, JokeRequestStatus.State.class);
+          JokeRequestSpec.class, JokeRequestStatus.class, JokeRequestSpec.Category.class, JokeRequestSpec.ExcludedTopic.class,
+          JokeRequestStatus.State.class);
 
       final CustomResourceDefinitionNames names = checkNames("JokeRequest",
-        "jokerequests", spec);
+          "jokerequests", spec);
       assertEquals(1, names.getShortNames().size());
       assertTrue(names.getShortNames().contains("jr"));
 
@@ -320,7 +332,7 @@ class CRDGeneratorTest {
       assertNotNull(version.getSubresources());
       // printer columns should be ordered in the alphabetical order of their json path
       final List<CustomResourceColumnDefinition> printerColumns = version
-        .getAdditionalPrinterColumns();
+          .getAdditionalPrinterColumns();
       assertEquals(2, printerColumns.size());
       CustomResourceColumnDefinition columnDefinition = printerColumns.get(0);
       assertEquals("string", columnDefinition.getType());
@@ -352,7 +364,7 @@ class CRDGeneratorTest {
   void checkCRDGenerator() {
     outputCRDIfFailed(Basic.class, (customResource) -> {
       final CustomResourceDefinitionVersion version = checkCRD(customResource, "Basic", "basics",
-        Scope.NAMESPACED, BasicSpec.class, BasicStatus.class);
+          Scope.NAMESPACED, BasicSpec.class, BasicStatus.class);
       assertNotNull(version.getSubresources());
       CustomResourceValidation schema = version.getSchema();
       assertNotNull(schema);
@@ -365,8 +377,9 @@ class CRDGeneratorTest {
     });
   }
 
-  private CustomResourceDefinitionVersion checkCRD(Class<? extends CustomResource<?,?>> customResource, String kind, String plural,
-    Scope scope, Class<?>... traversedClasses) {
+  private CustomResourceDefinitionVersion checkCRD(Class<? extends CustomResource<?, ?>> customResource, String kind,
+      String plural,
+      Scope scope, Class<?>... traversedClasses) {
     CustomResourceDefinitionSpec spec = checkSpec(customResource, scope, traversedClasses);
     checkNames(kind, plural, spec);
 
@@ -388,7 +401,7 @@ class CRDGeneratorTest {
   }
 
   private CustomResourceDefinitionSpec checkSpec(
-    Class<? extends CustomResource<?, ?>> customResource, Scope scope, Class<?>... mustContainTraversedClasses) {
+      Class<? extends CustomResource<?, ?>> customResource, Scope scope, Class<?>... mustContainTraversedClasses) {
     CRDGenerator generator = new CRDGenerator();
 
     // record info to be able to output it if the test fails
@@ -397,9 +410,9 @@ class CRDGeneratorTest {
     output.put(outputName, info);
     final String v1 = "v1";
     final CRDGenerationInfo generatedInfo = generator.withOutput(output)
-      .forCRDVersions(v1)
-      .customResources(info)
-      .detailedGenerate();
+        .forCRDVersions(v1)
+        .customResources(info)
+        .detailedGenerate();
     assertEquals(1, generatedInfo.numberOfGeneratedCRDs());
     final String crdName = info.crdName();
     final Map<String, CRDInfo> crdInfos = generatedInfo.getCRDInfos(crdName);
@@ -408,9 +421,10 @@ class CRDGeneratorTest {
     assertEquals(crdName, crdInfo.getCrdName());
     assertEquals(v1, crdInfo.getCrdSpecVersion());
     assertTrue(crdInfo.getFilePath().endsWith(CRDGenerator.getOutputName(crdName, v1))); // test output uses the CRD name as URI
-    if(mustContainTraversedClasses != null && mustContainTraversedClasses.length > 0) {
+    if (mustContainTraversedClasses != null && mustContainTraversedClasses.length > 0) {
       final Set<String> dependentClassNames = crdInfo.getDependentClassNames();
-      Arrays.stream(mustContainTraversedClasses).map(Class::getCanonicalName).forEach(c -> assertTrue(dependentClassNames.contains(c), "should contain " + c));
+      Arrays.stream(mustContainTraversedClasses).map(Class::getCanonicalName)
+          .forEach(c -> assertTrue(dependentClassNames.contains(c), "should contain " + c));
     }
 
     CustomResourceDefinition definition = output.definition(outputName);
@@ -431,6 +445,7 @@ class CRDGeneratorTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestCRDOutput.class);
     private final static Class<CustomResourceDefinition> crdClass = CustomResourceDefinition.class;
     private final Map<String, CustomResourceInfo> infos = new ConcurrentHashMap<>();
+
     @Override
     protected ByteArrayOutputStream createStreamFor(String crdName) throws IOException {
       return new ByteArrayOutputStream();

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMaps.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMaps.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.maps;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("map.fabric8.io")
+@Version("v1")
+public class ContainingMaps extends CustomResource<ContainingMapsSpec, Void> {
+
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsCRDTest.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsCRDTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.maps;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersion;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ContainingMapsCRDTest {
+
+  @Test
+  void testCrd() {
+    CustomResourceDefinition d = Serialization.unmarshal(getClass().getClassLoader()
+        .getResourceAsStream("META-INF/fabric8/containingmaps.map.fabric8.io-v1.yml"),
+        CustomResourceDefinition.class);
+    assertNotNull(d);
+
+    CustomResourceDefinitionVersion v1 = d.getSpec().getVersions().get(0);
+    assertNotNull(v1);
+    assertEquals("v1", v1.getName());
+    Map<String, JSONSchemaProps> spec = v1.getSchema().getOpenAPIV3Schema().getProperties().get("spec").getProperties();
+    assertNotNull(spec);
+
+    final Map<String, JSONSchemaProps> specProps = v1.getSchema().getOpenAPIV3Schema()
+        .getProperties().get("spec").getProperties();
+
+    assertEquals(7, specProps.size());
+
+    for (int i = 1; i <= 7; i++) {
+      String name = "stringToIntMultiMap" + i;
+      JSONSchemaProps schema = checkMapProp(specProps, name, "array");
+      assertEquals("integer", schema.getItems().getSchema().getType(), name + "'s array item type should be integer");
+    }
+  }
+
+  private JSONSchemaProps checkMapProp(Map<String, JSONSchemaProps> specProps, String name, String valueType) {
+    final JSONSchemaProps props = specProps.get(name);
+    assertNotNull(props, name + " should be contained in spec");
+    assertEquals("object", props.getType(), name + "'s type should be object");
+    assertEquals(valueType, props.getAdditionalProperties().getSchema().getType(),
+        name + "'s value type should be " + valueType);
+    return props.getAdditionalProperties().getSchema();
+  }
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsSpec.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsSpec.java
@@ -13,26 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.crd.example.map;
+package io.fabric8.crd.generator.maps;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ContainingMapsSpec {
-
-  private Map<String, List<String>> test = null;
-
-  public Map<String, List<String>> getTest() {
-    return test;
-  }
-
-  private Map<String, Map<String, List<Boolean>>> test2 = null;
-
-  public Map<String, Map<String, List<Boolean>>> getTest2() {
-    return test2;
-  }
-
   private MultiHashMap<String, Integer> stringToIntMultiMap1;
   private MultiMap<String, Integer> stringToIntMultiMap2;
   private SwappedParametersMap<List<Integer>, String> stringToIntMultiMap3;

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Core versions -->
-    <sundrio.version>0.93.0</sundrio.version>
+    <sundrio.version>0.93.1</sundrio.version>
     <okhttp.version>3.12.12</okhttp.version>
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
## Description
…ses), schema for multimaps is wrong

Logic in sundrio that is responsible for replacing generic type arguments on methods and properties with their concrete instantiations from subclasses contained a bug, in which it looped infinitely if the same type argument name was used at multiple classes in the hierarchy. A common occurence were multimaps.

A very similar code was also present in crd-generator, also suffering from the same bug.

Sundrio has been updated to account for this situation, and updated utilities from sundrio have been introduced to crd-generator, which replace the previous implementation of the same algorithm.

A test has been added to validate that multimaps (like `class MultiMap<K,V> implements Map<K,List<V>>`) are generated correctly.

Fixes fabric8io/kubernetes-client#4357
Fixes fabric8io/kubernetes-client#4487
Supersedes closes #4504 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
