### PR TITLE
fix #4530: allowing serialization to better handle primitive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 #### Improvements
 * Fix #4355: for exec, attach, upload, and copy operations the container id/name will be validated or chosen prior to the remote call.  You may also use the kubectl.kubernetes.io/default-container annotation to specify the default container.
+*  Fix #4530: generalizing the Serialization logic to allow for primitive values and clarifying the type expectations.
 
 #### Dependency Upgrade
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -286,10 +286,10 @@ public interface KubernetesClient extends Client {
   NonNamespaceOperation<ComponentStatus, ComponentStatusList, Resource<ComponentStatus>> componentstatuses();
 
   /**
-   * Load a Kubernetes resource object from file InputStream
+   * Load Kubernetes resource object(s) from the provided InputStream.
    *
-   * @param is File input stream object containing json/yaml content
-   * @return deserialized object
+   * @param is the input stream containing JSON/YAML content
+   * @return an operation instance to work on the list of Kubernetes Resource objects
    */
   ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> load(InputStream is);
 
@@ -297,7 +297,7 @@ public interface KubernetesClient extends Client {
    * Load a Kubernetes list object
    *
    * @param s kubernetes list as string
-   * @return deserialized KubernetesList object
+   * @return an operation instance to work on the deserialized KubernetesList objects
    */
   ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> resourceList(String s);
 
@@ -340,10 +340,19 @@ public interface KubernetesClient extends Client {
    * KubernetesResource operations. You can pass any Kubernetes resource as string object and do
    * all operations
    *
-   * @param s Kubernetes resource object as string
+   * @param s a Kubernetes resource object as string
    * @return operations object for Kubernetes resource
    */
   NamespaceableResource<HasMetadata> resource(String s);
+
+  /**
+   * KubernetesResource operations. You can pass any Kubernetes resource as an InputStream object and perform
+   * all operations
+   *
+   * @param is the InputStream containing a serialized Kubernetes resource.
+   * @return operations object for Kubernetes resource.
+   */
+  NamespaceableResource<HasMetadata> resource(InputStream is);
 
   /**
    * Operations for Binding resource in APIgroup core/v1
@@ -514,7 +523,7 @@ public interface KubernetesClient extends Client {
 
   /**
    * Visit all resources with the given {@link ApiVisitor}.
-   * 
+   *
    * @param visitor
    */
   void visitResources(ApiVisitor visitor);

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/NamespacedKubernetesClientAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/NamespacedKubernetesClientAdapter.java
@@ -284,6 +284,11 @@ public class NamespacedKubernetesClientAdapter<N extends NamespacedKubernetesCli
   }
 
   @Override
+  public NamespaceableResource<HasMetadata> resource(InputStream is) {
+    return getClient().resource(is);
+  }
+
+  @Override
   public MixedOperation<Binding, KubernetesResourceList<Binding>, Resource<Binding>> bindings() {
     return getClient().bindings();
   }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationSingleDocumentUnmarshalTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationSingleDocumentUnmarshalTest.java
@@ -27,24 +27,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SerializationSingleDocumentUnmarshalTest {
   @ParameterizedTest(name = "#{index} - unmarshal {0}")
-  @ValueSource(strings = {"document-with-trailing-document-delimiter.yml", "document-with-leading-document-delimiter.yml", "document-with-leading-and-trailing-document-delimiter.yml", "document-with-no-document-delimiter.yml"})
+  @ValueSource(strings = {
+      "document-with-trailing-document-delimiter.yml",
+      "document-with-leading-document-delimiter.yml",
+      "document-with-leading-and-trailing-document-delimiter.yml",
+      "document-with-no-document-delimiter.yml"
+  })
   void unmarshalWithSingleDocumentWithDocumentDelimiterShouldReturnKubernetesResource(String arg) {
     // When
     final KubernetesResource result = Serialization.unmarshal(
-      SerializationTest.class.getResourceAsStream(String.format("/serialization/%s", arg)),
-      Collections.emptyMap()
-    );
+        SerializationTest.class.getResourceAsStream(String.format("/serialization/%s", arg)),
+        Collections.emptyMap());
     // Then
     assertThat(result)
-      .asInstanceOf(InstanceOfAssertFactories.type(Service.class))
-      .hasFieldOrPropertyWithValue("apiVersion", "v1")
-      .hasFieldOrPropertyWithValue("kind", "Service")
-      .hasFieldOrPropertyWithValue("metadata.name", "redis-master")
-      .hasFieldOrPropertyWithValue("metadata.labels.app", "redis")
-      .hasFieldOrPropertyWithValue("metadata.labels.tier", "backend")
-      .hasFieldOrPropertyWithValue("metadata.labels.role", "master")
-      .hasFieldOrPropertyWithValue("spec.selector.app", "redis")
-      .hasFieldOrPropertyWithValue("spec.selector.tier", "backend")
-      .hasFieldOrPropertyWithValue("spec.selector.role", "master");
+        .asInstanceOf(InstanceOfAssertFactories.type(Service.class))
+        .hasFieldOrPropertyWithValue("apiVersion", "v1")
+        .hasFieldOrPropertyWithValue("kind", "Service")
+        .hasFieldOrPropertyWithValue("metadata.name", "redis-master")
+        .hasFieldOrPropertyWithValue("metadata.labels.app", "redis")
+        .hasFieldOrPropertyWithValue("metadata.labels.tier", "backend")
+        .hasFieldOrPropertyWithValue("metadata.labels.role", "master")
+        .hasFieldOrPropertyWithValue("spec.selector.app", "redis")
+        .hasFieldOrPropertyWithValue("spec.selector.tier", "backend")
+        .hasFieldOrPropertyWithValue("spec.selector.role", "master");
   }
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -52,6 +52,9 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,10 +68,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SerializationTest {
 
@@ -195,7 +200,7 @@ class SerializationTest {
   }
 
   @Test
-  void testClone() {
+  void cloneKubernetesResourceReturnsDifferentInstance() {
     // Given
     Pod pod = new PodBuilder().withNewMetadata().withName("pod").endMetadata().build();
     // When
@@ -208,7 +213,7 @@ class SerializationTest {
   }
 
   @Test
-  void testCloneNonResource() {
+  void cloneNonResourceReturnsDifferentInstance() {
     // Given
     Map<String, String> value = Collections.singletonMap("key", "value");
     // When
@@ -237,7 +242,7 @@ class SerializationTest {
   }
 
   @Test
-  void unmarshalWithInvalidYamlShouldThrowException() {
+  void unmarshalWithInvalidYamlShouldReturnRawExtension() {
     // Given
     final InputStream is = SerializationTest.class.getResourceAsStream("/serialization/invalid-yaml.yml");
     // When
@@ -247,27 +252,59 @@ class SerializationTest {
   }
 
   @Test
-  void unmarshalArrays() {
+  void unmarshalYamlArrayShouldThrowException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Serialization.unmarshal("- 1\n- 2"))
+        .withMessageStartingWith("Cannot parse a nested array containing non-object resource");
+  }
+
+  @Test
+  void unmarshalJsonArrayShouldThrowException() {
+    assertThatExceptionOfType(KubernetesClientException.class)
+        .isThrownBy(() -> Serialization.unmarshal("[1, 2]"))
+        .withMessage("An error has occurred.")
+        .havingCause()
+        .withMessageStartingWith("Cannot parse a nested array containing non-object resource");
+  }
+
+  @Test
+  void unmarshalYamlArrayWithProvidedTypeShouldDeserialize() {
     // not valid as KubernetesResource - we'd have to look ahead to know if the array values
     // were not hasmetadata
-    assertThrows(KubernetesClientException.class, () -> Serialization.unmarshal("[1, 2]"));
-    assertThrows(IllegalArgumentException.class, () -> Serialization.unmarshal("- 1\n- 2"));
-
-    assertEquals(Arrays.asList(1, 2), Serialization.unmarshal("[1, 2]", List.class));
     assertEquals(Arrays.asList(1, 2), Serialization.unmarshal("- 1\n- 2", List.class));
   }
 
   @Test
-  void unmarshalPrimitives() {
-    // as json
-    RawExtension raw = Serialization.unmarshal("\"a\"");
-    assertEquals("a", raw.getValue());
-    // as yaml
-    raw = Serialization.unmarshal("a");
-    assertEquals("a", raw.getValue());
+  void unmarshalJsonArrayWithProvidedTypeShouldDeserialize() {
+    // not valid as KubernetesResource - we'd have to look ahead to know if the array values
+    // were not hasmetadata
+    assertEquals(Arrays.asList(1, 2), Serialization.unmarshal("[1, 2]", List.class));
+  }
 
+  @ParameterizedTest(name = "''{0}'' should be deserialized as ''{1}''")
+  @MethodSource("unmarshalPrimitivesInput")
+  void unmarshalPrimitives(String input, Object expected) {
+    assertThat(Serialization.<RawExtension> unmarshal(input))
+        .extracting(RawExtension::getValue)
+        .isEqualTo(expected);
     assertEquals("a", Serialization.unmarshal("\"a\"", String.class));
     assertEquals("a", Serialization.unmarshal("a", String.class));
+  }
+
+  @ParameterizedTest(name = "''{0}'' and ''{2}'' target type should be deserialized as ''{1}''")
+  @MethodSource("unmarshalPrimitivesInput")
+  void unmarshalPrimitivesWithType(String input, Object expected, Class<?> targetType) {
+    assertThat(Serialization.unmarshal(input, targetType))
+        .isEqualTo(expected);
+  }
+
+  static Stream<Arguments> unmarshalPrimitivesInput() {
+    return Stream.of(
+        Arguments.arguments("\"a\"", "a", String.class), // JSON
+        Arguments.arguments("a", "a", String.class), // YAML
+        Arguments.arguments("1", 1, Integer.class),
+        Arguments.arguments("true", true, Boolean.class),
+        Arguments.arguments("1.2", 1.2, Double.class));
   }
 
   @Test

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/KubernetesClientImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/KubernetesClientImpl.java
@@ -357,12 +357,28 @@ public class KubernetesClientImpl extends BaseClient implements NamespacedKubern
     return new NamespaceableResourceAdapter<>(item, op);
   }
 
+  private NamespaceableResource<HasMetadata> resource(Object resource) {
+    if (resource instanceof HasMetadata) {
+      return resource((HasMetadata) resource);
+    }
+    throw new KubernetesClientException("Unable to create a valid resource from the provided object (" +
+        resource.getClass().getName() + ")");
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public NamespaceableResource<HasMetadata> resource(String s) {
-    return resource((HasMetadata) Serialization.unmarshal(s));
+    return resource(Serialization.<Object> unmarshal(s));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public NamespaceableResource<HasMetadata> resource(InputStream is) {
+    return resource(Serialization.<Object> unmarshal(is));
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/KubernetesClientImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/KubernetesClientImplTest.java
@@ -16,11 +16,14 @@
 package io.fabric8.kubernetes.client.impl;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.http.BasicBuilder;
 import io.fabric8.kubernetes.client.http.HttpHeaders;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
@@ -35,6 +38,7 @@ import org.mockito.Mockito;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -44,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -152,5 +158,66 @@ class KubernetesClientImplTest {
     assertEquals("a", currentConfig.getImpersonateUsername());
     assertArrayEquals(new String[] { "b" }, currentConfig.getImpersonateGroups());
     assertEquals(Collections.singletonList("d"), currentConfig.getImpersonateExtras().get("c"));
+  }
+
+  @Test
+  @DisplayName("resource(String).get with HasMetadata should deserialize")
+  void resourceFromStringWithHasMetadata() {
+    assertThat(new KubernetesClientImpl().resource("apiVersion: v1\nkind: Pod").get())
+        .isInstanceOf(Pod.class);
+  }
+
+  @Test
+  @DisplayName("resource(String) with no HasMetadata should throwException")
+  void resourceFromStringWithInvalid() {
+    final KubernetesClient kc = new KubernetesClientImpl();
+    assertThatExceptionOfType(KubernetesClientException.class)
+        .isThrownBy(() -> kc.resource("NotAPod"))
+        .withMessageStartingWith("Unable to create a valid resource from the provided object");
+  }
+
+  @Test
+  @DisplayName("resource(InputStream).get with HasMetadata should deserialize")
+  void resourceFromInputStreamWithHasMetadata() throws IOException {
+    final String podYaml = "apiVersion: v1\nkind: Pod";
+    try (InputStream is = new ByteArrayInputStream(podYaml.getBytes(StandardCharsets.UTF_8))) {
+      assertThat(new KubernetesClientImpl().resource(is).get())
+          .isInstanceOf(Pod.class);
+    }
+  }
+
+  @Test
+  @DisplayName("resource(InputStream) with no HasMetadata should throwException")
+  void resourceFromInputStreamWithInvalid() throws IOException {
+    final KubernetesClient kc = new KubernetesClientImpl();
+    final String podYaml = "NotAPod";
+    try (InputStream is = new ByteArrayInputStream(podYaml.getBytes(StandardCharsets.UTF_8))) {
+      assertThatExceptionOfType(KubernetesClientException.class)
+          .isThrownBy(() -> kc.resource(is))
+          .withMessageStartingWith("Unable to create a valid resource from the provided object");
+    }
+  }
+
+  @Test
+  @DisplayName("load(InputStream).get with HasMetadata should deserialize")
+  void loadFromInputStreamWithHasMetadata() throws IOException {
+    final String podYaml = "apiVersion: v1\nkind: Pod";
+    try (InputStream is = new ByteArrayInputStream(podYaml.getBytes(StandardCharsets.UTF_8))) {
+      assertThat(new KubernetesClientImpl().load(is).get())
+          .containsExactly(new Pod());
+    }
+  }
+
+  @Test
+  @DisplayName("load(InputStream).get with no HasMetadata should throwException")
+  void loadFromInputStreamWithInvalid() throws IOException {
+    final String podYaml = "NotAPod";
+    try (InputStream is = new ByteArrayInputStream(podYaml.getBytes(StandardCharsets.UTF_8))) {
+      final ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> load = new KubernetesClientImpl()
+          .load(is);
+      assertThatIllegalArgumentException()
+          .isThrownBy(load::get)
+          .withMessageStartingWith("Could not convert item to a list of HasMetadata");
+    }
   }
 }

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/runtime/RawExtension.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/runtime/RawExtension.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.AnyType;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.sundr.builder.annotations.Buildable;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
 public class RawExtension extends AnyType implements KubernetesResource {

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/internal/KubernetesDeserializer.java
@@ -89,9 +89,12 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
       return fromObjectNode(jp, node);
     } else if (node.isArray()) {
       return fromArrayNode(jp, node);
-    } else {
+    }
+    Object object = node.traverse(jp.getCodec()).readValueAs(Object.class);
+    if (object == null) {
       return null;
     }
+    return new RawExtension(object);
   }
 
   private KubernetesResource fromArrayNode(JsonParser jp, JsonNode node) throws IOException {
@@ -105,6 +108,8 @@ public class KubernetesDeserializer extends JsonDeserializer<KubernetesResource>
           throw new JsonMappingException(jp, "Cannot parse a nested array containing a non-HasMetadata resource");
         }
         list.add((HasMetadata) resource);
+      } else {
+        throw new JsonMappingException(jp, "Cannot parse a nested array containing non-object resource");
       }
     }
     return new KubernetesListBuilder().withItems(list).build();


### PR DESCRIPTION
## Description
Fixes #4530 - this removes some of the remaining cases where the `KubernetesDeserializer` was returning null and generalizes support for primitive values.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
