### PR TITLE
fix #4637: adding a generalized ready timeout to pod operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #4637: all pod operations that require a ready / succeeded pod may use withReadyWaitTimeout, which supersedes withLogWaitTimeout.
 
 #### Dependency Upgrade
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
@@ -26,7 +26,7 @@ public interface ContainerResource
 
   /**
    * Will send the given input stream via a polling mechanism.
-   * 
+   *
    * @deprecated use redirectingInput and the resulting {@link ExecWatch#getOutput()} with
    *             InputStream#transferTo(java.io.OutputStream) on JDK 9+
    *             or
@@ -45,7 +45,7 @@ public interface ContainerResource
   /**
    * Will provide an {@link OutputStream} via {@link ExecWatch#getInput()} with the
    * given buffer size.
-   * 
+   *
    * @param bufferSize if null will use the default
    */
   TtyExecOutputErrorable redirectingInput(Integer bufferSize);
@@ -53,4 +53,13 @@ public interface ContainerResource
   CopyOrReadable file(String path);
 
   CopyOrReadable dir(String path);
+
+  /**
+   * How long to wait for the pod to be ready before performing an operation, such as
+   * getting the logs, exec, attach, copy, etc.
+   *
+   * @param timeout in milliseconds
+   */
+  @Override
+  ContainerResource withReadyWaitTimeout(Integer timeout);
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CopyOrReadable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CopyOrReadable.java
@@ -40,4 +40,11 @@ public interface CopyOrReadable {
 
   boolean copy(Path destination);
 
+  /**
+   * How long to wait for a ready pod before performing the copy or read operation.
+   *
+   * @param timeout in milliseconds
+   */
+  CopyOrReadable withReadyWaitTimeout(Integer timeout);
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Execable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Execable.java
@@ -20,7 +20,7 @@ public interface Execable {
 
   /**
    * Execute a command in a container
-   * 
+   *
    * @param input the command to run
    * @return container with stdin, stdout, stderr streams
    *         (if redirectingInput(), redirectingOutput(), redirectingError() were called respectively)
@@ -29,10 +29,18 @@ public interface Execable {
 
   /**
    * Attach to the main process of a container
-   * 
+   *
    * @return container with stdin, stdout, stderr streams
    *         (if redirectingInput(), redirectingOutput(), redirectingError() were called respectively)
    */
   ExecWatch attach();
+
+  /**
+   * How long shall we wait until a Pod is ready before attaching or execing
+   *
+   * @param timeout in milliseconds
+   * @return {@link Loggable} for fetching logs
+   */
+  Execable withReadyWaitTimeout(Integer timeout);
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
@@ -78,7 +78,19 @@ public interface Loggable {
    *
    * @param logWaitTimeout timeout in milliseconds
    * @return {@link Loggable} for fetching logs
+   *
+   * @deprecated use {@link #withReadyWaitTimeout(Integer)}
    */
+  @Deprecated
   Loggable withLogWaitTimeout(Integer logWaitTimeout);
+
+  /**
+   * While waiting for Pod logs, how long shall we wait until a Pod
+   * becomes ready and starts producing logs
+   *
+   * @param timeout in milliseconds
+   * @return {@link Loggable} for fetching logs
+   */
+  Loggable withReadyWaitTimeout(Integer timeout);
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationContext.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal;
 
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.utils.URLUtils.URLBuilder;
 import lombok.AllArgsConstructor;
@@ -58,7 +59,7 @@ public class PodOperationContext {
   private String sinceTimestamp;
   private Integer sinceSeconds;
   private Integer tailingLines;
-  private Integer logWaitTimeout;
+  private Integer readyWaitTimeout;
   private boolean prettyOutput;
   private ExecListener execListener;
   private Integer limitBytes;
@@ -125,8 +126,8 @@ public class PodOperationContext {
     return this.toBuilder().dir(dir).build();
   }
 
-  public PodOperationContext withLogWaitTimeout(Integer logWaitTimeout) {
-    return this.toBuilder().logWaitTimeout(logWaitTimeout).build();
+  public PodOperationContext withReadyWaitTimeout(Integer logWaitTimeout) {
+    return this.toBuilder().readyWaitTimeout(logWaitTimeout).build();
   }
 
   public String getLogParameters() {
@@ -163,15 +164,22 @@ public class PodOperationContext {
     if (tty) {
       httpUrlBuilder.addQueryParameter("tty", "true");
     }
+    boolean usingStream = false;
     if (in != null || redirectingIn) {
       httpUrlBuilder.addQueryParameter("stdin", "true");
+      usingStream = true;
     }
     boolean debug = ExecWebSocketListener.LOGGER.isDebugEnabled();
     if (output != null || debug) {
       httpUrlBuilder.addQueryParameter("stdout", "true");
+      usingStream = true;
     }
     if (error != null || terminateOnError || debug) {
       httpUrlBuilder.addQueryParameter("stderr", "true");
+      usingStream = true;
+    }
+    if (!usingStream) {
+      throw new KubernetesClientException("Pod operation is not valid unless an in, out, or error stream is used.");
     }
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
@@ -169,7 +169,12 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
 
   @Override
   public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
-    return newInstance(rollingOperationContext.withLogWaitTimeout(logWaitTimeout), context);
+    return withReadyWaitTimeout(logWaitTimeout);
+  }
+
+  @Override
+  public Loggable withReadyWaitTimeout(Integer timeout) {
+    return newInstance(rollingOperationContext.withReadyWaitTimeout(timeout), context);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
@@ -169,7 +169,12 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
 
   @Override
   public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
-    return new JobOperationsImpl(podControllerOperationContext.withLogWaitTimeout(logWaitTimeout), context);
+    return withReadyWaitTimeout(logWaitTimeout);
+  }
+
+  @Override
+  public Loggable withReadyWaitTimeout(Integer timeout) {
+    return new JobOperationsImpl(podControllerOperationContext.withReadyWaitTimeout(timeout), context);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -92,7 +92,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     implements PodResource, CopyOrReadable {
 
   public static final int HTTP_TOO_MANY_REQUESTS = 429;
-  private static final Integer DEFAULT_POD_LOG_WAIT_TIMEOUT = 5;
+  private static final Integer DEFAULT_POD_READY_WAIT_TIMEOUT = 5;
   private static final String[] EMPTY_COMMAND = { "/bin/sh", "-i" };
   public static final String DEFAULT_CONTAINER_ANNOTATION_NAME = "kubectl.kubernetes.io/default-container";
 
@@ -172,8 +172,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   public LogWatch watchLog(OutputStream out) {
     checkForPiped(out);
     try {
-      PodOperationUtil.waitUntilReadyBeforeFetchingLogs(this,
-          getContext().getLogWaitTimeout() != null ? getContext().getLogWaitTimeout() : DEFAULT_POD_LOG_WAIT_TIMEOUT);
+      PodOperationUtil.waitUntilReadyOrSucceded(this,
+          getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT);
       // Issue Pod Logs HTTP request
       URL url = new URL(URLUtils.join(getResourceUrl().toString(), getContext().getLogParameters() + "&follow=true"));
       final LogWatchCallback callback = new LogWatchCallback(out, this.context.getExecutor());
@@ -184,8 +184,13 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
+  public PodOperationsImpl withReadyWaitTimeout(Integer logWaitTimeout) {
+    return new PodOperationsImpl(getContext().withReadyWaitTimeout(logWaitTimeout), context);
+  }
+
+  @Override
   public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
-    return new PodOperationsImpl(getContext().withLogWaitTimeout(logWaitTimeout), context);
+    return withReadyWaitTimeout(logWaitTimeout);
   }
 
   @Override
@@ -280,6 +285,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     String[] actualCommands = command.length >= 1 ? command : EMPTY_COMMAND;
     try {
       URL url = getURL("exec", actualCommands);
+
       return setupConnectionToPod(url.toURI());
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(forOperationType("exec"), e);
@@ -290,6 +296,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   public ExecWatch attach() {
     try {
       URL url = getURL("attach", null);
+
       return setupConnectionToPod(url.toURI());
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(forOperationType("attach"), e);
@@ -297,6 +304,9 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   private URL getURL(String operation, String[] commands) throws MalformedURLException {
+    Pod fromServer = PodOperationUtil.waitUntilReadyOrSucceded(this,
+        getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT);
+
     String url = URLUtils.join(getResourceUrl().toString(), operation);
     URLBuilder httpUrlBuilder = new URLBuilder(url);
     if (commands != null) {
@@ -305,7 +315,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
       }
     }
     PodOperationContext contextToUse = getContext();
-    contextToUse = contextToUse.withContainerId(validateOrDefaultContainerId(contextToUse.getContainerId()));
+    contextToUse = contextToUse.withContainerId(validateOrDefaultContainerId(contextToUse.getContainerId(), fromServer));
     contextToUse.addQueryParameters(httpUrlBuilder);
     return httpUrlBuilder.build();
   }
@@ -313,8 +323,10 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   /**
    * If not specified, choose an appropriate default container id
    */
-  String validateOrDefaultContainerId(String name) {
-    Pod pod = this.require();
+  String validateOrDefaultContainerId(String name, Pod pod) {
+    if (pod == null) {
+      pod = this.require();
+    }
     // spec and container null-checks are not necessary for real k8s clusters, added them to simplify some tests running in the mockserver
     if (pod.getSpec() == null || pod.getSpec().getContainers() == null || pod.getSpec().getContainers().isEmpty()) {
       throw new KubernetesClientException("Pod has no containers!");

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtil.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class PodOperationUtil {
   private static final Logger LOG = LoggerFactory.getLogger(PodOperationUtil.class);
@@ -114,14 +115,19 @@ public class PodOperationUtil {
     return PodOperationUtil.getFilteredPodsForLogs(podOperations, controllerPodList, controllerUid);
   }
 
-  public static void waitUntilReadyBeforeFetchingLogs(PodResource podOperation, Integer logWaitTimeout) {
+  public static Pod waitUntilReadyOrSucceded(PodResource podOperation, Integer logWaitTimeout) {
+    AtomicReference<Pod> podRef = new AtomicReference<>();
     try {
       // Wait for Pod to become ready or succeeded
-      podOperation.waitUntilCondition(p -> p != null && (Readiness.isPodReady(p) || Readiness.isPodSucceeded(p)),
+      podOperation.waitUntilCondition(p -> {
+        podRef.set(p);
+        return p != null && (Readiness.isPodReady(p) || Readiness.isPodSucceeded(p));
+      },
           logWaitTimeout,
           TimeUnit.SECONDS);
     } catch (Exception otherException) {
       LOG.debug("Error while waiting for Pod to become Ready: {}", otherException.getMessage());
     }
+    return podRef.get();
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
@@ -80,7 +80,7 @@ class PodOperationUtilTest {
   void testGetGenericPodOperations() {
     // When
     PodOperationsImpl podOperations = PodOperationUtil.getGenericPodOperations(operationContext,
-        new PodOperationContext().withPrettyOutput(false).withLogWaitTimeout(5).withContainerId("container1"));
+        new PodOperationContext().withPrettyOutput(false).withReadyWaitTimeout(5).withContainerId("container1"));
 
     // Then
     assertThat(podOperations).isNotNull();
@@ -91,7 +91,7 @@ class PodOperationUtilTest {
   @Test
   void testWaitUntilReadyBeforeFetchingLogs() {
     // When
-    PodOperationUtil.waitUntilReadyBeforeFetchingLogs(podOperations, 5);
+    PodOperationUtil.waitUntilReadyOrSucceded(podOperations, 5);
     // Then
     verify(podOperations, times(1)).waitUntilCondition(any(), eq(5L), eq(TimeUnit.SECONDS));
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @LoadKubernetesManifests("/pod-it.yml")
 class PodIT {
 
-  private static final int POD_READY_WAIT_IN_SECONDS = 60;
+  private static final int POD_READY_WAIT_IN_MILLIS = 60000;
 
   private static final Logger logger = LoggerFactory.getLogger(PodIT.class);
 
@@ -103,14 +103,12 @@ class PodIT {
 
   @Test
   void log() {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
-    String log = client.pods().withName("pod-standard").getLog();
+    String log = client.pods().withName("pod-standard").withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS).getLog();
     assertNotNull(log);
   }
 
   @Test
   void exec() throws Exception {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
     final CountDownLatch execLatch = new CountDownLatch(1);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     final AtomicBoolean closed = new AtomicBoolean();
@@ -144,7 +142,7 @@ class PodIT {
             exitCode[0] = code;
             exitStatus.complete(status);
           }
-        }).exec("sh", "-c", "echo 'hello world!'");
+        }).withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS).exec("sh", "-c", "echo 'hello world!'");
     assertThat(exitStatus.get(5, TimeUnit.SECONDS))
         .hasFieldOrPropertyWithValue("status", "Success");
     assertTrue(execLatch.await(5, TimeUnit.SECONDS));
@@ -156,10 +154,10 @@ class PodIT {
 
   @Test
   void execExitCode() throws Exception {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     ExecWatch watch = client.pods().withName("pod-standard")
         .writingOutput(out)
+        .withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS)
         .exec("sh", "-c", "echo 'hello world!'");
     assertEquals(0, watch.exitCode().join());
     assertNotNull("hello world!", out.toString());
@@ -167,13 +165,13 @@ class PodIT {
 
   @Test
   void execInteractiveShell() throws Exception {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ExecWatch watch = client.pods().withName("pod-standard")
         .redirectingInput()
         .redirectingOutput()
         .redirectingError()
         .withTTY()
+        .withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS)
         .exec("sh", "-i");
 
     InputStreamPumper.pump(watch.getOutput(), baos::write, Executors.newSingleThreadExecutor());
@@ -193,8 +191,6 @@ class PodIT {
 
   @Test
   void attach() throws Exception {
-    client.pods().withName("pod-interactive").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
-
     CountDownLatch latch = new CountDownLatch(1);
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     AtomicBoolean closed = new AtomicBoolean();
@@ -218,6 +214,7 @@ class PodIT {
             latch.countDown();
           }
         })
+        .withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS)
         .attach();
 
     watch.getInput().write("whoami\n".getBytes(StandardCharsets.UTF_8));
@@ -243,10 +240,11 @@ class PodIT {
 
   @Test
   void readFile() throws IOException {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
     try (
-        ExecWatch ignore = client.pods().withName("pod-standard").writingOutput(System.out).exec("sh", "-c",
-            "echo 'hello' > /msg");
+        ExecWatch ignore = client.pods().withName("pod-standard").writingOutput(System.out)
+            .withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS)
+            .exec("sh", "-c",
+                "echo 'hello' > /msg");
         InputStream is = client.pods().withName("pod-standard").file("/msg").read()) {
       String result = new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
       assertEquals("hello", result);
@@ -255,10 +253,11 @@ class PodIT {
 
   @Test
   void readFileEscapedParams() throws IOException {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
     try (
-        ExecWatch watch = client.pods().withName("pod-standard").writingOutput(System.out).exec("sh", "-c",
-            "echo 'H$ll* (W&RLD}' > /msg");
+        ExecWatch watch = client.pods().withName("pod-standard").writingOutput(System.out)
+            .withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS)
+            .exec("sh", "-c",
+                "echo 'H$ll* (W&RLD}' > /msg");
         InputStream is = client.pods().withName("pod-standard").file("/msg").read()) {
       String result = new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
       assertEquals("H$ll* (W&RLD}", result);
@@ -267,7 +266,7 @@ class PodIT {
 
   @Test
   void uploadFile() throws IOException {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
+    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_MILLIS, TimeUnit.SECONDS);
     // Wait for resources to get ready
     final Path tmpFile = Files.createTempFile("PodIT", "toBeUploaded");
     Files.write(tmpFile, Collections.singletonList("I'm uploaded"));
@@ -291,7 +290,6 @@ class PodIT {
 
   @Test
   void uploadDir() throws IOException {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
     final String[] files = new String[] { "1", "2", "a", "b", "c" };
     final Path tmpDir = Files.createTempDirectory("uploadDir");
     for (String fileName : files) {
@@ -301,7 +299,7 @@ class PodIT {
 
     PodResource podResource = client.pods().withName("pod-standard");
 
-    podResource.dir("/tmp/uploadDir").upload(tmpDir);
+    podResource.dir("/tmp/uploadDir").withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS).upload(tmpDir);
 
     for (String fileName : files) {
       try (InputStream checkIs = podResource.file("/tmp/uploadDir/" + fileName).read();
@@ -314,12 +312,10 @@ class PodIT {
 
   @Test
   void copyDir() throws IOException {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
-
     final Path tmpDir = Files.createTempDirectory("copyFile");
 
     PodResource podResource = client.pods().withName("pod-standard");
-    podResource.dir("/etc").copy(tmpDir);
+    podResource.dir("/etc").withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS).copy(tmpDir);
 
     Path msg = tmpDir.resolve("/etc/hosts");
     assertTrue(Files.exists(msg));
@@ -327,12 +323,11 @@ class PodIT {
 
   @Test
   void copyFile() throws IOException {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
-
     final Path tmpDir = Files.createTempDirectory("copyFile");
 
     PodResource podResource = client.pods().withName("pod-standard");
-    podResource.writingOutput(System.out).exec("sh", "-c", "echo 'hello' > /msg.txt");
+    podResource.writingOutput(System.out).withReadyWaitTimeout(POD_READY_WAIT_IN_MILLIS).exec("sh", "-c",
+        "echo 'hello' > /msg.txt");
     podResource.file("/msg.txt").copy(tmpDir);
 
     Path msg = tmpDir.resolve("msg.txt");
@@ -347,7 +342,7 @@ class PodIT {
 
   @Test
   void listFromServer() {
-    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_SECONDS, TimeUnit.SECONDS);
+    client.pods().withName("pod-standard").waitUntilReady(POD_READY_WAIT_IN_MILLIS, TimeUnit.SECONDS);
     final Pod pod1 = client.pods().withName("pod-standard").get();
     List<HasMetadata> resources = client.resourceList(pod1).fromServer().get();
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -232,11 +232,16 @@ public class DeploymentConfigOperationsImpl
 
   @Override
   public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
-    return new DeploymentConfigOperationsImpl(rollingOperationContext.withLogWaitTimeout(logWaitTimeout), context);
+    return withReadyWaitTimeout(logWaitTimeout);
+  }
+
+  @Override
+  public Loggable withReadyWaitTimeout(Integer timeout) {
+    return new DeploymentConfigOperationsImpl(rollingOperationContext.withReadyWaitTimeout(timeout), context);
   }
 
   private void waitUntilDeploymentConfigPodBecomesReady(DeploymentConfig deploymentConfig) {
-    Integer podLogWaitTimeout = rollingOperationContext.getLogWaitTimeout();
+    Integer podLogWaitTimeout = rollingOperationContext.getReadyWaitTimeout();
     List<PodResource> podOps = PodOperationUtil.getPodOperationsForController(context,
         rollingOperationContext,
         deploymentConfig.getMetadata().getUid(), getDeploymentConfigPodLabels(deploymentConfig));
@@ -246,7 +251,7 @@ public class DeploymentConfigOperationsImpl
 
   private static void waitForBuildPodToBecomeReady(List<PodResource> podOps, Integer podLogWaitTimeout) {
     for (PodResource podOp : podOps) {
-      PodOperationUtil.waitUntilReadyBeforeFetchingLogs(podOp, podLogWaitTimeout);
+      PodOperationUtil.waitUntilReadyOrSucceded(podOp, podLogWaitTimeout);
     }
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
@@ -143,7 +143,12 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
 
   @Override
   public Loggable withLogWaitTimeout(Integer logWaitTimeout) {
-    return new BuildOperationsImpl(getContext().withLogWaitTimeout(logWaitTimeout), context, version);
+    return withReadyWaitTimeout(logWaitTimeout);
+  }
+
+  @Override
+  public Loggable withReadyWaitTimeout(Integer timeout) {
+    return new BuildOperationsImpl(getContext().withReadyWaitTimeout(timeout), context, version);
   }
 
   @Override
@@ -192,12 +197,12 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
         getBuildPodLabels(build));
 
     waitForBuildPodToBecomeReady(podOps,
-        operationContext.getLogWaitTimeout() != null ? operationContext.getLogWaitTimeout() : DEFAULT_POD_LOG_WAIT_TIMEOUT);
+        operationContext.getReadyWaitTimeout() != null ? operationContext.getReadyWaitTimeout() : DEFAULT_POD_LOG_WAIT_TIMEOUT);
   }
 
   private static void waitForBuildPodToBecomeReady(List<PodResource> podOps, Integer podLogWaitTimeout) {
     for (PodResource podOp : podOps) {
-      PodOperationUtil.waitUntilReadyBeforeFetchingLogs(podOp, podLogWaitTimeout);
+      PodOperationUtil.waitUntilReadyOrSucceded(podOp, podLogWaitTimeout);
     }
   }
 


### PR DESCRIPTION
## Description

Fix #4637 

Addresses #4637 - generalizes withLogWaitTimeout as withReadyWaitTimeout, which is applicable to all pod operations that require a ready (or succeeded pod).  This uses the same paradigm of just setting the milliseconds - please comment if you want a different name, or the ability to specify the unit as we do with some of the other timeouts.

It also adds a validation to ensure that at least one of the streams is being used.  This doesn't appear to be an issue with other clients as kubectl will always use stdin and python will default to using both stderr and stdout.  I'm open as well to changing our default stream consumption behavior should we want to avoid this exception case.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
