### PR TITLE
fix: HttpClient.Factory instances can be prioritized

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
@@ -58,6 +58,15 @@ public interface HttpClient extends AutoCloseable {
       return false;
     }
 
+    /**
+     * The priority of the implementation. The higher the priority the more likely it will be used.
+     * 
+     * @return the priority.
+     */
+    default int priority() {
+      return 0;
+    }
+
   }
 
   interface DerivedClientBuilder {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -166,7 +166,8 @@ public class HttpClientUtils {
             + "choosing the first non-default implementation. "
             + "You should exclude dependencies that aren't needed or use an explicit association of the HttpClient.Factory.");
       }
-      if (factory == null || (factory.isDefault() && !possible.isDefault())) {
+      if (factory == null || (factory.isDefault() && !possible.isDefault())
+          || (!factory.isDefault()) && factory.priority() < possible.priority()) {
         factory = possible;
       }
     }


### PR DESCRIPTION
## Description
Introduce a scoring system so that `HttpClient.Factory` instances provided by the SPI can be prioritized.
The higher the priority, the higher the chances
that the factory instance will be selected automatically to create `HttpClient` instances.

Relates to https://github.com/quarkusio/quarkus/pull/30480

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
