### PR TITLE
Fix 4535 - support file uploads with filenames containing single quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #4534: Java Generator CLI default handling of skipGeneratedAnnotations
+* Fix #4535: The shell command string will now have single quotes sanitized
 * Fix #4547: preventing timing issues with leader election cancel
 
 #### Improvements

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -185,8 +185,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   public PortForward portForward(int port, ReadableByteChannel in, WritableByteChannel out) {
     try {
       return new PortForwarderWebsocket(httpClient, this.context.getExecutor()).forward(getResourceUrl(), port, in, out);
-    } catch (Throwable t) {
-      throw KubernetesClientException.launderThrowable(t);
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
     }
   }
 
@@ -194,8 +194,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   public LocalPortForward portForward(int port) {
     try {
       return new PortForwarderWebsocket(httpClient, this.context.getExecutor()).forward(getResourceUrl(), port);
-    } catch (Throwable t) {
-      throw KubernetesClientException.launderThrowable(t);
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
     }
   }
 
@@ -203,8 +203,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   public LocalPortForward portForward(int port, int localPort) {
     try {
       return new PortForwarderWebsocket(httpClient, this.context.getExecutor()).forward(getResourceUrl(), port, localPort);
-    } catch (Throwable t) {
-      throw KubernetesClientException.launderThrowable(t);
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(e);
     }
   }
 
@@ -274,8 +274,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     try {
       URL url = getExecURLWithCommandParams(actualCommands);
       return setupConnectionToPod(url.toURI());
-    } catch (Throwable t) {
-      throw KubernetesClientException.launderThrowable(forOperationType("exec"), t);
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(forOperationType("exec"), e);
     }
   }
 
@@ -284,8 +284,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     try {
       URL url = getAttachURL();
       return setupConnectionToPod(url.toURI());
-    } catch (Throwable t) {
-      throw KubernetesClientException.launderThrowable(forOperationType("attach"), t);
+    } catch (Exception e) {
+      throw KubernetesClientException.launderThrowable(forOperationType("attach"), e);
     }
   }
 
@@ -591,7 +591,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   public static String shellQuote(String value) {
-    return "'" + value.replace("'", "'\\\\''") + "'";
+    return "'" + value.replace("'", "'\\''") + "'";
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -179,6 +179,24 @@ class PodUploadTest {
     assertThat(result, equalTo("mkdir -p '/tmp/foo' && base64 -d - > '/tmp/foo/cp.log'"));
   }
 
+  @Test
+  void createExecCommandForUpload_withSingleQuoteInPath() {
+    // When
+    String result = PodUpload.createExecCommandForUpload("/tmp/fo'o/cp.log");
+
+    // Then
+    assertThat(result, equalTo("mkdir -p '/tmp/fo\'\\'\'o' && base64 -d - > '/tmp/fo\'\\'\'o/cp.log'"));
+  }
+
+  @Test
+  void createExecCommandForUpload_withMultipleSingleQuotesInPath() {
+    // When
+    String result = PodUpload.createExecCommandForUpload("/tmp/f'o'o/c'p.log");
+
+    // Then
+    assertThat(result, equalTo("mkdir -p '/tmp/f\'\\'\'o\'\\'\'o' && base64 -d - > '/tmp/f\'\\'\'o\'\\'\'o/c\'\\'\'p.log'"));
+  }
+
   void uploadFileAndVerify(PodUploadTester<Boolean> fileUploadMethodToTest) throws IOException, InterruptedException {
     this.operation = operation.file("/mock/dir/file");
     WebSocket.Builder builder = Mockito.mock(WebSocket.Builder.class, Mockito.RETURNS_SELF);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -274,6 +274,7 @@ class PodIT {
 
     assertUploaded("pod-standard", tmpFile, "/tmp/toBeUploaded");
     assertUploaded("pod-standard", tmpFile, "/tmp/001_special_!@#\\$^&(.mp4");
+    assertUploaded("pod-standard", tmpFile, "/tmp/002'special");
   }
 
   private void assertUploaded(String podName, final Path tmpFile, String filename) throws IOException {


### PR DESCRIPTION
## Description

Fix #4535

Single quotes in folder or file names were causing corruption of the shell command. The fix changes the ' character to '"'"'
For example a folder called te'st would now get shellQuoted to 'te'"'"'st'
1. ' ends the first quote,
2. " starts second quote,
3. ' is valid character in double quotes
4. " ends the second quote
5. ' starts the third quote
6. The end result when fed into the shell, is as we desired: te'st

https://github.com/fabric8io/kubernetes-client/issues/4535

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
