### PR TITLE
fix #4794: clarifying event processing wrt to a manual informer stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.5-SNAPSHOT
 
 #### Bugs
+* Fix #4794: improving the semantics of manually calling informer stop
 
 #### Improvements
 * Fix #4800: [java-generator] Reflect the `scope` field when implementing the `Namespaced` interface

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedIndexInformer.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/SharedIndexInformer.java
@@ -99,6 +99,9 @@ public interface SharedIndexInformer<T> extends AutoCloseable {
 
   /**
    * Stops the shared informer. The informer cannot be started again.
+   * <p>
+   * Once this call completes the informer will stop processing events, but the underlying watch closure may not yet be
+   * completed
    */
   void stop();
 
@@ -184,7 +187,8 @@ public interface SharedIndexInformer<T> extends AutoCloseable {
   SharedIndexInformer<T> exceptionHandler(ExceptionHandler handler);
 
   /**
-   * Return a {@link CompletionStage} that will allow notification of the informer stopping.
+   * Return a {@link CompletionStage} that will allow notification of the informer stopping. This will be completed after
+   * event processing has stopped.
    * <p>
    * If {@link #stop()} is called, the CompletionStage will complete normally.
    * <p>


### PR DESCRIPTION
## Description

Fix #4794 

Addresses #4794 ensures event processing will have stopped when the stopped future is completed.  And will also complete the future after isWatching returns false.  However since we have been setting the watching flag proactively to false (and even at the AbstractWatchManager level we call onClose immediately with the Watch.close call), this does not mean that the websocket / http connection is fully gone. 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
