### PR TITLE
feat(vertx): support for 8192 simultaneous connections

### DIFF
--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
@@ -57,6 +57,8 @@ import java.util.stream.Stream;
 
 public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http.HttpClient.Factory {
 
+  private static final int MAX_CONNECTIONS = 8192;
+
   private Vertx vertx;
 
   public VertxHttpClientFactory() {
@@ -76,6 +78,8 @@ public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http
 
       WebClientOptions options = new WebClientOptions();
 
+      options.setMaxPoolSize(MAX_CONNECTIONS);
+      options.setMaxWebSockets(MAX_CONNECTIONS);
       options.setIdleTimeoutUnit(TimeUnit.SECONDS);
 
       if (this.connectTimeout != null) {


### PR DESCRIPTION
## Description

Closes #4748 

Replaces #4748 with the rebased branch that contains the fix for the simultaneous connection test, and includes the changes to increase the hard max connection limit to 8192.

It's my understanding that this completes the initial working implementation of the client.

@vietj @shawkins 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
