### PR TITLE
chore: fallback to current class cloader if can't find httpClient

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceOperationsImpl.java
@@ -92,13 +92,9 @@ public class ServiceOperationsImpl extends HasMetadataOperation<Service, Service
   }
 
   private String getUrlHelper(String portName) {
-    ServiceLoader<ServiceToURLProvider> urlProvider = ServiceLoader.load(ServiceToURLProvider.class,
-        Thread.currentThread().getContextClassLoader());
-    Iterator<ServiceToURLProvider> iterator = urlProvider.iterator();
-    List<ServiceToURLProvider> servicesList = new ArrayList<>();
-
-    while (iterator.hasNext()) {
-      servicesList.add(iterator.next());
+    List<ServiceToURLProvider> servicesList = getServiceToURLProviders(Thread.currentThread().getContextClassLoader());
+    if (servicesList.isEmpty()) {
+      servicesList = getServiceToURLProviders(getClass().getClassLoader());
     }
 
     // Sort all loaded implementations according to priority
@@ -112,6 +108,16 @@ public class ServiceOperationsImpl extends HasMetadataOperation<Service, Service
     }
 
     return null;
+  }
+
+  private static List<ServiceToURLProvider> getServiceToURLProviders(ClassLoader loader) {
+    Iterator<ServiceToURLProvider> iterator = ServiceLoader.load(ServiceToURLProvider.class, loader).iterator();
+    List<ServiceToURLProvider> servicesList = new ArrayList<>();
+
+    while (iterator.hasNext()) {
+      servicesList.add(iterator.next());
+    }
+    return servicesList;
   }
 
   private Pod matchingPod() {


### PR DESCRIPTION
## Description

fixes #4563 

I added a fallback where the http client is looked up via the classloader of the `HttpUtils` class if lookup via the thread context classloader fails.
The current impl looks up a http client impl using the thread context classloader. This fails in IDEA (and also in Eclipse/OSGI) because the thread context classloader has no access to the plugin/bundle-resources. 
A typical workaround is to set the thread context classloader to the classloader of the bundle/plugin before calling the code that's using the thread context classloader. This is something one wants to avoid though, because it breaks platform isolation. 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
