### PR TITLE
fix #4355: adding logic to set/validate the container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #4547: preventing timing issues with leader election cancel
 
 #### Improvements
+* Fix #4355: for exec, attach, upload, and copy operations the container id/name will be validated or chosen prior to the remote call.  You may also use the kubectl.kubernetes.io/default-container annotation to specify the default container.
 
 #### Dependency Upgrade
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -315,10 +315,11 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
    */
   String validateOrDefaultContainerId(String name) {
     Pod pod = this.require();
-    List<Container> containers = pod.getSpec().getContainers();
-    if (containers.isEmpty()) {
+    // spec and container null-checks are not necessary for real k8s clusters, added them to simplify some tests running in the mockserver
+    if (pod.getSpec() == null || pod.getSpec().getContainers() == null || pod.getSpec().getContainers().isEmpty()) {
       throw new KubernetesClientException("Pod has no containers!");
     }
+    final List<Container> containers = pod.getSpec().getContainers();
     if (name == null) {
       name = pod.getMetadata().getAnnotations().get(DEFAULT_CONTAINER_ANNOTATION_NAME);
       if (name != null && !hasContainer(containers, name)) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -63,10 +63,6 @@ public class PodUpload {
 
   private static boolean upload(PodOperationsImpl operation, String command, UploadProcessor processor) throws IOException {
     operation = operation.redirectingInput().terminateOnError();
-    String containerId = operation.getContext().getContainerId();
-    if (Utils.isNotNullOrEmpty(containerId)) {
-      operation = operation.inContainer(containerId);
-    }
     CompletableFuture<Integer> exitFuture;
     try (ExecWatch execWatch = operation.exec("sh", "-c", command)) {
       OutputStream out = execWatch.getInput();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -55,7 +55,7 @@ public class PodUpload {
     throw new IllegalArgumentException("Provided arguments are not valid (file, directory, path)");
   }
 
-  private static interface UploadProcessor {
+  private interface UploadProcessor {
 
     void process(OutputStream out) throws IOException;
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl_CVE2021_20218_Test.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl_CVE2021_20218_Test.java
@@ -39,17 +39,17 @@ class PodOperationsImpl_CVE2021_20218_Test {
   }
 
   @Test
-  void testWithForgedTar(@TempDir Path targetDirParent) throws Exception {
+  void testWithForgedTar(@TempDir Path targetDirParent) {
     // Given
     final Path targetDir = targetDirParent.resolve("target");
     final PodOperationsImpl poi = spy(new PodOperationsImpl(baseContext.withDir("/var/source-dir"), new OperationContext()));
     doReturn(PodOperationsImpl_CVE2021_20218_Test.class.getResourceAsStream("/2021_20218/tar-with-parent-traversal.tar"))
-      .when(poi).readTar("/var/source-dir");
+        .when(poi).readTar("/var/source-dir");
     // When
     final KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> poi.copy(targetDir));
     // Then
     assertThat(exception).getCause()
-      .hasMessage("Tar entry '../youve-been-hacked' has an invalid name");
+        .hasMessage("Tar entry '../youve-been-hacked' has an invalid name");
     assertThat(targetDirParent).isDirectoryNotContaining("glob:**/youve-been-hacked");
   }
 
@@ -59,13 +59,13 @@ class PodOperationsImpl_CVE2021_20218_Test {
     final Path targetDir = targetDirParent.resolve("target");
     final PodOperationsImpl poi = spy(new PodOperationsImpl(baseContext.withDir("/var/source-dir"), new OperationContext()));
     doReturn(PodOperationsImpl_CVE2021_20218_Test.class.getResourceAsStream("/2021_20218/valid.tar"))
-      .when(poi).readTar("/var/source-dir");
+        .when(poi).readTar("/var/source-dir");
     // When
     final boolean result = poi.copy(targetDir);
     // Then
     assertThat(result).isTrue();
     assertThat(targetDir)
-      .isDirectoryContaining("glob:**/hello.txt")
-      .isDirectoryRecursivelyContaining("glob:**/very/nested/dir/answer.txt");
+        .isDirectoryContaining("glob:**/hello.txt")
+        .isDirectoryRecursivelyContaining("glob:**/very/nested/dir/answer.txt");
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.uploadable;
 
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.internal.ExecWebSocketListener;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
@@ -25,9 +27,10 @@ import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.impl.BaseClient;
 import io.fabric8.kubernetes.client.utils.CommonThreadPool;
 import io.fabric8.kubernetes.client.utils.InputStreamPumper;
-import io.fabric8.kubernetes.client.utils.InputStreamPumper.Writable;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
@@ -40,16 +43,17 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,7 +61,6 @@ import static org.mockito.Mockito.when;
 class PodUploadTest {
 
   private HttpClient mockClient;
-  private Path mockPathToUpload;
   private WebSocket mockWebSocket;
   private PodOperationsImpl operation;
 
@@ -67,39 +70,41 @@ class PodUploadTest {
   }
 
   @BeforeEach
-  void setUp() throws IOException {
-    mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
-    mockPathToUpload = Mockito.mock(Path.class, Mockito.RETURNS_DEEP_STUBS);
-    mockWebSocket = Mockito.mock(WebSocket.class, Mockito.RETURNS_DEEP_STUBS);
-    Mockito.when(mockWebSocket.send(Mockito.any())).thenReturn(true);
-
+  void setUp() {
+    mockClient = mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    mockWebSocket = mock(WebSocket.class, Mockito.RETURNS_DEEP_STUBS);
+    when(mockWebSocket.send(any())).thenReturn(true);
     when(mockClient.newBuilder().readTimeout(anyLong(), any(TimeUnit.class)).build()).thenReturn(mockClient);
 
-    BaseClient client = Mockito.mock(BaseClient.class, Mockito.RETURNS_SELF);
+    BaseClient client = mock(BaseClient.class, Mockito.RETURNS_SELF);
     Mockito.when(client.adapt(BaseClient.class).getExecutor()).thenReturn(CommonThreadPool.get());
-    Config config = Mockito.mock(Config.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = mock(Config.class, Mockito.RETURNS_DEEP_STUBS);
     when(config.getMasterUrl()).thenReturn("https://openshift.com:8443");
     when(config.getNamespace()).thenReturn("default");
     when(client.getConfiguration()).thenReturn(config);
     when(client.getHttpClient()).thenReturn(mockClient);
-    this.operation = new PodOperationsImpl(new PodOperationContext(), new OperationContext().withClient(client));
+    final Pod item = new PodBuilder()
+        .withNewMetadata().withName("pod").endMetadata()
+        .withNewSpec().addNewContainer().withName("container").endContainer().endSpec()
+        .build();
+    this.operation = new PodOperationsImpl(
+        new PodOperationContext(), new OperationContext().withItem(item).withClient(client));
   }
 
   @Test
-  void testUploadInvalidParametersShouldThrowException() {
-    final IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
-        () -> PodUpload.upload(operation, mockPathToUpload));
-
-    assertThat(result.getMessage(),
-        equalTo("Provided arguments are not valid (file, directory, path)"));
+  @DisplayName("With invalid parameters, should throw exception")
+  void uploadInvalidParametersShouldThrowException(@TempDir Path pathToUpload) {
+    final Path nonExistentPath = pathToUpload.resolve("non-existent");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> PodUpload.upload(operation, nonExistentPath))
+        .withMessage("Provided arguments are not valid (file, directory, path)");
   }
 
   @Test
-  void upload_whenFilePathProvided_shouldUploadFile() throws IOException, InterruptedException {
-    when(mockPathToUpload.toFile())
-        .thenReturn(new File(PodUpload.class.getResource("/upload/upload-sample.txt").getFile()));
-    uploadFileAndVerify(() -> PodUpload.upload(operation, mockPathToUpload));
-    verify(mockPathToUpload, atLeast(1)).toFile();
+  void upload_withFile_shouldUploadFile() throws IOException, InterruptedException {
+    final Path toUpload = new File(PodUpload.class.getResource("/upload/upload-sample.txt").getFile())
+        .toPath();
+    uploadFileAndVerify(() -> PodUpload.upload(operation, toUpload));
   }
 
   @Test
@@ -109,97 +114,66 @@ class PodUploadTest {
   }
 
   @Test
-  void testUploadDirectoryHappyScenarioShouldUploadDirectory() throws Exception {
-    uploadDirectoryAndVerify("/upload");
+  void upload_withDirectory_shouldUploadDirectory() throws Exception {
+    final Path toUpload = new File(PodUpload.class.getResource("/upload").getFile())
+        .toPath();
+    uploadDirectoryAndVerify(() -> PodUpload.upload(operation, toUpload));
   }
 
   @Test
-  void testUploadDirectoryLongFileNameShouldUploadDirectory() throws Exception {
-    uploadDirectoryAndVerify("/upload_long");
-  }
-
-  private void uploadDirectoryAndVerify(String resourcePath) throws IOException, InterruptedException {
-    this.operation = operation.dir("/mock/dir");
-    when(mockPathToUpload.toFile())
-        .thenReturn(new File(PodUpload.class.getResource(resourcePath).getFile()));
-    WebSocket.Builder builder = Mockito.mock(WebSocket.Builder.class, Mockito.RETURNS_SELF);
-    when(builder.buildAsync(any())).thenAnswer(newWebSocket -> {
-      final ExecWebSocketListener wsl = newWebSocket.getArgument(0, ExecWebSocketListener.class);
-      // Set ready status
-      wsl.onOpen(mockWebSocket);
-      wsl.onMessage(mockWebSocket, ByteBuffer.wrap(new byte[] { (byte) 0 }));
-      // Set complete status
-      Mockito.doAnswer(close -> {
-        wsl.onClose(mockWebSocket, close.getArgument(0), close.getArgument(1));
-        return null;
-      }).when(mockWebSocket).sendClose(anyInt(), anyString());
-      return CompletableFuture.completedFuture(mockWebSocket);
-    });
-    when(mockClient.newWebSocketBuilder()).thenReturn(builder);
-
-    final boolean result = PodUpload.upload(operation, mockPathToUpload);
-
-    assertThat(result, equalTo(true));
-    verify(mockPathToUpload, atLeast(1)).toFile();
-    verify(builder, times(1)).uri(argThat(request -> {
-      assertThat(request.toString(), equalTo(
-          "https://openshift.com:8443/api/v1/namespaces/default/pods/exec?command=sh&command=-c&command=mkdir%20-p%20%27%2Fmock%2Fdir%27%20%26%26%20base64%20-d%20-%20%7C%20tar%20-C%20%27%2Fmock%2Fdir%27%20-xzf%20-&stdin=true&stderr=true"));
-      return true;
-    }));
-    verify(mockWebSocket, atLeast(1)).send(any(ByteBuffer.class));
+  void upload_withDirectoryAndLongFileNames_shouldUploadDirectory() throws Exception {
+    final Path toUpload = new File(PodUpload.class.getResource("/upload_long").getFile())
+        .toPath();
+    uploadDirectoryAndVerify(() -> PodUpload.upload(operation, toUpload));
   }
 
   @Test
-  void testCopy() throws Exception {
+  void transferTo() throws Exception {
     final ByteArrayInputStream input = new ByteArrayInputStream("I'LL BE COPIED".getBytes(Charset.defaultCharset()));
-    final Writable consumer = (bytes, offset, length) -> {
-      assertThat(length, equalTo(14));
-      assertThat(new String(Arrays.copyOf(bytes, 14), Charset.defaultCharset()),
-          equalTo("I'LL BE COPIED"));
+    final AtomicReference<String> copiedStream = new AtomicReference<>();
+    final InputStreamPumper.Writable consumer = (bytes, offset, length) -> {
+      assertThat(length).isEqualTo(14);
+      copiedStream.set(new String(Arrays.copyOf(bytes, 14), Charset.defaultCharset()));
     };
-
     InputStreamPumper.transferTo(input, consumer);
+    assertThat(copiedStream).hasValue("I'LL BE COPIED");
   }
 
   @Test
   void createExecCommandForUpload_withFileInRootPath_shouldCreateValidExecCommandForUpload() {
     // When
     String result = PodUpload.createExecCommandForUpload("/cp.log");
-
     // Then
-    assertThat(result, equalTo("mkdir -p '/' && base64 -d - > '/cp.log'"));
+    assertThat(result).isEqualTo("mkdir -p '/' && base64 -d - > '/cp.log'");
   }
 
   @Test
   void createExecCommandForUpload_withNormalFile_shouldCreateValidExecCommandForUpload() {
     // When
     String result = PodUpload.createExecCommandForUpload("/tmp/foo/cp.log");
-
     // Then
-    assertThat(result, equalTo("mkdir -p '/tmp/foo' && base64 -d - > '/tmp/foo/cp.log'"));
+    assertThat(result).isEqualTo("mkdir -p '/tmp/foo' && base64 -d - > '/tmp/foo/cp.log'");
   }
 
   @Test
   void createExecCommandForUpload_withSingleQuoteInPath() {
     // When
     String result = PodUpload.createExecCommandForUpload("/tmp/fo'o/cp.log");
-
     // Then
-    assertThat(result, equalTo("mkdir -p '/tmp/fo\'\\'\'o' && base64 -d - > '/tmp/fo\'\\'\'o/cp.log'"));
+    assertThat(result).isEqualTo("mkdir -p '/tmp/fo\'\\'\'o' && base64 -d - > '/tmp/fo\'\\'\'o/cp.log'");
   }
 
   @Test
   void createExecCommandForUpload_withMultipleSingleQuotesInPath() {
     // When
     String result = PodUpload.createExecCommandForUpload("/tmp/f'o'o/c'p.log");
-
     // Then
-    assertThat(result, equalTo("mkdir -p '/tmp/f\'\\'\'o\'\\'\'o' && base64 -d - > '/tmp/f\'\\'\'o\'\\'\'o/c\'\\'\'p.log'"));
+    assertThat(result).isEqualTo("mkdir -p '/tmp/f\'\\'\'o\'\\'\'o' && base64 -d - > '/tmp/f\'\\'\'o\'\\'\'o/c\'\\'\'p.log'");
   }
 
   void uploadFileAndVerify(PodUploadTester<Boolean> fileUploadMethodToTest) throws IOException, InterruptedException {
-    this.operation = operation.file("/mock/dir/file");
-    WebSocket.Builder builder = Mockito.mock(WebSocket.Builder.class, Mockito.RETURNS_SELF);
+    operation = operation.file("/mock/dir/file");
+    WebSocket.Builder builder = mock(WebSocket.Builder.class, Mockito.RETURNS_SELF);
     when(builder.buildAsync(any())).thenAnswer(newWebSocket -> {
       final ExecWebSocketListener wsl = newWebSocket.getArgument(0, ExecWebSocketListener.class);
       // Set ready status
@@ -216,10 +190,39 @@ class PodUploadTest {
 
     final boolean result = fileUploadMethodToTest.apply();
 
-    assertThat(result, equalTo(true));
+    assertThat(result).isTrue();
     verify(builder, times(1)).uri(argThat(request -> {
-      assertThat(request.toString(), equalTo(
-          "https://openshift.com:8443/api/v1/namespaces/default/pods/exec?command=sh&command=-c&command=mkdir%20-p%20%27%2Fmock%2Fdir%27%20%26%26%20base64%20-d%20-%20%3E%20%27%2Fmock%2Fdir%2Ffile%27&stdin=true&stderr=true"));
+      assertThat(request).hasToString(
+          "https://openshift.com:8443/api/v1/namespaces/default/pods/exec?command=sh&command=-c&command=mkdir%20-p%20%27%2Fmock%2Fdir%27%20%26%26%20base64%20-d%20-%20%3E%20%27%2Fmock%2Fdir%2Ffile%27&container=container&stdin=true&stderr=true");
+      return true;
+    }));
+    verify(mockWebSocket, atLeast(1)).send(any(ByteBuffer.class));
+  }
+
+  private void uploadDirectoryAndVerify(PodUploadTester<Boolean> directoryUpload)
+      throws IOException, InterruptedException {
+    this.operation = operation.dir("/mock/dir");
+    WebSocket.Builder builder = mock(WebSocket.Builder.class, Mockito.RETURNS_SELF);
+    when(builder.buildAsync(any())).thenAnswer(newWebSocket -> {
+      final ExecWebSocketListener wsl = newWebSocket.getArgument(0, ExecWebSocketListener.class);
+      // Set ready status
+      wsl.onOpen(mockWebSocket);
+      wsl.onMessage(mockWebSocket, ByteBuffer.wrap(new byte[] { (byte) 0 }));
+      // Set complete status
+      Mockito.doAnswer(close -> {
+        wsl.onClose(mockWebSocket, close.getArgument(0), close.getArgument(1));
+        return null;
+      }).when(mockWebSocket).sendClose(anyInt(), anyString());
+      return CompletableFuture.completedFuture(mockWebSocket);
+    });
+    when(mockClient.newWebSocketBuilder()).thenReturn(builder);
+
+    final boolean result = directoryUpload.apply();
+
+    assertThat(result).isTrue();
+    verify(builder, times(1)).uri(argThat(request -> {
+      assertThat(request).hasToString(
+          "https://openshift.com:8443/api/v1/namespaces/default/pods/exec?command=sh&command=-c&command=mkdir%20-p%20%27%2Fmock%2Fdir%27%20%26%26%20base64%20-d%20-%20%7C%20tar%20-C%20%27%2Fmock%2Fdir%27%20-xzf%20-&container=container&stdin=true&stderr=true");
       return true;
     }));
     verify(mockWebSocket, atLeast(1)).send(any(ByteBuffer.class));

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.ContainerResource;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.mockwebserver.internal.WebSocketMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("unused")
+@EnableKubernetesMockClient(crud = true)
+class PodExecTest {
+
+  private KubernetesMockServer server;
+  private KubernetesClient client;
+
+  @BeforeEach
+  void setUp() {
+    client.pods().inAnyNamespace().delete();
+  }
+
+  @Test
+  @DisplayName("With no containers, should throw exception")
+  void withNoContainers() {
+    client.pods().resource(new PodBuilder().withNewMetadata().withName("no-containers").endMetadata().build())
+        .createOrReplace();
+    final PodResource pr = client.pods().withName("no-containers");
+    assertThatThrownBy(() -> pr.exec("sh", "-c", "echo Greetings Professor Falken"))
+        .isInstanceOf(KubernetesClientException.class)
+        .hasMessage("Pod has no containers!");
+  }
+
+  @Test
+  @DisplayName("With single container, should exec in the single container")
+  void withSingleContainer() throws Exception {
+    client.pods().resource(new PodBuilder().withNewMetadata().withName("single-container").endMetadata()
+        .withNewSpec()
+        .addNewContainer()
+        .withName("the-single-container")
+        .endContainer()
+        .endSpec()
+        .build())
+        .createOrReplace();
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/test/pods/single-container/exec?command=sleep%201&container=the-single-container")
+        .andUpgradeToWebSocket()
+        .open()
+        .immediately().andEmit(exitZeroEvent())
+        .done()
+        .always();
+    final ExecWatch result = client.pods().withName("single-container").exec("sleep 1");
+    assertThat(result.exitCode().get(1, TimeUnit.SECONDS)).isZero();
+  }
+
+  @Test
+  @DisplayName("With single container and inContainer with non-existent name, should throw exception")
+  void withSingleContainerAndInContainer() {
+    client.pods().resource(new PodBuilder().withNewMetadata().withName("single-container").endMetadata()
+        .withNewSpec()
+        .addNewContainer()
+        .withName("the-single-container")
+        .endContainer()
+        .endSpec()
+        .build())
+        .createOrReplace();
+    final ContainerResource cr = client.pods().withName("single-container").inContainer("non-existent");
+    assertThatThrownBy(() -> cr.exec("exit 0"))
+        .isInstanceOf(KubernetesClientException.class)
+        .hasMessage("container non-existent not found in pod single-container");
+  }
+
+  @Test
+  @DisplayName("With multiple containers, should exec in the first container")
+  void withMultipleContainers() throws Exception {
+    client.pods().resource(new PodBuilder().withNewMetadata().withName("multiple-containers").endMetadata()
+        .withNewSpec()
+        .addNewContainer()
+        .withName("the-first-container")
+        .endContainer()
+        .addNewContainer()
+        .withName("the-second-container")
+        .endContainer()
+        .endSpec()
+        .build())
+        .createOrReplace();
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/test/pods/multiple-containers/exec?command=sleep%201&container=the-first-container")
+        .andUpgradeToWebSocket()
+        .open()
+        .immediately().andEmit(exitZeroEvent())
+        .done()
+        .always();
+    final ExecWatch result = client.pods().withName("multiple-containers").exec("sleep 1");
+    assertThat(result.exitCode().get(1, TimeUnit.SECONDS)).isZero();
+  }
+
+  @Test
+  @DisplayName("With multiple containers and inContainer with existent name, should exec in the selected container")
+  void withMultipleContainersAndInContainer() throws Exception {
+    client.pods().resource(new PodBuilder().withNewMetadata().withName("multiple-containers").endMetadata()
+        .withNewSpec()
+        .addNewContainer()
+        .withName("the-first-container")
+        .endContainer()
+        .addNewContainer()
+        .withName("the-second-container")
+        .endContainer()
+        .endSpec()
+        .build())
+        .createOrReplace();
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/test/pods/multiple-containers/exec?command=sleep%201&container=the-second-container")
+        .andUpgradeToWebSocket()
+        .open()
+        .immediately().andEmit(exitZeroEvent())
+        .done()
+        .always();
+    final ExecWatch result = client.pods().withName("multiple-containers").inContainer("the-second-container").exec("sleep 1");
+    assertThat(result.exitCode().get(1, TimeUnit.SECONDS)).isZero();
+  }
+
+  private static WebSocketMessage exitZeroEvent() {
+    final Status success = new StatusBuilder().withStatus("Success").build();
+    return new WebSocketMessage(0L, "\u0003" + Serialization.asJson(success), false, true);
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -95,15 +95,27 @@ class PodTest {
   @Test
   void testList() {
     server.expect().withPath("/api/v1/namespaces/test/pods").andReturn(200, new PodListBuilder().build()).once();
-    server.expect().withPath("/api/v1/namespaces/ns1/pods").andReturn(200, new PodListBuilder()
-        .addNewItem().and()
-        .addNewItem().and().build()).once();
+    server.expect()
+        .withPath("/api/v1/namespaces/ns1/pods")
+        .andReturn(200, new PodListBuilder()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .build())
+        .once();
 
-    server.expect().withPath("/api/v1/pods").andReturn(200, new PodListBuilder()
-        .addNewItem().and()
-        .addNewItem().and()
-        .addNewItem()
-        .and().build()).once();
+    server.expect()
+        .withPath("/api/v1/pods")
+        .andReturn(200, new PodListBuilder()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .build())
+        .once();
 
     PodList podList = client.pods().list();
     assertNotNull(podList);
@@ -121,13 +133,19 @@ class PodTest {
   @Test
   void testListWithLabels() {
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3=value3"))
-        .andReturn(200, new PodListBuilder().build()).always();
-    server.expect().withPath("/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2"))
+        .withPath(
+            "/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3=value3"))
+        .andReturn(200, new PodListBuilder().build())
+        .always();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2"))
         .andReturn(200, new PodListBuilder()
-            .addNewItem().and()
-            .addNewItem().and()
-            .addNewItem().and()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
             .build())
         .once();
 
@@ -151,11 +169,15 @@ class PodTest {
 
   @Test
   void testListWithFields() {
-    server.expect().withPath(
-        "/api/v1/namespaces/test/pods?fieldSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2,key3!=value3,key3!=value4"))
+    server.expect()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector="
+                + Utils.toUrlEncoded("key1=value1,key2=value2,key3!=value3,key3!=value4"))
         .andReturn(200, new PodListBuilder()
-            .addNewItem().and()
-            .addNewItem().and()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
             .build())
         .once();
 
@@ -173,7 +195,10 @@ class PodTest {
   @Test
   void testEditMissing() {
     // Given
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(404, "error message from kubernetes").always();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1")
+        .andReturn(404, "error message from kubernetes")
+        .always();
 
     // When
     PodResource podOp = client.pods().withName("pod1");
@@ -228,19 +253,37 @@ class PodTest {
     Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
 
-    Boolean deleted = client.pods().inNamespace("test").withName("pod1").withPropagationPolicy(DeletionPropagation.FOREGROUND)
-        .delete().size() == 1;
+    Boolean deleted = client.pods()
+        .inNamespace("test")
+        .withName("pod1")
+        .withPropagationPolicy(DeletionPropagation.FOREGROUND)
+        .delete()
+        .size() == 1;
     assertTrue(deleted);
   }
 
   @Test
   void testEvict() {
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1/eviction").andReturn(200, new PodBuilder().build()).once();
-    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2/eviction").andReturn(200, new PodBuilder().build()).once();
-    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod3/eviction")
-        .andReturn(PodOperationsImpl.HTTP_TOO_MANY_REQUESTS, new PodBuilder().build()).once();
-    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod3/eviction").andReturn(200, new PodBuilder().build()).once();
-    server.expect().withPath("/api/v1/namespaces/ns1/pods/pod4/eviction").andReturn(500, new PodBuilder().build()).once();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1/eviction")
+        .andReturn(200, new PodBuilder().build())
+        .once();
+    server.expect()
+        .withPath("/api/v1/namespaces/ns1/pods/pod2/eviction")
+        .andReturn(200, new PodBuilder().build())
+        .once();
+    server.expect()
+        .withPath("/api/v1/namespaces/ns1/pods/pod3/eviction")
+        .andReturn(PodOperationsImpl.HTTP_TOO_MANY_REQUESTS, new PodBuilder().build())
+        .once();
+    server.expect()
+        .withPath("/api/v1/namespaces/ns1/pods/pod3/eviction")
+        .andReturn(200, new PodBuilder().build())
+        .once();
+    server.expect()
+        .withPath("/api/v1/namespaces/ns1/pods/pod4/eviction")
+        .andReturn(500, new PodBuilder().build())
+        .once();
 
     Boolean deleted = client.pods().withName("pod1").evict();
     assertTrue(deleted);
@@ -267,19 +310,23 @@ class PodTest {
   @Test
   void testEvictWithPolicyV1Eviction() {
     // Given
-    server.expect().post()
+    server.expect()
+        .post()
         .withPath("/api/v1/namespaces/ns1/pods/foo/eviction")
         .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().build())
         .once();
 
     // When
-    boolean evicted = client.pods().inNamespace("ns1").withName("foo").evict(new EvictionBuilder()
-        .withNewMetadata()
+    boolean evicted = client.pods()
+        .inNamespace("ns1")
         .withName("foo")
-        .withNamespace("ns1")
-        .endMetadata()
-        .withDeleteOptions(new DeleteOptionsBuilder().build())
-        .build());
+        .evict(new EvictionBuilder()
+            .withNewMetadata()
+            .withName("foo")
+            .withNamespace("ns1")
+            .endMetadata()
+            .withDeleteOptions(new DeleteOptionsBuilder().build())
+            .build());
 
     // Then
     assertTrue(evicted);
@@ -302,14 +349,22 @@ class PodTest {
 
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1/log?pretty=true").andReturn(200, pod1Log).once();
     server.expect().withPath("/api/v1/namespaces/test/pods/pod2/log?pretty=false").andReturn(200, pod2Log).once();
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod3/log?pretty=false&container=cnt3").andReturn(200, pod3Log)
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod3/log?pretty=false&container=cnt3")
+        .andReturn(200, pod3Log)
         .once();
-    server.expect().withPath("/api/v1/namespaces/test4/pods/pod4/log?pretty=true&container=cnt4").andReturn(200, pod4Log)
+    server.expect()
+        .withPath("/api/v1/namespaces/test4/pods/pod4/log?pretty=true&container=cnt4")
+        .andReturn(200, pod4Log)
         .once();
-    server.expect().withPath("/api/v1/namespaces/test4/pods/pod1/log?pretty=false&limitBytes=100").andReturn(200, pod1Log)
+    server.expect()
+        .withPath("/api/v1/namespaces/test4/pods/pod1/log?pretty=false&limitBytes=100")
+        .andReturn(200, pod1Log)
         .once();
-    server.expect().withPath("/api/v1/namespaces/test5/pods/pod1/log?pretty=false&tailLines=1&timestamps=true")
-        .andReturn(200, pod1Log).once();
+    server.expect()
+        .withPath("/api/v1/namespaces/test5/pods/pod1/log?pretty=false&tailLines=1&timestamps=true")
+        .andReturn(200, pod1Log)
+        .once();
 
     String log = client.pods().withName("pod1").getLog(true);
     assertEquals(pod1Log, log);
@@ -333,15 +388,29 @@ class PodTest {
   @Test
   void testExec() throws InterruptedException {
     String expectedOutput = "file1 file2";
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1/exec?command=ls&stdout=true")
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1/exec?command=ls&container=default&stdout=true")
         .andUpgradeToWebSocket()
         .open(new OutputStreamMessage(expectedOutput))
         .done()
         .always();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1")
+        .andReturn(200,
+            new PodBuilder().withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("default")
+                .endContainer()
+                .endSpec()
+                .build())
+        .once();
 
     final CountDownLatch execLatch = new CountDownLatch(1);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    ExecWatch watch = client.pods().withName("pod1")
+    ExecWatch watch = client.pods()
+        .withName("pod1")
         .writingOutput(baos)
         .usingListener(createCountDownLatchListener(execLatch))
         .exec("ls");
@@ -363,7 +432,8 @@ class PodTest {
 
     String shutdownInput = "shutdown";
 
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1/attach?stdin=true&stdout=true&stderr=true")
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1/attach?container=default&stdin=true&stdout=true&stderr=true")
         .andUpgradeToWebSocket()
         .open()
         .expect("\u0000" + validInput) // \u0000 is the file descriptor for stdin
@@ -378,13 +448,31 @@ class PodTest {
         .done()
         .always();
 
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1")
+        .andReturn(200,
+            new PodBuilder().withNewMetadata()
+                .addToAnnotations(PodOperationsImpl.DEFAULT_CONTAINER_ANNOTATION_NAME, "default")
+                .endMetadata()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("first")
+                .endContainer()
+                .addNewContainer()
+                .withName("default")
+                .endContainer()
+                .endSpec()
+                .build())
+        .once();
+
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
     CountDownLatch latch = new CountDownLatch(1);
 
     // When
-    ExecWatch watch = client.pods().withName("pod1")
+    ExecWatch watch = client.pods()
+        .withName("pod1")
         .redirectingInput()
 
         .writingOutput(stdout)
@@ -409,6 +497,38 @@ class PodTest {
   }
 
   @Test
+  void testExecExplicitDefaultContainerMissing() throws InterruptedException, IOException {
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1/exec?command=ls&container=first&stderr=true")
+        .andUpgradeToWebSocket()
+        .open()
+        .done()
+        .always();
+
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1")
+        .andReturn(200,
+            new PodBuilder().withNewMetadata()
+                .addToAnnotations(PodOperationsImpl.DEFAULT_CONTAINER_ANNOTATION_NAME, "default")
+                .endMetadata()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("first")
+                .endContainer()
+                .endSpec()
+                .build())
+        .once();
+
+    // When
+    ExecWatch watch = client.pods()
+        .withName("pod1")
+        .terminateOnError()
+        .exec("ls");
+
+    watch.close();
+  }
+
+  @Test
   void testAttachWithRedirectOutput() throws InterruptedException, IOException {
     // Given
     String validInput = "input";
@@ -417,7 +537,8 @@ class PodTest {
     String invalidInput = "invalid";
     String expectedError = "error";
 
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1/attach?stdin=true&stdout=true&stderr=true")
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1/attach?container=first&stdin=true&stdout=true&stderr=true")
         .andUpgradeToWebSocket()
         .open()
         .expect("\u0000" + validInput) // \u0000 is the file descriptor for stdin
@@ -429,13 +550,30 @@ class PodTest {
         .done()
         .always();
 
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1")
+        .andReturn(200,
+            new PodBuilder().withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("first")
+                .endContainer()
+                .addNewContainer()
+                .withName("default")
+                .endContainer()
+                .endSpec()
+                .build())
+        .once();
+
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
     CountDownLatch latch = new CountDownLatch(1);
 
     // When
-    ExecWatch watch = client.pods().withName("pod1")
+    ExecWatch watch = client.pods()
+        .withName("pod1")
         .redirectingInput()
         .redirectingOutput()
         .redirectingError()
@@ -451,7 +589,8 @@ class PodTest {
     InputStreamPumper.pump(watch.getError(), stderr::write, Executors.newSingleThreadExecutor());
 
     // Then
-    Awaitility.await().atMost(30, TimeUnit.SECONDS)
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
         .until(() -> stdout.toString().equals(expectedOutput) && stderr.toString().equals(expectedError));
 
     watch.close();
@@ -482,17 +621,21 @@ class PodTest {
         .withResourceVersion("1")
         .endMetadata()
         .build();
-    server.expect().withPath("/api/v1/namespaces/test/pods").andReturn(200, new PodListBuilder()
-        .withNewMetadata()
-        .withResourceVersion("1")
-        .endMetadata()
-        .addToItems(pod1)
-        .build()).once();
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods")
+        .andReturn(200, new PodListBuilder()
+            .withNewMetadata()
+            .withResourceVersion("1")
+            .endMetadata()
+            .addToItems(pod1)
+            .build())
+        .once();
     server.expect()
         .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(50).andEmit(new WatchEvent(pod1, "DELETED"))
+        .waitFor(50)
+        .andEmit(new WatchEvent(pod1, "DELETED"))
         .done()
         .always();
     final CountDownLatch deleteLatch = new CountDownLatch(1);
@@ -559,14 +702,20 @@ class PodTest {
         .endStatus()
         .build();
 
-    server.expect().get().withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1").andReturn(200, notReady)
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .andReturn(200, notReady)
         .once();
 
-    server.expect().get().withPath(
-        "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(50).andEmit(new WatchEvent(ready, "MODIFIED"))
+        .waitFor(50)
+        .andEmit(new WatchEvent(ready, "MODIFIED"))
         .done()
         .always();
 
@@ -576,13 +725,18 @@ class PodTest {
 
   @Test
   void testPortForward() throws IOException {
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1/portforward?ports=123")
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1/portforward?ports=123")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(10).andEmit(portForwardEncode(true, "12")) // data channel info
-        .waitFor(10).andEmit(portForwardEncode(false, "12")) // error channel info
-        .waitFor(10).andEmit(portForwardEncode(true, "Hell"))
-        .waitFor(10).andEmit(portForwardEncode(true, "o World"))
+        .waitFor(10)
+        .andEmit(portForwardEncode(true, "12")) // data channel info
+        .waitFor(10)
+        .andEmit(portForwardEncode(false, "12")) // error channel info
+        .waitFor(10)
+        .andEmit(portForwardEncode(true, "Hell"))
+        .waitFor(10)
+        .andEmit(portForwardEncode(true, "o World"))
         .done()
         .once();
 
@@ -619,13 +773,18 @@ class PodTest {
   @Test
   void testPortForwardWithChannel() throws InterruptedException, IOException {
 
-    server.expect().withPath("/api/v1/namespaces/test/pods/pod1/portforward?ports=123")
+    server.expect()
+        .withPath("/api/v1/namespaces/test/pods/pod1/portforward?ports=123")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(10).andEmit(portForwardEncode(true, "12")) // data channel info
-        .waitFor(10).andEmit(portForwardEncode(false, "12")) // error channel info
-        .waitFor(10).andEmit(portForwardEncode(true, "Hell"))
-        .waitFor(10).andEmit(portForwardEncode(true, "o World!"))
+        .waitFor(10)
+        .andEmit(portForwardEncode(true, "12")) // data channel info
+        .waitFor(10)
+        .andEmit(portForwardEncode(false, "12")) // error channel info
+        .waitFor(10)
+        .andEmit(portForwardEncode(true, "Hell"))
+        .waitFor(10)
+        .andEmit(portForwardEncode(true, "o World!"))
         .done()
         .once();
 
@@ -654,6 +813,22 @@ class PodTest {
 
   @Test
   void testOptionalCopy() {
+    server.expect()
+        .withPath("/api/v1/namespaces/ns1/pods/pod2")
+        .andReturn(200,
+            new PodBuilder().withNewMetadata()
+                .endMetadata()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("first")
+                .endContainer()
+                .addNewContainer()
+                .withName("default")
+                .endContainer()
+                .endSpec()
+                .build())
+        .once();
+
     Assertions.assertThrows(KubernetesClientException.class, () -> {
       client.pods().inNamespace("ns1").withName("pod2").file("/etc/hosts").copy(tempDir.toAbsolutePath());
     });
@@ -715,9 +890,11 @@ class PodTest {
         .endStatus()
         .build();
 
-    server.expect().get()
+    server.expect()
+        .get()
         .withPath("/api/v1/namespaces/test/pods/pod1")
-        .andReturn(200, serverPod).once();
+        .andReturn(200, serverPod)
+        .once();
 
     List<HasMetadata> resources = client.resourceList(clientPod).fromServer().get();
 


### PR DESCRIPTION
## Description
Fixes #4355 - direct or indirect (copy, upload) to exec / attach will now validate or set the container parameter in the same was as the kubectl client.  This requires always fetching the pod prior to the exec / attach call and will always add the container argument.

We do not yet need to do this for log operations as we don't have a similar option to specify "don't get from all" without specifying a container name.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
