### PR TITLE
Make the Java generator Maven Plugin able to directly download resources

### DIFF
--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -28,7 +28,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Paths;
 
@@ -117,10 +116,14 @@ public class JavaGeneratorMojo extends AbstractMojo {
   private void downloadFile(String url, String dest) {
     try {
       URL source = new URL(url);
-      ReadableByteChannel readableByteChannel = Channels.newChannel(source.openStream());
-      new File(dest).mkdirs();
-      FileOutputStream fileOutputStream = new FileOutputStream(Paths.get(dest, new File(source.getFile()).getName()).toFile());
-      fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+      File finalDestination = Paths.get(dest, new File(source.getFile()).getName()).toFile();
+
+      if (!finalDestination.exists()) {
+        new File(dest).mkdirs();
+        ReadableByteChannel readableByteChannel = Channels.newChannel(source.openStream());
+        FileOutputStream fileOutputStream = new FileOutputStream(finalDestination);
+        fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -129,7 +132,7 @@ public class JavaGeneratorMojo extends AbstractMojo {
   @Override
   public void execute() {
     if (urls != null && urls.length > 0) {
-      for (String url: urls) {
+      for (String url : urls) {
         downloadFile(url, downloadTarget.getAbsolutePath());
       }
       source = downloadTarget;

--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -115,17 +115,18 @@ public class JavaGeneratorMojo extends AbstractMojo {
 
   private void downloadFile(String url, String dest) {
     try {
-      URL source = new URL(url);
-      File finalDestination = Paths.get(dest, new File(source.getFile()).getName()).toFile();
+      URL s = new URL(url);
+      File finalDestination = Paths.get(dest, new File(s.getFile()).getName()).toFile();
 
       if (!finalDestination.exists()) {
         new File(dest).mkdirs();
-        ReadableByteChannel readableByteChannel = Channels.newChannel(source.openStream());
-        FileOutputStream fileOutputStream = new FileOutputStream(finalDestination);
-        fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        ReadableByteChannel readableByteChannel = Channels.newChannel(s.openStream());
+        try (FileOutputStream fileOutputStream = new FileOutputStream(finalDestination)) {
+          fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        }
       }
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException("Error downloading from url: " + url, e);
     }
   }
 

--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -120,8 +120,8 @@ public class JavaGeneratorMojo extends AbstractMojo {
 
       if (!finalDestination.exists()) {
         new File(dest).mkdirs();
-        ReadableByteChannel readableByteChannel = Channels.newChannel(s.openStream());
-        try (FileOutputStream fileOutputStream = new FileOutputStream(finalDestination)) {
+        try (ReadableByteChannel readableByteChannel = Channels.newChannel(s.openStream());
+            FileOutputStream fileOutputStream = new FileOutputStream(finalDestination)) {
           fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
         }
       }


### PR DESCRIPTION
## Description
Fix #4622

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
