### PR TITLE
Fix/pod it

### DIFF
--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -282,7 +282,7 @@ class PodIT {
   private void assertUploaded(String podName, final Path tmpFile, String filename) throws IOException {
     PodResource podResource = client.pods().withName(podName);
 
-    podResource.file(filename).upload(tmpFile);
+    assertTrue(podResource.file(filename).upload(tmpFile));
 
     try (InputStream checkIs = podResource.file(filename).read();
         BufferedReader br = new BufferedReader(new InputStreamReader(checkIs, StandardCharsets.UTF_8))) {

--- a/kubernetes-itests/src/test/resources/pod-it.yml
+++ b/kubernetes-itests/src/test/resources/pod-it.yml
@@ -25,7 +25,13 @@ spec:
   containers:
     - name: busybox
       image: busybox
-      command: ["sleep", "36000"]
+      command: ["sh", "-c", "touch /tmp/healthy; sleep 60m"]
+      readinessProbe:
+        exec:
+          command:
+            - cat
+            - /tmp/healthy
+        periodSeconds: 1
 ---
 apiVersion: v1
 kind: Pod
@@ -37,7 +43,7 @@ spec:
   containers:
     - name: busybox
       image: busybox
-      command: ["sleep", "36000"]
+      command: ["sh", "-c", "touch /tmp/healthy; sleep 60m"]
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
## Description
Possibly some additional changes for #4838

We aren't checking the upload return value, which can mask that it has failed.  Also there is a status being constructed that is not used.

The logs for the recent failed runs do contain:

2023-02-06T17:58:45.1252271Z [OkHttp WebSocket https://192.168.49.2:8443/...] WARN io.fabric8.kubernetes.client.dsl.internal.ExecWebSocketListener - Received [java.net.SocketException], with message:[Connection or outbound has been closed] after ExecWebSocketListener is closed, Ignoring.

But those can only occur after onClose or onError has already been called.  It shouldn't be happening after onError as the exitCode future would be completed with an exception.  If it is occurring after onClose, but the exitCode is not completed, that will currently cause the upload method timeout to be exceeded (there's no log the timeout was exceeded), so now it will complete the exitcode with an exception.  It's not clear from the log that this is actually occurring as it didn't look like the timeout was exceeded.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
