### PR TITLE
fix #4507: updating timeouts

### DIFF
--- a/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
+++ b/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
@@ -136,12 +136,12 @@ class OkHttpClientTest {
 
         });
 
-    assertFalse(latch.await(2, TimeUnit.SECONDS));
+    assertFalse(latch.await(10, TimeUnit.SECONDS));
     assertEquals(1, latch.getCount());
 
     startedFuture.get().request();
 
-    assertTrue(latch.await(1, TimeUnit.SECONDS));
+    assertTrue(latch.await(10, TimeUnit.SECONDS));
   }
 
   @Test
@@ -175,7 +175,7 @@ class OkHttpClientTest {
       }
     });
 
-    assertTrue(consumed.get(5, TimeUnit.SECONDS));
+    assertTrue(consumed.get(10, TimeUnit.SECONDS));
   }
 
   @DisplayName("Supported response body types")

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeleteIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeleteIT.java
@@ -54,7 +54,7 @@ class DeleteIT {
     boolean isDeleted = client.secrets().withName(name).delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.secrets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.secrets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -66,7 +66,7 @@ class DeleteIT {
         .withGracePeriod(0).delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.secrets().withName(name).waitUntilCondition(Objects::isNull, 5, TimeUnit.SECONDS);
+    client.secrets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -77,7 +77,7 @@ class DeleteIT {
     boolean isDeleted = client.apps().replicaSets().withName(name).cascading(true).delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -90,7 +90,7 @@ class DeleteIT {
         .delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -103,7 +103,7 @@ class DeleteIT {
         .delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -131,7 +131,7 @@ class DeleteIT {
     boolean isDeleted = client.resource(replicaSet).delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -143,7 +143,7 @@ class DeleteIT {
     boolean isDeleted = client.resource(replicaSet).cascading(true).delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -157,7 +157,7 @@ class DeleteIT {
         .delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -171,7 +171,7 @@ class DeleteIT {
         .delete().size() == 1;
     // Then
     assertTrue(isDeleted);
-    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+    client.apps().replicaSets().withName(name).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
   }
 
   @Test

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ResourceIT.java
@@ -143,7 +143,7 @@ class ResourceIT {
     resource.withGracePeriod(0L).delete();
     resource.waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
     client.apps().replicaSets().withLabel("run", deploymentName).informOnCondition(Collection::isEmpty)
-        .get(30, TimeUnit.SECONDS);
+        .get(60, TimeUnit.SECONDS);
     resource.create();
 
     List<ReplicaSet> replicaSets = client.apps().replicaSets().withLabel("run", deploymentName)
@@ -155,7 +155,7 @@ class ResourceIT {
     assertTrue(resource.withGracePeriod(0L).delete().size() == 1);
     // Check whether child resources are also deleted
     client.apps().replicaSets().withLabel("run", deploymentName).informOnCondition(List::isEmpty)
-        .get(30, TimeUnit.SECONDS);
+        .get(60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -188,7 +188,7 @@ class ResourceIT {
     assertTrue(resource.withPropagationPolicy(DeletionPropagation.FOREGROUND).withGracePeriod(0L).delete().size() == 1);
     // Check whether child resources are also deleted
     client.apps().replicaSets().withLabel("run", deploymentName).informOnCondition(List::isEmpty)
-        .get(30, TimeUnit.SECONDS);
+        .get(60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -206,7 +206,7 @@ class ResourceIT {
 
     // Check whether child resources are also deleted
     client.apps().replicaSets().withLabel("run", deploymentName).informOnCondition(List::isEmpty)
-        .get(30, TimeUnit.SECONDS);
+        .get(60, TimeUnit.SECONDS);
   }
 
   @Test
@@ -224,7 +224,7 @@ class ResourceIT {
 
     // wait till deployment is deleted
     client.apps().deployments().withLabel("run", deploymentName)
-        .informOnCondition(List::isEmpty).get(30, TimeUnit.SECONDS);
+        .informOnCondition(List::isEmpty).get(60, TimeUnit.SECONDS);
 
     // Check whether child resources are not deleted, they should be alive
     client.apps().replicaSets().withLabel("run", deploymentName).informOnCondition(l -> l.size() == 1)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
@@ -79,7 +79,7 @@ class ConfigMapCrudTest {
     client.configMaps().inAnyNamespace().waitUntilCondition(c -> {
       uids.add(c.getMetadata().getUid());
       return true;
-    }, 1, TimeUnit.SECONDS);
+    }, 10, TimeUnit.SECONDS);
 
     assertEquals(3, uids.size());
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CrudInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CrudInformerTest.java
@@ -44,23 +44,23 @@ class CrudInformerTest {
     SharedIndexInformer<Pod> podInformer = factory.sharedIndexInformerFor(Pod.class, 4000);
     BlockingQueue<Pod> events = new LinkedBlockingQueue<>();
     podInformer.addEventHandler(
-      new ResourceEventHandler<Pod>() {
-        @Override
-        public void onAdd(Pod obj) {
-          events.add(obj);
-        }
+        new ResourceEventHandler<Pod>() {
+          @Override
+          public void onAdd(Pod obj) {
+            events.add(obj);
+          }
 
-        @Override
-        public void onUpdate(Pod oldObj, Pod newObj) {
-        }
+          @Override
+          public void onUpdate(Pod oldObj, Pod newObj) {
+          }
 
-        @Override
-        public void onDelete(Pod oldObj, boolean deletedFinalStateUnknown) {
-        }
-      });
+          @Override
+          public void onDelete(Pod oldObj, boolean deletedFinalStateUnknown) {
+          }
+        });
     factory.startAllRegisteredInformers();
     client.pods().create(podToCreate);
-    Pod readPod = events.poll(5, TimeUnit.SECONDS);
+    Pod readPod = events.poll(10, TimeUnit.SECONDS);
     assertNotNull(readPod);
     assertEquals(readPod.getMetadata().getName(), podToCreate.getMetadata().getName());
     factory.stopAllRegisteredInformers();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -390,7 +390,7 @@ class CustomResourceTest {
         });
 
     // Then
-    assertTrue(anyEventReceived.await(1, TimeUnit.SECONDS));
+    assertTrue(anyEventReceived.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -421,7 +421,7 @@ class CustomResourceTest {
         });
 
     // Then
-    assertTrue(anyEventReceived.await(1, TimeUnit.SECONDS));
+    assertTrue(anyEventReceived.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -455,7 +455,7 @@ class CustomResourceTest {
         });
 
     // Then
-    assertTrue(anyEventReceieved.await(1, TimeUnit.SECONDS));
+    assertTrue(anyEventReceieved.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -488,7 +488,7 @@ class CustomResourceTest {
         });
 
     // Then
-    assertTrue(anyEventReceived.await(1, TimeUnit.SECONDS));
+    assertTrue(anyEventReceived.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -524,7 +524,7 @@ class CustomResourceTest {
         });
 
     // Then
-    assertTrue(anyEventReceived.await(1, TimeUnit.SECONDS));
+    assertTrue(anyEventReceived.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -561,7 +561,7 @@ class CustomResourceTest {
             });
 
     // Then
-    assertTrue(anyEventReceived.await(1, TimeUnit.SECONDS));
+    assertTrue(anyEventReceived.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -598,7 +598,7 @@ class CustomResourceTest {
             });
 
     // Then
-    assertTrue(anyEventReceived.await(1, TimeUnit.SECONDS));
+    assertTrue(anyEventReceived.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
@@ -49,17 +49,17 @@ class EventTest {
   void watch() throws InterruptedException {
     // Given
     Event testEvent = new EventBuilder()
-      .withNewMetadata()
-      .withName("nginx-deployment-54f57cf6bf-84ssh.161e26b7b76b629e")
-      .withNamespace("ns1")
-      .endMetadata()
-      .build();
+        .withNewMetadata()
+        .withName("nginx-deployment-54f57cf6bf-84ssh.161e26b7b76b629e")
+        .withNamespace("ns1")
+        .endMetadata()
+        .build();
 
     server.expect()
-      .withPath("/api/v1/namespaces/ns1/events?allowWatchBookmarks=true&watch=true")
-      .andUpgradeToWebSocket().open().waitFor(50)
-      .andEmit(new WatchEvent(testEvent, "ADDED"))
-      .done().once();
+        .withPath("/api/v1/namespaces/ns1/events?allowWatchBookmarks=true&watch=true")
+        .andUpgradeToWebSocket().open().waitFor(50)
+        .andEmit(new WatchEvent(testEvent, "ADDED"))
+        .done().once();
     final CountDownLatch eventReceivedLatch = new CountDownLatch(1);
 
     // When
@@ -76,7 +76,7 @@ class EventTest {
     });
 
     // Then
-    assertTrue(eventReceivedLatch.await(1, TimeUnit.SECONDS));
+    assertTrue(eventReceivedLatch.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -84,22 +84,25 @@ class EventTest {
   void testInvolvedObjectFieldQuery() {
     // Given
     server.expect().get().withPath("/api/v1/namespaces/ns1/events?fieldSelector="
-      + Utils.toUrlEncoded("involvedObject.name=foo," +
-      "involvedObject.namespace=ns1," +
-      "involvedObject.kind=Deployment," +
-      "involvedObject.uid=6d71451a-f8df-11ea-a8ac-0e13a02d8ebd"))
-      .andReturn(HttpURLConnection.HTTP_OK, new EventListBuilder().withItems(new EventBuilder()
-        .withNewMetadata().withName("foo-event").endMetadata()
-        .build())
-        .build()).once();
+        + Utils.toUrlEncoded("involvedObject.name=foo," +
+            "involvedObject.namespace=ns1," +
+            "involvedObject.kind=Deployment," +
+            "involvedObject.uid=6d71451a-f8df-11ea-a8ac-0e13a02d8ebd"))
+        .andReturn(HttpURLConnection.HTTP_OK, new EventListBuilder().withItems(new EventBuilder()
+            .withNewMetadata().withName("foo-event").endMetadata()
+            .build())
+            .build())
+        .once();
 
     // When
-    EventList eventList = client.v1().events().inNamespace("ns1").withInvolvedObject(new io.fabric8.kubernetes.api.model.ObjectReferenceBuilder()
-      .withName("foo")
-      .withNamespace("ns1")
-      .withKind("Deployment")
-      .withUid("6d71451a-f8df-11ea-a8ac-0e13a02d8ebd")
-      .build()).list();
+    EventList eventList = client.v1().events().inNamespace("ns1")
+        .withInvolvedObject(new io.fabric8.kubernetes.api.model.ObjectReferenceBuilder()
+            .withName("foo")
+            .withNamespace("ns1")
+            .withKind("Deployment")
+            .withUid("6d71451a-f8df-11ea-a8ac-0e13a02d8ebd")
+            .build())
+        .list();
 
     // Then
     assertNotNull(eventList);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
@@ -132,12 +132,12 @@ public class LeaderElectionTest {
                 .build())
             .build().run()));
     // Then
-    assertTrue(leaderLatch.await(5, TimeUnit.SECONDS));
+    assertTrue(leaderLatch.await(10, TimeUnit.SECONDS));
     assertEquals(id, newLeaderRecord.get());
     assertEquals(0, leaderLatch.getCount());
     leaderElectorTask.cancel(true);
     executorService.shutdownNow();
-    executorService.awaitTermination(5, TimeUnit.SECONDS);
-    assertTrue(stoppedLeading.await(5, TimeUnit.SECONDS));
+    executorService.awaitTermination(10, TimeUnit.SECONDS);
+    assertTrue(stoppedLeading.await(10, TimeUnit.SECONDS));
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -251,11 +251,11 @@ class PodCrudTest {
           new PodBuilder().withNewMetadata().withName("pod1").addToLabels("testKey", "testValue").endMetadata().build());
 
       assertEquals(1, client.pods().inNamespace("ns1").list().getItems().size());
-      assertTrue(lw.addLatch.await(1, TimeUnit.SECONDS));
-      assertTrue(lw.editLatch.await(1, TimeUnit.SECONDS));
-      assertTrue(lw.deleteLatch.await(1, TimeUnit.SECONDS));
+      assertTrue(lw.addLatch.await(10, TimeUnit.SECONDS));
+      assertTrue(lw.editLatch.await(10, TimeUnit.SECONDS));
+      assertTrue(lw.deleteLatch.await(10, TimeUnit.SECONDS));
     }
-    assertTrue(lw.closeLatch.await(3, TimeUnit.SECONDS));
+    assertTrue(lw.closeLatch.await(10, TimeUnit.SECONDS));
   }
 
   private static final class LatchedWatcher implements Watcher<Pod> {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -570,7 +570,7 @@ class PodTest {
         .done()
         .always();
 
-    Pod result = client.pods().withName("pod1").waitUntilReady(5, TimeUnit.SECONDS);
+    Pod result = client.pods().withName("pod1").waitUntilReady(10, TimeUnit.SECONDS);
     Assert.assertEquals("2", result.getMetadata().getResourceVersion());
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -221,7 +221,7 @@ public class ResourceListTest {
 
     KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
     List<HasMetadata> results = client.resourceList(list).inNamespace("ns1")
-        .waitUntilCondition(isReady, 5, SECONDS);
+        .waitUntilCondition(isReady, 10, SECONDS);
     assertThat(results)
         .containsExactlyInAnyOrder(ready1, ready2);
   }
@@ -273,7 +273,7 @@ public class ResourceListTest {
     KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
     final ListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> ops = client.resourceList(list).inNamespace("ns1");
     KubernetesClientTimeoutException ex = assertThrows(KubernetesClientTimeoutException.class,
-        () -> ops.waitUntilCondition(isReady, 5, SECONDS));
+        () -> ops.waitUntilCondition(isReady, 10, SECONDS));
     assertThat(ex.getResourcesNotReady())
         .containsExactly(pod1);
   }
@@ -323,7 +323,7 @@ public class ResourceListTest {
     KubernetesList list = new KubernetesListBuilder().withItems(pod1, pod2).build();
     final ListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> ops = client.resourceList(list).inNamespace("ns1");
     KubernetesClientTimeoutException ex = assertThrows(KubernetesClientTimeoutException.class,
-        () -> ops.waitUntilCondition(isReady, 5, SECONDS));
+        () -> ops.waitUntilCondition(isReady, 10, SECONDS));
     assertThat(ex.getResourcesNotReady())
         .containsExactlyInAnyOrder(pod1, pod2);
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -317,7 +317,7 @@ class ResourceTest {
         .done()
         .always();
 
-    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -365,7 +365,7 @@ class ResourceTest {
         .done()
         .always();
 
-    Pod p = client.pods().withName("pod1").waitUntilReady(5, SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilReady(10, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -436,7 +436,7 @@ class ResourceTest {
                 .getConditions()
                 .stream()
                 .anyMatch(c -> "Dummy".equals(c.getType()) && "True".equals(c.getStatus())),
-            8, SECONDS);
+            10, SECONDS);
 
     assertThat(p.getStatus().getConditions())
         .extracting("type", "status")
@@ -484,7 +484,7 @@ class ResourceTest {
         .done()
         .once();
 
-    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -529,7 +529,7 @@ class ResourceTest {
         .done()
         .once();
 
-    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -548,7 +548,7 @@ class ResourceTest {
     // once not ready, to begin watch
     list(ready);
 
-    Pod p = client.resource(noReady).waitUntilReady(5, SECONDS);
+    Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
@@ -584,7 +584,7 @@ class ResourceTest {
 
     list(ready);
 
-    client.resource(noReady).waitUntilReady(5, SECONDS);
+    client.resource(noReady).waitUntilReady(10, SECONDS);
   }
 
   @Test
@@ -615,7 +615,7 @@ class ResourceTest {
         .done()
         .once();
 
-    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 8, SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 10, SECONDS);
     assertNull(p);
   }
 
@@ -700,7 +700,7 @@ class ResourceTest {
     // When
     HasMetadata response = client
         .resource(new PodBuilder(conditionMetPod).build())
-        .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 1, SECONDS);
+        .waitUntilCondition(p -> "MET".equals(p.getMetadata().getLabels().get("CONDITION")), 10, SECONDS);
     // Then
     assertEquals(conditionMetPod, response);
     assertEquals(2, server.getRequestCount());
@@ -715,7 +715,7 @@ class ResourceTest {
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
 
-    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 1, SECONDS);
+    Pod p = client.pods().withName("pod1").waitUntilCondition(Objects::isNull, 10, SECONDS);
     assertNull(p);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -175,7 +175,7 @@ class WatchTest {
     });
 
     // Then
-    assertTrue(eventReceivedLatch.await(3, TimeUnit.SECONDS));
+    assertTrue(eventReceivedLatch.await(10, TimeUnit.SECONDS));
     watch.close();
   }
 
@@ -423,6 +423,6 @@ class WatchTest {
     });
 
     // ensure that the exception does not inhibit further message processing
-    assertTrue(latch.await(5, TimeUnit.SECONDS));
+    assertTrue(latch.await(10, TimeUnit.SECONDS));
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -277,7 +277,7 @@ class DeploymentConfigTest {
     LogWatch logWatch = client.deploymentConfigs().inNamespace("ns1").withName("dc1").watchLog(byteArrayOutputStream);
 
     // Then
-    await().atMost(2, TimeUnit.SECONDS).until(() -> byteArrayOutputStream.toString().length() > 0);
+    await().atMost(10, TimeUnit.SECONDS).until(() -> byteArrayOutputStream.toString().length() > 0);
     assertNotNull(byteArrayOutputStream.toString());
     assertEquals("testlog", byteArrayOutputStream.toString());
     logWatch.close();
@@ -299,7 +299,7 @@ class DeploymentConfigTest {
     InputStreamPumper.pump(is, byteArrayOutputStream::write, exec);
 
     // Then
-    await().atMost(2, TimeUnit.SECONDS).until(() -> byteArrayOutputStream.toString().length() > 0);
+    await().atMost(10, TimeUnit.SECONDS).until(() -> byteArrayOutputStream.toString().length() > 0);
     assertNotNull(byteArrayOutputStream.toString());
     assertEquals("testlog", byteArrayOutputStream.toString());
     // graceful close


### PR DESCRIPTION
## Description
Partially addresses #4507 - updating all mock timeouts to be 10 seconds, that seems to be the most common value used across the tests.  We can also consider extracting / parameterizing this.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
