### PR TITLE
[java-generator] enable url as a source in the cli

### DIFF
--- a/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
+++ b/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
@@ -18,19 +18,36 @@ package io.fabric8.java.generator.cli;
 import io.fabric8.java.generator.Config;
 import io.fabric8.java.generator.FileJavaGenerator;
 import io.fabric8.java.generator.JavaGenerator;
+import io.fabric8.java.generator.URLJavaGenerator;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Command(name = "java-gen", mixinStandardHelpOptions = true, helpCommand = true, versionProvider = KubernetesClientVersionProvider.class)
 public class GenerateJavaSources implements Runnable {
 
+  @CommandLine.Spec
+  CommandLine.Model.CommandSpec spec;
+
   @Option(names = { "-s",
-      "--source" }, description = "The source(file or folder) with the CustomResourceDefinition(s) to use", required = true)
+      "--source" }, description = "The source(file or folder) with the CustomResourceDefinition(s) to use")
   File source;
+
+  @Option(names = { "-u",
+      "--urls" }, description = "The source urls with the CustomResourceDefinition(s) to use")
+  String[] urls;
+
+  @Option(names = { "-dt", "--download-target" }, description = "The folder to be used as a target for the downloaded crds")
+  File downloadTarget;
 
   @Option(names = { "-t", "--target" }, description = "The folder to write the generated sources", required = true)
   File target;
@@ -80,8 +97,39 @@ public class GenerateJavaSources implements Runnable {
         structure,
         generatedAnnotations,
         packageOverrides);
-    final JavaGenerator runner = new FileJavaGenerator(config, source);
-    runner.run(target);
+
+    List<JavaGenerator> runners = new ArrayList<>();
+
+    if (urls != null && urls.length > 0) {
+      final List<URL> urlList = new ArrayList<>();
+      for (String url : urls) {
+        try {
+          urlList.add(new URL(url));
+        } catch (MalformedURLException e) {
+          throw new CommandLine.ParameterException(spec.commandLine(), "URL '" + url + "' is not valid", e);
+        }
+      }
+      if (downloadTarget == null) {
+        try {
+          downloadTarget = Files.createTempDirectory("java-gen").toFile();
+        } catch (IOException e) {
+          throw new CommandLine.ParameterException(spec.commandLine(),
+              "Unable to create a temporary folder, please provide an explicit '--download-target' option", e);
+        }
+      }
+
+      runners.add(new URLJavaGenerator(config, urlList, downloadTarget));
+    }
+
+    if (source != null) {
+      runners.add(new FileJavaGenerator(config, source));
+    }
+
+    if (runners.isEmpty()) {
+      throw new CommandLine.ParameterException(spec.commandLine(), "No source or urls specified");
+    }
+
+    runners.forEach(r -> r.run(target));
   }
 
   public static void main(String[] args) {

--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -135,9 +135,9 @@ public class JavaGeneratorMojo extends AbstractMojo {
         .packageOverrides(packageOverrides)
         .build();
 
-    boolean executed = false;
+    List<JavaGenerator> runners = new ArrayList<>();
+
     if (urls != null && urls.length > 0) {
-      executed = true;
       final List<URL> urlList = new ArrayList<>();
       for (String url : urls) {
         try {
@@ -146,16 +146,18 @@ public class JavaGeneratorMojo extends AbstractMojo {
           throw new MojoExecutionException("URL '" + url + "' is not valid", e);
         }
       }
-      new URLJavaGenerator(config, urlList, downloadTarget).run(target);
+      runners.add(new URLJavaGenerator(config, urlList, downloadTarget));
     }
+
     if (source != null) {
-      executed = true;
-      final JavaGenerator runner = new FileJavaGenerator(config, source);
-      runner.run(target);
+      runners.add(new FileJavaGenerator(config, source));
     }
-    if (!executed) {
+
+    if (runners.isEmpty()) {
       throw new MojoExecutionException("No source or urls specified");
     }
+
+    runners.forEach(r -> r.run(target));
     project.addCompileSourceRoot(target.getAbsolutePath());
   }
 }


### PR DESCRIPTION
## Description
Expose the option to download the CRD from URL to the CLI.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

