### PR TITLE
fix #4851: cloning the incoming buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.5-SNAPSHOT
 
 #### Bugs
+* Fix #4851: adding buffer cloning to ensure buffers cannot be modified after sending
 * Fix #4794: improving the semantics of manually calling informer stop
 * Fix #4798: fix leader election release on cancel
 * Fix #4815: (java-generator) create target download directory if it doesn't exist

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkWebSocketImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkWebSocketImpl.java
@@ -16,6 +16,7 @@
 
 package io.fabric8.kubernetes.client.jdkhttp;
 
+import io.fabric8.kubernetes.client.http.BufferUtil;
 import io.fabric8.kubernetes.client.http.WebSocket;
 
 import java.io.ByteArrayOutputStream;
@@ -101,6 +102,7 @@ class JdkWebSocketImpl implements WebSocket {
 
   @Override
   public boolean send(ByteBuffer buffer) {
+    buffer = BufferUtil.copy(buffer);
     final int size = buffer.remaining();
     queueSize.addAndGet(size);
     CompletableFuture<java.net.http.WebSocket> cf = webSocket.sendBinary(buffer, true);

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.jetty;
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.http.BufferUtil;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
@@ -66,6 +67,7 @@ public class JettyWebSocket implements WebSocket, WebSocketListener {
     if (closed.get() || !webSocketSession.isOpen()) {
       return false;
     }
+    buffer = BufferUtil.copy(buffer);
     final int size = buffer.remaining();
     sendQueue.addAndGet(size);
     webSocketSession.getRemote().sendBytes(buffer, new WriteCallback() {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
@@ -103,7 +103,8 @@ public interface WebSocket {
   }
 
   /**
-   * Send some data
+   * Send some data. The buffer will be copied if needed by
+   * the implementation to allow for modifications after this call.
    *
    * @return true if the message was successfully enqueued.
    */


### PR DESCRIPTION
## Description
Fix #4851 

The other clients already copy the buffer contents.  

An alternative is to use the paradigm of returning a future such that completion indicates the buffer can be reused.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
