### PR TITLE
fix: disable Vertx DNS resolver when creating Vertx instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix #4644: generate CRDs in parallel and optimize code
 * Fix #4795: don't print warning message when service account token property is unset
 * Fix #4788: moved retry logic into the standard client so that it applies to all requests, including websockets
+* Fix #4848: Vert.x async DNS resolver is disabled
 
 #### Dependency Upgrade
 * Fix #4655: Upgrade Fabric8 Kubernetes Model to Kubernetes v1.26.0

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
@@ -17,13 +17,16 @@
 package io.fabric8.kubernetes.client.vertx;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+
+import static io.vertx.core.spi.resolver.ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME;
 
 public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http.HttpClient.Factory {
 
-  private Vertx vertx;
+  private final Vertx vertx;
 
   public VertxHttpClientFactory() {
-    this.vertx = Vertx.vertx();
+    this.vertx = createVertxInstance();
   }
 
   @Override
@@ -31,4 +34,24 @@ public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http
     return new VertxHttpClientBuilder<>(this, vertx);
   }
 
+  private static synchronized Vertx createVertxInstance() {
+    // We must disable the async DNS resolver as it can cause issues when resolving the Vault instance.
+    // This is done using the DISABLE_DNS_RESOLVER_PROP_NAME system property.
+    // The DNS resolver used by vert.x is configured during the (synchronous) initialization.
+    // So, we just need to disable the async resolver around the Vert.x instance creation.
+    final String originalValue = System.getProperty(DISABLE_DNS_RESOLVER_PROP_NAME);
+    Vertx vertx;
+    try {
+      System.setProperty(DISABLE_DNS_RESOLVER_PROP_NAME, "true");
+      vertx = Vertx.vertx(new VertxOptions());
+    } finally {
+      // Restore the original value
+      if (originalValue == null) {
+        System.clearProperty(DISABLE_DNS_RESOLVER_PROP_NAME);
+      } else {
+        System.setProperty(DISABLE_DNS_RESOLVER_PROP_NAME, originalValue);
+      }
+    }
+    return vertx;
+  }
 }


### PR DESCRIPTION
## Description
Port of https://github.com/quarkusio/quarkus/pull/30952 / https://github.com/quarkusio/quarkus/issues/30951

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
