### PR TITLE
Fix #4832 - Match cidr with bit suffix <10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.5-SNAPSHOT
 
 #### Bugs
+* Fix #4832: NO_PROXY can match cidr with bit suffix <10
 * Fix #4851: adding buffer cloning to ensure buffers cannot be modified after sending
 * Fix #4794: improving the semantics of manually calling informer stop
 * Fix #4798: fix leader election release on cancel

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -76,7 +76,7 @@ public class HttpClientUtils {
   private static final String KUBERNETES_BACKWARDS_COMPATIBILITY_INTERCEPTOR_DISABLE = "kubernetes.backwardsCompatibilityInterceptor.disable";
   private static final String BACKWARDS_COMPATIBILITY_DISABLE_DEFAULT = "true";
   private static final Pattern IPV4_PATTERN = Pattern.compile(
-      "(http://|https://)?(?<ipAddressOrSubnet>(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])(\\/[0-9]\\d|1[0-9]\\d|2[0-9]\\d|3[0-2]\\d)?)");
+      "(http://|https://)?(?<ipAddressOrSubnet>(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])(\\/([1-2]\\d|3[0-2]|\\d))?)(\\D+|$)");
   private static final Pattern INVALID_HOST_PATTERN = Pattern.compile("[^\\da-zA-Z.\\-/:]+");
   private static final AtomicBoolean MULTIPLE_HTTP_CLIENT_WARNING_LOGGED = new AtomicBoolean();
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
@@ -129,7 +129,9 @@ class HttpClientUtilsTest {
           arguments("192.168.1.110", new String[] { "http://192.168.1.110" }),
           arguments("192.168.1.110", new String[] { "https://192.168.1.110" }),
           arguments("192.168.1.110", new String[] { "192.168.1.0/24" }),
-          arguments("192.168.1.110", new String[] { "http://192.168.1.0/24" }));
+          arguments("192.168.1.110", new String[] { "http://192.168.1.0/24" }),
+          arguments("192.168.1.110", new String[] { "192.0.0.0/8" }),
+          arguments("192.168.1.110", new String[] { "http://192.0.0.0/8" }));
     }
 
     @DisplayName("With httpProxy and noProxy not matching master url, should return proxy url")
@@ -158,7 +160,8 @@ class HttpClientUtilsTest {
           arguments("192.168.1.110", new String[] { "http://192.168.1.111" }),
           arguments("192.168.1.110", new String[] { "https://192.168.1.111" }),
           arguments("192.168.1.110", new String[] { "192.168.10.0/24" }),
-          arguments("192.168.1.110", new String[] { "http://192.168.1.0/32" }));
+          arguments("192.168.1.110", new String[] { "http://192.168.1.0/32" }),
+          arguments("192.168.1.110", new String[] { "http://192.168.1.0/33" }));
     }
 
     @DisplayName("With httpProxy and invalid noProxy should throw Exception")


### PR DESCRIPTION
## Description

Fix #4832 

Alter the regex which is used to extract cidr ranges, which are then tested against the target master url. This change should allow for single digit suffixes eg 10.0.0.0/8 to be matched, where before it did not appear to be. 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
