### PR TITLE
Fix #4739: Mock server doesn't handle optimistic concurrency control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #4739: honor optimistic concurrency control semantics in the mock server for `PUT` and `PATCH` requests.
 
 #### Dependency Upgrade
 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PatchHandler.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PatchHandler.java
@@ -63,6 +63,7 @@ public class PatchHandler implements KubernetesCrudDispatcherHandler {
       fullPatch = persistence.merge(currentResource, requestBody);
     }
     validatePath(query, fullPatch);
+    validateResourceVersion(currentResource, fullPatch);
 
     final JsonNode updatedResource;
     if (isStatusPath(path)) {

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PutHandler.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PutHandler.java
@@ -57,6 +57,8 @@ public class PutHandler implements KubernetesCrudDispatcherHandler {
       }
     }
     validatePath(attributes, updatedResource);
+    validateResourceVersion(currentResource, updatedResource);
+
     persistence.preserveMetadata(currentResource, updatedResource);
     if (!isStatusPath(path)) {
       persistence.touchGeneration(currentResource, updatedResource);


### PR DESCRIPTION
## Description

This PR fixes #4739.

A couple of minor points worthy of discussion:

1. I added the check to the path for `PATCH` as well as `PUT` requests, but I haven't added a unit test for this case.
2. When constructing the error message Kubernetes refers to the resource type using the singular name of the resource (e.g. `configmap`), but I don't have ready access to that in the `KubernetesCrudDispatcherHandler`, so I've used the `metadata.kind` instead (e.g. `ConfigMap`). Therefore there is a slight difference in the `KubernetesClientException` error message.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
