### PR TITLE
fix #4673 ensures token is shared by the same logical instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.4-SNAPSHOT
 
 #### Bugs
+* Fix #4673: fixes a regression in sharing the OpenShiftOAuthInterceptor token
 
 #### Improvements
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/impl/OpenShiftClientImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/impl/OpenShiftClientImpl.java
@@ -179,6 +179,7 @@ import java.net.URL;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -730,7 +731,8 @@ public class OpenShiftClientImpl extends KubernetesClientImpl
     this.config = wrapped;
     HttpClient.DerivedClientBuilder builder = httpClient.newBuilder().authenticatorNone();
     this.httpClient = builder
-        .addOrReplaceInterceptor(TokenRefreshInterceptor.NAME, new OpenShiftOAuthInterceptor(httpClient, wrapped))
+        .addOrReplaceInterceptor(TokenRefreshInterceptor.NAME,
+            new OpenShiftOAuthInterceptor(httpClient, wrapped, new AtomicReference<>()))
         .build();
     try {
       this.openShiftUrl = new URL(wrapped.getOpenShiftUrl());

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
@@ -73,16 +73,17 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
 
   private final HttpClient client;
   private final Config config;
-  private final AtomicReference<String> oauthToken = new AtomicReference<>();
+  private final AtomicReference<String> oauthToken;
 
-  public OpenShiftOAuthInterceptor(HttpClient client, Config config) {
+  public OpenShiftOAuthInterceptor(HttpClient client, Config config, AtomicReference<String> oauthToken) {
     this.client = client;
     this.config = config;
+    this.oauthToken = oauthToken;
   }
 
   @Override
-  public Interceptor withConfig(Config config) {
-    return new OpenShiftOAuthInterceptor(client, config);
+  public OpenShiftOAuthInterceptor withConfig(Config config) {
+    return new OpenShiftOAuthInterceptor(client, config, oauthToken);
   }
 
   @Override
@@ -187,5 +188,9 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
       return false;
     }
     return response.code() != HTTP_UNAUTHORIZED && response.code() != HTTP_FORBIDDEN;
+  }
+
+  AtomicReference<String> getOauthToken() {
+    return oauthToken;
   }
 }

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptorTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptorTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client.internal;
+
+import io.fabric8.kubernetes.client.Config;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+class OpenShiftOAuthInterceptorTest {
+
+  @Test
+  void testTokenSharing() {
+    AtomicReference<String> reference = new AtomicReference<>();
+    OpenShiftOAuthInterceptor interceptor = new OpenShiftOAuthInterceptor(null, null, reference);
+    OpenShiftOAuthInterceptor other = interceptor.withConfig(Config.empty());
+    assertNotSame(interceptor, other);
+    assertSame(reference, other.getOauthToken());
+  }
+
+}


### PR DESCRIPTION
## Description
Partially address #4673 - it at least addresses the regression that was introduced by changing how the RequestConfig was passed down.

The other two cases - making requests smarter about waiting for an existing auth request, or sharing across possible instances of the OpenShift client haven not been addressed.  These are not new to 6.x.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
