### PR TITLE
feat(java-generator): generalized Java class generation from remote CRDs

### DIFF
--- a/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
+++ b/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
@@ -15,8 +15,9 @@
  */
 package io.fabric8.java.generator.cli;
 
-import io.fabric8.java.generator.CRGeneratorRunner;
 import io.fabric8.java.generator.Config;
+import io.fabric8.java.generator.FileJavaGenerator;
+import io.fabric8.java.generator.JavaGenerator;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -73,8 +74,8 @@ public class GenerateJavaSources implements Runnable {
         addExtraAnnotations,
         structure,
         generatedAnnotations);
-    final CRGeneratorRunner runner = new CRGeneratorRunner(config);
-    runner.run(source, target);
+    final JavaGenerator runner = new FileJavaGenerator(config, source);
+    runner.run(target);
   }
 
   public static void main(String[] args) {

--- a/java-generator/core/pom.xml
+++ b/java-generator/core/pom.xml
@@ -76,17 +76,14 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -103,6 +100,11 @@
     <dependency>
       <groupId>com.approvaltests</groupId>
       <artifactId>approvaltests</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/java-generator/core/pom.xml
+++ b/java-generator/core/pom.xml
@@ -75,17 +75,17 @@
     <!-- Testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -105,14 +105,4 @@
       <artifactId>approvaltests</artifactId>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-            <compilerArgument>-proc:none</compilerArgument>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
@@ -19,29 +19,20 @@ import io.fabric8.java.generator.exceptions.JavaGeneratorException;
 import io.fabric8.java.generator.nodes.AbstractJSONSchema2Pojo;
 import io.fabric8.java.generator.nodes.GeneratorResult;
 import io.fabric8.java.generator.nodes.JCRObject;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionSpec;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersion;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
-import io.fabric8.kubernetes.client.utils.Serialization;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.FileVisitOption;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class CRGeneratorRunner {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(CRGeneratorRunner.class);
 
   private final Config config;
 
@@ -49,63 +40,7 @@ public class CRGeneratorRunner {
     this.config = config;
   }
 
-  public void run(File source, File basePath) {
-    if (source.isDirectory()) {
-      try (Stream<Path> walk = Files.walk(source.toPath(), FileVisitOption.FOLLOW_LINKS)) {
-        walk.forEach(
-            f -> {
-              if (!f.toFile().getAbsolutePath().equals(source.getAbsolutePath())) {
-                run(f.toFile(), basePath);
-              }
-            });
-      } catch (IOException e) {
-        throw new JavaGeneratorException(
-            "Error visiting the folder " + source.getAbsolutePath(), e);
-      }
-    } else {
-      runOnSingleSource(source, basePath);
-    }
-  }
-
-  private void runOnSingleSource(File source, File basePath) {
-    try (FileInputStream fis = new FileInputStream(source)) {
-      List<HasMetadata> resources = new ArrayList<>();
-
-      Object deserialized = Serialization.unmarshal(fis);
-      if (deserialized instanceof List) {
-        resources.addAll((List<HasMetadata>) deserialized);
-      } else {
-        resources.add((CustomResourceDefinition) deserialized);
-      }
-
-      resources.parallelStream()
-          .forEach(
-              resource -> {
-                if (resource.getKind()
-                    .toLowerCase(Locale.ROOT)
-                    .equals("customresourcedefinition")) {
-                  CustomResourceDefinition crd = (CustomResourceDefinition) resource;
-
-                  String pkg = getPackage(crd.getSpec().getGroup());
-                  List<WritableCRCompilationUnit> writables = generate(crd, pkg);
-
-                  writables.parallelStream()
-                      .forEach(w -> w.writeAllJavaClasses(basePath, pkg));
-                } else {
-                  LOGGER.warn(
-                      "Not generating nothing for resource of kind: "
-                          + resource.getKind());
-                }
-              });
-    } catch (FileNotFoundException e) {
-      throw new JavaGeneratorException("File " + source.getAbsolutePath() + " not found", e);
-    } catch (IOException e) {
-      throw new JavaGeneratorException("Exception reading " + source.getAbsolutePath(), e);
-    }
-  }
-
-  public List<WritableCRCompilationUnit> generate(
-      CustomResourceDefinition crd, String basePackageName) {
+  public List<WritableCRCompilationUnit> generate(CustomResourceDefinition crd, String basePackageName) {
     CustomResourceDefinitionSpec crSpec = crd.getSpec();
     String crName = crSpec.getNames().getKind();
     String group = crSpec.getGroup();
@@ -182,10 +117,10 @@ public class CRGeneratorRunner {
     return generatorResult;
   }
 
-  protected String getPackage(String group) {
+  protected static String groupToPackage(String group) {
     final List<String> groupElements = Arrays.asList(group.replace('-', '_').split("\\."));
 
     Collections.reverse(groupElements);
-    return groupElements.stream().collect(Collectors.joining("."));
+    return String.join(".", groupElements);
   }
 }

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
@@ -71,7 +71,7 @@ public class CRGeneratorRunner {
     try (FileInputStream fis = new FileInputStream(source)) {
       List<HasMetadata> resources = new ArrayList<>();
 
-      Object deserialized = Serialization.unmarshal(fis, Collections.emptyMap());
+      Object deserialized = Serialization.unmarshal(fis);
       if (deserialized instanceof List) {
         resources.addAll((List<HasMetadata>) deserialized);
       } else {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
@@ -18,7 +18,7 @@ package io.fabric8.java.generator;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 public class Config {
   public enum CodeStructure {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
@@ -15,6 +15,11 @@
  */
 package io.fabric8.java.generator;
 
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
 public class Config {
   public enum CodeStructure {
     FLAT,
@@ -48,9 +53,6 @@ public class Config {
   private Boolean objectExtraAnnotations = DEFAULT_ADD_EXTRA_ANNOTATIONS;
   private CodeStructure structure = DEFAULT_CODE_STRUCTURE;
   private Boolean generatedAnnotations = DEFAULT_ADD_GENERATED_ANNOTATIONS;
-
-  public Config() {
-  }
 
   public Config(
       Boolean uppercaseEnums,

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/FileJavaGenerator.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/FileJavaGenerator.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.java.generator;
+
+import io.fabric8.java.generator.exceptions.JavaGeneratorException;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static io.fabric8.java.generator.CRGeneratorRunner.groupToPackage;
+
+/**
+ * {@link JavaGenerator} implementation that reads CRD files or directories containing CRD files and generates
+ * Java classes for them.
+ */
+public class FileJavaGenerator implements JavaGenerator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileJavaGenerator.class);
+
+  private final File source;
+  private final CRGeneratorRunner crGeneratorRunner;
+
+  public FileJavaGenerator(Config config, File source) {
+    crGeneratorRunner = new CRGeneratorRunner(config);
+    this.source = source;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void run(File outputDirectory) {
+    if (source.isDirectory()) {
+      try (Stream<Path> walk = Files.walk(source.toPath(), FileVisitOption.FOLLOW_LINKS)) {
+        walk
+            .map(Path::toFile)
+            .filter(f -> !f.getAbsolutePath().equals(source.getAbsolutePath()))
+            .forEach(f -> runOnSingleSource(f, outputDirectory));
+      } catch (IOException e) {
+        throw new JavaGeneratorException(
+            "Error visiting the folder " + source.getAbsolutePath(), e);
+      }
+    } else {
+      runOnSingleSource(source, outputDirectory);
+    }
+  }
+
+  private void runOnSingleSource(File source, File basePath) {
+    try (FileInputStream fis = new FileInputStream(source)) {
+      List<HasMetadata> resources = new ArrayList<>();
+
+      Object deserialized = Serialization.unmarshal(fis);
+      if (deserialized instanceof List) {
+        resources.addAll((List<HasMetadata>) deserialized);
+      } else {
+        resources.add((CustomResourceDefinition) deserialized);
+      }
+
+      resources.parallelStream()
+          .forEach(
+              resource -> {
+                if (resource.getKind()
+                    .toLowerCase(Locale.ROOT)
+                    .equals("customresourcedefinition")) {
+                  CustomResourceDefinition crd = (CustomResourceDefinition) resource;
+
+                  final String basePackage = groupToPackage(crd.getSpec().getGroup());
+                  List<WritableCRCompilationUnit> writables = crGeneratorRunner.generate(crd, basePackage);
+
+                  writables.parallelStream()
+                      .forEach(w -> w.writeAllJavaClasses(basePath, basePackage));
+                } else {
+                  LOGGER.warn("Not generating nothing for resource of kind: {}", resource.getKind());
+                }
+              });
+    } catch (FileNotFoundException e) {
+      throw new JavaGeneratorException("File " + source.getAbsolutePath() + " not found", e);
+    } catch (IOException e) {
+      throw new JavaGeneratorException("Exception reading " + source.getAbsolutePath(), e);
+    }
+  }
+}

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/JavaGenerator.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/JavaGenerator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.java.generator;
+
+import java.io.File;
+
+public interface JavaGenerator {
+
+  /**
+   * Generate Java classes from a CRD file or multiple CRD files and write them to the provided output directory.
+   * 
+   * @param outputDirectory the directory where the generated Java classes will be written.
+   */
+  void run(File outputDirectory);
+}

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/URLJavaGenerator.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/URLJavaGenerator.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.java.generator;
+
+import io.fabric8.java.generator.exceptions.JavaGeneratorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.util.Collection;
+
+/**
+ * {@link JavaGenerator} implementation that reads CRD from remote URLs and generates
+ * Java classes for them.
+ */
+public class URLJavaGenerator implements JavaGenerator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(URLJavaGenerator.class);
+
+  private final Collection<URL> urls;
+  private final File downloadDirectory;
+  private final FileJavaGenerator delegate;
+
+  public URLJavaGenerator(Config config, Collection<URL> urls, File downloadDirectory) {
+    this.urls = urls;
+    this.downloadDirectory = downloadDirectory;
+    delegate = new FileJavaGenerator(config, downloadDirectory);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void run(File outputDirectory) {
+    if (urls == null || urls.isEmpty()) {
+      throw new JavaGeneratorException("No URLs provided");
+    }
+    if (downloadDirectory == null) {
+      throw new JavaGeneratorException(
+          "Download directory is required");
+    }
+    if (!downloadDirectory.isDirectory()) {
+      throw new JavaGeneratorException(
+          "Download directory " + downloadDirectory.getAbsolutePath() + " is not a valid directory");
+    }
+    if (!downloadDirectory.exists() && !downloadDirectory.mkdirs()) {
+      throw new JavaGeneratorException("Unable to create download directory " + downloadDirectory.getAbsolutePath());
+    }
+    LOGGER.info("Downloading CRDs from URLs: {}", urls);
+    urls.forEach(this::downloadCRD);
+    LOGGER.info("Generating Java classes from downloaded CRDs");
+    delegate.run(outputDirectory);
+  }
+
+  private void downloadCRD(URL url) {
+    final File finalDestination = new File(downloadDirectory, new File(url.getFile()).getName());
+    if (finalDestination.exists()) {
+      LOGGER.warn("Skipping download of {} because it already exists at {}", url, finalDestination);
+      return;
+    }
+    try (ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
+        FileOutputStream fileOutputStream = new FileOutputStream(finalDestination)) {
+      fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+    } catch (IOException e) {
+      throw new JavaGeneratorException("Error downloading CRD from URL: " + url, e);
+    }
+  }
+}

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/ApprovalTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/ApprovalTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.fabric8.java.generator.CRGeneratorRunner.groupToPackage;
 
 class ApprovalTest {
 
@@ -54,7 +55,7 @@ class ApprovalTest {
       CustomResourceDefinition crd = getCRD(crdYaml);
 
       // Act
-      List<WritableCRCompilationUnit> writables = runner.generate(crd, runner.getPackage("test.org"));
+      List<WritableCRCompilationUnit> writables = runner.generate(crd, groupToPackage("test.org"));
 
       // Assert
       assertThat(writables).hasSize(1);

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -17,10 +17,12 @@ package io.fabric8.java.generator;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.tools.JavaFileObject;
 
@@ -39,12 +42,88 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CompilationTest {
 
-  private static TemporaryFolder tmpFolder = TemporaryFolder.builder().build();
+  @TempDir
+  private File tempDir;
 
-  CRGeneratorRunner defaultRunner = new CRGeneratorRunner(
-      new Config(null, null, null, null, null, Config.CodeStructure.PACKAGE_NESTED, false));
+  private Config config;
 
-  List<JavaFileObject> getSources(File basePath) throws IOException {
+  @BeforeEach
+  void setUp() {
+    config = Config.builder()
+        .structure(Config.CodeStructure.PACKAGE_NESTED)
+        .generatedAnnotations(false)
+        .build();
+  }
+
+  private static Stream<Arguments> compilationTestData() {
+    return Stream.of(
+        Arguments.of("crontab-crd.yml", 3),
+        Arguments.of("keycloak-crd.yml", 50),
+        Arguments.of("akka-microservices-crd.yml", 28),
+        Arguments.of("strimzi-kafka-crd.yml", 704),
+        Arguments.of("spark-crd.yml", 358),
+        Arguments.of("crunchy-postgres-crd.yml", 267),
+        Arguments.of("kamelet-crd.yml", 16),
+        Arguments.of("jokerequests-crd.yml", 3),
+        Arguments.of("cert-manager-crd.yml", 5),
+        Arguments.of("two-crds.yml", 6),
+        Arguments.of("folder", 6));
+  }
+
+  @ParameterizedTest(name = "{0} should generate {1} source files and compile OK")
+  @MethodSource("compilationTestData")
+  void yamlCompiles(String yamlFile, int expectedGeneratedSourceFiles) throws Exception {
+    // Arrange
+    File crd = getCRD(yamlFile);
+
+    // Act
+    new FileJavaGenerator(config, crd).run(tempDir);
+    Compilation compilation = javac().compile(getSources(tempDir));
+
+    // Assert
+    assertTrue(compilation.errors().isEmpty());
+    assertEquals(expectedGeneratedSourceFiles, compilation.sourceFiles().size());
+    assertEquals(Compilation.Status.SUCCESS, compilation.status());
+  }
+
+  @Test
+  void crontabCRDCompilesWithFlatPackage() throws Exception {
+    // Arrange
+    File crd = getCRD("crontab-crd.yml");
+    config = config.toBuilder()
+        .structure(Config.CodeStructure.FLAT)
+        .build();
+
+    // Act
+    new FileJavaGenerator(config, crd).run(tempDir);
+    Compilation compilation = javac().compile(getSources(tempDir));
+
+    // Assert
+    assertTrue(compilation.errors().isEmpty());
+    assertEquals(3, compilation.sourceFiles().size());
+    assertEquals(Compilation.Status.SUCCESS, compilation.status());
+  }
+
+  @Test
+  void testCrontabCRDCompilesWithExtraAnnotationsAndUnknownFields() throws Exception {
+    // Arrange
+    File crd = getCRD("crontab-crd.yml");
+    config = config.toBuilder()
+        .objectExtraAnnotations(true)
+        .alwaysPreserveUnknownFields(true)
+        .build();
+
+    // Act
+    new FileJavaGenerator(config, crd).run(tempDir);
+    Compilation compilation = javac().compile(getSources(tempDir));
+
+    // Assert
+    assertTrue(compilation.errors().isEmpty());
+    assertEquals(3, compilation.sourceFiles().size());
+    assertEquals(Compilation.Status.SUCCESS, compilation.status());
+  }
+
+  static List<JavaFileObject> getSources(File basePath) throws IOException {
     List<JavaFileObject> sources = new ArrayList<JavaFileObject>();
     for (Path f : Files.list(basePath.toPath()).collect(Collectors.toList())) {
       if (f.toFile().isDirectory()) {
@@ -57,228 +136,7 @@ class CompilationTest {
     return sources;
   }
 
-  File getCRD(String name) throws Exception {
-    return Paths.get(this.getClass().getClassLoader().getResource(name).toURI()).toFile();
-  }
-
-  @BeforeAll
-  public static void beforeAll() throws IOException {
-    tmpFolder.create();
-  }
-
-  @Test
-  void testCrontabCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("crontab-crd.yml");
-    File dest = tmpFolder.newFolder("crontab-default");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(3, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testCrontabCRDCompilesWithFlatPackage() throws Exception {
-    // Arrange
-    File crd = getCRD("crontab-crd.yml");
-    File dest = tmpFolder.newFolder("crontab-flat");
-    CRGeneratorRunner runner = new CRGeneratorRunner(
-        new Config(null, null, null, null, null, Config.CodeStructure.FLAT, false));
-
-    // Act
-    runner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(3, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testCrontabCRDCompilesWithExtraAnnotationsAndUnknownFields() throws Exception {
-    // Arrange
-    File crd = getCRD("crontab-crd.yml");
-    File dest = tmpFolder.newFolder("crontab-extra-annot");
-    CRGeneratorRunner runner = new CRGeneratorRunner(new Config(null, null, null, true, true, null, false));
-
-    // Act
-    runner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(3, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testKeycloakCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("keycloak-crd.yml");
-    File dest = tmpFolder.newFolder("keycloak");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(50, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testAkkaMicroservicesCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("akka-microservices-crd.yml");
-    File dest = tmpFolder.newFolder("akka-microservices");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(28, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testStrimziCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("strimzi-kafka-crd.yml");
-    File dest = tmpFolder.newFolder("strimzi");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(704, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testSparkCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("spark-crd.yml");
-    File dest = tmpFolder.newFolder("spark");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(358, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testCrunchyCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("crunchy-postgres-crd.yml");
-    File dest = tmpFolder.newFolder("crunchy");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(267, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testKameletCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("kamelet-crd.yml");
-    File dest = tmpFolder.newFolder("kamelet");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(16, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testJokeRequestsCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("jokerequests-crd.yml");
-    File dest = tmpFolder.newFolder("jokes");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(3, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testCertManagerCRDCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("cert-manager-crd.yml");
-    File dest = tmpFolder.newFolder("cert-manager");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(5, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testMultipleCRDsCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("two-crds.yml");
-    File dest = tmpFolder.newFolder("two-crds");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(6, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testCRDsInFolderCompiles() throws Exception {
-    // Arrange
-    File crd = getCRD("folder");
-    File dest = tmpFolder.newFolder("folder");
-
-    // Act
-    defaultRunner.run(crd, dest);
-    Compilation compilation = javac().compile(getSources(dest));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(6, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @AfterAll
-  public static void afterAll() {
-    tmpFolder.delete();
+  static File getCRD(String name) throws Exception {
+    return Paths.get(CompilationTest.class.getClassLoader().getResource(name).toURI()).toFile();
   }
 }

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/ConfigTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/ConfigTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.java.generator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigTest {
+
+  @Test
+  void defaultValuesWithAllArgsConstructor() {
+    final Config result = new Config(null, null, null, null, null, null, null);
+    assertThat(result)
+        .returns(true, Config::isUppercaseEnums)
+        .returns(Config.Prefix.TOP_LEVEL, Config::getPrefixStrategy)
+        .returns(Config.Suffix.TOP_LEVEL, Config::getSuffixStrategy)
+        .returns(false, Config::isAlwaysPreserveUnknownFields)
+        .returns(false, Config::isObjectExtraAnnotations)
+        .returns(Config.CodeStructure.PACKAGE_NESTED, Config::getCodeStructure)
+        .returns(true, Config::isGeneratedAnnotations);
+  }
+
+  @Test
+  void defaultValuesWithNoArgsConstructor() {
+    final Config result = new Config();
+    assertThat(result)
+        .returns(true, Config::isUppercaseEnums)
+        .returns(Config.Prefix.TOP_LEVEL, Config::getPrefixStrategy)
+        .returns(Config.Suffix.TOP_LEVEL, Config::getSuffixStrategy)
+        .returns(false, Config::isAlwaysPreserveUnknownFields)
+        .returns(false, Config::isObjectExtraAnnotations)
+        .returns(Config.CodeStructure.PACKAGE_NESTED, Config::getCodeStructure)
+        .returns(true, Config::isGeneratedAnnotations);
+  }
+
+  @Test
+  void defaultValuesWithBuilder() {
+    final Config result = Config.builder().build();
+    assertThat(result)
+        .returns(true, Config::isUppercaseEnums)
+        .returns(Config.Prefix.TOP_LEVEL, Config::getPrefixStrategy)
+        .returns(Config.Suffix.TOP_LEVEL, Config::getSuffixStrategy)
+        .returns(false, Config::isAlwaysPreserveUnknownFields)
+        .returns(false, Config::isObjectExtraAnnotations)
+        .returns(Config.CodeStructure.PACKAGE_NESTED, Config::getCodeStructure)
+        .returns(true, Config::isGeneratedAnnotations);
+  }
+}

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
+import static io.fabric8.java.generator.CRGeneratorRunner.groupToPackage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -45,11 +46,8 @@ class GeneratorTest {
 
   @Test
   void testCorrectInterpolationOfPackage() {
-    // Arrange
-    CRGeneratorRunner runner = new CRGeneratorRunner(defaultConfig);
-
     // Act
-    String packageName = runner.getPackage("test.org");
+    String packageName = groupToPackage("test.org");
 
     // Assert
     assertEquals("org.test", packageName);

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/URLJavaGeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/URLJavaGeneratorTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.java.generator;
+
+import io.fabric8.java.generator.exceptions.JavaGeneratorException;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.mockwebserver.DefaultMockServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class URLJavaGeneratorTest {
+
+  @TempDir
+  private File downloadLocation;
+  @TempDir
+  private File outputLocation;
+
+  @Test
+  void nullUrlsThrowsException() {
+    final URLJavaGenerator generator = new URLJavaGenerator(new Config(), null, downloadLocation);
+    assertThatThrownBy(() -> generator.run(outputLocation))
+        .isInstanceOf(JavaGeneratorException.class)
+        .hasMessage("No URLs provided");
+  }
+
+  @Test
+  void emptyUrlsThrowsException() {
+    final URLJavaGenerator generator = new URLJavaGenerator(new Config(), Collections.emptyList(), downloadLocation);
+    assertThatThrownBy(() -> generator.run(outputLocation))
+        .isInstanceOf(JavaGeneratorException.class)
+        .hasMessage("No URLs provided");
+  }
+
+  @Test
+  void nullDirectoryThrowsException() throws IOException {
+    final List<URL> urls = Collections.singletonList(new URL("https://www.example.com"));
+    final URLJavaGenerator generator = new URLJavaGenerator(new Config(), urls, null);
+    assertThatThrownBy(() -> generator.run(outputLocation))
+        .isInstanceOf(JavaGeneratorException.class)
+        .hasMessage("Download directory is required");
+  }
+
+  @Test
+  void directoryIsInvalidThrowsException() throws IOException {
+    final File invalidDirectory = Files.createTempFile(downloadLocation.toPath(), "invalid", "file")
+        .toFile();
+    final List<URL> urls = Collections.singletonList(new URL("https://www.example.com"));
+    final URLJavaGenerator generator = new URLJavaGenerator(new Config(), urls, invalidDirectory);
+    assertThatThrownBy(() -> generator.run(outputLocation))
+        .isInstanceOf(JavaGeneratorException.class)
+        .hasMessageStartingWith("Download directory")
+        .hasMessageEndingWith("file is not a valid directory");
+  }
+
+  @Test
+  void downloadsFileAndGeneratesJavaClasses() throws IOException {
+    final DefaultMockServer server = new DefaultMockServer();
+    try {
+      server.start();
+      server.expect().withPath("/cert-manager-crd.yml")
+          .andReturn(200, Serialization.unmarshal(URLJavaGeneratorTest.class.getResourceAsStream("/cert-manager-crd.yml")))
+          .always();
+      final URLJavaGenerator generator = new URLJavaGenerator(new Config(),
+          Collections.singletonList(new URL(server.url("/cert-manager-crd.yml"))), downloadLocation);
+      generator.run(outputLocation);
+      assertThat(new File(downloadLocation, "cert-manager-crd.yml"))
+          .isFile().exists().isNotEmpty();
+      assertThat(outputLocation.toPath().resolve("io").resolve("cert_manager").resolve("v1").resolve("CertificateRequest.java"))
+          .exists()
+          .isNotEmptyFile();
+    } finally {
+      server.shutdown();
+    }
+  }
+}

--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -15,8 +15,9 @@
  */
 package io.fabric8.java.generator.maven.plugin;
 
-import io.fabric8.java.generator.CRGeneratorRunner;
 import io.fabric8.java.generator.Config;
+import io.fabric8.java.generator.FileJavaGenerator;
+import io.fabric8.java.generator.JavaGenerator;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -147,8 +148,8 @@ public class JavaGeneratorMojo extends AbstractMojo {
         extraAnnotations,
         codeStructure,
         generatedAnnotations);
-    final CRGeneratorRunner runner = new CRGeneratorRunner(config);
-    runner.run(source, target);
+    final JavaGenerator runner = new FileJavaGenerator(config, source);
+    runner.run(target);
     project.addCompileSourceRoot(target.getAbsolutePath());
   }
 }


### PR DESCRIPTION
## Description

Fix #4709 

Generalizes the generate Java from remote URL CRD.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
