### PR TITLE
fix #4569: accounting for 0 timeouts that are not supported by jdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #4535: The shell command string will now have single quotes sanitized
 * Fix #4543: (Java Generator) additionalProperties JsonAny setter method generated as setAdditionalProperty
 * Fix #4547: preventing timing issues with leader election cancel
+* Fix #4569: fixing jdk httpclient regression with 0 timeouts
 
 #### Improvements
 * Fix #4355: for exec, attach, upload, and copy operations the container id/name will be validated or chosen prior to the remote call.  You may also use the kubectl.kubernetes.io/default-container annotation to specify the default container.

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
@@ -53,7 +53,7 @@ class JdkHttpClientBuilderImpl
       return new JdkHttpClientImpl(this, client.getHttpClient(), this.requestConfig);
     }
     java.net.http.HttpClient.Builder builder = clientFactory.createNewHttpClientBuilder();
-    if (connectTimeout != null) {
+    if (connectTimeout != null && !java.time.Duration.ZERO.equals(connectTimeout)) {
       builder.connectTimeout(connectTimeout);
     }
     if (sslContext != null) {

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -35,6 +35,7 @@ import java.net.http.HttpResponse.BodySubscribers;
 import java.net.http.WebSocketHandshakeException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -404,8 +405,9 @@ public class JdkHttpClientImpl implements HttpClient {
     }
     // the Watch logic sets a websocketTimeout as the readTimeout
     // TODO: this should probably be made clearer in the docs
-    if (this.builder.getReadTimeout() != null) {
-      newBuilder.connectTimeout(this.builder.getReadTimeout());
+    Duration readTimeout = this.builder.getReadTimeout();
+    if (readTimeout != null && !java.time.Duration.ZERO.equals(readTimeout)) {
+      newBuilder.connectTimeout(readTimeout);
     }
 
     AtomicLong queueSize = new AtomicLong();

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpRequestImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpRequestImpl.java
@@ -115,7 +115,7 @@ class JdkHttpRequestImpl implements HttpRequest {
     }
 
     public Builder timeout(Duration duration) {
-      if (duration != null) {
+      if (duration != null && !Duration.ZERO.equals(duration)) {
         builder.timeout(duration);
       }
       return this;

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class JdkHttpClientBuilderTest {
+
+  @Test
+  void testZeroTimeouts() {
+    JdkHttpClientFactory factory = new JdkHttpClientFactory();
+    JdkHttpClientBuilderImpl builder = factory.newBuilder();
+
+    // should build and be usable without an issue
+    try (HttpClient client = builder.readTimeout(0, TimeUnit.MILLISECONDS).connectTimeout(0, TimeUnit.MILLISECONDS)
+        .writeTimeout(0,
+            TimeUnit.MILLISECONDS)
+        .build();) {
+      assertNotNull(client.newHttpRequestBuilder().uri("http://localhost").build());
+    }
+  }
+
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractWebSocketSendTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractWebSocketSendTest.java
@@ -62,7 +62,10 @@ public abstract class AbstractWebSocketSendTest {
           .done()
           .always();
       final BlockingQueue<String> receivedText = new ArrayBlockingQueue<>(1);
-      final WebSocket ws = client.newWebSocketBuilder()
+      final WebSocket ws = client
+          // ensure that both a derived builder and a 0, or no, timeout works
+          // as that is a common logic path in the client
+          .newBuilder().readTimeout(0, TimeUnit.SECONDS).build().newWebSocketBuilder()
           // TODO: JDK HttpClient implementation doesn't work with ws URIs
           // - Currently we are using an HttpRequest.Builder which is then
           //   mapped to a WebSocket.Builder. We should probably user the WebSocket.Builder
@@ -70,6 +73,7 @@ public abstract class AbstractWebSocketSendTest {
           //.uri(URI.create(String.format("ws://%s:%s/send-text", server.getHostName(), server.getPort())))
           .uri(URI.create(server.url("send-text")))
           .buildAsync(new WebSocket.Listener() {
+            @Override
             public void onMessage(WebSocket webSocket, String text) {
               assertTrue(receivedText.offer(text));
             }


### PR DESCRIPTION
## Description
Fix #4569 - the regression from #4490.  We need more pervasive checks in the jdk client for the 0 (no) timeout value.  

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
