### PR TITLE
fix #4663: changes to help prevent the client from waiting indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### _**Note**_: Breaking changes
 * Fix #4574: fromServer has been deprecated - it no longer needs to be called.  All get() operations will fetch the resource(s) from the api server.  If you need the context item that was passed in from a resource, load, or resourceList methods, use the item or items method.
 * Fix #4633: client.run().withRunConfig was deprecated.  Use withNewRunConfig instead.
+* Fix #4663: Config.maxConcurrentRequests and Config.maxConcurrentRequestsPerHost will no longer be used.  Instead they will default to unlimited for all clients.  Due to the ability of the fabric8 client to start long running requests (either websocket or regular http) and how this is treated by the underlying clients you can easily exhaust these values and enter a state where the client is unresponsive without any additional information on what is occurring.
 
 ### 6.3.1 (2022-12-15)
 

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -58,6 +58,9 @@ public class JettyHttpClientBuilder
       sslContextFactory.setIncludeProtocols(Stream.of(tlsVersions).map(TlsVersion::javaName).toArray(String[]::new));
     }
     HttpClient sharedHttpClient = new HttpClient(newTransport(sslContextFactory, preferHttp11));
+    // long running http requests count against this and eventually exhaust
+    // the work that can be done
+    sharedHttpClient.setMaxConnectionsPerDestination(Integer.MAX_VALUE);
     WebSocketClient sharedWebSocketClient = new WebSocketClient(new HttpClient(newTransport(sslContextFactory, preferHttp11)));
     sharedWebSocketClient.setIdleTimeout(Duration.ZERO);
     if (connectTimeout != null) {

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
@@ -84,12 +84,14 @@ public class OkHttpClientFactory implements HttpClient.Factory {
         httpClientBuilder.pingInterval(config.getWebsocketPingInterval(), TimeUnit.MILLISECONDS);
       }
 
-      if (config.getMaxConcurrentRequests() > 0 && config.getMaxConcurrentRequestsPerHost() > 0) {
-        Dispatcher dispatcher = new Dispatcher();
-        dispatcher.setMaxRequests(config.getMaxConcurrentRequests());
-        dispatcher.setMaxRequestsPerHost(config.getMaxConcurrentRequestsPerHost());
-        httpClientBuilder.dispatcher(dispatcher);
-      }
+      Dispatcher dispatcher = new Dispatcher();
+      // websockets and long running http requests count against this and eventually starve
+      // the work that can be done
+      dispatcher.setMaxRequests(Integer.MAX_VALUE);
+      // long running http requests count against this and eventually exhaust
+      // the work that can be done
+      dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
+      httpClientBuilder.dispatcher(dispatcher);
 
       HttpClientUtils.applyCommonConfiguration(config, builderWrapper, this);
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactoryTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactoryTest.java
@@ -25,24 +25,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class OkHttpClientFactoryTest {
 
   @Test
-  void shouldRespectMaxRequests() {
+  void shouldNotRespectMaxRequests() {
     OkHttpClientImpl client = new OkHttpClientFactory().newBuilder(new ConfigBuilder().build()).build();
 
-    assertEquals(64, client.getOkHttpClient().dispatcher().getMaxRequests());
+    assertEquals(Integer.MAX_VALUE, client.getOkHttpClient().dispatcher().getMaxRequests());
 
     Config config = new ConfigBuilder()
         .withMaxConcurrentRequests(120)
         .build();
 
     client = new OkHttpClientFactory().newBuilder(config).build();
-    assertEquals(120, client.getOkHttpClient().dispatcher().getMaxRequests());
+    assertEquals(Integer.MAX_VALUE, client.getOkHttpClient().dispatcher().getMaxRequests());
   }
 
   @Test
-  void shouldRespectMaxRequestsPerHost() {
+  void shouldNotRespectMaxRequestsPerHost() {
     OkHttpClientImpl client = new OkHttpClientFactory().newBuilder(new ConfigBuilder().build()).build();
 
-    assertEquals(5, client.getOkHttpClient().dispatcher().getMaxRequestsPerHost());
+    assertEquals(Integer.MAX_VALUE, client.getOkHttpClient().dispatcher().getMaxRequestsPerHost());
 
     Config config = new ConfigBuilder()
         .withMaxConcurrentRequestsPerHost(20)
@@ -50,7 +50,7 @@ class OkHttpClientFactoryTest {
 
     client = new OkHttpClientFactory().newBuilder(config).build();
 
-    assertEquals(20, client.getOkHttpClient().dispatcher().getMaxRequestsPerHost());
+    assertEquals(Integer.MAX_VALUE, client.getOkHttpClient().dispatcher().getMaxRequestsPerHost());
   }
 
 }


### PR DESCRIPTION
## Description
Fix #4663

Addresses #4663 by enforcing the request timeout at a higher level and setting connection / request limits to unlimited.

@manusa in looking at the current state what I see is that after 64 websockets okhttp will stop accepting additional websockets or regular requests.  It appears that at least with http1 against the mockserver, you can start as many regular requests you want - waiting to consume the body does not hold the connection, it is immediately released back to the pool.

For jetty 64 concurrent regular requests is all it supports - https://www.eclipse.org/lists/jetty-dev/msg02788.html#:~:text=So%20if%20you%20send%20requests,next%20one%20will%20be%20rejected. maxConnectionsPerDestination.  This number does not affect websockets.  The only way this would be exhausted currently is for the user to have 64 long running requests going at the same time - http watches, log watches, etc. 

For jdk there doesn't seem to be built-in limitations.

You had mentioned possibly creating some abstract test across the http clients for this.  There were a couple of drawbacks to my initial attempts, so I haven't included that in this pr.

Based upon what we talked about for this meeting, we're ok with this breakage of the config properties and the potential for thread allocation issues with okttp - but at least those should be accompanied by a stacktrace.

@vietj we touched on this a little in our discussion about connection or request limits in vertx.  Because we may start a number of long running operations simultaneously (non-websockets could still be things like http watches or following a log), we'd like to simply to just turn off any limit by default.  If there are some system or other upper end limits that we should be aware of, we'd want to address later by ensuring that user is aware the system has become exhausted - the current behavior with okhttp makes it completely non-obvious why the fabric8 client seems to be doing nothing.



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
