### PR TITLE
fix #4598: support for free-form objects in crd generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.3-SNAPSHOT
 
 #### Bugs
+* Fix #4598: support for free-form objects in crd generato
 * Fix #4590: only using a builder if there are visitors
 * Fix #4159: ensure the token refresh obeys how the Config was created
 * Fix #4491: added a more explicit shutdown exception for okhttp

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -637,6 +637,12 @@ public abstract class AbstractJsonSchema<T, B> {
       }
 
       final TypeRef valueType = TypeAs.UNWRAP_MAP_VALUE_OF.apply(typeRef);
+      if (valueType instanceof ClassRef) {
+        ClassRef classRef = (ClassRef) valueType;
+        if (Object.class.getName().equals(classRef.getFullyQualifiedName())) {
+          return mapLikeProperty(true);
+        }
+      }
       T schema = internalFromImpl(name, valueType, visited, schemaSwaps);
       if (schema == null) {
         LOGGER.warn(
@@ -723,6 +729,14 @@ public abstract class AbstractJsonSchema<T, B> {
    * @return the schema for the map-like property
    */
   protected abstract T mapLikeProperty(T schema);
+
+  /**
+   * Builds the schema for map-like properties
+   *
+   * @param allows allows
+   * @return the schema for the map-like property
+   */
+  protected abstract T mapLikeProperty(boolean allows);
 
   /**
    * Builds the schema for standard, simple (e.g. string) property types

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -109,6 +109,16 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   }
 
   @Override
+  protected JSONSchemaProps mapLikeProperty(boolean allows) {
+    return new JSONSchemaPropsBuilder()
+      .withType("object")
+      .withNewAdditionalProperties()
+      .withAllows(allows)
+      .endAdditionalProperties()
+      .build();
+  }
+
+  @Override
   protected JSONSchemaProps singleProperty(String typeName) {
     return new JSONSchemaPropsBuilder().withType(typeName).build();
   }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -110,6 +110,16 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   }
 
   @Override
+  protected JSONSchemaProps mapLikeProperty(boolean allows) {
+    return new JSONSchemaPropsBuilder()
+      .withType("object")
+      .withNewAdditionalProperties()
+      .withAllows(allows)
+      .endAdditionalProperties()
+      .build();
+  }
+
+  @Override
   protected JSONSchemaProps singleProperty(String typeName) {
     return new JSONSchemaPropsBuilder()
         .withType(typeName)

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/inherited/ChildSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/inherited/ChildSpec.java
@@ -18,7 +18,7 @@ package io.fabric8.crd.example.inherited;
 import java.util.Map;
 
 public class ChildSpec extends BaseSpec {
-  private Map<String, Object> unsupported;
+  private Map<String, Object> freeform;
   private Map<String, String> supported;
   private Map unsupported2;
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/map/ContainingMapsSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/map/ContainingMapsSpec.java
@@ -33,6 +33,12 @@ public class ContainingMapsSpec {
     return test2;
   }
 
+  private Map<String, Object> freeFormObject;
+
+  public Map<String, Object> getFreeFormObject() {
+    return freeFormObject;
+  }
+
   private MultiHashMap<String, Integer> stringToIntMultiMap1;
   private MultiMap<String, Integer> stringToIntMultiMap2;
   private SwappedParametersMap<List<Integer>, String> stringToIntMultiMap3;

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -277,7 +277,7 @@ class CRDGeneratorTest {
           .getProperties().get("spec").getProperties();
       assertEquals(4, specProps.size());
       assertEquals("integer", specProps.get("baseInt").getType());
-      checkMapProp(specProps, "unsupported", "object");
+      checkFreeFormObject(specProps, "freeform");
       checkMapProp(specProps, "unsupported2", "object");
       checkMapProp(specProps, "supported", "string");
     });
@@ -293,7 +293,7 @@ class CRDGeneratorTest {
       final Map<String, JSONSchemaProps> specProps = version.getSchema().getOpenAPIV3Schema()
           .getProperties().get("spec").getProperties();
 
-      assertEquals(9, specProps.size());
+      assertEquals(10, specProps.size());
 
       JSONSchemaProps testSchema = checkMapProp(specProps, "test", "array");
       assertEquals("string", testSchema.getItems().getSchema().getType());
@@ -304,6 +304,7 @@ class CRDGeneratorTest {
       assertEquals("array", valueType);
       assertEquals("boolean", valueSchema.getItems().getSchema().getType());
 
+      checkFreeFormObject(specProps, "freeFormObject");
       for (int i = 1; i <= 7; i++) {
         String name = "stringToIntMultiMap" + i;
         JSONSchemaProps schema = checkMapProp(specProps, name, "array");
@@ -319,6 +320,13 @@ class CRDGeneratorTest {
     assertEquals(valueType, props.getAdditionalProperties().getSchema().getType(),
         name + "'s value type should be " + valueType);
     return props.getAdditionalProperties().getSchema();
+  }
+
+  private void checkFreeFormObject(Map<String, JSONSchemaProps> specProps, String name) {
+    final JSONSchemaProps freeFormObjectSchema = specProps.get(name);
+    assertEquals("object", freeFormObjectSchema.getType());
+    assertNull(freeFormObjectSchema.getAdditionalProperties().getSchema());
+    assertTrue(freeFormObjectSchema.getAdditionalProperties().getAllows());
   }
 
   @Test

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -24,6 +24,7 @@ import io.fabric8.crd.example.extraction.IncorrectExtraction;
 import io.fabric8.crd.example.extraction.IncorrectExtraction2;
 import io.fabric8.crd.example.extraction.MultipleSchemaSwaps;
 import io.fabric8.crd.example.json.ContainingJson;
+import io.fabric8.crd.example.map.ContainingMaps;
 import io.fabric8.crd.example.person.Person;
 import io.fabric8.crd.generator.utils.Types;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
@@ -168,6 +169,23 @@ class JsonSchemaTest {
 
     assertEquals("object", fooField.getType());
     assertTrue(fooField.getXKubernetesPreserveUnknownFields());
+  }
+
+
+  @Test
+  void shouldProduceFreeFormObject() {
+    TypeDef containingMaps = Types.typeDefFrom(ContainingMaps.class);
+    JSONSchemaProps schema = JsonSchema.from(containingMaps);
+    assertNotNull(schema);
+    Map<String, JSONSchemaProps> properties = assertSchemaHasNumberOfProperties(schema, 2);
+    final JSONSchemaProps specSchema = properties.get("spec");
+    Map<String, JSONSchemaProps> spec = assertSchemaHasNumberOfProperties(specSchema, 10);
+
+    assertTrue(spec.containsKey("freeFormObject"));
+    JSONSchemaProps freeFormObject = spec.get("freeFormObject");
+
+    assertEquals("object", freeFormObject.getType());
+    assertTrue(freeFormObject.getAdditionalProperties().getAllows());
   }
 
   @Test

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsCRDTest.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsCRDTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ContainingMapsCRDTest {
 
@@ -44,7 +46,12 @@ class ContainingMapsCRDTest {
     final Map<String, JSONSchemaProps> specProps = v1.getSchema().getOpenAPIV3Schema()
         .getProperties().get("spec").getProperties();
 
-    assertEquals(7, specProps.size());
+    assertEquals(8, specProps.size());
+
+    final JSONSchemaProps freeFormObjectSchema = specProps.get("freeFormObject");
+    assertEquals("object", freeFormObjectSchema.getType());
+    assertNull(freeFormObjectSchema.getAdditionalProperties().getSchema());
+    assertTrue(freeFormObjectSchema.getAdditionalProperties().getAllows());
 
     for (int i = 1; i <= 7; i++) {
       String name = "stringToIntMultiMap" + i;

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsSpec.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/maps/ContainingMapsSpec.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ContainingMapsSpec {
+  private Map<String, Object> freeFormObject;
   private MultiHashMap<String, Integer> stringToIntMultiMap1;
   private MultiMap<String, Integer> stringToIntMultiMap2;
   private SwappedParametersMap<List<Integer>, String> stringToIntMultiMap3;


### PR DESCRIPTION
## Description
Fix #4598 

Maps with Object as value type (e.g. Map<String, Object>) will now produce a spec like 

```
config:
   additionalProperties: true
   type: object
```

this is a breaking change somehow, the same source code now generated a different crd.
However before the generated code was more restrictive.

Source code:
```
Map<String, Object> config;
```

now generates:
```
config:
   additionalProperties: true
   type: object
```

before:
```
config:
  additionalProperties:
    type: object         
  type: object
```
which is the same as above except values of only type of objects were accepted.
To restore the same generated code the user will have to modify the source code to:

```
Map config;
```

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [] Bug fix (non-breaking change which fixes an issue)
 - [x ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
