### PR TITLE
fix(vertx): ReadStream pause before propagating WS message

### DIFF
--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxWebSocket.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxWebSocket.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class VertxWebSocket implements WebSocket {
 
-  private io.vertx.core.http.WebSocket ws;
+  private final io.vertx.core.http.WebSocket ws;
   private final AtomicInteger pending = new AtomicInteger();
   private final Listener listener;
 
@@ -37,12 +37,12 @@ class VertxWebSocket implements WebSocket {
 
   void init() {
     ws.binaryMessageHandler(msg -> {
-      listener.onMessage(this, msg.getByteBuf().nioBuffer());
       ws.pause();
+      listener.onMessage(this, msg.getByteBuf().nioBuffer());
     });
     ws.textMessageHandler(msg -> {
-      listener.onMessage(this, msg);
       ws.pause();
+      listener.onMessage(this, msg);
     });
     ws.closeHandler(v -> listener.onClose(this, ws.closeStatusCode(), ws.closeReason()));
     ws.exceptionHandler(err -> listener.onError(this, err));

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientNewWebSocketBuilderTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientNewWebSocketBuilderTest.java
@@ -25,7 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -80,6 +83,33 @@ public abstract class AbstractHttpClientNewWebSocketBuilderTest {
           }
         }).get(10L, TimeUnit.SECONDS);
     assertThat(open).isTrue();
+  }
+
+  @Test
+  void buildAsyncReceivesMultipleMessages() throws Exception {
+    server.expect().withPath("/websocket-multiple-message")
+        .andUpgradeToWebSocket()
+        .open()
+        .waitFor(10L)
+        .andEmit("First")
+        .waitFor(10L)
+        .andEmit("Second")
+        .done()
+        .always();
+    final CountDownLatch latch = new CountDownLatch(2);
+    final Set<String> messages = ConcurrentHashMap.newKeySet();
+    final WebSocket ws = httpClient.newWebSocketBuilder()
+        .uri(URI.create(server.url("/websocket-multiple-message")))
+        .buildAsync(new WebSocket.Listener() {
+          @Override
+          public void onMessage(WebSocket webSocket, String text) {
+            messages.add(text);
+            webSocket.request();
+            latch.countDown();
+          }
+        }).get(10L, TimeUnit.SECONDS);
+    assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+    assertThat(messages).containsExactlyInAnyOrder("First", "Second");
   }
 
   @Test


### PR DESCRIPTION
## Description
fix(vertx): ReadStream pause before propagating WS message

E2E reveals that the place where ws.pause is called prevents further messages from being received at the Watcher level. The stream needs to be paused first and then propagate the message downstream, in case the handler calls the WebSocket.request method.

/cc @vietj @shawkins 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
