### PR TITLE
Fix: Handle NullPointerException for Thread.currentThread().getContextClassLoader()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.5-SNAPSHOT
 
 #### Bugs
+* Fix #4791: handle the `NullPointerException` in `Thread.currentThread().getContextClassLoader()`
 * Fix #4832: NO_PROXY can match cidr with bit suffix <10
 * Fix #4851: adding buffer cloning to ensure buffers cannot be modified after sending
 * Fix #4794: improving the semantics of manually calling informer stop

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientBuilder.java
@@ -50,11 +50,10 @@ public class KubernetesClientBuilder {
 
   public KubernetesClientBuilder() {
     // basically the same logic as in KubernetesResourceUtil for finding list types
-    // we're not guarding against a null context class loader
     String className = "io.fabric8.kubernetes.client.impl.KubernetesClientImpl";
     try {
       clazz = (Class<KubernetesClient>) Thread.currentThread().getContextClassLoader().loadClass(className);
-    } catch (ClassNotFoundException | ClassCastException e) {
+    } catch (ClassNotFoundException | ClassCastException | NullPointerException e) {
       try {
         clazz = (Class<KubernetesClient>) KubernetesClient.class.getClassLoader().loadClass(className);
       } catch (Exception ex) {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -413,10 +413,10 @@ public class KubernetesResourceUtil {
   private static Class<?> loadRelated(Class<?> type, String suffix, Class<?> defaultClass) {
     try {
       return Thread.currentThread().getContextClassLoader().loadClass(type.getName() + suffix);
-    } catch (ClassNotFoundException | ClassCastException e) {
+    } catch (ClassNotFoundException | ClassCastException | NullPointerException e) {
       try {
         return type.getClassLoader().loadClass(type.getName() + suffix);
-      } catch (ClassNotFoundException | ClassCastException ex) {
+      } catch (ClassNotFoundException | ClassCastException | NullPointerException ex) {
         return defaultClass;
       }
     }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtilTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtilTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import org.junit.jupiter.api.Test;
+
+import static io.fabric8.kubernetes.client.utils.KubernetesResourceUtil.inferListType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KubernetesResourceUtilTest {
+  /**
+   * To verify null in Thread.currentThread().getContextClassLoader() would be handled in loadRelated()
+   */
+  @Test
+  void testNullContextClassLoader() {
+    ClassLoader currContextClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(null);
+      assertEquals(PodList.class, inferListType(Pod.class));
+    } finally {
+      Thread.currentThread().setContextClassLoader(currContextClassLoader);
+    }
+  }
+}


### PR DESCRIPTION
## Description
Fix #4791 
Continue #4792 with my personal account
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
