### PR TITLE
Fixed CertUtils.handleOtherKeys() behavior with Cavium

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
@@ -51,7 +51,8 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 public class CertUtils {
-  private CertUtils() { }
+  private CertUtils() {
+  }
 
   private static final Logger LOG = LoggerFactory.getLogger(CertUtils.class);
   private static final String TRUST_STORE_SYSTEM_PROPERTY = "javax.net.ssl.trustStore";
@@ -70,7 +71,8 @@ public class CertUtils {
     return null;
   }
 
-  public static KeyStore createTrustStore(String caCertData, String caCertFile, String trustStoreFile, String trustStorePassphrase) throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+  public static KeyStore createTrustStore(String caCertData, String caCertFile, String trustStoreFile,
+      String trustStorePassphrase) throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
     try (InputStream pemInputStream = getInputStreamFromDataOrFile(caCertData, caCertFile)) {
       return createTrustStore(pemInputStream, trustStoreFile, getTrustStorePassphrase(trustStorePassphrase));
     }
@@ -84,7 +86,7 @@ public class CertUtils {
   }
 
   private static KeyStore createTrustStore(InputStream pemInputStream, String trustStoreFile, char[] trustStorePassphrase)
-    throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+      throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
 
     final String trustStoreType = System.getProperty(TRUST_STORE_TYPE_SYSTEM_PROPERTY, KeyStore.getDefaultType());
     KeyStore trustStore = KeyStore.getInstance(trustStoreType);
@@ -106,37 +108,41 @@ public class CertUtils {
     return trustStore;
   }
 
-  public static KeyStore createKeyStore(InputStream certInputStream, InputStream keyInputStream, String clientKeyAlgo, char[] clientKeyPassphrase, String keyStoreFile, char[] keyStorePassphrase) throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException, KeyStoreException {
-      CertificateFactory certFactory = CertificateFactory.getInstance("X509");
-      Collection<? extends Certificate> certificates = certFactory.generateCertificates(certInputStream);
-      PrivateKey privateKey = loadKey(keyInputStream, clientKeyAlgo);
+  public static KeyStore createKeyStore(InputStream certInputStream, InputStream keyInputStream, String clientKeyAlgo,
+      char[] clientKeyPassphrase, String keyStoreFile, char[] keyStorePassphrase)
+      throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException, KeyStoreException {
+    CertificateFactory certFactory = CertificateFactory.getInstance("X509");
+    Collection<? extends Certificate> certificates = certFactory.generateCertificates(certInputStream);
+    PrivateKey privateKey = loadKey(keyInputStream, clientKeyAlgo);
 
-      KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-      if (Utils.isNotNullOrEmpty(keyStoreFile)){
-        try (FileInputStream fis = new FileInputStream(keyStoreFile)) {
-          keyStore.load(fis, keyStorePassphrase);
-        }
-      } else {
-        loadDefaultKeyStoreFile(keyStore, keyStorePassphrase);
+    KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+    if (Utils.isNotNullOrEmpty(keyStoreFile)) {
+      try (FileInputStream fis = new FileInputStream(keyStoreFile)) {
+        keyStore.load(fis, keyStorePassphrase);
       }
+    } else {
+      loadDefaultKeyStoreFile(keyStore, keyStorePassphrase);
+    }
 
-      String alias = certificates.stream().map(cert->((X509Certificate)cert).getIssuerX500Principal().getName()).collect(Collectors.joining("_"));
-      keyStore.setKeyEntry(alias, privateKey, clientKeyPassphrase, certificates.toArray(new Certificate[0]));
+    String alias = certificates.stream().map(cert -> ((X509Certificate) cert).getIssuerX500Principal().getName())
+        .collect(Collectors.joining("_"));
+    keyStore.setKeyEntry(alias, privateKey, clientKeyPassphrase, certificates.toArray(new Certificate[0]));
 
-      return keyStore;
+    return keyStore;
   }
 
-  private static PrivateKey loadKey(InputStream keyInputStream, String clientKeyAlgo) throws IOException, InvalidKeySpecException, NoSuchAlgorithmException {
-      if(clientKeyAlgo == null) {
-        clientKeyAlgo = "RSA"; // by default let's assume it's RSA
-      }
-      if(clientKeyAlgo.equals("EC")) {
-        return handleECKey(keyInputStream);
-      } else if(clientKeyAlgo.equals("RSA")) {
-        return handleOtherKeys(keyInputStream, clientKeyAlgo);
-      }
+  private static PrivateKey loadKey(InputStream keyInputStream, String clientKeyAlgo)
+      throws IOException, InvalidKeySpecException, NoSuchAlgorithmException {
+    if (clientKeyAlgo == null) {
+      clientKeyAlgo = "RSA"; // by default let's assume it's RSA
+    }
+    if (clientKeyAlgo.equals("EC")) {
+      return handleECKey(keyInputStream);
+    } else if (clientKeyAlgo.equals("RSA")) {
+      return handleOtherKeys(keyInputStream, clientKeyAlgo);
+    }
 
-      throw new InvalidKeySpecException("Unknown type of PKCS8 Private Key, tried RSA and ECDSA");
+    throw new InvalidKeySpecException("Unknown type of PKCS8 Private Key, tried RSA and ECDSA");
   }
 
   private static PrivateKey handleECKey(InputStream keyInputStream) {
@@ -150,10 +156,7 @@ public class CertUtils {
               Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
             }
             PEMKeyPair keys = (PEMKeyPair) new PEMParser(new InputStreamReader(keyInputStream)).readObject();
-            return new
-              JcaPEMKeyConverter().
-              getKeyPair(keys).
-              getPrivate();
+            return new JcaPEMKeyConverter().getKeyPair(keys).getPrivate();
           } catch (IOException exception) {
             exception.printStackTrace();
           }
@@ -161,11 +164,13 @@ public class CertUtils {
         }
       }.call();
     } catch (NoClassDefFoundError e) {
-      throw new KubernetesClientException("JcaPEMKeyConverter is provided by BouncyCastle, an optional dependency. To use support for EC Keys you must explicitly add this dependency to classpath.");
+      throw new KubernetesClientException(
+          "JcaPEMKeyConverter is provided by BouncyCastle, an optional dependency. To use support for EC Keys you must explicitly add this dependency to classpath.");
     }
   }
 
-  private static PrivateKey handleOtherKeys(InputStream keyInputStream, String clientKeyAlgo) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+  private static PrivateKey handleOtherKeys(InputStream keyInputStream, String clientKeyAlgo)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
     byte[] keyBytes = decodePem(keyInputStream);
     try {
       // First let's try PKCS8
@@ -177,9 +182,8 @@ public class CertUtils {
     }
   }
 
-
   private static void loadDefaultTrustStoreFile(KeyStore keyStore, char[] trustStorePassphrase)
-    throws CertificateException, NoSuchAlgorithmException, IOException {
+      throws CertificateException, NoSuchAlgorithmException, IOException {
 
     File trustStoreFile = getDefaultTrustStoreFile();
 
@@ -189,8 +193,8 @@ public class CertUtils {
   }
 
   private static File getDefaultTrustStoreFile() {
-    String securityDirectory =
-      System.getProperty("java.home") + File.separator + "lib" + File.separator + "security" + File.separator;
+    String securityDirectory = System.getProperty("java.home") + File.separator + "lib" + File.separator + "security"
+        + File.separator;
 
     String trustStorePath = System.getProperty(TRUST_STORE_SYSTEM_PROPERTY);
     if (Utils.isNotNullOrEmpty(trustStorePath)) {
@@ -206,7 +210,7 @@ public class CertUtils {
   }
 
   private static void loadDefaultKeyStoreFile(KeyStore keyStore, char[] keyStorePassphrase)
-    throws CertificateException, NoSuchAlgorithmException, IOException {
+      throws CertificateException, NoSuchAlgorithmException, IOException {
 
     String keyStorePath = System.getProperty(KEY_STORE_SYSTEM_PROPERTY);
     if (Utils.isNotNullOrEmpty(keyStorePath)) {
@@ -222,7 +226,7 @@ public class CertUtils {
   private static boolean loadDefaultStoreFile(KeyStore keyStore, File fileToLoad, char[] passphrase) {
 
     String notLoadedMessage = "There is a problem with reading default keystore/truststore file %s with the passphrase %s "
-      + "- the file won't be loaded. The reason is: %s";
+        + "- the file won't be loaded. The reason is: %s";
 
     if (fileToLoad.exists() && fileToLoad.isFile() && fileToLoad.length() > 0) {
       try {
@@ -239,12 +243,13 @@ public class CertUtils {
   }
 
   public static KeyStore createKeyStore(String clientCertData, String clientCertFile, String clientKeyData,
-    String clientKeyFile, String clientKeyAlgo, String clientKeyPassphrase, String keyStoreFile,
-    String keyStorePassphrase)
-    throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException, KeyStoreException {
-    try (InputStream certInputStream = getInputStreamFromDataOrFile(clientCertData, clientCertFile); InputStream keyInputStream = getInputStreamFromDataOrFile(clientKeyData, clientKeyFile)) {
+      String clientKeyFile, String clientKeyAlgo, String clientKeyPassphrase, String keyStoreFile,
+      String keyStorePassphrase)
+      throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException, KeyStoreException {
+    try (InputStream certInputStream = getInputStreamFromDataOrFile(clientCertData, clientCertFile);
+        InputStream keyInputStream = getInputStreamFromDataOrFile(clientKeyData, clientKeyFile)) {
       return createKeyStore(certInputStream, keyInputStream, clientKeyAlgo, clientKeyPassphrase.toCharArray(),
-        keyStoreFile, getKeyStorePassphrase(keyStorePassphrase));
+          keyStoreFile, getKeyStorePassphrase(keyStorePassphrase));
     }
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/CertUtils.java
@@ -167,14 +167,13 @@ public class CertUtils {
 
   private static PrivateKey handleOtherKeys(InputStream keyInputStream, String clientKeyAlgo) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
     byte[] keyBytes = decodePem(keyInputStream);
-    KeyFactory keyFactory = KeyFactory.getInstance(clientKeyAlgo);
     try {
       // First let's try PKCS8
-      return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+      return KeyFactory.getInstance(clientKeyAlgo).generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
     } catch (InvalidKeySpecException e) {
       // Otherwise try PKCS8
       RSAPrivateCrtKeySpec keySpec = PKCS1Util.decodePKCS1(keyBytes);
-      return keyFactory.generatePrivate(keySpec);
+      return KeyFactory.getInstance(clientKeyAlgo).generatePrivate(keySpec);
     }
   }
 


### PR DESCRIPTION
## Description
Fixes #4509

This took a while to find the root cause:

The internal SPI fallback logic inside `KeyFactory.generatePrivate()` has the weird side effect of latching onto the LAST registered provider (which in our case was Cavium) after `InvalidKeySpecException` is thrown.

This choice is sticky for a single instance of KeyFactory and the fix for our issue is to get fresh `KeyFactory` instance when retrying.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
