### PR TITLE
[java-generator] Escape '*/' in generated JavaDocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #4794: improving the semantics of manually calling informer stop
 * Fix #4798: fix leader election release on cancel
 * Fix #4815: (java-generator) create target download directory if it doesn't exist
+* Fix #4818: [java-generator] Escape `*/` in generated JavaDocs
 
 #### Improvements
 * Fix #4800: (java-generator) Reflect the `scope` field when implementing the `Namespaced` interface

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -216,7 +216,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
         objField.createSetter();
 
         if (Utils.isNotNullOrEmpty(prop.getDescription())) {
-          objField.setJavadocComment(prop.getDescription());
+          objField.setJavadocComment(prop.getDescription().replace("*/", "&#042;&#047;"));
 
           objField.addAnnotation(
               new SingleMemberAnnotationExpr(

--- a/java-generator/core/src/test/resources/akka-microservices-crd.yml
+++ b/java-generator/core/src/test/resources/akka-microservices-crd.yml
@@ -50,7 +50,7 @@ spec:
                   description: 'Number of desired pods.'
                 image:
                   type: string
-                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images */'
                 imagePullPolicy:
                   type: string
                   description: 'Image pull policy. One of Always, Never, IfNotPresent. No setting falls back to the container default. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testAkkaMicroservicesCrd.approved.txt
@@ -232,11 +232,11 @@ public class AkkaMicroserviceSpec implements io.fabric8.kubernetes.api.model.Kub
     }
 
     /**
-     * Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+     * Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images &#042;&#047;
      */
     @com.fasterxml.jackson.annotation.JsonProperty("image")
     @io.fabric8.generator.annotation.Required()
-    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images */")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private String image;
 


### PR DESCRIPTION
## Description
Fix #4818 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
