### PR TITLE
fix #4519: correcting how the config refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.3-SNAPSHOT
 
 #### Bugs
+* Fix #4159: ensure the token refresh obeys how the Config was created
 * Fix #4491: added a more explicit shutdown exception for okhttp
 * Fix #4534: Java Generator CLI default handling of skipGeneratedAnnotations
 * Fix #4535: The shell command string will now have single quotes sanitized

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptor.java
@@ -72,8 +72,7 @@ public class TokenRefreshInterceptor implements Interceptor {
   }
 
   private CompletableFuture<Boolean> refreshToken(BasicBuilder headerBuilder) {
-    final String currentContextName = config.getCurrentContext() != null ? config.getCurrentContext().getName() : null;
-    final Config newestConfig = Config.autoConfigure(currentContextName);
+    Config newestConfig = config.refresh();
     final CompletableFuture<String> newAccessToken = extractNewAccessTokenFrom(newestConfig);
 
     return newAccessToken.thenApply(token -> overrideNewAccessTokenToConfig(token, headerBuilder, config));

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/TokenRefreshInterceptorTest.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import io.fabric8.kubernetes.client.http.TestHttpResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -39,9 +38,7 @@ import static io.fabric8.kubernetes.client.Config.KUBERNETES_AUTH_TRYKUBECONFIG_
 import static io.fabric8.kubernetes.client.Config.KUBERNETES_KUBECONFIG_FILE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 /**
  * Ignoring for now - the token refresh should be based upon the java 11 client or the provided client library and not okhttp
@@ -100,47 +97,41 @@ class TokenRefreshInterceptorTest {
   @Test
   @DisplayName("#4442 token auto refresh should not overwrite existing token when not applicable")
   void refreshShouldNotOverwriteExistingToken() throws Exception {
-    try (MockedStatic<Config> configMock = mockStatic(Config.class, CALLS_REAL_METHODS)) {
-      // Given
-      final Config autoConfig = new ConfigBuilder(Config.empty())
-          .withOauthToken("") // empty token
-          .build();
-      configMock.when(() -> Config.autoConfigure(any())).thenReturn(autoConfig);
-      final Config config = new ConfigBuilder(Config.empty())
-          .withOauthToken("existing-token")
-          .build();
-      final TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(
-          config, null, Instant.now().minusSeconds(61));
-      // When
-      final boolean result = tokenRefreshInterceptor
-          .afterFailure(new StandardHttpRequest.Builder(), new TestHttpResponse<>().withCode(401)).get();
-      // Then
-      assertThat(result).isFalse();
-      assertThat(config).hasFieldOrPropertyWithValue("oauthToken", "existing-token");
-    }
+    // Given
+    final Config autoConfig = new ConfigBuilder(Config.empty())
+        .withOauthToken("") // empty token
+        .build();
+    final Config config = Mockito.mock(Config.class);
+    Mockito.when(config.getOauthToken()).thenReturn("existing-token");
+    Mockito.when(config.refresh()).thenReturn(autoConfig);
+    final TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(
+        config, null, Instant.now().minusSeconds(61));
+    // When
+    final boolean result = tokenRefreshInterceptor
+        .afterFailure(new StandardHttpRequest.Builder(), new TestHttpResponse<>().withCode(401)).get();
+    // Then
+    assertThat(result).isFalse();
+    Mockito.verify(config, never()).setOauthToken("new-token");
   }
 
   @Test
   @DisplayName("#4442 token auto refresh should  overwrite existing token when applicable")
   void refreshShouldOverwriteExistingToken() throws Exception {
-    try (MockedStatic<Config> configMock = mockStatic(Config.class, CALLS_REAL_METHODS)) {
-      // Given
-      final Config autoConfig = new ConfigBuilder(Config.empty())
-          .withOauthToken("new-token")
-          .build();
-      configMock.when(() -> Config.autoConfigure(any())).thenReturn(autoConfig);
-      final Config config = new ConfigBuilder(Config.empty())
-          .withOauthToken("existing-token")
-          .build();
-      final TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(
-          config, null, Instant.now().minusSeconds(61));
-      // When
-      final boolean result = tokenRefreshInterceptor
-          .afterFailure(new StandardHttpRequest.Builder(), new TestHttpResponse<>().withCode(401)).get();
-      // Then
-      assertThat(result).isTrue();
-      assertThat(config).hasFieldOrPropertyWithValue("oauthToken", "new-token");
-    }
+    // Given
+    final Config autoConfig = new ConfigBuilder(Config.empty())
+        .withOauthToken("new-token")
+        .build();
+    final Config config = Mockito.mock(Config.class);
+    Mockito.when(config.getOauthToken()).thenReturn("existing-token");
+    Mockito.when(config.refresh()).thenReturn(autoConfig);
+    final TokenRefreshInterceptor tokenRefreshInterceptor = new TokenRefreshInterceptor(
+        config, null, Instant.now().minusSeconds(61));
+    // When
+    final boolean result = tokenRefreshInterceptor
+        .afterFailure(new StandardHttpRequest.Builder(), new TestHttpResponse<>().withCode(401)).get();
+    // Then
+    assertThat(result).isTrue();
+    Mockito.verify(config).setOauthToken("new-token");
   }
 
   @Test


### PR DESCRIPTION
## Description
fix for #4519 - refining how the config refreshes

It seems like a good idea also to always apply the system/env properties after loading the kubeconfig - https://github.com/fabric8io/kubernetes-client/compare/master...shawkins:refresh_config?expand=1#diff-7506ddc44edef04cb34dcde13c56d00ed3b1d35d848ded8f1924ed44c03db953R608

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
