### PR TITLE
adds a null check - the initial list can be served from cache

### DIFF
--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericCustomResourceIT.java
@@ -59,8 +59,9 @@ class GenericCustomResourceIT {
     client.apiextensions().v1().customResourceDefinitions()
         .withName("animals.jungle.example.com")
         .waitUntilCondition(
-            c -> c.getStatus() != null && c.getStatus().getConditions() != null && c.getStatus().getConditions().stream()
-                .anyMatch(crdc -> crdc.getType().equals("Established") && crdc.getStatus().equals("True")),
+            c -> c != null && c.getStatus() != null && c.getStatus().getConditions() != null
+                && c.getStatus().getConditions().stream()
+                    .anyMatch(crdc -> crdc.getType().equals("Established") && crdc.getStatus().equals("True")),
             10L, TimeUnit.SECONDS);
     final CustomResourceDefinitionContext customResourceDefinitionContext = new CustomResourceDefinitionContext.Builder()
         .withName("animals.jungle.example.com")


### PR DESCRIPTION
## Description
Small change to prevent a test npe

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
