### PR TITLE
fix (extensions) : isSupported doesn't check all of the applicable API Groups (#4447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #4590: only using a builder if there are visitors
 * Fix #4159: ensure the token refresh obeys how the Config was created
+* Fix #4447: `isSupported` doesn't check all of the applicable API Groups
 * Fix #4491: added a more explicit shutdown exception for okhttp
 * Fix #4510: Fix StackOverflow on cyclic references involving collections.
 * Fix #4534: Java Generator CLI default handling of skipGeneratedAnnotations

--- a/extensions/camel-k/client/pom.xml
+++ b/extensions/camel-k/client/pom.xml
@@ -84,7 +84,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions/camel-k/client/src/main/java/io/fabric8/camelk/client/DefaultCamelKClient.java
+++ b/extensions/camel-k/client/src/main/java/io/fabric8/camelk/client/DefaultCamelKClient.java
@@ -62,7 +62,7 @@ public class DefaultCamelKClient extends ExtensionRootClientAdapter<DefaultCamel
 
   @Override
   public boolean isSupported() {
-    return hasApiGroup("camel.apache.org", true);
+    return hasApiGroup("camel.apache.org", false);
   }
 
 }

--- a/extensions/camel-k/client/src/test/java/io/fabric8/camelk/client/CamelKClientAdaptTest.java
+++ b/extensions/camel-k/client/src/test/java/io/fabric8/camelk/client/CamelKClientAdaptTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.camelk.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class CamelKClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(CamelKClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("camel.apache.org", true),
+        Arguments.of("test.camel.apache.org", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/camel-k/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/camel-k/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/chaosmesh/client/pom.xml
+++ b/extensions/chaosmesh/client/pom.xml
@@ -95,7 +95,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions/chaosmesh/client/src/main/java/io/fabric8/chaosmesh/client/DefaultChaosMeshClient.java
+++ b/extensions/chaosmesh/client/src/main/java/io/fabric8/chaosmesh/client/DefaultChaosMeshClient.java
@@ -136,6 +136,6 @@ public class DefaultChaosMeshClient extends ExtensionRootClientAdapter<DefaultCh
 
   @Override
   public boolean isSupported() {
-    return hasApiGroup("chaos-mesh.org", true);
+    return hasApiGroup("chaos-mesh.org", false);
   }
 }

--- a/extensions/chaosmesh/client/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/chaosmesh/client/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/chaosmesh/client/src/test/java/io/fabric8/chaosmesh/client/ChaosMeshClientAdaptTest.java
+++ b/extensions/chaosmesh/client/src/test/java/io/fabric8/chaosmesh/client/ChaosMeshClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.chaosmesh.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class ChaosMeshClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(ChaosMeshClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("chaos-mesh.org", true),
+        Arguments.of("test.chaos-mesh.org", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/istio/client/pom.xml
+++ b/extensions/istio/client/pom.xml
@@ -83,6 +83,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/extensions/istio/client/src/main/java/io/fabric8/istio/client/DefaultIstioClient.java
+++ b/extensions/istio/client/src/main/java/io/fabric8/istio/client/DefaultIstioClient.java
@@ -60,6 +60,6 @@ public class DefaultIstioClient extends ExtensionRootClientAdapter<DefaultIstioC
 
   @Override
   public boolean isSupported() {
-    return hasApiGroup("networking.istio.io", true);
+    return hasApiGroup("istio.io", false);
   }
 }

--- a/extensions/istio/client/src/test/java/io/fabric8/istio/client/IstioClientAdaptTest.java
+++ b/extensions/istio/client/src/test/java/io/fabric8/istio/client/IstioClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.istio.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class IstioClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(IstioClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("istio.io", true),
+        Arguments.of("security.istio.io", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/istio/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/istio/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/knative/client/pom.xml
+++ b/extensions/knative/client/pom.xml
@@ -80,7 +80,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions/knative/client/src/main/java/io/fabric8/knative/client/DefaultKnativeClient.java
+++ b/extensions/knative/client/src/main/java/io/fabric8/knative/client/DefaultKnativeClient.java
@@ -241,6 +241,6 @@ public class DefaultKnativeClient extends ExtensionRootClientAdapter<DefaultKnat
 
   @Override
   public boolean isSupported() {
-    return hasApiGroup("knative.dev", true);
+    return hasApiGroup("knative.dev", false);
   }
 }

--- a/extensions/knative/client/src/test/java/io/fabric8/knative/client/KnativeClientAdaptTest.java
+++ b/extensions/knative/client/src/test/java/io/fabric8/knative/client/KnativeClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.knative.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class KnativeClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(KnativeClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("knative.dev", true),
+        Arguments.of("serving.knative.dev", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/knative/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/knative/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/open-cluster-management/client/pom.xml
+++ b/extensions/open-cluster-management/client/pom.xml
@@ -127,7 +127,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions/open-cluster-management/client/src/test/java/io/fabric8/openclustermanagement/client/OpenClusterManagementClientAdaptTest.java
+++ b/extensions/open-cluster-management/client/src/test/java/io/fabric8/openclustermanagement/client/OpenClusterManagementClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openclustermanagement.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class OpenClusterManagementClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(OpenClusterManagementClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("open-cluster-management.io", true),
+        Arguments.of("operator.open-cluster-management.io", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/open-cluster-management/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/open-cluster-management/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/service-catalog/client/pom.xml
+++ b/extensions/service-catalog/client/pom.xml
@@ -94,7 +94,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/DefaultServiceCatalogClient.java
+++ b/extensions/service-catalog/client/src/main/java/io/fabric8/servicecatalog/client/DefaultServiceCatalogClient.java
@@ -114,6 +114,6 @@ public class DefaultServiceCatalogClient extends ExtensionRootClientAdapter<Defa
 
   @Override
   public boolean isSupported() {
-    return hasApiGroup("servicecatalog.k8s.io", true);
+    return hasApiGroup("servicecatalog.k8s.io", false);
   }
 }

--- a/extensions/service-catalog/client/src/test/java/io/fabric8/servicecatalog/client/ServiceCatalogClientAdaptTest.java
+++ b/extensions/service-catalog/client/src/test/java/io/fabric8/servicecatalog/client/ServiceCatalogClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.servicecatalog.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class ServiceCatalogClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(ServiceCatalogClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("servicecatalog.k8s.io", true),
+        Arguments.of("test.servicecatalog.k8s.io", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/service-catalog/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/service-catalog/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/tekton/client/pom.xml
+++ b/extensions/tekton/client/pom.xml
@@ -92,7 +92,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
+++ b/extensions/tekton/client/src/main/java/io/fabric8/tekton/client/DefaultTektonClient.java
@@ -62,7 +62,7 @@ public class DefaultTektonClient extends ExtensionRootClientAdapter<DefaultTekto
 
   @Override
   public boolean isSupported() {
-    return hasApiGroup("tekton.dev", true);
+    return hasApiGroup("tekton.dev", false);
   }
 
 }

--- a/extensions/tekton/client/src/test/java/io/fabric8/tekton/client/TektonClientAdaptTest.java
+++ b/extensions/tekton/client/src/test/java/io/fabric8/tekton/client/TektonClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tekton.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class TektonClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(TektonClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("tekton.dev", true),
+        Arguments.of("triggers.tekton.dev", true),
+        Arguments.of("knative.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/tekton/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/tekton/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/verticalpodautoscaler/client/pom.xml
+++ b/extensions/verticalpodautoscaler/client/pom.xml
@@ -81,7 +81,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions/verticalpodautoscaler/client/src/main/java/io/fabric8/verticalpodautoscaler/client/DefaultVerticalPodAutoscalerClient.java
+++ b/extensions/verticalpodautoscaler/client/src/main/java/io/fabric8/verticalpodautoscaler/client/DefaultVerticalPodAutoscalerClient.java
@@ -56,7 +56,7 @@ public class DefaultVerticalPodAutoscalerClient extends ExtensionRootClientAdapt
 
   @Override
   public boolean isSupported() {
-    return getClient().hasApiGroup(VerticalPodAutoscalerExtensionAdapter.API_GROUP, true);
+    return getClient().hasApiGroup(VerticalPodAutoscalerExtensionAdapter.API_GROUP, false);
   }
 
 }

--- a/extensions/verticalpodautoscaler/client/src/test/java/io/fabric8/verticalpodautoscaler/client/VerticalPodAutoscalerClientAdaptTest.java
+++ b/extensions/verticalpodautoscaler/client/src/test/java/io/fabric8/verticalpodautoscaler/client/VerticalPodAutoscalerClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.verticalpodautoscaler.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class VerticalPodAutoscalerClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(VerticalPodAutoscalerClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("autoscaling.k8s.io", true),
+        Arguments.of("test.autoscaling.k8s.io", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/verticalpodautoscaler/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/verticalpodautoscaler/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/volcano/client/pom.xml
+++ b/extensions/volcano/client/pom.xml
@@ -80,6 +80,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/extensions/volcano/client/src/main/java/io/fabric8/volcano/client/DefaultVolcanoClient.java
+++ b/extensions/volcano/client/src/main/java/io/fabric8/volcano/client/DefaultVolcanoClient.java
@@ -75,6 +75,6 @@ public class DefaultVolcanoClient extends ExtensionRootClientAdapter<DefaultVolc
 
   @Override
   public boolean isSupported() {
-    return getClient().hasApiGroup(VolcanoExtensionAdapter.API_GROUP, true);
+    return getClient().hasApiGroup(VolcanoExtensionAdapter.API_GROUP, false);
   }
 }

--- a/extensions/volcano/client/src/test/java/io/fabric8/volcano/client/VolcanoClientAdaptTest.java
+++ b/extensions/volcano/client/src/test/java/io/fabric8/volcano/client/VolcanoClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.volcano.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class VolcanoClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(VolcanoClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("scheduling.volcano.sh", true),
+        Arguments.of("test.scheduling.volcano.sh", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/volcano/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/volcano/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/extensions/volumesnapshot/client/pom.xml
+++ b/extensions/volumesnapshot/client/pom.xml
@@ -94,7 +94,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/DefaultVolumeSnapshotClient.java
+++ b/extensions/volumesnapshot/client/src/main/java/io/fabric8/volumesnapshot/client/DefaultVolumeSnapshotClient.java
@@ -73,6 +73,6 @@ public class DefaultVolumeSnapshotClient extends ExtensionRootClientAdapter<Defa
 
   @Override
   public boolean isSupported() {
-    return getClient().hasApiGroup(VolumeSnapshotExtensionAdapter.API_GROUP, true);
+    return getClient().hasApiGroup(VolumeSnapshotExtensionAdapter.API_GROUP, false);
   }
 }

--- a/extensions/volumesnapshot/client/src/test/java/io/fabric8/volumesnapshot/client/VolumeSnapshotClientAdaptTest.java
+++ b/extensions/volumesnapshot/client/src/test/java/io/fabric8/volumesnapshot/client/VolumeSnapshotClientAdaptTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.volumesnapshot.client;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.APIGroupList;
+import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.OperationSupport;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class VolumeSnapshotClientAdaptTest {
+  private KubernetesClient kubernetesClient;
+
+  @BeforeEach
+  public void setUp() {
+    HttpClient mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+    Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
+    kubernetesClient = new KubernetesClientImpl(mockClient, config);
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesClient.close();
+    kubernetesClient = null;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInputData")
+  void isSupported_withGivenApiGroup_shouldValidateSupport(String apiGroupName, boolean expectedResult) {
+    try (MockedConstruction<OperationSupport> ignored = mockConstruction(OperationSupport.class, (mock, ctx) -> {
+      givenApiGroupsCallReturns(mock, new APIGroupBuilder().withName(apiGroupName).build());
+    })) {
+      assertThat(kubernetesClient.isAdaptable(VolumeSnapshotClient.class)).isEqualTo(expectedResult);
+    }
+  }
+
+  private static Stream<Arguments> getInputData() {
+    return Stream.of(
+        Arguments.of("snapshot.storage.k8s.io", true),
+        Arguments.of("serving.snapshot.storage.k8s.io", true),
+        Arguments.of("tekton.dev", false));
+  }
+
+  private void givenApiGroupsCallReturns(OperationSupport operationSupport, APIGroup apiGroup) {
+    when(operationSupport.restCall(APIGroupList.class, "/apis"))
+        .thenReturn(new APIGroupListBuilder()
+            .addToGroups(apiGroup)
+            .build());
+  }
+}

--- a/extensions/volumesnapshot/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/volumesnapshot/client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Description
Fix #4447


+ ~Extension client interfaces should extend SupportTestingClient rather than implementations~
+ Disable exact apiGroup match in isSupported method call in extension clients. This effects Istio, Knative and Tekton extensions that use more than one apiGroups

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
