### PR TITLE
fix #4670: using a 0 resourceVersion for the initial informer listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #4670: the initial informer listing will use a resourceVersion of 0 to utilize the watch cache if possible.  This means that the initial cache state when the informer is returned, or the start future is completed, may not be as fresh as the previous behavior which forced the latest version.  It will of course become more consistent as the watch will already have been established.
 
 #### Dependency Upgrade
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/URLUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/URLUtils.java
@@ -48,7 +48,7 @@ public class URLUtils {
 
     public URL build() {
       try {
-        return new URL(this.url.toString());
+        return new URL(toString());
       } catch (MalformedURLException e) {
         throw new IllegalArgumentException(e.getMessage(), e);
       }
@@ -56,7 +56,7 @@ public class URLUtils {
 
     @Override
     public String toString() {
-      return build().toString();
+      return this.url.toString();
     }
 
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/ProjectRequestIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/ProjectRequestIT.java
@@ -50,7 +50,7 @@ class ProjectRequestIT {
     client.projects()
         .withName(name)
         .informOnCondition(pl -> pl.stream().anyMatch(p -> p.getMetadata().getName().equals(name)))
-        .get(1, TimeUnit.SECONDS);
+        .get(30, TimeUnit.SECONDS);
     final Project createdProject = client.projects().withName(name).get();
     assertNotNull(createdProject);
     assertEquals(name, createdProject.getMetadata().getName());

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -66,7 +66,7 @@ class InformTest {
         .build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label")
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();
@@ -121,7 +121,7 @@ class InformTest {
     list.setItems(Arrays.asList(dummy));
 
     server.expect()
-        .withPath("/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label")
+        .withPath("/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK, list)
         .once();
 
@@ -188,7 +188,7 @@ class InformTest {
         .build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();
@@ -253,7 +253,7 @@ class InformTest {
         .build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label")
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();
@@ -320,7 +320,7 @@ class InformTest {
         .build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?limit=1")
+        .withPath("/api/v1/namespaces/test/pods?limit=1&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata()
                 .withResourceVersion("2")
@@ -381,7 +381,7 @@ class InformTest {
         .build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods")
+        .withPath("/api/v1/namespaces/test/pods?resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();
@@ -447,7 +447,7 @@ class InformTest {
         .build());
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods")
+        .withPath("/api/v1/namespaces/test/pods?resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
@@ -55,7 +55,7 @@ class NodeMetricsTest {
   @Test
   void testInform() {
     // Given
-    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes").andReturn(HTTP_OK,
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?resourceVersion=0").andReturn(HTTP_OK,
         new NodeMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
     server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
@@ -72,7 +72,7 @@ class PodMetricsTest {
   @Test
   void testInform() {
     // Given
-    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods").andReturn(HTTP_OK,
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?resourceVersion=0").andReturn(HTTP_OK,
         new PodMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
     server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -704,7 +704,7 @@ class PodTest {
 
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=0")
         .andReturn(200, notReady)
         .once();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
@@ -208,7 +208,7 @@ class ReplicaSetTest {
 
     // list for waiting
     server.expect()
-        .withPath("/apis/apps/v1/namespaces/test/replicasets?fieldSelector=metadata.name%3Drepl1")
+        .withPath("/apis/apps/v1/namespaces/test/replicasets?fieldSelector=metadata.name%3Drepl1&resourceVersion=0")
         .andReturn(200,
             new ReplicaSetListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
         .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
@@ -212,7 +212,7 @@ class ReplicationControllerTest {
 
     // list for waiting
     server.expect()
-        .withPath("/api/v1/namespaces/test/replicationcontrollers?fieldSelector=metadata.name%3Drepl1")
+        .withPath("/api/v1/namespaces/test/replicationcontrollers?fieldSelector=metadata.name%3Drepl1&resourceVersion=0")
         .andReturn(200,
             new ReplicationControllerListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
         .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -159,11 +159,12 @@ public class ResourceListTest {
   void testCreateOrReplaceWithDeleteExisting() throws Exception {
     server.expect().delete().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK, service).once();
     server.expect().delete().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, configMap).once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dmy-service")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dmy-service&resourceVersion=0")
         .andReturn(HTTP_OK,
             new KubernetesListBuilder().withNewMetadata().endMetadata().build())
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/configmaps?fieldSelector=metadata.name%3Dmy-configmap")
+    server.expect().get()
+        .withPath("/api/v1/namespaces/ns1/configmaps?fieldSelector=metadata.name%3Dmy-configmap&resourceVersion=0")
         .andReturn(HTTP_OK,
             new KubernetesListBuilder().withNewMetadata().endMetadata().build())
         .once();
@@ -201,8 +202,8 @@ public class ResourceListTest {
         .anyMatch(c -> "True".equals(c.getStatus()));
 
     // The pods are never ready if you request them directly.
-    ResourceTest.list(server, noReady1);
-    ResourceTest.list(server, noReady2);
+    ResourceTest.list(server, noReady1, "0");
+    ResourceTest.list(server, noReady2, "0");
 
     server.expect().get().withPath(
         "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
@@ -246,8 +247,8 @@ public class ResourceListTest {
         .anyMatch(c -> "True".equals(c.getStatus()));
 
     // The pods are never ready if you request them directly.
-    ResourceTest.list(server, noReady1);
-    ResourceTest.list(server, noReady2);
+    ResourceTest.list(server, noReady1, "0");
+    ResourceTest.list(server, noReady2, "0");
 
     Status gone = new StatusBuilder()
         .withCode(HTTP_GONE)
@@ -297,8 +298,8 @@ public class ResourceListTest {
         .anyMatch(c -> "True".equals(c.getStatus()));
 
     // The pods are never ready if you request them directly.
-    ResourceTest.list(server, noReady1);
-    ResourceTest.list(server, noReady2);
+    ResourceTest.list(server, noReady1, null);
+    ResourceTest.list(server, noReady2, null);
 
     Status gone = new StatusBuilder()
         .withCode(HTTP_GONE)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -321,15 +321,20 @@ class ResourceTest {
     Assert.assertTrue(Readiness.isPodReady(p));
   }
 
+  /**
+   * List the pod for the initial request from an informer
+   * 
+   * @param pod
+   */
   private void list(Pod pod) {
-    list(server, pod);
+    list(server, pod, "0");
   }
 
-  static void list(KubernetesMockServer server, Pod pod) {
+  static void list(KubernetesMockServer server, Pod pod, String resourceVersion) {
     server.expect()
         .get()
         .withPath("/api/v1/namespaces/" + pod.getMetadata().getNamespace() + "/pods?fieldSelector=metadata.name%3D"
-            + pod.getMetadata().getName())
+            + pod.getMetadata().getName() + (resourceVersion != null ? ("&resourceVersion=" + resourceVersion) : ""))
         .andReturn(200,
             new PodListBuilder().withItems(pod).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
@@ -350,7 +355,7 @@ class ResourceTest {
     // and again so that "periodicWatchUntilReady" successfully begins
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=0")
         .andReturn(200, noReady)
         .times(2);
 
@@ -582,7 +587,7 @@ class ResourceTest {
         .done()
         .once();
 
-    list(ready);
+    list(server, ready, null);
 
     client.resource(noReady).waitUntilReady(10, SECONDS);
   }
@@ -710,7 +715,7 @@ class ResourceTest {
   void testWaitNullDoesntExist() throws InterruptedException {
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=0")
         .andReturn(200,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
@@ -210,11 +210,11 @@ class ServiceTest {
             .addToPorts(new EndpointPortBuilder().withPort(8443).build())
             .build())
         .build();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/endpoints?fieldSelector=metadata.name%3Dsvc1")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/endpoints?fieldSelector=metadata.name%3Dsvc1&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new EndpointsListBuilder().withItems(endpoint).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dsvc1")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dsvc1&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new ServiceListBuilder().withItems(svc1).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -250,7 +250,7 @@ public class StatefulSetTest {
 
     // list for waiting
     server.expect()
-        .withPath("/apis/apps/v1/namespaces/test/statefulsets?fieldSelector=metadata.name%3Drepl1")
+        .withPath("/apis/apps/v1/namespaces/test/statefulsets?fieldSelector=metadata.name%3Drepl1&resourceVersion=0")
         .andReturn(200,
             new StatefulSetListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
         .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -405,7 +405,8 @@ class DeploymentConfigTest {
         .withReplicas(1).withAvailableReplicas(1)
         .endStatus().build();
     server.expect().get()
-        .withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs?fieldSelector=metadata.name%3Ddc1")
+        .withPath(
+            "/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs?fieldSelector=metadata.name%3Ddc1&resourceVersion=0")
         .andReturn(HttpURLConnection.HTTP_OK,
             new DeploymentConfigListBuilder().withItems(deploymentConfig).withMetadata(new ListMeta()).build())
         .always();


### PR DESCRIPTION
## Description
Addresses #4670 by setting an initial list resourceVersion of 0, which matches the behavior of the go client.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
