### PR TITLE
fix #4659: deprecating support testing client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 #### Improvements
 * Fix #3805: DeletionTimestamp and Finalizer support in Mock server.
 * Fix #4644: generate CRDs in parallel and optimize code
+* Fix #4659: added a generic support(apiversion, kind) method in addition to the class based check
 * Fix #4739: honor optimistic concurrency control semantics in the mock server for `PUT` and `PATCH` requests.
 * Fix #4747: migrate to SnakeYAML Engine
 * Fix #4788: moved retry logic into the standard client so that it applies to all requests, including websockets
@@ -38,6 +39,7 @@
 * Fix #4758: added support for pod ephemeral container operations
 
 #### _**Note**_: Breaking changes
+* Fix #4659: The SupportTestingClient interface has been deprecated.  Please use one of the supports methods or getApiGroup to determine what is available on the api server.
 
 ### 6.4.1 (2023-01-31)
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Client.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Client.java
@@ -56,6 +56,19 @@ public interface Client extends Closeable {
   <R extends KubernetesResource> boolean supports(Class<R> type);
 
   /**
+   * Checks the Kubernetes server for support for the given type.
+   *
+   * <p>
+   * The response is not cached, a new check will be performed for each method invocation. In case custom resource
+   * definition is installed in between invocations, this method might return different values.
+   *
+   * @param apiVersion the api/version. This should be fully qualified - that is for openshift, please include the api.
+   * @param kind the resource kind
+   * @return boolean value indicating whether this type is supported
+   */
+  boolean supports(String apiVersion, String kind);
+
+  /**
    * Checks for the api group. exact = false will scan all groups
    * for a suffix match. exact = true will look only for that apiGroup.
    *

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ClientAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ClientAdapter.java
@@ -69,6 +69,11 @@ public abstract class ClientAdapter<C extends ClientAdapter<C>> implements Clien
   }
 
   @Override
+  public boolean supports(String apiVersion, String kind) {
+    return client.supports(apiVersion, kind);
+  }
+
+  @Override
   public boolean hasApiGroup(String apiGroup, boolean exact) {
     return client.hasApiGroup(apiGroup, exact);
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/SupportTestingClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/SupportTestingClient.java
@@ -24,7 +24,10 @@ import io.fabric8.kubernetes.client.Client;
  * Moving forward only clients with special support needs, such as
  * the openshift client should implement this interface. For those classes,
  * this interface can be part of the public contract.
+ *
+ * @deprecated will be removed in future versions
  */
+@Deprecated
 public interface SupportTestingClient extends Client {
 
   /**
@@ -34,7 +37,10 @@ public interface SupportTestingClient extends Client {
    * {@link Client#hasApiGroup(String, boolean)} to be compatible with mock support
    *
    * @return true if supported
+   *
+   * @deprecated use {@link Client#supports(Class)} or {@link Client#supports(String, String)} instead
    */
+  @Deprecated
   boolean isSupported();
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/BaseClient.java
@@ -193,14 +193,21 @@ public abstract class BaseClient implements Client {
     if (Utils.isNullOrEmpty(typeApiVersion) || Utils.isNullOrEmpty(typeKind)) {
       return false;
     }
-    final APIResourceList apiResources = getApiResources(ApiVersionUtil.joinApiGroupAndVersion(
-        HasMetadata.getGroup(type), HasMetadata.getVersion(type)));
+    return supports(ApiVersionUtil.joinApiGroupAndVersion(
+        HasMetadata.getGroup(type), HasMetadata.getVersion(type)), typeKind);
+  }
+
+  @Override
+  public boolean supports(String apiVersion, String kind) {
+    Utils.checkNotNull(kind, "kind cannot be null");
+    Utils.checkNotNull(apiVersion, "apiVersion cannot be null");
+    final APIResourceList apiResources = getApiResources(apiVersion);
     if (apiResources == null) {
       return false;
     }
     return apiResources.getResources()
         .stream()
-        .anyMatch(r -> typeKind.equals(r.getKind()));
+        .anyMatch(r -> kind.equals(r.getKind()));
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/BaseClientTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/BaseClientTest.java
@@ -126,4 +126,16 @@ class BaseClientTest {
     }
   }
 
+  @Test
+  void supportsGeneric() {
+    try (MockedConstruction<OperationSupport> ignore = mockConstruction(OperationSupport.class,
+        (mock, ctx) -> when(mock.restCall(APIResourceList.class, "/apis", "networking.k8s.io/v1"))
+            .thenReturn(new APIResourceListBuilder().addNewResource().withKind("Ingress").endResource().build()))) {
+      // When
+      final boolean result = baseClient.supports("networking.k8s.io/v1", "Ingress");
+      // Then
+      assertThat(result).isTrue();
+    }
+  }
+
 }


### PR DESCRIPTION
## Description

Resolves the next step in #4659, which is to deprecate before full removal - at which point we'll stop internally using it for isAdaptable

Also adding a generic supports method.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
