### PR TITLE
fix #4633: improving run operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #4633: provided inline access to all RunConfig builder methods via run().withNewRunConfig()
 * Fix #4670: the initial informer listing will use a resourceVersion of 0 to utilize the watch cache if possible.  This means that the initial cache state when the informer is returned, or the start future is completed, may not be as fresh as the previous behavior which forced the latest version.  It will of course become more consistent as the watch will already have been established.
 
 #### Dependency Upgrade
@@ -13,6 +14,7 @@
 
 #### _**Note**_: Breaking changes
 * Fix #4574: fromServer has been deprecated - it no longer needs to be called.  All get() operations will fetch the resource(s) from the api server.  If you need the context item that was passed in from a resource, load, or resourceList methods, use the item or items method.
+* Fix #4633: client.run().withRunConfig was deprecated.  Use withNewRunConfig instead.
 
 ### 6.3.1 (2022-12-15)
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/run/RunOperationsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/run/RunOperationsTest.java
@@ -53,7 +53,7 @@ class RunOperationsTest {
         .withPort(5701)
         .withLimits(limits)
         .withRequests(requests);
-    RunOperations deploymentGenerator = new RunOperations(Mockito.mock(KubernetesClient.class), generatorRunConfig);
+    RunOperations deploymentGenerator = new RunOperations(Mockito.mock(KubernetesClient.class), generatorRunConfig.build());
 
     // When
     Pod pod = deploymentGenerator.convertRunConfigIntoPod();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/KubernetesClientImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/KubernetesClientImpl.java
@@ -705,7 +705,7 @@ public class KubernetesClientImpl extends BaseClient implements NamespacedKubern
    */
   @Override
   public RunOperations run() {
-    return new RunOperations(this, new RunConfigBuilder());
+    return new RunOperations(this, new RunConfigBuilder().build());
   }
 
   /**

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodRunEquivalent.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/kubectl/equivalents/PodRunEquivalent.java
@@ -25,7 +25,7 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 public class PodRunEquivalent {
   public static void main(String[] args) {
     try (final KubernetesClient k8s = new KubernetesClientBuilder().build()) {
-      k8s.run().inNamespace("default")
+      k8s.run().inNamespace("default").withNewRunConfig()
           .withImage("nginx:mainline-alpine")
           .withName("my-pod")
           .done();


### PR DESCRIPTION
## Description

Fix #4633

Deprecates withRunConfig and adds a withNewRunConfig that provides inline access to all of the run config builder methods.  The only reason that RunOperations is not directly a RunConfigNested is that builders are mutable whereas our contexts not - so RunConfigNested nested = run().withNewRunConfig(), is the same instance as nested.withName("name").  If we don't care about the distinction then we can do away with the need to call withNewRunConfig().

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
