### PR TITLE
fix #4666: addressing okhttp sources needing explicit close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.4-SNAPSHOT
 
 #### Bugs
+* Fix #4666: fixed okhttp calls not explicitly closing
 
 #### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### 6.4-SNAPSHOT
 
 #### Bugs
-* Fix #4666: fixed okhttp calls not explicitly closing
 
 #### Improvements
 
@@ -12,6 +11,11 @@
 #### New Features
 
 #### _**Note**_: Breaking changes
+
+### 6.3.1-SNAPSHOT
+
+#### Bugs
+* Fix #4666: fixed okhttp calls not explicitly closing
 
 ### 6.3.0 (2022-12-12)
 

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -75,13 +75,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -80,6 +80,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Function;
@@ -80,16 +81,18 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
     return result;
   }
 
-  private abstract class OkHttpAsyncBody<T> implements AsyncBody {
+  abstract static class OkHttpAsyncBody<T> implements AsyncBody {
     private final AsyncBody.Consumer<T> consumer;
     private final BufferedSource source;
     private final CompletableFuture<Void> done = new CompletableFuture<>();
     private boolean consuming;
     private boolean requested;
+    private Executor executor;
 
-    private OkHttpAsyncBody(AsyncBody.Consumer<T> consumer, BufferedSource source) {
+    OkHttpAsyncBody(AsyncBody.Consumer<T> consumer, BufferedSource source, Executor executor) {
       this.consumer = consumer;
       this.source = source;
+      this.executor = executor;
     }
 
     @Override
@@ -103,7 +106,7 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
       }
       try {
         // consume should not block a caller, delegate to the dispatcher thread pool
-        httpClient.dispatcher().executorService().execute(this::doConsume);
+        executor.execute(this::doConsume);
       } catch (Exception e) {
         // executor is likely shutdown
         Utils.closeQuietly(source);
@@ -125,6 +128,8 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
             T value = process(source);
             consumer.consume(value, this);
           } else {
+            // even if we've read everything an explicit close is still needed
+            source.close();
             done.complete(null);
           }
         }
@@ -311,7 +316,8 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
   @Override
   public CompletableFuture<HttpResponse<AsyncBody>> consumeBytesDirect(StandardHttpRequest request,
       Consumer<List<ByteBuffer>> consumer) {
-    Function<BufferedSource, AsyncBody> handler = s -> new OkHttpAsyncBody<List<ByteBuffer>>(consumer, s) {
+    Function<BufferedSource, AsyncBody> handler = s -> new OkHttpAsyncBody<List<ByteBuffer>>(consumer, s,
+        this.httpClient.dispatcher().executorService()) {
       @Override
       protected List<ByteBuffer> process(BufferedSource source) throws IOException {
         // read only what is available otherwise okhttp will block trying to read

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -87,7 +87,7 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
     private final CompletableFuture<Void> done = new CompletableFuture<>();
     private boolean consuming;
     private boolean requested;
-    private Executor executor;
+    private final Executor executor;
 
     OkHttpAsyncBody(AsyncBody.Consumer<T> consumer, BufferedSource source, Executor executor) {
       this.consumer = consumer;

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/ConnectionPoolLeakageTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/ConnectionPoolLeakageTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import io.fabric8.kubernetes.client.http.AsyncBody;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import okhttp3.ConnectionPool;
+import okhttp3.Protocol;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConnectionPoolLeakageTest {
+
+  private MockWebServer server;
+
+  private ConnectionPool connectionPool;
+  private OkHttpClientBuilderImpl clientBuilder;
+
+  @BeforeEach
+  void setUp() {
+    server = new MockWebServer();
+    final char[] chars = new char[10485760];
+    Arrays.fill(chars, '1');
+    server.enqueue(new MockResponse().setResponseCode(200).setChunkedBody(new String(chars), 1024));
+    connectionPool = new ConnectionPool(10, 100, TimeUnit.SECONDS);
+    clientBuilder = new OkHttpClientFactory().newBuilder();
+    clientBuilder.getBuilder().connectionPool(connectionPool);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    server.shutdown();
+    connectionPool.evictAll();
+  }
+
+  @ParameterizedTest(name = "with protocol {0}")
+  @DisplayName("consumeBytes should not leak connections")
+  @ValueSource(strings = { "h2_prior_knowledge", "http/1.1" })
+  void consumeBytes(String protocol) throws Exception {
+    final Protocol p = Protocol.get(protocol);
+    server.setProtocols(Collections.singletonList(p));
+    server.start();
+    clientBuilder.getBuilder().protocols(Collections.singletonList(p));
+    try (HttpClient httpClient = clientBuilder.build()) {
+      final HttpResponse<AsyncBody> asyncBodyResponse = httpClient.consumeBytes(
+          httpClient.newHttpRequestBuilder().uri(server.url("/").toString()).build(),
+          (value, asyncBody) -> {
+            asyncBody.consume();
+          })
+          .get(10L, TimeUnit.SECONDS);
+      assertThat(activeConnections()).isEqualTo(1);
+      asyncBodyResponse.body().consume();
+      asyncBodyResponse.body().done().get(10L, TimeUnit.SECONDS);
+      assertThat(activeConnections()).isZero();
+    }
+  }
+
+  private int activeConnections() {
+    return connectionPool.connectionCount() - connectionPool.idleConnectionCount();
+  }
+}

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpAsyncBodyTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpAsyncBodyTest.java
@@ -17,11 +17,36 @@ package io.fabric8.kubernetes.client.okhttp;
 
 import io.fabric8.kubernetes.client.http.AbstractAsyncBodyTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl.OkHttpAsyncBody;
+import okio.BufferedSource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
 
 @SuppressWarnings("java:S2187")
 public class OkHttpAsyncBodyTest extends AbstractAsyncBodyTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new OkHttpClientFactory();
+  }
+
+  @Test
+  void testClosedWhenExhausted() throws Exception {
+    BufferedSource source = Mockito.mock(BufferedSource.class);
+    Mockito.when(source.exhausted()).thenReturn(true);
+    OkHttpClientImpl.OkHttpAsyncBody<List<ByteBuffer>> asyncBody = new OkHttpAsyncBody<List<ByteBuffer>>(null, source,
+        Runnable::run) {
+
+      @Override
+      protected List<ByteBuffer> process(BufferedSource source) throws IOException {
+        return null;
+      }
+    };
+
+    asyncBody.consume();
+    Mockito.verify(source).close();
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpAsyncBodyTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpAsyncBodyTest.java
@@ -17,14 +17,6 @@ package io.fabric8.kubernetes.client.okhttp;
 
 import io.fabric8.kubernetes.client.http.AbstractAsyncBodyTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
-import io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl.OkHttpAsyncBody;
-import okio.BufferedSource;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.List;
 
 @SuppressWarnings("java:S2187")
 public class OkHttpAsyncBodyTest extends AbstractAsyncBodyTest {
@@ -33,20 +25,4 @@ public class OkHttpAsyncBodyTest extends AbstractAsyncBodyTest {
     return new OkHttpClientFactory();
   }
 
-  @Test
-  void testClosedWhenExhausted() throws Exception {
-    BufferedSource source = Mockito.mock(BufferedSource.class);
-    Mockito.when(source.exhausted()).thenReturn(true);
-    OkHttpClientImpl.OkHttpAsyncBody<List<ByteBuffer>> asyncBody = new OkHttpAsyncBody<List<ByteBuffer>>(null, source,
-        Runnable::run) {
-
-      @Override
-      protected List<ByteBuffer> process(BufferedSource source) throws IOException {
-        return null;
-      }
-    };
-
-    asyncBody.consume();
-    Mockito.verify(source).close();
-  }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpImplAsyncBodyTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpImplAsyncBodyTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import okio.BufferedSource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OkHttpImplAsyncBodyTest {
+
+  @Test
+  void testClosedWhenExhausted() throws Exception {
+    BufferedSource source = mock(BufferedSource.class);
+    when(source.exhausted()).thenReturn(true);
+    OkHttpClientImpl.OkHttpAsyncBody<List<ByteBuffer>> asyncBody = new OkHttpClientImpl.OkHttpAsyncBody<List<ByteBuffer>>(null,
+        source,
+        Runnable::run) {
+
+      @Override
+      protected List<ByteBuffer> process(BufferedSource source) {
+        return null;
+      }
+    };
+
+    asyncBody.consume();
+    Mockito.verify(source).close();
+  }
+}


### PR DESCRIPTION
## Description
Fixes #4666 the AsyncBody implementation even after reading to exhaustion still needs to close the source to satisfy okhttp.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
