### PR TITLE
fix #4675: adding an informer timeout handled directly in our client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #4723: [java-generator] Fix a race in the use of JavaParser hitting large CRDs
 
 #### Improvements
+* Fix #4675: adding a fully client side timeout for informer watches
 * Fix #3805: DeletionTimestamp and Finalizer support in Mock server.
 * Fix #4644: generate CRDs in parallel and optimize code
 * Fix #4739: honor optimistic concurrency control semantics in the mock server for `PUT` and `PATCH` requests.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElector.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElector.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.LongSupplier;
 
 public class LeaderElector {
 
@@ -257,7 +257,7 @@ public class LeaderElector {
    * @param delaySupplier to schedule the run of the provided consumer
    * @return the future to be completed
    */
-  protected static CompletableFuture<Void> loop(Consumer<CompletableFuture<?>> consumer, Supplier<Long> delaySupplier,
+  protected static CompletableFuture<Void> loop(Consumer<CompletableFuture<?>> consumer, LongSupplier delaySupplier,
       Executor executor) {
     CompletableFuture<Void> completion = new CompletableFuture<>();
     Utils.scheduleWithVariableRate(completion, executor, () -> consumer.accept(completion), 0,

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -39,6 +39,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,6 +49,13 @@ import java.util.function.Supplier;
 import static java.net.HttpURLConnection.HTTP_GONE;
 
 public abstract class AbstractWatchManager<T extends HasMetadata> implements Watch {
+
+  public static class WatchRequestState {
+
+    private final AtomicBoolean reconnected = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+  }
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractWatchManager.class);
 
@@ -65,6 +73,8 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
   private final URL requestUrl;
 
   private final boolean receiveBookmarks;
+
+  private volatile WatchRequestState latestRequestState;
 
   AbstractWatchManager(
       Watcher<T> watcher, BaseOperation<T, ?, ?> baseOperation, ListOptions listOptions, int reconnectLimit,
@@ -87,9 +97,20 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     startWatch();
   }
 
-  protected abstract void start(URL url, Map<String, String> headers);
+  protected abstract void start(URL url, Map<String, String> headers, WatchRequestState state);
 
-  protected abstract void closeRequest();
+  /**
+   * Attempt to gracefully close the current request.
+   * <p>
+   * If forceClosed has not been set, then it's expected that the watch will
+   * attempt to reconnect
+   */
+  public void closeRequest() {
+    Optional.ofNullable(latestRequestState).ifPresent(s -> s.closed.set(true));
+    closeCurrentRequest();
+  }
+
+  protected abstract void closeCurrentRequest();
 
   final void close(WatcherException cause) {
     if (!forceClosed.compareAndSet(false, true)) {
@@ -122,7 +143,10 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
   /**
    * Called to reestablish the connection. Should only be called once per request.
    */
-  void scheduleReconnect() {
+  void scheduleReconnect(WatchRequestState state) {
+    if (!state.reconnected.compareAndSet(false, true)) {
+      return;
+    }
     if (isForceClosed()) {
       logger.debug("Ignoring already closed/closing connection");
       return;
@@ -167,7 +191,10 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     return retryIntervalCalculator.nextReconnectInterval();
   }
 
-  void resetReconnectAttempts() {
+  void resetReconnectAttempts(WatchRequestState state) {
+    if (state.closed.get()) {
+      return;
+    }
     retryIntervalCalculator.resetReconnectAttempts();
   }
 
@@ -218,7 +245,8 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     logger.debug("Watching {}...", url);
 
     closeRequest(); // only one can be active at a time
-    start(url, headers);
+    latestRequestState = new WatchRequestState();
+    start(url, headers, latestRequestState);
   }
 
   @Override
@@ -248,7 +276,10 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     }
   }
 
-  protected void onMessage(String message) {
+  protected void onMessage(String message, WatchRequestState state) {
+    if (state.closed.get() || forceClosed.get()) {
+      return;
+    }
     try {
       WatchEvent event = contextAwareWatchEventDeserializer(message);
       Object object = event.getObject();
@@ -257,7 +288,7 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
         if (object instanceof Status) {
           Status status = (Status) object;
 
-          onStatus(status);
+          onStatus(status, state);
         } else {
           logger.error("Error received, but object is not a status - will retry");
           closeRequest();
@@ -282,7 +313,10 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
     }
   }
 
-  protected boolean onStatus(Status status) {
+  protected boolean onStatus(Status status, WatchRequestState state) {
+    if (state.closed.get()) {
+      return true;
+    }
     // The resource version no longer exists - this has to be handled by the caller.
     if (status.getCode() == HTTP_GONE) {
       close(new WatcherException(status.getMessage(), new KubernetesClientException(status)));

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -106,7 +106,7 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
    * attempt to reconnect
    */
   public void closeRequest() {
-    Optional.ofNullable(latestRequestState).ifPresent(s -> s.closed.set(true));
+    Optional.ofNullable(latestRequestState).ifPresent(state -> state.closed.set(true));
     closeCurrentRequest();
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -614,13 +614,13 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public Watch watch(ListOptions options, final Watcher<T> watcher) {
-    CompletableFuture<Watch> startedFuture = submitWatch(options, watcher);
+    CompletableFuture<? extends Watch> startedFuture = submitWatch(options, watcher);
     Utils.waitUntilReadyOrFail(startedFuture, -1, TimeUnit.SECONDS);
     return startedFuture.join();
   }
 
   @Override
-  public CompletableFuture<Watch> submitWatch(ListOptions options, final Watcher<T> watcher) {
+  public CompletableFuture<AbstractWatchManager<T>> submitWatch(ListOptions options, final Watcher<T> watcher) {
     WatcherToggle<T> watcherToggle = new WatcherToggle<>(watcher, true);
     ListOptions optionsToUse = defaultListOptions(options, true);
     WatchConnectionManager<T, L> watch;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -77,10 +77,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   }
 
   @Override
-  protected void closeRequest() {
-    if (this.listener != null) {
-      this.listener.close();
-    }
+  protected void closeCurrentRequest() {
     Optional.ofNullable(this.websocketFuture).ifPresent(theFuture -> {
       this.websocketFuture = null;
       theFuture.whenComplete((w, t) -> {
@@ -96,8 +93,8 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
   }
 
   @Override
-  protected void start(URL url, Map<String, String> headers) {
-    this.listener = new WatcherWebSocketListener<>(this);
+  protected void start(URL url, Map<String, String> headers, WatchRequestState state) {
+    this.listener = new WatcherWebSocketListener<>(this, state);
     Builder builder = client.newWebSocketBuilder();
     headers.forEach(builder::header);
     builder.uri(URI.create(url.toString()));

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
@@ -16,44 +16,41 @@
 package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 class WatcherWebSocketListener<T extends HasMetadata> implements WebSocket.Listener {
   protected static final Logger logger = LoggerFactory.getLogger(WatcherWebSocketListener.class);
 
+  protected final WatchRequestState state;
   protected final AbstractWatchManager<T> manager;
 
-  private AtomicBoolean reconnected = new AtomicBoolean();
-  private AtomicBoolean closed = new AtomicBoolean();
-
-  protected WatcherWebSocketListener(AbstractWatchManager<T> manager) {
+  protected WatcherWebSocketListener(AbstractWatchManager<T> manager, WatchRequestState state) {
     this.manager = manager;
+    this.state = state;
   }
 
   @Override
   public void onOpen(final WebSocket webSocket) {
     logger.debug("WebSocket successfully opened");
-    manager.resetReconnectAttempts();
+    manager.resetReconnectAttempts(state);
   }
 
   @Override
   public void onError(WebSocket webSocket, Throwable t) {
     logger.debug("WebSocket error received", t);
-    scheduleReconnect();
+    manager.scheduleReconnect(state);
   }
 
   @Override
   public void onMessage(WebSocket webSocket, String text) {
     try {
-      if (!closed.get()) {
-        manager.onMessage(text);
-      }
+      manager.onMessage(text, state);
     } finally {
       webSocket.request();
     }
@@ -68,17 +65,7 @@ class WatcherWebSocketListener<T extends HasMetadata> implements WebSocket.Liste
   public void onClose(WebSocket webSocket, int code, String reason) {
     logger.debug("WebSocket close received. code: {}, reason: {}", code, reason);
     webSocket.sendClose(code, reason);
-    scheduleReconnect();
-  }
-
-  private void scheduleReconnect() {
-    if (reconnected.compareAndSet(false, true)) {
-      manager.scheduleReconnect();
-    }
-  }
-
-  public void close() {
-    closed.set(true);
+    manager.scheduleReconnect(state);
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/ListerWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/ListerWatcher.java
@@ -15,9 +15,10 @@
  */
 package io.fabric8.kubernetes.client.informers.impl;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ListOptions;
-import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -28,8 +29,8 @@ import java.util.concurrent.CompletableFuture;
  * @param <T> type
  * @param <L> list for that type
  */
-public interface ListerWatcher<T, L> {
-  CompletableFuture<Watch> submitWatch(ListOptions params, Watcher<T> watcher);
+public interface ListerWatcher<T extends HasMetadata, L> {
+  CompletableFuture<AbstractWatchManager<T>> submitWatch(ListOptions params, Watcher<T> watcher);
 
   CompletableFuture<L> submitList(ListOptions listOptions);
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
+import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager;
 import io.fabric8.kubernetes.client.informers.ExceptionHandler;
 import io.fabric8.kubernetes.client.informers.impl.ListerWatcher;
 import io.fabric8.kubernetes.client.utils.ExponentialBackoffIntervalCalculator;
@@ -35,23 +36,29 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T>> {
 
   private static final Logger log = LoggerFactory.getLogger(Reflector.class);
+
+  private static long MIN_TIMEOUT = TimeUnit.MINUTES.toSeconds(5);
 
   private volatile String lastSyncResourceVersion;
   private final ListerWatcher<T, L> listerWatcher;
   private final SyncableStore<T> store;
   private final ReflectorWatcher watcher;
   private volatile boolean watching;
-  private volatile CompletableFuture<Watch> watchFuture;
+  private volatile CompletableFuture<AbstractWatchManager<T>> watchFuture;
   private volatile CompletableFuture<?> reconnectFuture;
   private final CompletableFuture<Void> startFuture = new CompletableFuture<>();
   private final CompletableFuture<Void> stopFuture = new CompletableFuture<>();
   private final ExponentialBackoffIntervalCalculator retryIntervalCalculator;
   //default behavior - retry if started and it's not a watcherexception
   private volatile ExceptionHandler handler = (b, t) -> b && !(t instanceof WatcherException);
+  private long minTimeout = MIN_TIMEOUT;
+
+  private CompletableFuture<Void> timeoutFuture;
 
   public Reflector(ListerWatcher<T, L> listerWatcher, SyncableStore<T> store) {
     this.listerWatcher = listerWatcher;
@@ -83,13 +90,15 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private synchronized void stopWatcher() {
     Optional.ofNullable(watchFuture).ifPresent(theFuture -> {
       watchFuture = null;
-      theFuture.cancel(true);
       theFuture.whenComplete((w, t) -> {
         if (w != null) {
           stopWatch(w);
         }
       });
     });
+    if (timeoutFuture != null) {
+      timeoutFuture.cancel(true);
+    }
   }
 
   /**
@@ -185,18 +194,36 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
     watchStopped(); // proactively report as stopped
   }
 
-  private synchronized CompletableFuture<Watch> startWatcher(final String latestResourceVersion) {
+  private synchronized CompletableFuture<? extends Watch> startWatcher(final String latestResourceVersion) {
     if (isStopped()) {
       return CompletableFuture.completedFuture(null);
     }
     log.debug("Starting watcher for {} at v{}", this, latestResourceVersion);
     // there's no need to stop the old watch, that will happen automatically when this call completes
-    watchFuture = listerWatcher.submitWatch(
+    CompletableFuture<AbstractWatchManager<T>> future = listerWatcher.submitWatch(
         new ListOptionsBuilder().withResourceVersion(latestResourceVersion)
-            .withTimeoutSeconds(null)
+            // this would match the behavior of the go client, but requires changing a lot of mock expectations
+            // so instead we'll terminate below and set a fail-safe here
+            // .withTimeoutSeconds((long) ((Math.random() + 1) * minTimeout))
+            .withTimeoutSeconds(minTimeout * 2)
             .build(),
         watcher);
+
+    // the alternative to this is to localize the logic in the AbstractWatchManager, however since
+    // we only need it for informers, it seems fine here
+    LongSupplier timeout = () -> (long) ((Math.random() + 1) * minTimeout);
+    if (timeoutFuture != null) {
+      timeoutFuture.cancel(true);
+    }
+    timeoutFuture = new CompletableFuture<>();
+    Utils.scheduleWithVariableRate(timeoutFuture, Runnable::run,
+        () -> future.thenAccept(AbstractWatchManager::closeRequest), timeout.getAsLong(), timeout, TimeUnit.SECONDS);
+    watchFuture = future;
     return watchFuture;
+  }
+
+  public void setMinTimeout(long minTimeout) {
+    this.minTimeout = minTimeout;
   }
 
   private synchronized void watchStopped() {
@@ -219,9 +246,8 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
 
     @Override
     public void eventReceived(Action action, T resource) {
-      if (stopFuture.isDone()) {
-        return;
-      }
+      // always process what we receive as the watch manager will have already
+      // processed the resourceVersion update
       if (action == null) {
         throw new KubernetesClientException("Unrecognized event for " + Reflector.this);
       }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchHttpManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchHttpManagerTest.java
@@ -52,8 +52,9 @@ class WatchHttpManagerTest {
     CountDownLatch reconnect = new CountDownLatch(1);
     WatchHTTPManager<HasMetadata, KubernetesResourceList<HasMetadata>> watch = new WatchHTTPManager(client,
         baseOperation, Mockito.mock(ListOptions.class), Mockito.mock(Watcher.class), 1, 0) {
+
       @Override
-      void scheduleReconnect() {
+      void scheduleReconnect(WatchRequestState state) {
         reconnect.countDown();
       }
     };

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -200,7 +200,7 @@ class PodUploadTest {
     ArgumentCaptor<URI> captor = ArgumentCaptor.forClass(URI.class);
     verify(builder, times(2)).uri(captor.capture());
     assertEquals(
-        "https://openshift.com:8443/api/v1/namespaces/default/pods?fieldSelector=metadata.name%3Dpod&allowWatchBookmarks=true&watch=true",
+        "https://openshift.com:8443/api/v1/namespaces/default/pods?fieldSelector=metadata.name%3Dpod&timeoutSeconds=600&allowWatchBookmarks=true&watch=true",
         captor.getAllValues().get(0).toString());
     assertEquals(
         "https://openshift.com:8443/api/v1/namespaces/default/pods/pod/exec?command=sh&command=-c&command=mkdir%20-p%20%27%2Fmock%2Fdir%27%20%26%26%20base64%20-d%20-%20%3E%20%27%2Fmock%2Fdir%2Ffile%27&container=container&stdin=true&stderr=true",
@@ -232,7 +232,7 @@ class PodUploadTest {
     ArgumentCaptor<URI> captor = ArgumentCaptor.forClass(URI.class);
     verify(builder, times(2)).uri(captor.capture());
     assertEquals(
-        "https://openshift.com:8443/api/v1/namespaces/default/pods?fieldSelector=metadata.name%3Dpod&allowWatchBookmarks=true&watch=true",
+        "https://openshift.com:8443/api/v1/namespaces/default/pods?fieldSelector=metadata.name%3Dpod&timeoutSeconds=600&allowWatchBookmarks=true&watch=true",
         captor.getAllValues().get(0).toString());
     assertEquals(
         "https://openshift.com:8443/api/v1/namespaces/default/pods/pod/exec?command=sh&command=-c&command=mkdir%20-p%20%27%2Fmock%2Fdir%27%20%26%26%20base64%20-d%20-%20%7C%20tar%20-C%20%27%2Fmock%2Fdir%27%20-xzf%20-&container=container&stdin=true&stderr=true",

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformerResyncTest.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.informers.impl;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
-import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,7 +52,7 @@ class DefaultSharedIndexInformerResyncTest {
   @BeforeEach
   void beforeEach() {
     Mockito.when(listerWatcher.submitWatch(Mockito.any(), Mockito.any()))
-        .thenReturn(CompletableFuture.completedFuture(Mockito.mock(Watch.class)));
+        .thenReturn(CompletableFuture.completedFuture(Mockito.mock(AbstractWatchManager.class)));
     PodList result = new PodListBuilder().withNewMetadata().endMetadata().build();
     Mockito.when(listerWatcher.submitList(Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(result));

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/ReflectorTest.java
@@ -17,24 +17,25 @@
 package io.fabric8.kubernetes.client.informers.impl.cache;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher.Action;
 import io.fabric8.kubernetes.client.WatcherException;
+import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager;
 import io.fabric8.kubernetes.client.informers.impl.ListerWatcher;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.atLeast;
 
 class ReflectorTest {
 
@@ -59,7 +60,7 @@ class ReflectorTest {
     // throw an exception, then watch normally
     Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
         .thenThrow(new KubernetesClientException("error"))
-        .thenReturn(CompletableFuture.completedFuture(Mockito.mock(Watch.class)));
+        .thenReturn(CompletableFuture.completedFuture(Mockito.mock(AbstractWatchManager.class)));
 
     CompletableFuture<Void> future = reflector.start();
 
@@ -78,16 +79,7 @@ class ReflectorTest {
     assertTrue(future.isDone());
     assertTrue(!future.isCompletedExceptionally());
 
-    reflector.getStopFuture().whenComplete((t, v) -> {
-      // try to process an event once stopped
-      reflector.getWatcher().eventReceived(Action.ADDED,
-          new PodBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build());
-    });
-
     reflector.stop();
-
-    // verify no event processing after stopped
-    Mockito.verify(mockStore, times(0)).add(Mockito.any());
 
     assertFalse(reflector.isWatching());
     assertTrue(reflector.isStopped());
@@ -123,7 +115,7 @@ class ReflectorTest {
     Reflector<Pod, PodList> reflector = new Reflector<>(mock, Mockito.mock(SyncableStore.class));
 
     Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
-        .thenReturn(CompletableFuture.completedFuture(Mockito.mock(Watch.class)));
+        .thenReturn(CompletableFuture.completedFuture(Mockito.mock(AbstractWatchManager.class)));
 
     reflector.start();
 
@@ -134,6 +126,34 @@ class ReflectorTest {
 
     assertFalse(reflector.isWatching());
     assertTrue(reflector.isStopped());
+  }
+
+  @Test
+  void testTimeout() {
+    ListerWatcher<Pod, PodList> mock = Mockito.mock(ListerWatcher.class);
+    PodList list = new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build();
+    Mockito.when(mock.submitList(Mockito.any())).thenReturn(CompletableFuture.completedFuture(list));
+
+    Reflector<Pod, PodList> reflector = new Reflector<>(mock, Mockito.mock(SyncableStore.class));
+    reflector.setMinTimeout(1);
+
+    AbstractWatchManager manager = Mockito.mock(AbstractWatchManager.class);
+    Mockito.when(mock.submitWatch(Mockito.any(), Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(manager));
+
+    reflector.start();
+
+    assertTrue(reflector.isWatching());
+    assertFalse(reflector.isStopped());
+
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+      try {
+        Mockito.verify(manager, atLeast(2)).closeRequest();
+      } catch (TooFewActualInvocations e) {
+        return false;
+      }
+      return true;
+    });
   }
 
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -130,7 +130,7 @@ class DefaultSharedIndexInformerTest {
     server.expect()
         .withPath(
             "/api/v1/namespaces/test/pods?resourceVersion=" + startResourceVersion
-                + "&allowWatchBookmarks=true&watch=true")
+                + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -183,13 +183,14 @@ class DefaultSharedIndexInformerTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=" + Utils.toUrlEncoded("metadata.name=pod1") + "&resourceVersion=0")
+            "/api/v1/namespaces/test/pods?fieldSelector=" + Utils.toUrlEncoded("metadata.name=pod1")
+                + "&resourceVersion=0")
         .andReturn(200, getList(startResourceVersion, Pod.class))
         .once();
     server.expect()
         .withPath("/api/v1/namespaces/test/pods?fieldSelector=" + Utils.toUrlEncoded("metadata.name=pod1")
             + "&resourceVersion="
-            + startResourceVersion + "&allowWatchBookmarks=true&watch=true")
+            + startResourceVersion + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -253,7 +254,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -315,7 +317,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -345,7 +348,8 @@ class DefaultSharedIndexInformerTest {
                 .build())
         .times(2);
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + mid2ResourceVersion + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?resourceVersion=" + mid2ResourceVersion
+            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -401,7 +405,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -468,7 +473,7 @@ class DefaultSharedIndexInformerTest {
     server.expect()
         .withPath(
             "/api/v1/namespaces/test/pods?resourceVersion=" + startResourceVersion
-                + "&allowWatchBookmarks=true&watch=true")
+                + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -974,7 +979,8 @@ class DefaultSharedIndexInformerTest {
         .endMetadata()
         .build();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -1003,7 +1009,8 @@ class DefaultSharedIndexInformerTest {
 
     // should pick this up after the termination
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + midResourceVersion + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?resourceVersion=" + midResourceVersion
+            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -1074,7 +1081,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -1264,6 +1272,7 @@ class DefaultSharedIndexInformerTest {
 
     URLBuilder watchBuilder = new URLUtils.URLBuilder(watchUrl);
     watchUrl = watchBuilder.addQueryParameter("resourceVersion", startResourceVersion)
+        .addQueryParameter("timeoutSeconds", "600")
         .addQueryParameter("allowWatchBookmarks", "true")
         .addQueryParameter("watch", "true")
         .toString();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -73,7 +73,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -127,7 +127,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label&resourceVersion=2&allowWatchBookmarks=true&watch=true")
+            "/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label&resourceVersion=2&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -195,7 +195,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -260,7 +260,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -337,7 +337,7 @@ class InformTest {
         .once();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?resourceVersion=2&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/namespaces/test/pods?resourceVersion=2&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()
@@ -387,7 +387,7 @@ class InformTest {
         .once();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()
@@ -453,7 +453,7 @@ class InformTest {
         .once();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
@@ -57,7 +57,7 @@ class NodeMetricsTest {
     // Given
     server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?resourceVersion=0").andReturn(HTTP_OK,
         new NodeMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
-    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?allowWatchBookmarks=true&watch=true")
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
@@ -74,7 +74,7 @@ class PodMetricsTest {
     // Given
     server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?resourceVersion=0").andReturn(HTTP_OK,
         new PodMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
-    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?allowWatchBookmarks=true&watch=true")
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -712,7 +712,7 @@ class PodTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(50)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -206,7 +206,7 @@ public class ResourceListTest {
     ResourceTest.list(server, noReady2, "0");
 
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(ready1, "MODIFIED"))
@@ -214,7 +214,7 @@ public class ResourceListTest {
         .once();
 
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
@@ -256,7 +256,7 @@ public class ResourceListTest {
 
     // This pod has a non-retryable error.
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
@@ -265,7 +265,7 @@ public class ResourceListTest {
 
     // This pod succeeds.
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
@@ -307,7 +307,7 @@ public class ResourceListTest {
 
     // Both pods have a non-retryable error.
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
@@ -315,7 +315,7 @@ public class ResourceListTest {
         .once();
 
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -309,7 +309,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -362,7 +362,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(100)
@@ -422,7 +422,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(1000)
@@ -470,7 +470,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -481,7 +481,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -515,7 +515,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -526,7 +526,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -579,7 +579,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -612,7 +612,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(1000)
@@ -642,7 +642,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(1000)
@@ -693,7 +693,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .immediately()


### PR DESCRIPTION
## Description

Fix #4675

This seems like a little less work than updating the mock and other tests with fixed expectations.  Here we'll trigger the shutdown of the websocket after 5 - 10 minutes (the same as the go client).

Another thought is to eliminate the random strategy specifically for the mock client, but that also seems hackish.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
