### PR TITLE
Making raw/generic buildable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #4535: The shell command string will now have single quotes sanitized
 * Fix #4543: (Java Generator) additionalProperties JsonAny setter method generated as setAdditionalProperty
 * Fix #4547: preventing timing issues with leader election cancel
+* Fix #4540: treating GenericKubernetesResource and RawExtension as buildable
 * Fix #4569: fixing jdk httpclient regression with 0 timeouts
 
 #### Improvements

--- a/extensions/camel-k/generator-v1/Makefile
+++ b/extensions/camel-k/generator-v1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/camel-k/generator-v1alpha1/Makefile
+++ b/extensions/camel-k/generator-v1alpha1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1alpha1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/camel-k/model-v1/pom.xml
+++ b/extensions/camel-k/model-v1/pom.xml
@@ -78,32 +78,42 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                      <!-- removing the generated Schema class -->
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/camelk/api/model/CamelKSchemaV1.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                  <!-- removing the generated Schema class -->
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/camelk/api/model/CamelKSchemaV1.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>

--- a/extensions/camel-k/model-v1alpha1/pom.xml
+++ b/extensions/camel-k/model-v1alpha1/pom.xml
@@ -85,32 +85,42 @@
         <scope>provided</scope>
       </dependency>
     </dependencies>
+    
+    <profiles>
+      <profile>
+        <id>generate</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.jsonschema2pojo</groupId>
+              <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>generate-sources</phase>
+                  <configuration>
+                    <target>
+                      <!-- removing the generated Schema class -->
+                      <delete
+                        file="${generate.targetDirectory}/io/fabric8/camelk/api/model/CamelKSchemaV1alpha1.java"
+                        verbose="true"/>
+                    </target>
+                  </configuration>
+                  <goals>
+                    <goal>run</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
 
     <build>
       <plugins>
-        <plugin>
-          <groupId>org.jsonschema2pojo</groupId>
-          <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-        </plugin>
-        <plugin>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>generate-sources</phase>
-              <configuration>
-                <target>
-                  <!-- removing the generated Schema class -->
-                  <delete
-                    file="${generate.targetDirectory}/io/fabric8/camelk/api/model/CamelKSchemaV1alpha1.java"
-                    verbose="true"/>
-                </target>
-              </configuration>
-              <goals>
-                <goal>run</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>

--- a/extensions/certmanager/generator-v1/Makefile
+++ b/extensions/certmanager/generator-v1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/certmanager/generator-v1alpha2/Makefile
+++ b/extensions/certmanager/generator-v1alpha2/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1alpha2 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/certmanager/generator-v1alpha3/Makefile
+++ b/extensions/certmanager/generator-v1alpha3/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1alpha3 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/certmanager/generator-v1beta1/Makefile
+++ b/extensions/certmanager/generator-v1beta1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1beta1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/certmanager/model-v1/pom.xml
+++ b/extensions/certmanager/model-v1/pom.xml
@@ -81,32 +81,42 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <echo>removing the duplicate generated class</echo>
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/certmanager/api/model/v1/CertificateRequestSpec.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <echo>removing the duplicate generated class</echo>
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/certmanager/api/model/v1/CertificateRequestSpec.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/certmanager/model-v1alpha2/pom.xml
+++ b/extensions/certmanager/model-v1alpha2/pom.xml
@@ -73,13 +73,23 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/certmanager/model-v1alpha3/pom.xml
+++ b/extensions/certmanager/model-v1alpha3/pom.xml
@@ -73,13 +73,23 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/certmanager/model-v1beta1/pom.xml
+++ b/extensions/certmanager/model-v1beta1/pom.xml
@@ -73,32 +73,42 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <echo>removing the duplicate generated class</echo>
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/certmanager/api/model/v1beta1/CertificateRequestSpec.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <echo>removing the duplicate generated class</echo>
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/certmanager/api/model/v1beta1/CertificateRequestSpec.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/chaosmesh/generator/Makefile
+++ b/extensions/chaosmesh/generator/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/chaosmesh/model/pom.xml
+++ b/extensions/chaosmesh/model/pom.xml
@@ -74,12 +74,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/istio/generator-v1alpha3/Makefile
+++ b/extensions/istio/generator-v1alpha3/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1alpha3 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/istio/generator-v1beta1/Makefile
+++ b/extensions/istio/generator-v1beta1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1beta1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/istio/model-v1alpha3/pom.xml
+++ b/extensions/istio/model-v1alpha3/pom.xml
@@ -64,31 +64,41 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <!-- removing the generated Schema class -->
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/istio/api/model/IstioSchema.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <!-- removing the generated Schema class -->
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/istio/api/model/IstioSchema.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/istio/model-v1beta1/pom.xml
+++ b/extensions/istio/model-v1beta1/pom.xml
@@ -64,31 +64,41 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <!-- removing the generated Schema class -->
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/istio/api/model/IstioSchema.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <!-- removing the generated Schema class -->
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/istio/api/model/IstioSchema.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/knative/generator/Makefile
+++ b/extensions/knative/generator/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -73,32 +73,42 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <!-- removing the generated Schema class -->
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/knative/api/model/KnativeSchema.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <!-- removing the generated Schema class -->
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/knative/api/model/KnativeSchema.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/generator-agent/Makefile
+++ b/extensions/open-cluster-management/generator-agent/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-agent && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-apps/Makefile
+++ b/extensions/open-cluster-management/generator-apps/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-apps && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-cluster/Makefile
+++ b/extensions/open-cluster-management/generator-cluster/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-cluster && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-discovery/Makefile
+++ b/extensions/open-cluster-management/generator-discovery/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-discovery && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-observability/Makefile
+++ b/extensions/open-cluster-management/generator-observability/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-observability && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-operator/Makefile
+++ b/extensions/open-cluster-management/generator-operator/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-operator && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-placementruleapps/Makefile
+++ b/extensions/open-cluster-management/generator-placementruleapps/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-placementruleapps && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-policy/Makefile
+++ b/extensions/open-cluster-management/generator-policy/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-policy && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/generator-search/Makefile
+++ b/extensions/open-cluster-management/generator-search/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-search && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/open-cluster-management/model-agent/pom.xml
+++ b/extensions/open-cluster-management/model-agent/pom.xml
@@ -73,13 +73,23 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/model-apps/pom.xml
+++ b/extensions/open-cluster-management/model-apps/pom.xml
@@ -74,13 +74,18 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/extensions/open-cluster-management/model-cluster/pom.xml
+++ b/extensions/open-cluster-management/model-cluster/pom.xml
@@ -74,12 +74,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/model-discovery/pom.xml
+++ b/extensions/open-cluster-management/model-discovery/pom.xml
@@ -74,12 +74,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/model-observability/pom.xml
+++ b/extensions/open-cluster-management/model-observability/pom.xml
@@ -74,12 +74,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/model-operator/pom.xml
+++ b/extensions/open-cluster-management/model-operator/pom.xml
@@ -74,12 +74,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/model-placementruleapps/pom.xml
+++ b/extensions/open-cluster-management/model-placementruleapps/pom.xml
@@ -73,13 +73,23 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/model-policy/pom.xml
+++ b/extensions/open-cluster-management/model-policy/pom.xml
@@ -73,13 +73,23 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/open-cluster-management/model-search/pom.xml
+++ b/extensions/open-cluster-management/model-search/pom.xml
@@ -74,12 +74,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -51,7 +51,24 @@
           <configuration>
             <customAnnotator>io.fabric8.kubernetes.jsonschema2pojo.ExtensionTypeAnnotator</customAnnotator>
           </configuration>
-        </plugin> 
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>${generate.targetDirectory}</source>
+                </sources>
+              </configuration>
+            </execution>
+           </executions>
+         </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/extensions/service-catalog/generator/Makefile
+++ b/extensions/service-catalog/generator/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/service-catalog/model/pom.xml
+++ b/extensions/service-catalog/model/pom.xml
@@ -72,13 +72,23 @@
       <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/tekton/generator-triggers-v1alpha1/Makefile
+++ b/extensions/tekton/generator-triggers-v1alpha1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-triggers-v1alpha1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/tekton/generator-triggers-v1beta1/Makefile
+++ b/extensions/tekton/generator-triggers-v1beta1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-triggers-v1beta1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/tekton/generator-v1alpha1/Makefile
+++ b/extensions/tekton/generator-v1alpha1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1alpha1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/tekton/generator-v1beta1/Makefile
+++ b/extensions/tekton/generator-v1beta1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1beta1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
 	popd
 
 gobuild:

--- a/extensions/tekton/model-triggers-v1alpha1/pom.xml
+++ b/extensions/tekton/model-triggers-v1alpha1/pom.xml
@@ -79,31 +79,41 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                      <!-- removing the generated Schema class -->
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaTriggers.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                  <!-- removing the generated Schema class -->
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaTriggers.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>

--- a/extensions/tekton/model-triggers-v1alpha1/src/generated/java/io/fabric8/tekton/triggers/v1alpha1/Resources.java
+++ b/extensions/tekton/model-triggers-v1alpha1/src/generated/java/io/fabric8/tekton/triggers/v1alpha1/Resources.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -24,6 +25,7 @@ import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -57,6 +59,8 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class),
     @BuildableReference(EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),

--- a/extensions/tekton/model-triggers-v1alpha1/src/generated/java/io/fabric8/tekton/triggers/v1alpha1/TriggerTemplateSpec.java
+++ b/extensions/tekton/model-triggers-v1alpha1/src/generated/java/io/fabric8/tekton/triggers/v1alpha1/TriggerTemplateSpec.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
@@ -27,6 +28,7 @@ import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -60,6 +62,8 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class),
     @BuildableReference(EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),

--- a/extensions/tekton/model-triggers-v1beta1/pom.xml
+++ b/extensions/tekton/model-triggers-v1beta1/pom.xml
@@ -79,31 +79,41 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                      <!-- removing the generated Schema class -->
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaTriggers.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                  <!-- removing the generated Schema class -->
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaTriggers.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>

--- a/extensions/tekton/model-triggers-v1beta1/src/generated/java/io/fabric8/tekton/triggers/v1beta1/Resources.java
+++ b/extensions/tekton/model-triggers-v1beta1/src/generated/java/io/fabric8/tekton/triggers/v1beta1/Resources.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -24,6 +25,7 @@ import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -57,6 +59,8 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class),
     @BuildableReference(EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),

--- a/extensions/tekton/model-triggers-v1beta1/src/generated/java/io/fabric8/tekton/triggers/v1beta1/TriggerTemplateSpec.java
+++ b/extensions/tekton/model-triggers-v1beta1/src/generated/java/io/fabric8/tekton/triggers/v1beta1/TriggerTemplateSpec.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
@@ -27,6 +28,7 @@ import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -60,6 +62,8 @@ import lombok.experimental.Accessors;
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class),
     @BuildableReference(EnvVar.class),
     @BuildableReference(ContainerPort.class),
     @BuildableReference(Volume.class),

--- a/extensions/tekton/model-v1alpha1/pom.xml
+++ b/extensions/tekton/model-v1alpha1/pom.xml
@@ -77,31 +77,41 @@
       </dependency>
     </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>generate-sources</phase>
+                  <configuration>
+                    <target>
+                      <!-- removing the generated Schema class -->
+                      <delete
+                        file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaV1alpha1.java"
+                        verbose="true"/>
+                    </target>
+                  </configuration>
+                  <goals>
+                    <goal>run</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  
     <build>
       <plugins>
-        <plugin>
-          <groupId>org.jsonschema2pojo</groupId>
-          <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-        </plugin>
-        <plugin>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>generate-sources</phase>
-              <configuration>
-                <target>
-                  <!-- removing the generated Schema class -->
-                  <delete
-                    file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaV1alpha1.java"
-                    verbose="true"/>
-                </target>
-              </configuration>
-              <goals>
-                <goal>run</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>

--- a/extensions/tekton/model-v1beta1/pom.xml
+++ b/extensions/tekton/model-v1beta1/pom.xml
@@ -78,32 +78,42 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                      <!-- removing the generated Schema class -->
+                    <delete
+                      file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaV1beta1.java"
+                      verbose="true" />
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                  <!-- removing the generated Schema class -->
-                <delete
-                  file="${generate.targetDirectory}/io/fabric8/tekton/api/model/TektonSchemaV1beta1.java"
-                  verbose="true" />
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>

--- a/extensions/verticalpodautoscaler/generator-v1/Makefile
+++ b/extensions/verticalpodautoscaler/generator-v1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/verticalpodautoscaler/model-v1/pom.xml
+++ b/extensions/verticalpodautoscaler/model-v1/pom.xml
@@ -78,28 +78,38 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <echo>removing the duplicate generated class</echo>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <echo>removing the duplicate generated class</echo>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/volcano/generator-v1beta1/Makefile
+++ b/extensions/volcano/generator-v1beta1/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model-v1beta1 && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/volcano/model-v1beta1/pom.xml
+++ b/extensions/volcano/model-v1beta1/pom.xml
@@ -69,12 +69,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/extensions/volumesnapshot/generator/Makefile
+++ b/extensions/volumesnapshot/generator/Makefile
@@ -20,7 +20,7 @@ all: build
 
 build: gobuild
 	pushd ../model && \
-	mvn clean install -o && \
+	mvn -Pgenerate clean install -DskipTests -o && \
   popd
 
 gobuild:

--- a/extensions/volumesnapshot/model/pom.xml
+++ b/extensions/volumesnapshot/model/pom.xml
@@ -74,12 +74,22 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jsonschema2pojo</groupId>
-        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionRequest.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionRequest.java
@@ -1,10 +1,6 @@
 
 package io.fabric8.kubernetes.api.model.apiextensions.v1;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -13,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -22,12 +19,18 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -55,7 +58,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class),
 })
 public class ConversionRequest implements KubernetesResource
 {
@@ -71,13 +76,13 @@ public class ConversionRequest implements KubernetesResource
 
     /**
      * No args constructor for use in serialization
-     * 
+     *
      */
     public ConversionRequest() {
     }
 
     /**
-     * 
+     *
      * @param uid
      * @param objects
      * @param desiredAPIVersion

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionRequest.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionRequest.java
@@ -1,6 +1,10 @@
 
 package io.fabric8.kubernetes.api.model.apiextensions.v1;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -26,11 +30,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -60,7 +59,7 @@ import java.util.Map;
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(GenericKubernetesResource.class),
-    @BuildableReference(RawExtension.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ConversionRequest implements KubernetesResource
 {
@@ -76,13 +75,13 @@ public class ConversionRequest implements KubernetesResource
 
     /**
      * No args constructor for use in serialization
-     *
+     * 
      */
     public ConversionRequest() {
     }
 
     /**
-     *
+     * 
      * @param uid
      * @param objects
      * @param desiredAPIVersion

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionResponse.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionResponse.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -23,6 +24,7 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -56,7 +58,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ConversionResponse implements KubernetesResource
 {

--- a/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/ControllerRevision.java
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/generated/java/io/fabric8/kubernetes/api/model/apps/ControllerRevision.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
@@ -21,6 +22,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
@@ -57,7 +59,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 @TemplateTransformations({
     @TemplateTransformation(value = "/manifest.vm", outputPath = "META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource", gather = true)

--- a/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/ExtensionTypeAnnotator.java
+++ b/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/ExtensionTypeAnnotator.java
@@ -16,11 +16,11 @@
 
 package io.fabric8.kubernetes.jsonschema2pojo;
 
-import com.sun.codemodel.JAnnotationArrayMember;
-import com.sun.codemodel.JClassAlreadyExistsException;
-import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
 import io.sundr.builder.annotations.BuildableReference;
 import org.jsonschema2pojo.GenerationConfig;
+
+import java.util.List;
 
 /**
  * Adds more {@link BuildableReference}s to regular annotator to minimize
@@ -33,15 +33,12 @@ public class ExtensionTypeAnnotator extends KubernetesTypeAnnotator {
   }
 
   @Override
-  protected void addBuildableTypes(JAnnotationArrayMember arrayMember) throws JClassAlreadyExistsException {
-    arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-        new JCodeModel()._class("io.fabric8.kubernetes.api.model.EnvVar"));
-    arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-        new JCodeModel()._class("io.fabric8.kubernetes.api.model.ContainerPort"));
-    arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-        new JCodeModel()._class("io.fabric8.kubernetes.api.model.Volume"));
-    arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-        new JCodeModel()._class("io.fabric8.kubernetes.api.model.VolumeMount"));
+  protected void addBuildableTypes(JDefinedClass clazz, List<String> types) {
+    super.addBuildableTypes(clazz, types);
+    types.add("io.fabric8.kubernetes.api.model.EnvVar");
+    types.add("io.fabric8.kubernetes.api.model.ContainerPort");
+    types.add("io.fabric8.kubernetes.api.model.Volume");
+    types.add("io.fabric8.kubernetes.api.model.VolumeMount");
   }
 
 }

--- a/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/KubernetesTypeAnnotator.java
+++ b/kubernetes-model-generator/kubernetes-model-jsonschema2pojo/src/main/java/io/fabric8/kubernetes/jsonschema2pojo/KubernetesTypeAnnotator.java
@@ -15,60 +15,40 @@
  */
 package io.fabric8.kubernetes.jsonschema2pojo;
 
-import com.sun.codemodel.JAnnotationArrayMember;
-import com.sun.codemodel.JAnnotationUse;
-import com.sun.codemodel.JClassAlreadyExistsException;
-import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
-import io.sundr.builder.annotations.Buildable;
-import io.sundr.builder.annotations.BuildableReference;
 import org.jsonschema2pojo.GenerationConfig;
 
-public class KubernetesTypeAnnotator extends KubernetesCoreTypeAnnotator {
+import java.util.List;
 
-  public static final String BUILDABLE_REFERENCE_VALUE = "value";
+public class KubernetesTypeAnnotator extends KubernetesCoreTypeAnnotator {
 
   public KubernetesTypeAnnotator(GenerationConfig generationConfig) {
     super(generationConfig);
   }
 
   @Override
-  public void processBuildable(JDefinedClass clazz) {
-    try {
-      JAnnotationUse buildable = clazz.annotate(Buildable.class)
-          .param("editableEnabled", false)
-          .param("validationEnabled", false)
-          .param("generateBuilderPackage", false)
-          .param("lazyCollectionInitEnabled", false)
-          .param("builderPackage", "io.fabric8.kubernetes.api.builder");
-
-      JAnnotationArrayMember arrayMember = buildable.paramArray("refs");
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.ObjectMeta"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.LabelSelector"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.Container"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.PodTemplateSpec"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.ResourceRequirements"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.IntOrString"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.ObjectReference"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.LocalObjectReference"));
-      arrayMember.annotate(BuildableReference.class).param(BUILDABLE_REFERENCE_VALUE,
-          new JCodeModel()._class("io.fabric8.kubernetes.api.model.PersistentVolumeClaim"));
-      addBuildableTypes(arrayMember);
-    } catch (JClassAlreadyExistsException e) {
-      e.printStackTrace();
-    }
+  protected boolean generateBuilderPackage() {
+    return false;
   }
 
-  protected void addBuildableTypes(JAnnotationArrayMember arrayMember) throws JClassAlreadyExistsException {
-
+  @Override
+  protected void addBuildableTypes(JDefinedClass clazz, List<String> types) {
+    types.add("io.fabric8.kubernetes.api.model.ObjectMeta");
+    types.add("io.fabric8.kubernetes.api.model.LabelSelector");
+    types.add("io.fabric8.kubernetes.api.model.Container");
+    types.add("io.fabric8.kubernetes.api.model.PodTemplateSpec");
+    types.add("io.fabric8.kubernetes.api.model.ResourceRequirements");
+    types.add("io.fabric8.kubernetes.api.model.IntOrString");
+    types.add("io.fabric8.kubernetes.api.model.ObjectReference");
+    types.add("io.fabric8.kubernetes.api.model.LocalObjectReference");
+    types.add("io.fabric8.kubernetes.api.model.PersistentVolumeClaim");
+    if (clazz.fields().values().stream()
+        .anyMatch(f -> f.type().fullName().contains("io.fabric8.kubernetes.api.model.KubernetesResource")
+            || f.type().fullName().contains("io.fabric8.kubernetes.api.model.HasMetadata")
+            || f.type().fullName().contains("io.fabric8.kubernetes.api.model.RawExtension"))) {
+      types.add("io.fabric8.kubernetes.api.model.GenericKubernetesResource");
+      types.add("io.fabric8.kubernetes.api.model.runtime.RawExtension");
+    }
   }
 
 }

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/AuthenticationSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/AuthenticationSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class AuthenticationSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CSISnapshotControllerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CSISnapshotControllerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class CSISnapshotControllerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CloudCredentialSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/CloudCredentialSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -56,7 +58,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class CloudCredentialSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ClusterCSIDriverSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ClusterCSIDriverSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ClusterCSIDriverSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ConfigSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ConfigSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ConfigSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ConsoleSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ConsoleSpec.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -22,6 +23,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -61,7 +63,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ConsoleSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/EtcdSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/EtcdSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -58,7 +60,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class EtcdSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/IngressControllerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/IngressControllerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -18,6 +19,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.fabric8.openshift.api.model.config.v1.ConfigMapNameReference;
 import io.fabric8.openshift.api.model.config.v1.TLSSecurityProfile;
 import io.sundr.builder.annotations.Buildable;
@@ -67,7 +69,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(io.fabric8.kubernetes.api.model.LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class IngressControllerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeAPIServerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeAPIServerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -58,7 +60,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class KubeAPIServerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeControllerManagerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeControllerManagerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -59,7 +61,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class KubeControllerManagerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeSchedulerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeSchedulerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -58,7 +60,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class KubeSchedulerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeStorageVersionMigratorSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/KubeStorageVersionMigratorSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class KubeStorageVersionMigratorSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/NetworkSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/NetworkSpec.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -22,6 +23,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -68,7 +70,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class NetworkSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftAPIServerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftAPIServerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class OpenShiftAPIServerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftControllerManagerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/OpenShiftControllerManagerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class OpenShiftControllerManagerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCASpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCASpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ServiceCASpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogAPIServerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogAPIServerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ServiceCatalogAPIServerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogControllerManagerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ServiceCatalogControllerManagerSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class ServiceCatalogControllerManagerSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/StorageSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/StorageSpec.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -55,7 +57,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class StorageSpec implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/LocalResourceAccessReview.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/LocalResourceAccessReview.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -21,6 +22,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
@@ -64,7 +66,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 @TemplateTransformations({
     @TemplateTransformation(value = "/manifest.vm", outputPath = "META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource", gather = true)

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/LocalSubjectAccessReview.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/LocalSubjectAccessReview.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -23,6 +24,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
@@ -69,7 +71,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 @TemplateTransformations({
     @TemplateTransformation(value = "/manifest.vm", outputPath = "META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource", gather = true)

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/PolicyRule.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/PolicyRule.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -22,6 +23,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -58,7 +60,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 public class PolicyRule implements KubernetesResource
 {

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ResourceAccessReview.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ResourceAccessReview.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -20,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
@@ -63,7 +65,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 @TemplateTransformations({
     @TemplateTransformation(value = "/manifest.vm", outputPath = "META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource", gather = true)

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/SubjectAccessReview.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/SubjectAccessReview.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -22,6 +23,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
@@ -68,7 +70,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 @TemplateTransformations({
     @TemplateTransformation(value = "/manifest.vm", outputPath = "META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource", gather = true)

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Template.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Template.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelector;
@@ -23,6 +24,7 @@ import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.sundr.builder.annotations.Buildable;
@@ -61,7 +63,9 @@ import lombok.experimental.Accessors;
     @BuildableReference(IntOrString.class),
     @BuildableReference(ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
-    @BuildableReference(PersistentVolumeClaim.class)
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(GenericKubernetesResource.class),
+    @BuildableReference(RawExtension.class)
 })
 @TemplateTransformations({
     @TemplateTransformation(value = "/manifest.vm", outputPath = "META-INF/services/io.fabric8.kubernetes.api.model.KubernetesResource", gather = true)

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressControllerTest.java
@@ -15,30 +15,46 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.api.model.runtime.RawExtension;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.v1.IngressController;
 import io.fabric8.openshift.api.model.operator.v1.IngressControllerBuilder;
 import io.fabric8.openshift.api.model.operator.v1.IngressControllerList;
 import io.fabric8.openshift.api.model.operator.v1.IngressControllerListBuilder;
+import io.fabric8.openshift.api.model.operator.v1.IngressControllerSpec;
+import io.fabric8.openshift.api.model.operator.v1.IngressControllerSpecBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class IngressControllerTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
+
+  @Test
+  void build() {
+    IngressControllerSpec ic = new IngressControllerSpecBuilder()
+        .withUnsupportedConfigOverrides(new RawExtension(Arrays.asList(1, 2)))
+        .build();
+    // make sure the value is not dropped
+    assertNotNull(ic.getUnsupportedConfigOverrides());
+  }
 
   @Test
   void create() {
     // Given
     IngressController dnsrecord = getIngressController();
-    server.expect().post()
+    server.expect()
+        .post()
         .withPath("/apis/operator.openshift.io/v1/namespaces/ns1/ingresscontrollers")
         .andReturn(HttpURLConnection.HTTP_OK, dnsrecord)
         .once();
@@ -54,7 +70,8 @@ class IngressControllerTest {
   @Test
   void get() {
     // Given
-    server.expect().get()
+    server.expect()
+        .get()
         .withPath("/apis/operator.openshift.io/v1/namespaces/ns1/ingresscontrollers/foo")
         .andReturn(HttpURLConnection.HTTP_OK, getIngressController())
         .once();
@@ -70,9 +87,11 @@ class IngressControllerTest {
   @Test
   void list() {
     // Given
-    server.expect().get()
+    server.expect()
+        .get()
         .withPath("/apis/operator.openshift.io/v1/namespaces/ns1/ingresscontrollers")
-        .andReturn(HttpURLConnection.HTTP_OK, new IngressControllerListBuilder().withItems(getIngressController()).build())
+        .andReturn(HttpURLConnection.HTTP_OK,
+            new IngressControllerListBuilder().withItems(getIngressController()).build())
         .once();
 
     // When
@@ -87,7 +106,8 @@ class IngressControllerTest {
   @Test
   void delete() {
     // Given
-    server.expect().delete()
+    server.expect()
+        .delete()
         .withPath("/apis/operator.openshift.io/v1/namespaces/ns1/ingresscontrollers/foo")
         .andReturn(HttpURLConnection.HTTP_OK, getIngressController())
         .once();


### PR DESCRIPTION
## Description

Fix #4540

This addresses #4540 as much as we can on the fabric8 side, it will allow the use of generic or raw extension in builders methods that expect a kubernetesresource.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
