### PR TITLE
fix #4201: moving consumeLines out of the clients

### DIFF
--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -253,16 +253,6 @@ public class JdkHttpClientImpl implements HttpClient {
   }
 
   @Override
-  public CompletableFuture<HttpResponse<AsyncBody>> consumeLines(HttpRequest request, AsyncBody.Consumer<String> consumer) {
-    return sendAsync(request, () -> {
-      AsyncBodySubscriber<String> subscriber = new AsyncBodySubscriber<>(consumer);
-      BodyHandler<Void> handler = BodyHandlers.fromLineSubscriber(subscriber);
-      BodyHandler<AsyncBody> handlerAdapter = new BodyHandlerAdapter(subscriber, handler);
-      return new HandlerAndAsyncBody<>(handlerAdapter, subscriber);
-    }).thenApply(r -> new JdkHttpResponseImpl<>(r.response, r.asyncBody));
-  }
-
-  @Override
   public CompletableFuture<HttpResponse<AsyncBody>> consumeBytes(HttpRequest request,
       AsyncBody.Consumer<List<ByteBuffer>> consumer) {
     return sendAsync(request, () -> {

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
@@ -30,7 +30,6 @@ import org.eclipse.jetty.client.util.StringRequestContent;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -74,29 +73,6 @@ public class JettyHttpClient implements io.fabric8.kubernetes.client.http.HttpCl
   @Override
   public DerivedClientBuilder newBuilder() {
     return builder.copy(this);
-  }
-
-  @Override
-  public CompletableFuture<HttpResponse<AsyncBody>> consumeLines(
-      HttpRequest originalRequest, AsyncBody.Consumer<String> consumer) {
-    final var request = toStandardHttpRequest(originalRequest);
-    final var future = new JettyAsyncResponseListener(request) {
-
-      final StringBuilder builder = new StringBuilder();
-
-      @Override
-      protected void onContent(ByteBuffer content) throws Exception {
-        for (char c : StandardCharsets.UTF_8.decode(content).array()) {
-          if (c == '\n') {
-            consumer.consume(builder.toString(), this);
-            builder.setLength(0);
-          } else {
-            builder.append(c);
-          }
-        }
-      }
-    }.listen(newRequest(request));
-    return interceptResponse(request.toBuilder(), future, r -> consumeLines(r, consumer));
   }
 
   @Override

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -215,21 +215,6 @@ public class OkHttpClientImpl implements HttpClient {
   }
 
   @Override
-  public CompletableFuture<HttpResponse<AsyncBody>> consumeLines(
-      HttpRequest request, AsyncBody.Consumer<String> consumer) {
-    Function<BufferedSource, AsyncBody> handler = s -> new OkHttpAsyncBody<String>(consumer, s) {
-      @Override
-      protected String process(BufferedSource source) throws IOException {
-        // this should probably be strict instead
-        // when non-strict if no newline is present, this will create a truncated string from
-        // what is available.  However as strict it will be blocking.
-        return source.readUtf8Line();
-      }
-    };
-    return sendAsync(request, handler);
-  }
-
-  @Override
   public CompletableFuture<HttpResponse<AsyncBody>> consumeBytes(
       HttpRequest request, AsyncBody.Consumer<List<ByteBuffer>> consumer) {
     Function<BufferedSource, AsyncBody> handler = s -> new OkHttpAsyncBody<List<ByteBuffer>>(consumer, s) {

--- a/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
+++ b/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
@@ -32,8 +32,6 @@ import java.io.Reader;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -182,41 +180,6 @@ class OkHttpClientTest {
     });
 
     assertEquals(byteCount, consumed.get(10, TimeUnit.SECONDS));
-  }
-
-  @Test
-  void testConsumeLines() throws Exception {
-    server.expect().withPath("/async").andReturn(200, "hello\nworld\nlines\n").always();
-
-    ArrayList<String> strings = new ArrayList<>();
-    CompletableFuture<Void> consumed = new CompletableFuture<>();
-
-    CompletableFuture<HttpResponse<AsyncBody>> responseFuture = client.getHttpClient().consumeLines(
-        client.getHttpClient().newHttpRequestBuilder().uri(URI.create(client.getConfiguration().getMasterUrl() + "async"))
-            .build(),
-        (value, asyncBody) -> {
-          strings.add(value);
-          asyncBody.consume();
-        });
-
-    responseFuture.whenComplete((r, t) -> {
-      if (t != null) {
-        consumed.completeExceptionally(t);
-      }
-      if (r != null) {
-        r.body().consume();
-        r.body().done().whenComplete((v, ex) -> {
-          if (ex != null) {
-            consumed.completeExceptionally(ex);
-          } else {
-            consumed.complete(null);
-          }
-        });
-      }
-    });
-
-    consumed.get(10, TimeUnit.SECONDS);
-    assertEquals(Arrays.asList("hello", "world", "lines"), strings);
   }
 
   @DisplayName("Supported response body types")

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 
-import java.io.BufferedReader;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -178,16 +177,6 @@ public interface HttpClient extends AutoCloseable {
   default <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, Class<T> type) {
     return HttpResponse.SupportedResponses.from(type).sendAsync(request, this);
   }
-
-  /**
-   * Send a request and consume the lines of the response body using the same logic as {@link BufferedReader} to
-   * break up the lines.
-   *
-   * @param request the HttpRequest to send
-   * @param consumer the response body consumer
-   * @return the future which will be ready after the headers have been read
-   */
-  CompletableFuture<HttpResponse<AsyncBody>> consumeLines(HttpRequest request, AsyncBody.Consumer<String> consumer);
 
   /**
    * Send a request and consume the bytes of the resulting response body

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -116,41 +116,6 @@ public abstract class AbstractInterceptorTest {
   }
 
   @Test
-  @DisplayName("afterFailure (HTTP), replaces the HttpResponse produced by HttpClient.consumeLines")
-  public void afterHttpFailureReplacesResponseInConsumeLines() throws Exception {
-    // Given
-    server.expect().withPath("/intercepted-url").andReturn(200, "This works\n").once();
-    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
-        .addOrReplaceInterceptor("test", new Interceptor() {
-          @Override
-          public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
-            builder.uri(URI.create(server.url("/intercepted-url")));
-            return CompletableFuture.completedFuture(true);
-          }
-        });
-    final CompletableFuture<String> result = new CompletableFuture<>();
-    // When
-    try (HttpClient client = builder.build()) {
-      final HttpResponse<AsyncBody> asyncR = client.consumeLines(
-          client.newHttpRequestBuilder().uri(server.url("/not-found")).build(), (s, ab) -> {
-            result.complete(s);
-            ab.consume();
-          })
-          .get(10L, TimeUnit.SECONDS);
-      asyncR.body().consume();
-      asyncR.body().done().whenComplete((v, t) -> {
-        if (t != null) {
-          result.completeExceptionally(t);
-        } else {
-          result.complete(null);
-        }
-      });
-      // Then
-      assertThat(result.get(10L, TimeUnit.SECONDS)).isEqualTo("This works");
-    }
-  }
-
-  @Test
   @DisplayName("afterFailure (HTTP), replaces the HttpResponse produced by HttpClient.consumeBytes")
   public void afterHttpFailureReplacesResponseInConsumeBytes() throws Exception {
     // Given

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchHttpManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchHttpManagerTest.java
@@ -47,7 +47,7 @@ class WatchHttpManagerTest {
     BaseOperation baseOperation = Mockito.mock(BaseOperation.class);
     Mockito.when(baseOperation.getNamespacedUrl()).thenReturn(new URL("http://localhost"));
     CompletableFuture<HttpResponse<AsyncBody>> future = new CompletableFuture<>();
-    Mockito.when(client.consumeLines(Mockito.any(), Mockito.any())).thenReturn(future);
+    Mockito.when(client.consumeBytes(Mockito.any(), Mockito.any())).thenReturn(future);
 
     CountDownLatch reconnect = new CountDownLatch(1);
     WatchHTTPManager<HasMetadata, KubernetesResourceList<HasMetadata>> watch = new WatchHTTPManager(client,


### PR DESCRIPTION
## Description
Follow up to #4430 that moves consumeLines directly to the http watch.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
