### PR TITLE
Add Maven Plugin descriptions and remove readonly

### DIFF
--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -31,31 +31,67 @@ public class JavaGeneratorMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project}")
   private MavenProject project;
 
+  /**
+   * The input file or directory to be used for generating sources
+   *
+   */
   @Parameter(property = "fabric8.java-generator.source", required = true)
   File source;
 
+  /**
+   * The target folder to generate the Java sources
+   *
+   */
   @Parameter(property = "fabric8.java-generator.target", defaultValue = "${basedir}/target/generated-sources/java")
   File target;
 
+  /**
+   * Generate uppercase Enums
+   *
+   */
   @Parameter(property = "fabric8.java-generator.enum-uppercase", required = false)
   Boolean enumUppercase = null;
 
-  @Parameter(property = "fabric8.java-generator.prefix-strategy", required = false, readonly = true)
+  /**
+   * *advanced* The prefix strategy for name mangling
+   *
+   */
+  @Parameter(property = "fabric8.java-generator.prefix-strategy", required = false)
   Config.Prefix prefixStrategy = null;
 
+  /**
+   * *advanced* The suffix strategy for name mangling
+   *
+   */
   @Parameter(property = "fabric8.java-generator.suffix-strategy", required = false)
   Config.Suffix suffixStrategy = null;
 
-  @Parameter(property = "fabric8.java-generator.always-preserve-unknown", required = false, readonly = true)
+  /**
+   * *advanced* Always inject additional properties in the generated classes
+   *
+   */
+  @Parameter(property = "fabric8.java-generator.always-preserve-unknown", required = false)
   Boolean alwaysPreserveUnknown = null;
 
+  /**
+   * Generate Extra annotation for lombok and sundrio integration
+   *
+   */
   @Parameter(property = "fabric8.java-generator.extra-annotations", required = false)
   Boolean extraAnnotations = null;
 
-  @Parameter(property = "fabric8.java-generator.code-structure", required = false, readonly = true)
+  /**
+   * *advanced* The code structure to be used when generating java sources
+   *
+   */
+  @Parameter(property = "fabric8.java-generator.code-structure", required = false)
   protected Config.CodeStructure codeStructure = null;
 
-  @Parameter(property = "fabric8.java-generator.generated-annotations", required = false, readonly = true)
+  /**
+   * *advanced* Emit the @javax.annotation.processing.Generated annotation on the generated sources
+   *
+   */
+  @Parameter(property = "fabric8.java-generator.generated-annotations", required = false)
   Boolean generatedAnnotations = null;
 
   @Override


### PR DESCRIPTION
## Description

Closes #4661 

Additional fix for #4661

You can check the new output by:

```
mvn clean install -f java-generator/pom.xml -DskipTests 
mvn help:describe -DgroupId=io.fabric8 -DartifactId=java-generator-maven-plugin -Dversion=6.4-SNAPSHOT -Ddetail
```

It looks as follows now:

```
Name: Fabric8 :: Java generator :: Maven Plugin
Description: Java client for Kubernetes and OpenShift
Group Id: io.fabric8
Artifact Id: java-generator-maven-plugin
Version: 6.4-SNAPSHOT
Goal Prefix: java-generator

This plugin has 1 goal:

java-generator:generate
  Description: (no description available)
  Implementation: io.fabric8.java.generator.maven.plugin.JavaGeneratorMojo
  Language: java
  Bound to phase: generate-sources

  Available parameters:

    alwaysPreserveUnknown
      User property: fabric8.java-generator.always-preserve-unknown
      *advanced* Always inject additional properties in the generated classes

    codeStructure
      User property: fabric8.java-generator.code-structure
      *advanced* The code structure to be used when generating java sources

    enumUppercase
      User property: fabric8.java-generator.enum-uppercase
      Generate uppercase Enums

    extraAnnotations
      User property: fabric8.java-generator.extra-annotations
      Generate Extra annotation for lombok and sundrio integration

    generatedAnnotations
      User property: fabric8.java-generator.generated-annotations
      *advanced* Emit the @javax.annotation.processing.Generated annotation on
      the generated sources

    prefixStrategy
      User property: fabric8.java-generator.prefix-strategy
      *advanced* The prefix strategy for name mangling

    project (Default: ${project})
      (no description available)

    source
      Required: true
      User property: fabric8.java-generator.source
      The input file or directory to be used for generating sources

    suffixStrategy
      User property: fabric8.java-generator.suffix-strategy
      *advanced* The suffix strategy for name mangling

    target (Default: ${basedir}/target/generated-sources/java)
      User property: fabric8.java-generator.target
      The target folder to generate the Java sources
```

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
