### PR TITLE
adding a small note about waitable

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Waitable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Waitable.java
@@ -26,7 +26,9 @@ public interface Waitable<T, P> {
    * Wait for the given condition to be true.
    * <p>
    * The processing of events will be in the IO thread, blocking operations should be avoided.
-   * 
+   * <p>
+   * If nothing exists, the condition will be tested with a null value.
+   *
    * @param condition
    * @param amount
    * @param timeUnit

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericClusterScopedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericClusterScopedCustomResourceIT.java
@@ -51,8 +51,9 @@ class GenericClusterScopedCustomResourceIT {
     client.apiextensions().v1().customResourceDefinitions()
         .withName("satellites.demos.fabric8.io")
         .waitUntilCondition(
-            c -> c.getStatus() != null && c.getStatus().getConditions() != null && c.getStatus().getConditions().stream()
-                .anyMatch(crdc -> crdc.getType().equals("Established") && crdc.getStatus().equals("True")),
+            c -> c != null && c.getStatus() != null && c.getStatus().getConditions() != null
+                && c.getStatus().getConditions().stream()
+                    .anyMatch(crdc -> crdc.getType().equals("Established") && crdc.getStatus().equals("True")),
             10L, TimeUnit.SECONDS);
   }
 


### PR DESCRIPTION
## Description
This is to address the test failure https://github.com/fabric8io/kubernetes-client/actions/runs/3856547075/jobs/6576802948#step:6:480

More than likely this is due to the change to initially start the informer with a list at a cached version - it's not guaranteed that the newly created crd will initially be there.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
