### PR TITLE
[crd-generator] Fix inconsistent additionalPrinterColumns jsonPath

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/decorator/AddAdditionPrinterColumnDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/decorator/AddAdditionPrinterColumnDecorator.java
@@ -43,7 +43,7 @@ public class AddAdditionPrinterColumnDecorator extends
   @Override
   public void andThenVisit(CustomResourceDefinitionVersionFluent<?> spec) {
     Predicate<CustomResourceColumnDefinitionBuilder> matchingColumn = col -> col.getName() != null
-        && col.getName().equals(columnName);
+        && col.getName().equals(columnName) && col.getJsonPath() != null && col.getJsonPath().equals(path);
     spec.removeMatchingFromAdditionalPrinterColumns(matchingColumn);
 
     spec.addNewAdditionalPrinterColumn()

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/AddAdditionPrinterColumnDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/AddAdditionPrinterColumnDecorator.java
@@ -43,7 +43,7 @@ public class AddAdditionPrinterColumnDecorator extends
   @Override
   public void andThenVisit(CustomResourceDefinitionVersionFluent<?> spec) {
     Predicate<CustomResourceColumnDefinitionBuilder> matchingColumn = col -> col.getName() != null
-        && col.getName().equals(columnName);
+        && col.getName().equals(columnName) && col.getJSONPath() != null && col.getJSONPath().equals(path);
     spec.removeMatchingFromAdditionalPrinterColumns(matchingColumn);
 
     spec.addNewAdditionalPrinterColumn()

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequestStatus.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequestStatus.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.crd.example.joke;
 
+import io.fabric8.kubernetes.model.annotation.PrinterColumn;
+
 public class JokeRequestStatus {
   public enum State {
     CREATED,
@@ -27,6 +29,9 @@ public class JokeRequestStatus {
   private State state = State.UNKNOWN;
   private boolean error;
   private String message;
+
+  @PrinterColumn(name = "jokeCategory")
+  private JokeRequestSpec.Category category = JokeRequestSpec.Category.Any;
 
   public State getState() {
     return state;
@@ -50,5 +55,13 @@ public class JokeRequestStatus {
 
   public void setMessage(String message) {
     this.message = message;
+  }
+
+  public JokeRequestSpec.Category getCategory() {
+    return category;
+  }
+
+  public void setCategory(JokeRequestSpec.Category category) {
+    this.category = category;
   }
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -347,7 +347,7 @@ class CRDGeneratorTest {
       // printer columns should be ordered in the alphabetical order of their json path
       final List<CustomResourceColumnDefinition> printerColumns = version
           .getAdditionalPrinterColumns();
-      assertEquals(2, printerColumns.size());
+      assertEquals(3, printerColumns.size());
       CustomResourceColumnDefinition columnDefinition = printerColumns.get(0);
       assertEquals("string", columnDefinition.getType());
       assertEquals(".spec.category", columnDefinition.getJsonPath());
@@ -356,6 +356,10 @@ class CRDGeneratorTest {
       assertEquals("string", columnDefinition.getType());
       assertEquals(".spec.excluded", columnDefinition.getJsonPath());
       assertEquals("excludedTopics", columnDefinition.getName());
+      columnDefinition = printerColumns.get(2);
+      assertEquals("string", columnDefinition.getType());
+      assertEquals(".status.category", columnDefinition.getJsonPath());
+      assertEquals("jokeCategory", columnDefinition.getName());
       CustomResourceValidation schema = version.getSchema();
       assertNotNull(schema);
       Map<String, JSONSchemaProps> properties = schema.getOpenAPIV3Schema().getProperties();


### PR DESCRIPTION
## Description
This is a proposal to fix #4610 

After this fix, `additionalPrinterColumns` with different paths will be emitted with colliding names. I'm not sure if this has implications.

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
