### PR TITLE
Fix for watch regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix #4534: Java Generator CLI default handling of skipGeneratedAnnotations
 * Fix #4535: The shell command string will now have single quotes sanitized
 * Fix #4543: (Java Generator) additionalProperties JsonAny setter method generated as setAdditionalProperty
+* Fix #4641: fixed regression with missing initial watch event
 * Fix #4547: preventing timing issues with leader election cancel
 * Fix #4540: treating GenericKubernetesResource and RawExtension as buildable
 * Fix #4569: fixing jdk httpclient regression with 0 timeouts

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/KubernetesNamespacedTestExtension.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/KubernetesNamespacedTestExtension.java
@@ -39,9 +39,6 @@ import java.util.stream.Stream;
 
 public class KubernetesNamespacedTestExtension implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback {
 
-  private static final ExtensionContext.Namespace EXT_NAMESPACE = ExtensionContext.Namespace
-      .create(KubernetesNamespacedTestExtension.class);
-
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
     final KubernetesClient client = new KubernetesClientBuilder().build();
@@ -82,7 +79,9 @@ public class KubernetesNamespacedTestExtension implements BeforeAllCallback, Bef
   }
 
   private static ExtensionContext.Store getStore(ExtensionContext context) {
-    return context.getRoot().getStore(EXT_NAMESPACE);
+    ExtensionContext.Namespace namespace = ExtensionContext.Namespace.create(KubernetesNamespacedTestExtension.class,
+        context.getRequiredTestClass());
+    return context.getRoot().getStore(namespace);
   }
 
   /**


### PR DESCRIPTION
## Description
Addresses #4641 - the changes for https://github.com/fabric8io/kubernetes-client/commit/951a7f58888c2df03d338bf754d6bb9c390c360c introduced a regression via a timing issue of when the websocketfuture is set.

If there is to be another 6.2 release, this should be included.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
