### PR TITLE
[java-generator] Fix a race condition in the usage of JavaParser for large CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #4798: fix leader election release on cancel
 * Fix #4815: (java-generator) create target download directory if it doesn't exist
 * Fix #4818: [java-generator] Escape `*/` in generated JavaDocs
+* Fix #4723: [java-generator] Fix a race in the use of JavaParser hitting large CRDs
 
 #### Improvements
 * Fix #4747: migrate to SnakeYAML Engine

--- a/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
+++ b/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
@@ -75,7 +75,7 @@ public class GenerateJavaSources implements Runnable {
   String codeStructure = null;
 
   @Option(names = { "-skip-generated-annotations",
-      "--skip-generated-annotations" }, description = "Add extra lombok and sundrio annotation to the generated classes", required = false, hidden = true)
+      "--skip-generated-annotations" }, description = "Skip emitting the @javax.annotation.processing.Generated annotation on the generated sources", required = false, hidden = true)
   Boolean skipGeneratedAnnotations = null;
 
   @Option(names = { "-package-overrides",
@@ -87,7 +87,7 @@ public class GenerateJavaSources implements Runnable {
     final Config.Prefix pSt = (prefixStrategy != null) ? Config.Prefix.valueOf(prefixStrategy) : null;
     final Config.Suffix sSt = (suffixStrategy != null) ? Config.Suffix.valueOf(suffixStrategy) : null;
     final Config.CodeStructure structure = (codeStructure != null) ? Config.CodeStructure.valueOf(codeStructure) : null;
-    final Boolean generatedAnnotations = (skipGeneratedAnnotations != null) ? skipGeneratedAnnotations : null;
+    final Boolean noGeneratedAnnotations = (skipGeneratedAnnotations != null) ? skipGeneratedAnnotations : false;
     final Config config = new Config(
         uppercaseEnum,
         pSt,
@@ -95,7 +95,7 @@ public class GenerateJavaSources implements Runnable {
         alwaysPreserveUnkownFields,
         addExtraAnnotations,
         structure,
-        generatedAnnotations,
+        !noGeneratedAnnotations,
         packageOverrides);
 
     List<JavaGenerator> runners = new ArrayList<>();

--- a/java-generator/core/pom.xml
+++ b/java-generator/core/pom.xml
@@ -49,13 +49,6 @@
 
     <dependency>
       <groupId>io.sundr</groupId>
-      <artifactId>sundr-adapter-reflect</artifactId>
-      <version>${sundrio.version}</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
       <version>${sundrio.version}</version>
       <scope>compile</scope>

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
@@ -98,7 +98,7 @@ public class CRGeneratorRunner {
 
       List<GeneratorResult.ClassResult> classResults = validateAndAggregate(crGenerator, specGenerator, statusGenerator);
 
-      writableCUs.add(new WritableCRCompilationUnit(classResults));
+      writableCUs.add(new WritableCRCompilationUnit(classResults, basePackageName));
     }
 
     return writableCUs;

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/FileJavaGenerator.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/FileJavaGenerator.java
@@ -95,10 +95,9 @@ public class FileJavaGenerator implements JavaGenerator {
                     CustomResourceDefinition crd = (CustomResourceDefinition) resource;
 
                     final String basePackage = groupToPackage(crd.getSpec().getGroup());
-                    List<WritableCRCompilationUnit> writables = crGeneratorRunner.generate(crd, basePackage);
 
-                    writables.parallelStream()
-                        .forEach(w -> w.writeAllJavaClasses(basePath, basePackage));
+                    crGeneratorRunner.generate(crd, basePackage).parallelStream()
+                        .forEach(w -> w.writeAllJavaClasses(basePath));
                   } else {
                     LOGGER.warn("Not generating nothing for resource of kind: {}", resource.getKind());
                   }

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/WritableCRCompilationUnit.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/WritableCRCompilationUnit.java
@@ -34,16 +34,18 @@ public class WritableCRCompilationUnit {
   private static final Logger LOGGER = LoggerFactory.getLogger(WritableCRCompilationUnit.class);
 
   private final List<GeneratorResult.ClassResult> classResults;
+  private final String basePackage;
 
-  WritableCRCompilationUnit(List<GeneratorResult.ClassResult> classResults) {
+  WritableCRCompilationUnit(List<GeneratorResult.ClassResult> classResults, String basePackage) {
     this.classResults = classResults;
+    this.basePackage = basePackage;
   }
 
   public List<GeneratorResult.ClassResult> getClassResults() {
     return classResults;
   }
 
-  public void writeAllJavaClasses(File basePath, String basePackage) {
+  public void writeAllJavaClasses(File basePath) {
     try {
       createFolders(basePackage, basePath);
       for (GeneratorResult.ClassResult cr : this.classResults) {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -42,9 +42,11 @@ public abstract class AbstractJSONSchema2Pojo {
   static final String OBJECT_CRD_TYPE = "object";
   static final String ARRAY_CRD_TYPE = "array";
 
-  public static final AnnotationExpr GENERATED_ANNOTATION = new SingleMemberAnnotationExpr(
-      new Name("javax.annotation.processing.Generated"),
-      new StringLiteralExpr("io.fabric8.java.generator.CRGeneratorRunner"));
+  public static final AnnotationExpr newGeneratedAnnotation() {
+    return new SingleMemberAnnotationExpr(
+        new Name("javax.annotation.processing.Generated"),
+        new StringLiteralExpr("io.fabric8.java.generator.CRGeneratorRunner"));
+  }
 
   protected final String description;
   protected final Config config;

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -140,7 +140,7 @@ public class JCRObject extends AbstractJSONSchema2Pojo implements JObjectExtraAn
     }
 
     if (config.isGeneratedAnnotations()) {
-      clz.addAnnotation(GENERATED_ANNOTATION);
+      clz.addAnnotation(newGeneratedAnnotation());
     }
     if (config.isObjectExtraAnnotations()) {
       addExtraAnnotations(clz);

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -150,7 +150,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
                 "using = com.fasterxml.jackson.databind.JsonDeserializer.None.class")));
 
     if (config.isGeneratedAnnotations()) {
-      clz.addAnnotation(GENERATED_ANNOTATION);
+      clz.addAnnotation(newGeneratedAnnotation());
     }
     if (config.isObjectExtraAnnotations()) {
       addExtraAnnotations(clz);

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -452,6 +452,7 @@ class GeneratorTest {
         null,
         Boolean.FALSE,
         null);
+    String generatedAnnotationName = AbstractJSONSchema2Pojo.newGeneratedAnnotation().getNameAsString();
 
     // Act
     GeneratorResult res1 = obj1.generateJava();
@@ -459,10 +460,10 @@ class GeneratorTest {
 
     // Assert
     Optional<ClassOrInterfaceDeclaration> clz1 = res1.getTopLevelClasses().get(0).getCompilationUnit().getClassByName("T");
-    assertTrue(clz1.get().getAnnotationByName(AbstractJSONSchema2Pojo.GENERATED_ANNOTATION.getNameAsString()).isPresent());
+    assertTrue(clz1.get().getAnnotationByName(generatedAnnotationName).isPresent());
 
     Optional<ClassOrInterfaceDeclaration> clz2 = res2.getTopLevelClasses().get(0).getCompilationUnit().getClassByName("T");
-    assertFalse(clz2.get().getAnnotationByName(AbstractJSONSchema2Pojo.GENERATED_ANNOTATION.getNameAsString()).isPresent());
+    assertFalse(clz2.get().getAnnotationByName(generatedAnnotationName).isPresent());
   }
 
   @Test


### PR DESCRIPTION
## Description

Fix #4723



### Old Description

This is just a placeholder to keep track of the progress in debugging a race happening in the `java-generator`.

How to reproduce the issue:

- clone this repo
- `mvn clean install -DskipTests` once (and have a ☕ meanwhile)
- from now on you will be able to check your changes with `mvn clean install -f java-generator/pom.xml`
- download a "big enough" yaml description, e.g. [this one](https://github.com/kserve/kserve/releases/download/v0.10.0/kserve.yaml)
- run the CLI using jbang: `jbang io.fabric8:java-generator-cli:6.5-SNAPSHOT -s kserve.yaml --target=./test`

running this sequence multiple times produces non-deterministic errors.

Considerations:

- Disabling the `paralleStreams` in [FileJavaGenerator](https://github.com/fabric8io/kubernetes-client/blob/master/java-generator/core/src/main/java/io/fabric8/java/generator/FileJavaGenerator.java) "solve" the issue at the price of a serious performance degradation.
- I'm struggling to understand where I might be triggering the race, as each `JObject` node of the internal AST is creating [it's own CompilationUnit](https://github.com/fabric8io/kubernetes-client/blob/02f5599e965ef3ebd0506fc1283515f590efac12/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java#L129) and fields are [processed sequentially](https://github.com/fabric8io/kubernetes-client/blob/02f5599e965ef3ebd0506fc1283515f590efac12/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java#L164)