### PR TITLE
[java-gen] Fix default value encoding for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### Bugs
 * Fix #4666: fixed okhttp calls not explicitly closing
+* Fix #4677: [java-generator] Fix default encoding of enums
 
 ### 6.3.0 (2022-12-12)
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -168,7 +168,8 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
       GeneratorResult gr = prop.generateJava();
 
       // For now the inner types are only for enums
-      if (!gr.getInnerClasses().isEmpty()) {
+      boolean isEnum = !gr.getInnerClasses().isEmpty();
+      if (isEnum) {
         for (GeneratorResult.ClassResult enumCR : gr.getInnerClasses()) {
           Optional<EnumDeclaration> ed = enumCR.getCompilationUnit().getEnumByName(enumCR.getName());
           if (ed.isPresent()) {
@@ -244,7 +245,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
         }
 
         if (prop.getDefaultValue() != null) {
-          Expression primitiveDefault = generatePrimitiveDefaultInitializerExpression(prop);
+          Expression primitiveDefault = (isEnum) ? null : generatePrimitiveDefaultInitializerExpression(prop);
 
           if (primitiveDefault != null) {
             objField.getVariable(0).setInitializer(primitiveDefault);

--- a/java-generator/it/src/it/default-values-instantiation/src/test/java/io/fabric8/it/certmanager/TestDefaultValues.java
+++ b/java-generator/it/src/it/default-values-instantiation/src/test/java/io/fabric8/it/certmanager/TestDefaultValues.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.cert_manager.v1.CertificateRequestSpec.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestDefaultValues {
@@ -44,6 +45,7 @@ class TestDefaultValues {
     Double eight = cr.getSpec().getEight();
     List<String> nine = cr.getSpec().getNine();
     Ten ten = cr.getSpec().getTen();
+    Eleven eleven = cr.getSpec().getEleven();
 
     // Assert
     assertEquals("one", one);
@@ -59,5 +61,6 @@ class TestDefaultValues {
     assertEquals("nine2", nine.get(1));
     assertEquals("tenone", ten.getTenOne());
     assertEquals("tentwo", ten.getTenTwo());
+    assertEquals(Eleven.BAZ, eleven);
   }
 }

--- a/java-generator/it/src/it/default-values-instantiation/src/test/resources/example.yaml
+++ b/java-generator/it/src/it/default-values-instantiation/src/test/resources/example.yaml
@@ -90,5 +90,12 @@ spec:
                   default:
                     tenOne: "tenone"
                     tenTwo: "tentwo"
+                eleven:
+                  type: string
+                  enum:
+                    - "foo"
+                    - "bar"
+                    - "baz"
+                  default: "baz"
       served: true
       storage: true


### PR DESCRIPTION
## Description

Fix #4674
Fix #4664 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

