### PR TITLE
fix #4720: ensuring the previous response is closed

### DIFF
--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -81,7 +81,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -159,7 +159,7 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
     private T body;
     private Class<T> type;
 
-    public OkHttpResponseImpl(Response response, T body) throws IOException {
+    public OkHttpResponseImpl(Response response, T body) {
       this.response = response;
       this.body = body;
     }

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
@@ -81,6 +81,7 @@ class OkHttpWebSocketImpl implements WebSocket {
           if (response != null) {
             try {
               future.complete(new WebSocketResponse(null,
+                  // passing null as the type ensures that the response body is closed
                   new WebSocketHandshakeException(new OkHttpResponseImpl<>(response, null)).initCause(t)));
             } catch (IOException e) {
               // can't happen

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpResponseImplTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpResponseImplTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import okhttp3.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class OkHttpResponseImplTest {
+
+  @Test
+  @DisplayName("constructor, with type=null, should close the response body")
+  void nullTypeClosesResponseBody() throws IOException {
+    // Given
+    final Response response = mock(Response.class, RETURNS_DEEP_STUBS);
+    // When
+    new OkHttpClientImpl.OkHttpResponseImpl<>(response, null);
+    // Then
+    verify(response.body(), times(1)).close();
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
@@ -63,6 +63,8 @@ public abstract class StandardHttpClient<C extends HttpClient, F extends HttpCli
               .afterFailure(copy, response)
               .thenCompose(b -> {
                 if (Boolean.TRUE.equals(b)) {
+                  // before starting another request, make sure the old one is cancelled / closed
+                  response.body().cancel();
                   return consumeBytesDirect(copy.build(), consumer);
                 }
                 return CompletableFuture.completedFuture(response);

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractInterceptorTest {
 
@@ -148,13 +148,11 @@ public abstract class AbstractInterceptorTest {
   public void afterHttpFailureReplacesResponseInSendAsync() throws Exception {
     // Given
     server.expect().withPath("/intercepted-url").andReturn(200, "This works").once();
-    AtomicReference<HttpResponse<?>> responseRef = new AtomicReference<>();
     final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
         .addOrReplaceInterceptor("test", new Interceptor() {
           @Override
           public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
             builder.uri(URI.create(server.url("/intercepted-url")));
-            responseRef.set(response);
             return CompletableFuture.completedFuture(true);
           }
         });
@@ -167,8 +165,6 @@ public abstract class AbstractInterceptorTest {
       assertThat(result)
           .returns("This works", HttpResponse::body)
           .returns(200, HttpResponse::code);
-
-      assertTrue(((AsyncBody) responseRef.get().body()).done().isDone());
     }
   }
 
@@ -177,13 +173,11 @@ public abstract class AbstractInterceptorTest {
   public void afterHttpFailureReplacesResponseInConsumeBytes() throws Exception {
     // Given
     server.expect().withPath("/intercepted-url").andReturn(200, "This works").once();
-    AtomicReference<HttpResponse<?>> responseRef = new AtomicReference<>();
     final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
         .addOrReplaceInterceptor("test", new Interceptor() {
           @Override
           public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
             builder.uri(URI.create(server.url("/intercepted-url")));
-            responseRef.set(response);
             return CompletableFuture.completedFuture(true);
           }
         });
@@ -201,9 +195,44 @@ public abstract class AbstractInterceptorTest {
       asyncR.body().done().get(10L, TimeUnit.SECONDS);
       // Then
       assertThat(result.get()).isEqualTo("This works");
-
-      assertTrue(((AsyncBody) responseRef.get().body()).done().isDone());
     }
+  }
+
+  @Test
+  @DisplayName("afterFailure (HTTP), previous consumed response bodies are closed")
+  public void afterHttpFailurePreviousResponsesAreClosed() throws Exception {
+    // Given
+    server.expect().withPath("/intercepted-url").andReturn(200, "This works").once();
+    final Set<HttpResponse<?>> interceptedResponses = ConcurrentHashMap.newKeySet();
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .addOrReplaceInterceptor("invalid-url", new Interceptor() {
+          @Override
+          public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
+            builder.uri(URI.create(server.url("/still-not-found")));
+            interceptedResponses.add(response);
+            return CompletableFuture.completedFuture(true);
+          }
+        })
+        .addOrReplaceInterceptor("valid-url", new Interceptor() {
+          @Override
+          public CompletableFuture<Boolean> afterFailure(BasicBuilder builder, HttpResponse<?> response) {
+            builder.uri(URI.create(server.url("/intercepted-url")));
+            interceptedResponses.add(response);
+            return CompletableFuture.completedFuture(true);
+          }
+        });
+    // When
+    try (HttpClient client = builder.build()) {
+      client.consumeBytes(
+          client.newHttpRequestBuilder().uri(server.url("/not-found")).build(),
+          (s, ab) -> ab.consume())
+          .get(10, TimeUnit.SECONDS);
+    }
+    // Then
+    assertThat(interceptedResponses)
+        .hasSize(2)
+        .extracting(r -> ((AsyncBody) r.body()).done().isDone())
+        .containsOnly(true, true);
   }
 
   @Test


### PR DESCRIPTION
## Description

Fix #4720

Addresses #4720 - this must have been a latent bug in the jdk interceptor handling that when elevated caused the previous response to not be closed. 

It turns out that we don't need explicit handling in the websocket case - we are passing a null type in the okhttp logic, which auto-closes the response.  The other clients (jdk, jetty) start from exceptional cases that do not provide usable responses.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
