### PR TITLE
[java-generator] Reflect the `scope` field when implementing the `Namespaced` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #4800: [java-generator] Reflect the `scope` field when implementing the `Namespaced` interface
 * Fix #4739: honor optimistic concurrency control semantics in the mock server for `PUT` and `PATCH` requests.
 * Fix #4644: generate CRDs in parallel and optimize code
 * Fix #4795: don't print warning message when service account token property is unset

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
@@ -44,6 +44,7 @@ public class CRGeneratorRunner {
     CustomResourceDefinitionSpec crSpec = crd.getSpec();
     String crName = crSpec.getNames().getKind();
     String group = crSpec.getGroup();
+    String scope = crSpec.getScope();
 
     List<WritableCRCompilationUnit> writableCUs = new ArrayList<>(crSpec.getVersions().size());
     for (CustomResourceDefinitionVersion crdv : crSpec.getVersions()) {
@@ -84,6 +85,7 @@ public class CRGeneratorRunner {
           crName,
           group,
           version,
+          scope,
           prefix + "Spec",
           prefix + "Status",
           specGenerator != null,

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -33,6 +33,7 @@ public class JCRObject extends AbstractJSONSchema2Pojo implements JObjectExtraAn
   private final String className;
   private final String group;
   private final String version;
+  private final String scope;
   private final String specClassName;
   private final String statusClassName;
   private final boolean withSpec;
@@ -48,6 +49,7 @@ public class JCRObject extends AbstractJSONSchema2Pojo implements JObjectExtraAn
       String type,
       String group,
       String version,
+      String scope,
       String specClassName,
       String statusClassName,
       boolean withSpec,
@@ -64,6 +66,7 @@ public class JCRObject extends AbstractJSONSchema2Pojo implements JObjectExtraAn
     this.className = type;
     this.group = group;
     this.version = version;
+    this.scope = scope;
     this.specClassName = specClassName;
     this.statusClassName = statusClassName;
     this.withSpec = withSpec;
@@ -131,7 +134,10 @@ public class JCRObject extends AbstractJSONSchema2Pojo implements JObjectExtraAn
         .setTypeArguments(spec, status);
 
     clz.addExtendedType(crType);
-    clz.addImplementedType("io.fabric8.kubernetes.api.model.Namespaced");
+
+    if (scope.equals("Namespaced")) {
+      clz.addImplementedType("io.fabric8.kubernetes.api.model.Namespaced");
+    }
 
     if (config.isGeneratedAnnotations()) {
       clz.addAnnotation(GENERATED_ANNOTATION);

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -61,6 +61,7 @@ class GeneratorTest {
         "t",
         "g",
         "v",
+        "Namespaced",
         "Spec",
         "Status",
         true,
@@ -82,6 +83,59 @@ class GeneratorTest {
   }
 
   @Test
+  void testNamespacedCR() {
+    // Arrange
+    JCRObject cro = new JCRObject(
+        null,
+        "t",
+        "g",
+        "v",
+        "Namespaced",
+        "Spec",
+        "Status",
+        true,
+        true,
+        true,
+        true,
+        "t",
+        "ts",
+        defaultConfig);
+
+    // Act
+    GeneratorResult res = cro.generateJava();
+
+    // Assert
+    assertEquals("io.fabric8.kubernetes.api.model.Namespaced", res.getTopLevelClasses().get(0).getCompilationUnit()
+        .getClassByName("t").get().getImplementedTypes().get(0).getNameWithScope());
+  }
+
+  @Test
+  void testClusterScopeCR() {
+    // Arrange
+    JCRObject cro = new JCRObject(
+        null,
+        "t",
+        "g",
+        "v",
+        "Cluster",
+        "Spec",
+        "Status",
+        true,
+        true,
+        true,
+        true,
+        "t",
+        "ts",
+        defaultConfig);
+
+    // Act
+    GeneratorResult res = cro.generateJava();
+
+    // Assert
+    assertTrue(res.getTopLevelClasses().get(0).getCompilationUnit().getClassByName("t").get().getImplementedTypes().isEmpty());
+  }
+
+  @Test
   void testCRWithoutNamespace() {
     // Arrange
     JCRObject cro = new JCRObject(
@@ -89,6 +143,7 @@ class GeneratorTest {
         "t",
         "g",
         "v",
+        "Namespaced",
         "Spec",
         "Status",
         true,


### PR DESCRIPTION
## Description
Fix #4800 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
