### PR TITLE
Doc: Cheatsheet ingress should use network v1 api

### DIFF
--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -910,14 +910,14 @@ client.serviceAccounts().inNamespace("default").withName("serviceaccount1").dele
 ```
 
 ### Ingress
-`Ingress` resource is available in Kubernetes Client API via `client.network().ingress()`. Here are some examples regarding its usage:
+`Ingress` resource is available in Kubernetes Client API via `client.network().v1().ingress()`. Here are some examples regarding its usage:
 - Load `Ingress` from yaml:
 ```
-Ingress ingress = client.network().ingress().load(new FileInputStream("ingress.yml")).get();
+Ingress ingress = client.network().v1().ingress().load(new FileInputStream("ingress.yml")).get();
 ```
 - Get `Ingress` from Kubernetes API server:
 ```
-Ingress ingress = client.network().ingress().inNamespace("default").withName("ingress1").get();
+Ingress ingress = client.network().v1().ingress().inNamespace("default").withName("ingress1").get();
 ```
 - Create `Ingress`:
 ```
@@ -933,27 +933,27 @@ Ingress ingress = new IngressBuilder()
   .endRule()
   .endSpec()
   .build();
-client.network().ingress().inNamespace("default").create(ingress);
+client.network().v1().ingress().inNamespace("default").create(ingress);
 ```
 - Create or Replace `Ingress`:
 ```
-Ingress igx = client.network().ingress().inNamespace("default").createOrReplace(ingress);
+Ingress igx = client.network().v1().ingress().inNamespace("default").createOrReplace(ingress);
 ```
 - List `Ingress` in some namespace:
 ```
-IngressList ingressList = client.network().ingress().inNamespace("default").list();
+IngressList ingressList = client.network().v1().ingress().inNamespace("default").list();
 ```
 - List `Ingress` in any namespace:
 ```
-IngressList ingressList = client.network().ingress().inAnyNamespace().list();
+IngressList ingressList = client.network().v1().ingress().inAnyNamespace().list();
 ```
 - List `Ingress` with some label in any namespace:
 ```
-IngressList ingressList = client.network().ingress().inNamespace("default").withLabel("foo", "bar").list();
+IngressList ingressList = client.network().v1().ingress().inNamespace("default").withLabel("foo", "bar").list();
 ```
 - Delete `Ingress`:
 ```
-client.network().ingress().inNamespace("default").withName("ingress1").delete();
+client.network().v1().ingress().inNamespace("default").withName("ingress1").delete();
 ```
 
 ### StatefulSet


### PR DESCRIPTION
## Description

Fix #4776

This is a docs fix for Issue #4776
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
