### PR TITLE
Attempt to fix occasional CRD generation issues with subresources

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/PromoteSingleVersionAttributesDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/PromoteSingleVersionAttributesDecorator.java
@@ -41,7 +41,8 @@ public class PromoteSingleVersionAttributesDecorator
     super(name);
   }
 
-  private CustomResourceSubresources mergeSubresources(CustomResourceSubresources versionSub, CustomResourceSubresources topLevelSub) {
+  private CustomResourceSubresources mergeSubresources(CustomResourceSubresources versionSub,
+      CustomResourceSubresources topLevelSub) {
     if (versionSub == null) {
       return topLevelSub;
     } else if (topLevelSub == null) {
@@ -73,10 +74,10 @@ public class PromoteSingleVersionAttributesDecorator
       }
 
       return new CustomResourceSubresourcesBuilder()
-        .withAdditionalProperties(additionalProperties)
-        .withScale(scale)
-        .withStatus(status)
-        .build();
+          .withAdditionalProperties(additionalProperties)
+          .withScale(scale)
+          .withStatus(status)
+          .build();
     }
   }
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/PromoteSingleVersionAttributesDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/PromoteSingleVersionAttributesDecorator.java
@@ -21,11 +21,16 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceColum
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionSpecFluent;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersion;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersionBuilder;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresourceScale;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresourceStatus;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresources;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresourcesBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceValidation;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,13 +41,52 @@ public class PromoteSingleVersionAttributesDecorator
     super(name);
   }
 
+  private CustomResourceSubresources mergeSubresources(CustomResourceSubresources versionSub, CustomResourceSubresources topLevelSub) {
+    if (versionSub == null) {
+      return topLevelSub;
+    } else if (topLevelSub == null) {
+      return versionSub;
+    } else {
+      // merge additional properties
+      Map<String, Object> additionalProperties = new HashMap<>();
+      if (versionSub.getAdditionalProperties() != null) {
+        additionalProperties.putAll(versionSub.getAdditionalProperties());
+      }
+      if (topLevelSub.getAdditionalProperties() != null) {
+        additionalProperties.putAll(topLevelSub.getAdditionalProperties());
+      }
+
+      // merge scale
+      CustomResourceSubresourceScale scale = null;
+      if (topLevelSub.getScale() != null) {
+        scale = topLevelSub.getScale();
+      } else if (versionSub.getScale() != null) {
+        scale = versionSub.getScale();
+      }
+
+      // merge status
+      CustomResourceSubresourceStatus status = null;
+      if (topLevelSub.getStatus() != null) {
+        status = topLevelSub.getStatus();
+      } else if (versionSub.getStatus() != null) {
+        status = versionSub.getStatus();
+      }
+
+      return new CustomResourceSubresourcesBuilder()
+        .withAdditionalProperties(additionalProperties)
+        .withScale(scale)
+        .withStatus(status)
+        .build();
+    }
+  }
+
   @Override
   public void andThenVisit(CustomResourceDefinitionSpecFluent<?> spec, ObjectMeta resourceMeta) {
     List<CustomResourceDefinitionVersion> versions = spec.buildVersions();
 
     if (versions.size() == 1) {
       CustomResourceDefinitionVersion version = versions.get(0);
-      spec.withSubresources(version.getSubresources())
+      spec.withSubresources(mergeSubresources(version.getSubresources(), spec.buildSubresources()))
           .withValidation(version.getSchema())
           .withAdditionalPrinterColumns(version.getAdditionalPrinterColumns());
 
@@ -70,7 +114,7 @@ public class PromoteSingleVersionAttributesDecorator
       }
 
       if (hasIdenticalSubresources) {
-        spec.withSubresources(subresources.iterator().next());
+        spec.withSubresources(mergeSubresources(subresources.iterator().next(), spec.buildSubresources()));
       }
 
       if (hasIdenticalAdditionalPrinterColumns) {


### PR DESCRIPTION
## Description

This is an attempt to fix #4680 

I think that the Decorator I'm touching might be the root cause of the issue (directly or inderectly related).
Overall, this implementation should be more solid than before.
Let see how it goes 🤞 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
