### PR TITLE
refactor: Kubernetes JUnit extension is more granular

### DIFF
--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/KubernetesExtension.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/KubernetesExtension.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.junit.jupiter;
+
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class KubernetesExtension implements HasKubernetesClient, BeforeAllCallback, BeforeEachCallback {
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    for (Field field : extractFields(context, KubernetesClient.class, f -> Modifier.isStatic(f.getModifiers()))) {
+      setFieldValue(field, null, getClient(context).adapt((Class<Client>) field.getType()));
+    }
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    for (Field field : extractFields(context, KubernetesClient.class, f -> !Modifier.isStatic(f.getModifiers()))) {
+      setFieldValue(field, context.getRequiredTestInstance(), getClient(context).adapt((Class<Client>) field.getType()));
+    }
+  }
+}

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/LoadKubernetesManifestsExtension.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/LoadKubernetesManifestsExtension.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
- * Must be used in conjunction with {@link KubernetesNamespacedTestExtension} to be able to consume a KubernetesClient
+ * Must be used in conjunction with {@link KubernetesExtension} to be able to consume a KubernetesClient
  */
 public class LoadKubernetesManifestsExtension implements HasKubernetesClient, BeforeAllCallback, AfterAllCallback {
 

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/NamespaceExtension.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/NamespaceExtension.java
@@ -19,7 +19,6 @@ import io.fabric8.junit.jupiter.api.KubernetesTest;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectReference;
-import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
@@ -35,8 +34,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-public class KubernetesNamespacedTestExtension
-    implements HasKubernetesClient, BeforeAllCallback, BeforeEachCallback, AfterAllCallback {
+public class NamespaceExtension implements HasKubernetesClient, BeforeAllCallback, BeforeEachCallback, AfterAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
@@ -47,9 +45,6 @@ public class KubernetesNamespacedTestExtension
       getStore(context).put(KubernetesClient.class,
           client.adapt(NamespacedKubernetesClient.class).inNamespace(getKubernetesNamespace(context).getMetadata().getName()));
     }
-    for (Field field : extractFields(context, KubernetesClient.class, f -> Modifier.isStatic(f.getModifiers()))) {
-      setFieldValue(field, null, getClient(context).adapt((Class<Client>) field.getType()));
-    }
     for (Field field : extractFields(context, Namespace.class, f -> Modifier.isStatic(f.getModifiers()))) {
       setFieldValue(field, null, getKubernetesNamespace(context));
     }
@@ -57,9 +52,6 @@ public class KubernetesNamespacedTestExtension
 
   @Override
   public void beforeEach(ExtensionContext context) throws Exception {
-    for (Field field : extractFields(context, KubernetesClient.class, f -> !Modifier.isStatic(f.getModifiers()))) {
-      setFieldValue(field, context.getRequiredTestInstance(), getClient(context).adapt((Class<Client>) field.getType()));
-    }
     for (Field field : extractFields(context, Namespace.class, f -> !Modifier.isStatic(f.getModifiers()))) {
       setFieldValue(field, context.getRequiredTestInstance(), getKubernetesNamespace(context));
     }

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/KubernetesTest.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/KubernetesTest.java
@@ -15,7 +15,8 @@
  */
 package io.fabric8.junit.jupiter.api;
 
-import io.fabric8.junit.jupiter.KubernetesNamespacedTestExtension;
+import io.fabric8.junit.jupiter.KubernetesExtension;
+import io.fabric8.junit.jupiter.NamespaceExtension;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -28,7 +29,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Enables and configures the {@link KubernetesNamespacedTestExtension} extension.
+ * Enables and configures the {@link KubernetesExtension} extension.
  *
  * <p>
  * Creates a {@link KubernetesClient} instance that will
@@ -48,7 +49,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Target({ TYPE, METHOD, ANNOTATION_TYPE })
 @Retention(RUNTIME)
-@ExtendWith(KubernetesNamespacedTestExtension.class)
+@ExtendWith(NamespaceExtension.class)
+@ExtendWith(KubernetesExtension.class)
 public @interface KubernetesTest {
   /**
    * Create an ephemeral Namespace for the test.

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/LoadKubernetesManifests.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/LoadKubernetesManifests.java
@@ -15,8 +15,9 @@
  */
 package io.fabric8.junit.jupiter.api;
 
-import io.fabric8.junit.jupiter.KubernetesNamespacedTestExtension;
+import io.fabric8.junit.jupiter.KubernetesExtension;
 import io.fabric8.junit.jupiter.LoadKubernetesManifestsExtension;
+import io.fabric8.junit.jupiter.NamespaceExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.Retention;
@@ -36,7 +37,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Target({ TYPE, METHOD, ANNOTATION_TYPE })
 @Retention(RUNTIME)
-@ExtendWith(KubernetesNamespacedTestExtension.class)
+@ExtendWith(NamespaceExtension.class)
+@ExtendWith(KubernetesExtension.class)
 @ExtendWith(LoadKubernetesManifestsExtension.class)
 public @interface LoadKubernetesManifests {
 

--- a/junit/kubernetes-junit-jupiter/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/junit/kubernetes-junit-jupiter/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,2 @@
-io.fabric8.junit.jupiter.KubernetesNamespacedTestExtension
+io.fabric8.junit.jupiter.NamespaceExtension
+io.fabric8.junit.jupiter.KubernetesExtension


### PR DESCRIPTION
## Description
refactor: Kubernetes JUnit extension is more granular

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
