### PR TITLE
Fix primitive types encoding of default values

### DIFF
--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
@@ -21,7 +21,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
     @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Akka Management (Cluster Bootstrap) HTTP port in the range 1024 - 65535. Can be disabled with \"off\". This port is exposed as HTTP_MGMT_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String akkaManagementPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"8558\"", String.class);
+    private String akkaManagementPort = "8558";
 
     public String getAkkaManagementPort() {
         return akkaManagementPort;
@@ -186,7 +186,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
     @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("gRPC port in the range 1024 - 65535. Can be disabled with \"off\". This port is exposed as GRPC_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String grpcPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"8101\"", String.class);
+    private String grpcPort = "8101";
 
     public String getGrpcPort() {
         return grpcPort;
@@ -219,7 +219,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
     @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("HTTP port in the range 1024 - 65535. Disabled by default. This port is exposed as HTTP_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String httpPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"off\"", String.class);
+    private String httpPort = "off";
 
     public String getHttpPort() {
         return httpPort;
@@ -285,7 +285,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
     @com.fasterxml.jackson.annotation.JsonProperty("javaOptions")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Additional arguments to the application JVM. It will be added to the `JAVA_TOOL_OPTIONS` environment variable, which will be used by most JVM implementations.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String javaOptions = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"\"", String.class);
+    private String javaOptions = "";
 
     public String getJavaOptions() {
         return javaOptions;
@@ -398,7 +398,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
     @io.fabric8.generator.annotation.Pattern("^(off)$|^(102[4-9]|10[3-9][0-9]|1[1-9][0-9]{2}|[2-9][0-9]{3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("HTTP port to expose metrics for Prometheus to scrape. Must be  in the range 1024 - 65535. Disabled by default. This port is exposed as HTTP_PROMETHEUS_PORT environment variable if it is enabled.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String prometheusPort = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("\"off\"", String.class);
+    private String prometheusPort = "off";
 
     public String getPrometheusPort() {
         return prometheusPort;
@@ -432,7 +432,7 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
     @io.fabric8.generator.annotation.Min(0.0)
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Number of desired pods.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private Long replicas = io.fabric8.kubernetes.client.utils.Serialization.unmarshal("1", Long.class);
+    private Long replicas = 1L;
 
     public Long getReplicas() {
         return replicas;

--- a/java-generator/it/src/it/default-values-instantiation/invoker.properties
+++ b/java-generator/it/src/it/default-values-instantiation/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=test

--- a/java-generator/it/src/it/default-values-instantiation/pom.xml
+++ b/java-generator/it/src/it/default-values-instantiation/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>default-values-instantiation</artifactId>
+  <groupId>io.fabric8.it</groupId>
+  <version>0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>@maven.compiler.source@</maven.compiler.source>
+    <maven.compiler.target>@maven.compiler.target@</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>sundr-adapter-reflect</artifactId>
+      <version>@sundrio.version@</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>builder-annotations</artifactId>
+      <version>@sundrio.version@</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>@lombok.version@</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>java-generator-integration-tests</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>generator-annotations</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>@junit.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>@junit.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>java-generator-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <source>src/test/resources/example.yaml</source>
+          <generatedAnnotations>false</generatedAnnotations>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M7</version>
+        <configuration>
+          <useFile>false</useFile>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/java-generator/it/src/it/default-values-instantiation/src/test/java/io/fabric8/it/certmanager/TestDefaultValues.java
+++ b/java-generator/it/src/it/default-values-instantiation/src/test/java/io/fabric8/it/certmanager/TestDefaultValues.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.it.certmanager;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.cert_manager.v1.CertificateRequest;
+import io.cert_manager.v1.certificaterequestspec.Ten;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestDefaultValues {
+
+  @Test
+  void testDefaultValues() throws Exception {
+    // Arrange
+    CertificateRequest cr =
+      Serialization.unmarshal(getClass().getResourceAsStream("/empty.yaml"), CertificateRequest.class);
+
+    // Act
+    String one = cr.getSpec().getOne();
+    Boolean two = cr.getSpec().getTwo();
+    Integer three = cr.getSpec().getThree();
+    Long four = cr.getSpec().getFour();
+    Long five = cr.getSpec().getFive();
+    Float six = cr.getSpec().getSix();
+    Double seven = cr.getSpec().getSeven();
+    Double eight = cr.getSpec().getEight();
+    List<String> nine = cr.getSpec().getNine();
+    Ten ten = cr.getSpec().getTen();
+
+    // Assert
+    assertEquals("one", one);
+    assertEquals(true, two);
+    assertEquals(3, three);
+    assertEquals(4L, four);
+    assertEquals(5L, five);
+    assertEquals(6,1f, six);
+    assertEquals(7.2d, seven);
+    assertEquals(8.2d, eight);
+    assertEquals(2, nine.size());
+    assertEquals("nine1", nine.get(0));
+    assertEquals("nine2", nine.get(1));
+    assertEquals("tenone", ten.getTenOne());
+    assertEquals("tentwo", ten.getTenTwo());
+  }
+}

--- a/java-generator/it/src/it/default-values-instantiation/src/test/resources/empty.yaml
+++ b/java-generator/it/src/it/default-values-instantiation/src/test/resources/empty.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: cert-manager.io/v1
+kind: CertificateRequest
+metadata:
+  name: my-ca-cr
+spec: {}

--- a/java-generator/it/src/it/default-values-instantiation/src/test/resources/example.yaml
+++ b/java-generator/it/src/it/default-values-instantiation/src/test/resources/example.yaml
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+---
+# Source: cert-manager/templates/templates.out
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificaterequests.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+      - cr
+      - crs
+    singular: certificaterequest
+    categories:
+      - cert-manager
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "A sample to verify all default values"
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              description: Desired state of the CertificateRequest resource.
+              type: object
+              properties:
+                one:
+                  type: string
+                  default: one
+                two:
+                  type: boolean
+                  default: true
+                three:
+                  type: integer
+                  format: int32
+                  default: 3
+                four:
+                  type: integer
+                  format: int64
+                  default: 4
+                five:
+                  type: integer
+                  default: 5
+                six:
+                  type: number
+                  format: float
+                  default: 6.1
+                seven:
+                  type: number
+                  format: double
+                  default: 7.2
+                eight:
+                  type: number
+                  default: 8.2
+                nine:
+                  type: array
+                  items:
+                    type: string
+                  default: ['nine1', 'nine2']
+                ten:
+                  type: object
+                  properties:
+                    tenOne:
+                      type: string
+                    tenTwo:
+                      type: string
+                  default:
+                    tenOne: "tenone"
+                    tenTwo: "tentwo"
+      served: true
+      storage: true


### PR DESCRIPTION
## Description
Fix #4530 

Here I'm proposing to specialize the encoding of default values skipping the Jackson deserialization completely.

This is not complete yet as the handling of primitive arrays is still broken. cc. @shawkins 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
