### PR TITLE
[java-generator] Fix minor issues with CRD download

### DIFF
--- a/java-generator/core/src/main/java/io/fabric8/java/generator/FileJavaGenerator.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/FileJavaGenerator.java
@@ -61,7 +61,7 @@ public class FileJavaGenerator implements JavaGenerator {
       try (Stream<Path> walk = Files.walk(source.toPath(), FileVisitOption.FOLLOW_LINKS)) {
         walk
             .map(Path::toFile)
-            .filter(f -> !f.getAbsolutePath().equals(source.getAbsolutePath()))
+            .filter(f -> !f.getAbsolutePath().equals(source.getAbsolutePath()) && f.isFile())
             .forEach(f -> runOnSingleSource(f, outputDirectory));
       } catch (IOException e) {
         throw new JavaGeneratorException(

--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -146,6 +146,9 @@ public class JavaGeneratorMojo extends AbstractMojo {
           throw new MojoExecutionException("URL '" + url + "' is not valid", e);
         }
       }
+      if (!downloadTarget.isDirectory()) {
+        downloadTarget.mkdirs();
+      }
       runners.add(new URLJavaGenerator(config, urlList, downloadTarget));
     }
 


### PR DESCRIPTION
## Description
A few minor tweaks to the java generator CRD download functionality were found using it on other projects.

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
