### PR TITLE
fix #4729: completablefuture cancel will close the underlying resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.4-SNAPSHOT
 
 #### Bugs
+* Fix #4729: ensuring completablefuture cancel will close / cancel the underlying resource
 
 #### Improvements
 * Fix #4637: all pod operations that require a ready / succeeded pod may use withReadyWaitTimeout, which supersedes withLogWaitTimeout.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
@@ -174,9 +174,7 @@ public interface HttpClient extends AutoCloseable {
    * @param type one of InputStream, Reader, String, byte[]
    * @return a CompletableFuture that returns the resulting HttpResponse when complete
    */
-  default <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, Class<T> type) {
-    return HttpResponse.SupportedResponses.from(type).sendAsync(request, this);
-  }
+  <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, Class<T> type);
 
   /**
    * Send a request and consume the bytes of the resulting response body

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.client.http.WebSocket.Listener;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -28,32 +29,39 @@ import java.util.concurrent.CompletableFuture;
 
 class StandardHttpClientTest {
 
+  private static final class TestableStandardHttpClient
+      extends StandardHttpClient<HttpClient, Factory, StandardHttpClientBuilder<HttpClient, Factory, ?>> {
+    CompletableFuture<WebSocketResponse> wsFuture;
+    CompletableFuture<HttpResponse<AsyncBody>> respFuture;
+
+    private TestableStandardHttpClient() {
+      super(Mockito.mock(StandardHttpClientBuilder.class));
+    }
+
+    @Override
+    public void close() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<WebSocketResponse> buildWebSocketDirect(StandardWebSocketBuilder standardWebSocketBuilder,
+        Listener listener) {
+      this.wsFuture = new CompletableFuture<>();
+      return wsFuture;
+    }
+
+    @Override
+    public CompletableFuture<HttpResponse<AsyncBody>> consumeBytesDirect(StandardHttpRequest request,
+        Consumer<List<ByteBuffer>> consumer) {
+      this.respFuture = new CompletableFuture<>();
+      return respFuture;
+    }
+  }
+
+  private TestableStandardHttpClient client = new TestableStandardHttpClient();
+
   @Test
-  void futureCancel() {
-    CompletableFuture<WebSocketResponse> wsFuture = new CompletableFuture<WebSocketResponse>();
-    CompletableFuture<HttpResponse<AsyncBody>> respFuture = new CompletableFuture<HttpResponse<AsyncBody>>();
-    StandardHttpClientBuilder<HttpClient, Factory, StandardHttpClientBuilder<HttpClient, Factory, ?>> builder = Mockito
-        .mock(StandardHttpClientBuilder.class);
-    StandardHttpClient<HttpClient, Factory, StandardHttpClientBuilder<HttpClient, Factory, ?>> client = new StandardHttpClient<HttpClient, Factory, StandardHttpClientBuilder<HttpClient, Factory, ?>>(
-        builder) {
-
-      @Override
-      public void close() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public CompletableFuture<WebSocketResponse> buildWebSocketDirect(StandardWebSocketBuilder standardWebSocketBuilder,
-          Listener listener) {
-        return wsFuture;
-      }
-
-      @Override
-      public CompletableFuture<HttpResponse<AsyncBody>> consumeBytesDirect(StandardHttpRequest request,
-          Consumer<List<ByteBuffer>> consumer) {
-        return respFuture;
-      }
-    };
+  void webSocketFutureCancel() {
     CompletableFuture<WebSocket> future = client.newWebSocketBuilder().uri(URI.create("ws://localhost"))
         .buildAsync(new Listener() {
         });
@@ -62,11 +70,14 @@ class StandardHttpClientTest {
 
     // cancel the future before the websocket response
     future.cancel(true);
-    wsFuture.complete(new WebSocketResponse(ws, null));
+    client.wsFuture.complete(new WebSocketResponse(ws, null));
 
     // ensure that the ws has been closed
     Mockito.verify(ws).sendClose(1000, null);
+  }
 
+  @Test
+  void consumeBytesFutureCancel() {
     HttpResponse<AsyncBody> asyncResp = Mockito.mock(HttpResponse.class, Mockito.RETURNS_DEEP_STUBS);
     Mockito.when(asyncResp.body()).thenReturn(Mockito.mock(AsyncBody.class));
 
@@ -80,7 +91,22 @@ class StandardHttpClientTest {
 
     // cancel the future before the response
     consumeFuture.cancel(true);
-    respFuture.complete(asyncResp);
+    client.respFuture.complete(asyncResp);
+    Mockito.verify(asyncResp.body()).cancel();
+  }
+
+  @Test
+  void sendAsyncFutureCancel() {
+    HttpResponse<AsyncBody> asyncResp = Mockito.mock(HttpResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(asyncResp.body()).thenReturn(Mockito.mock(AsyncBody.class));
+    Mockito.when(asyncResp.body().done()).thenReturn(new CompletableFuture<>());
+
+    CompletableFuture<?> sendAsyncFuture = client.sendAsync(client.newHttpRequestBuilder().uri("http://localhost").build(),
+        InputStream.class);
+
+    // cancel the future before the response
+    sendAsyncFuture.cancel(true);
+    client.respFuture.complete(asyncResp);
     Mockito.verify(asyncResp.body()).cancel();
   }
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.kubernetes.client.http.AsyncBody.Consumer;
+import io.fabric8.kubernetes.client.http.HttpClient.Factory;
+import io.fabric8.kubernetes.client.http.WebSocket.Listener;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+class StandardHttpClientTest {
+
+  @Test
+  void futureCancel() {
+    CompletableFuture<WebSocketResponse> wsFuture = new CompletableFuture<WebSocketResponse>();
+    CompletableFuture<HttpResponse<AsyncBody>> respFuture = new CompletableFuture<HttpResponse<AsyncBody>>();
+    StandardHttpClientBuilder<HttpClient, Factory, StandardHttpClientBuilder<HttpClient, Factory, ?>> builder = Mockito
+        .mock(StandardHttpClientBuilder.class);
+    StandardHttpClient<HttpClient, Factory, StandardHttpClientBuilder<HttpClient, Factory, ?>> client = new StandardHttpClient<HttpClient, Factory, StandardHttpClientBuilder<HttpClient, Factory, ?>>(
+        builder) {
+
+      @Override
+      public void close() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public CompletableFuture<WebSocketResponse> buildWebSocketDirect(StandardWebSocketBuilder standardWebSocketBuilder,
+          Listener listener) {
+        return wsFuture;
+      }
+
+      @Override
+      public CompletableFuture<HttpResponse<AsyncBody>> consumeBytesDirect(StandardHttpRequest request,
+          Consumer<List<ByteBuffer>> consumer) {
+        return respFuture;
+      }
+    };
+    CompletableFuture<WebSocket> future = client.newWebSocketBuilder().uri(URI.create("ws://localhost"))
+        .buildAsync(new Listener() {
+        });
+
+    WebSocket ws = Mockito.mock(WebSocket.class);
+
+    // cancel the future before the websocket response
+    future.cancel(true);
+    wsFuture.complete(new WebSocketResponse(ws, null));
+
+    // ensure that the ws has been closed
+    Mockito.verify(ws).sendClose(1000, null);
+
+    HttpResponse<AsyncBody> asyncResp = Mockito.mock(HttpResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(asyncResp.body()).thenReturn(Mockito.mock(AsyncBody.class));
+
+    CompletableFuture<?> consumeFuture = client.consumeBytes(client.newHttpRequestBuilder().uri("http://localhost").build(),
+        new Consumer<List<ByteBuffer>>() {
+          @Override
+          public void consume(List<ByteBuffer> value, AsyncBody asyncBody) throws Exception {
+
+          }
+        });
+
+    // cancel the future before the response
+    consumeFuture.cancel(true);
+    respFuture.complete(asyncResp);
+    Mockito.verify(asyncResp.body()).cancel();
+  }
+
+}


### PR DESCRIPTION
## Description

Fix #4729 

@manusa  in reviewing the other recent issues along these lines, I think this is another corner-ish case.  It addresses the possibility of a resource leak due to an ill-defined expectation of cancelling the CompletableFutures returned by the http client layer.  If the cancel happens before the future is completed, then the resource may not get closed.

The fix here is to bake that responsibility into the standardhttpclient.  A different way of addressing this is to instead have HttpClient return a CompletionStage - which makes it clear that you are instead supposed to "cancel" via a thenAccept or whenComplete handler that closes things out.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
