### PR TITLE
improve: generate crds in parallel and optimize code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@
 
 #### Improvements
 * Fix #4739: honor optimistic concurrency control semantics in the mock server for `PUT` and `PATCH` requests.
+* Fix #4644: generate crds in parallel and optimize code
 
 #### Dependency Upgrade
 
 #### New Features
 
 #### _**Note**_: Breaking changes
+
+### 6.4.1-SNAPSHOT
+
+#### Improvements
+* Fix #4644: generate crds in parallel and optimize code
 
 ### 6.4.0 (2023-01-19)
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
@@ -39,6 +39,7 @@ public class CRDGenerator {
   private final Resources resources;
   private final Map<String, AbstractCustomResourceHandler> handlers = new HashMap<>(2);
   private CRDOutput<? extends OutputStream> output;
+  private boolean parallel;
   private Map<String, CustomResourceInfo> infos;
 
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
@@ -68,6 +69,11 @@ public class CRDGenerator {
     return this;
   }
 
+  public CRDGenerator withParallelGenerationEnabled(boolean parallel) {
+    this.parallel = parallel;
+    return this;
+  }
+
   public CRDGenerator forCRDVersions(List<String> versions) {
     return versions != null && !versions.isEmpty() ? forCRDVersions(versions.toArray(new String[0]))
         : this;
@@ -80,11 +86,11 @@ public class CRDGenerator {
           switch (version) {
             case CustomResourceHandler.VERSION:
               handlers.computeIfAbsent(CustomResourceHandler.VERSION,
-                  s -> new CustomResourceHandler(resources));
+                  s -> new CustomResourceHandler(resources, parallel));
               break;
             case io.fabric8.crd.generator.v1beta1.CustomResourceHandler.VERSION:
               handlers.computeIfAbsent(io.fabric8.crd.generator.v1beta1.CustomResourceHandler.VERSION,
-                  s -> new io.fabric8.crd.generator.v1beta1.CustomResourceHandler(resources));
+                  s -> new io.fabric8.crd.generator.v1beta1.CustomResourceHandler(resources, parallel));
               break;
             default:
               LOGGER.warn("Ignoring unsupported CRD version: {}", version);

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/CustomResourceHandler.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/CustomResourceHandler.java
@@ -40,8 +40,8 @@ public class CustomResourceHandler extends AbstractCustomResourceHandler {
 
   public static final String VERSION = "v1";
 
-  public CustomResourceHandler(Resources resources) {
-    super(resources);
+  public CustomResourceHandler(Resources resources, boolean parallel) {
+    super(resources, parallel);
   }
 
   @Override

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/CustomResourceHandler.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/CustomResourceHandler.java
@@ -40,8 +40,8 @@ import java.util.Optional;
 public class CustomResourceHandler extends AbstractCustomResourceHandler {
   public static final String VERSION = "v1beta1";
 
-  public CustomResourceHandler(Resources resources) {
-    super(resources);
+  public CustomResourceHandler(Resources resources, boolean parallel) {
+    super(resources, parallel);
   }
 
   @Override

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedPropertyPathDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedPropertyPathDetector.java
@@ -17,6 +17,7 @@ package io.fabric8.crd.generator.visitor;
 
 import io.fabric8.crd.generator.utils.Types;
 import io.sundr.builder.TypedVisitor;
+import io.sundr.model.AnnotationRef;
 import io.sundr.model.ClassRef;
 import io.sundr.model.Property;
 import io.sundr.model.TypeDef;
@@ -56,44 +57,62 @@ public class AnnotatedPropertyPathDetector extends TypedVisitor<TypeDefBuilder> 
     this.reference = reference;
   }
 
-  private boolean excludePropertyProcessing(Property p) {
-    return p.getAnnotations().stream()
-        .anyMatch(ann -> ann.getClassRef().getFullyQualifiedName().equals(ANNOTATION_JSON_IGNORE));
+  private static boolean excludePropertyProcessing(Property p) {
+    for (AnnotationRef annotation : p.getAnnotations()) {
+      if (annotation.getClassRef().getFullyQualifiedName().equals(ANNOTATION_JSON_IGNORE)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
   public void visit(TypeDefBuilder builder) {
     TypeDef type = builder.build();
     final List<Property> properties = type.getProperties();
+    if (visitProperties(properties)) {
+      return;
+    }
+    visitPropertiesClasses(properties);
+  }
+
+  private void visitPropertiesClasses(List<Property> properties) {
+    for (Property p : properties) {
+      if (!(p.getTypeRef() instanceof ClassRef)) {
+        continue;
+      }
+      if (!parents.contains(p) && !excludePropertyProcessing(p)) {
+        ClassRef classRef = (ClassRef) p.getTypeRef();
+        TypeDef propertyType = Types.typeDefFrom(classRef);
+        if (!propertyType.isEnum()) {
+          List<Property> newParents = new ArrayList<>(parents);
+          newParents.add(p);
+          new TypeDefBuilder(propertyType)
+              .accept(new AnnotatedPropertyPathDetector(prefix, annotationName, newParents, reference))
+              .build();
+        }
+      }
+    }
+  }
+
+  private boolean visitProperties(List<Property> properties) {
     for (Property p : properties) {
       if (parents.contains(p)) {
         continue;
       }
 
       List<Property> newParents = new ArrayList<>(parents);
-      boolean match = p.getAnnotations().stream().anyMatch(a -> a.getClassRef().getName().equals(annotationName));
-      if (match) {
-        newParents.add(p);
-        reference.set(Optional.of(newParents.stream().map(Property::getName).collect(Collectors.joining(DOT, prefix, ""))));
-        return;
+      boolean match = false;
+      for (AnnotationRef annotation : p.getAnnotations()) {
+        match = annotation.getClassRef().getName().equals(annotationName);
+        if (match) {
+          newParents.add(p);
+          reference.set(Optional.of(newParents.stream().map(Property::getName).collect(Collectors.joining(DOT, prefix, ""))));
+          return true;
+        }
       }
     }
-
-    properties.stream()
-        .filter(p -> p.getTypeRef() instanceof ClassRef)
-        .forEach(p -> {
-          if (!parents.contains(p) && !excludePropertyProcessing(p)) {
-            ClassRef classRef = (ClassRef) p.getTypeRef();
-            TypeDef propertyType = Types.typeDefFrom(classRef);
-            if (!propertyType.isEnum()) {
-              List<Property> newParents = new ArrayList<>(parents);
-              newParents.add(p);
-              new TypeDefBuilder(propertyType)
-                  .accept(new AnnotatedPropertyPathDetector(prefix, annotationName, newParents, reference))
-                  .build();
-            }
-          }
-        });
+    return false;
   }
 
   public Optional<String> getPath() {

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -58,10 +58,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class CRDGeneratorTest {
 
   private final TestCRDOutput output = new TestCRDOutput();
+  protected boolean parallelCRDGeneration;
 
   @Test
   void choosingCRDVersionsShouldWork() {
-    CRDGenerator generator = new CRDGenerator();
+    CRDGenerator generator = newCRDGenerator();
     assertTrue(generator.getHandlers().isEmpty());
 
     generator.forCRDVersions();
@@ -91,7 +92,7 @@ class CRDGeneratorTest {
 
   @Test
   void addingCustomResourceInfosShouldWork() {
-    CRDGenerator generator = new CRDGenerator();
+    CRDGenerator generator = newCRDGenerator();
     assertTrue(generator.getCustomResourceInfos().isEmpty());
 
     generator.customResourceClasses();
@@ -133,7 +134,7 @@ class CRDGeneratorTest {
 
   @Test
   void shouldProperlyRecordNumberOfGeneratedCRDs() {
-    CRDGenerator generator = new CRDGenerator();
+    CRDGenerator generator = newCRDGenerator();
     assertEquals(0, generator.generate());
     assertEquals(0, generator.detailedGenerate().numberOfGeneratedCRDs());
 
@@ -158,7 +159,7 @@ class CRDGeneratorTest {
 
   @Test
   void shouldProperlyGenerateMultipleVersionsOfCRDs() {
-    CRDGenerator generator = new CRDGenerator();
+    CRDGenerator generator = newCRDGenerator();
     final String specVersion = "v1beta1";
     final CRDGenerationInfo info = generator
         .customResourceClasses(Multiple.class, io.fabric8.crd.example.multiple.v2.Multiple.class)
@@ -195,7 +196,7 @@ class CRDGeneratorTest {
 
   @Test
   void notDefiningOutputShouldNotGenerateAnything() {
-    CRDGenerator generator = new CRDGenerator();
+    CRDGenerator generator = newCRDGenerator();
     assertEquals(0, generator.generate());
 
     CustomResourceInfo joke = CustomResourceInfo.fromClass(Joke.class);
@@ -206,7 +207,7 @@ class CRDGeneratorTest {
 
   @Test
   void generatingACycleShouldFail() {
-    final CRDGenerator generator = new CRDGenerator()
+    final CRDGenerator generator = newCRDGenerator()
         .customResourceClasses(Cyclic.class)
         .forCRDVersions("v1", "v1beta1")
         .withOutput(output);
@@ -217,9 +218,14 @@ class CRDGeneratorTest {
         "An IllegalArgument Exception hasn't been thrown when generating a CRD with cyclic references");
   }
 
+  private CRDGenerator newCRDGenerator() {
+    return new CRDGenerator()
+        .withParallelGenerationEnabled(parallelCRDGeneration);
+  }
+
   @Test
   void generatingACycleInListShouldFail() {
-    final CRDGenerator generator = new CRDGenerator()
+    final CRDGenerator generator = newCRDGenerator()
         .customResourceClasses(CyclicList.class)
         .forCRDVersions("v1", "v1beta1")
         .withOutput(output);
@@ -232,7 +238,7 @@ class CRDGeneratorTest {
 
   @Test
   void notGeneratingACycleShouldSucceed() {
-    final CRDGenerator generator = new CRDGenerator()
+    final CRDGenerator generator = newCRDGenerator()
         .customResourceClasses(NoCyclic.class)
         .forCRDVersions("v1", "v1beta1")
         .withOutput(output);
@@ -420,7 +426,7 @@ class CRDGeneratorTest {
 
   private CustomResourceDefinitionSpec checkSpec(
       Class<? extends CustomResource<?, ?>> customResource, Scope scope, Class<?>... mustContainTraversedClasses) {
-    CRDGenerator generator = new CRDGenerator();
+    CRDGenerator generator = newCRDGenerator();
 
     // record info to be able to output it if the test fails
     final String outputName = keyFor(customResource);

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/ParallelCRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/ParallelCRDGeneratorTest.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator;
+
+class ParallelCRDGeneratorTest extends CRDGeneratorTest {
+
+  public ParallelCRDGeneratorTest() {
+    parallelCRDGeneration = false;
+  }
+}

--- a/crd-generator/test/pom.xml
+++ b/crd-generator/test/pom.xml
@@ -90,6 +90,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Aio.fabric8.crd.generator.parallel=false</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -442,3 +442,32 @@ The CRD generator will add the additional `labels`:
 | `io.fabric8.crd.generator.annotation.Labels`                 | Additional `labels` in `metadata`                                                     |
 
 A field of type `com.fasterxml.jackson.databind.JsonNode` is encoded as an empty object with `x-kubernetes-preserve-unknown-fields: true` defined.
+
+## Experimental
+
+### Generate CRDs in parallel
+It's possible to speed up the CRDs generation by using parallel computation.
+Please note that this feature is experimental, and it may lead to unexpected results.
+
+To enable it, you need to set the `io.fabric8.crd.generator.parallel` property to `true` in the processor.
+
+with Maven:
+
+```xml
+<plugin>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <configuration>
+    <compilerArgs>
+      <arg>-Aio.fabric8.crd.generator.parallel=true</arg>
+    </compilerArgs>
+  </configuration>
+</plugin>
+```
+
+with Gradle:
+
+```groovy
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ["-Aio.fabric8.crd.generator.parallel=true"]
+}
+```


### PR DESCRIPTION
## Description
In my project I have 10 CRDs classes. 
I've taken a CPU flamegraph and I figured out the usage of java streams api adds a relevant overhead while visiting specs/status classes via reflection. 

Also the visitors can access the crd in parallel since the base typeref is stateless.

Changes included:
- Enable concurrent crd visitors using nCPU threads.
- Moved some hot path code from using streams to old plain java for-loop

FYI I did a similar fix in sundrio: https://github.com/sundrio/sundrio/pull/352

The net result of this patch is that generation time moved from ~30 seconds to to ~11 seconds.  

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
