### PR TITLE
feat: request retry backoff limit defaults to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix #4800: (java-generator) Reflect the `scope` field when implementing the `Namespaced` interface
 * Fix #4853: adding a wait on the pod for log operations
 * Fix #4848: Vert.x async DNS resolver is disabled
+* Fix #4863: default HttpClient retry logic to 100ms interval
 * Fix #4865: (java-generator) performance improvements
 
 #### Dependency Upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix #4853: adding a wait on the pod for log operations
 * Fix #4848: Vert.x async DNS resolver is disabled
 * Fix #4863: default HttpClient retry logic to 100ms interval
+* Fix #4863: default HttpClient retry logic to 10 attempts
 * Fix #4865: (java-generator) performance improvements
 
 #### Dependency Upgrade

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -144,7 +144,7 @@ public class Config {
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS = 64;
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST = 5;
 
-  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFLIMIT = 0;
+  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFLIMIT = 10;
   public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL = 100;
 
   public static final int DEFAULT_UPLOAD_CONNECTION_TIMEOUT = 10 * 1000;

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -145,7 +145,7 @@ public class Config {
   public static final Integer DEFAULT_MAX_CONCURRENT_REQUESTS_PER_HOST = 5;
 
   public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFLIMIT = 0;
-  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL = 1000;
+  public static final Integer DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL = 100;
 
   public static final int DEFAULT_UPLOAD_CONNECTION_TIMEOUT = 10 * 1000;
   public static final int DEFAULT_UPLOAD_REQUEST_TIMEOUT = 120 * 1000;

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -172,6 +172,8 @@ public class HttpClientUtils {
   public static void applyCommonConfiguration(Config config, HttpClient.Builder builder, HttpClient.Factory factory) {
     builder.followAllRedirects();
 
+    builder.requestConfig(config);
+
     if (config.getConnectionTimeout() > 0) {
       builder.connectTimeout(config.getConnectionTimeout(), TimeUnit.MILLISECONDS);
     }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -27,6 +27,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,14 +92,15 @@ class StandardHttpClientTest {
   }
 
   @Test
-  void testNoHttpRetryWithDefaultConfig() throws InterruptedException {
+  void test10RetriesWithDefaultConfig() throws Exception {
     CompletableFuture<?> sendAsyncFuture = client.sendAsync(client.newHttpRequestBuilder().uri("http://localhost").build(),
         InputStream.class);
 
     client.getRespFutures().get(0).completeExceptionally(new IOException());
+    IntStream.range(1, 11).forEach(i -> client.getRespFutures().add(client.getRespFutures().get(0)));
 
     try {
-      sendAsyncFuture.get();
+      sendAsyncFuture.get(30, TimeUnit.SECONDS);
       fail();
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof IOException);

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/ExponentialBackoffIntervalCalculatorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/ExponentialBackoffIntervalCalculatorTest.java
@@ -32,13 +32,13 @@ class ExponentialBackoffIntervalCalculatorTest {
     // Given
     final ExponentialBackoffIntervalCalculator calculator = ExponentialBackoffIntervalCalculator.from(null);
     // When-Then
-    assertThat(calculator.nextReconnectInterval()).isEqualTo(1000);
-    assertThat(calculator.nextReconnectInterval()).isEqualTo(2000);
-    assertThat(calculator.nextReconnectInterval()).isEqualTo(4000);
-    assertThat(calculator.nextReconnectInterval()).isEqualTo(8000);
-    assertThat(calculator.nextReconnectInterval()).isEqualTo(16000);
-    assertThat(calculator.nextReconnectInterval()).isEqualTo(32000);
-    assertThat(calculator.nextReconnectInterval()).isEqualTo(32000);
+    assertThat(calculator.nextReconnectInterval()).isEqualTo(100);
+    assertThat(calculator.nextReconnectInterval()).isEqualTo(200);
+    assertThat(calculator.nextReconnectInterval()).isEqualTo(400);
+    assertThat(calculator.nextReconnectInterval()).isEqualTo(800);
+    assertThat(calculator.nextReconnectInterval()).isEqualTo(1600);
+    assertThat(calculator.nextReconnectInterval()).isEqualTo(3200);
+    assertThat(calculator.nextReconnectInterval()).isEqualTo(3200);
   }
 
   @Test

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/ExponentialBackoffIntervalCalculatorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/ExponentialBackoffIntervalCalculatorTest.java
@@ -60,11 +60,24 @@ class ExponentialBackoffIntervalCalculatorTest {
   }
 
   @Test
-  @DisplayName("shouldRetry, from null config, should use default values returns false (always)")
-  void shouldRetryFromNullConfig() {
+  @DisplayName("shouldRetry, from null config within limit, should use default values returns true")
+  void shouldRetryFromNullConfigReturnsFalse() {
     // Given
     final ExponentialBackoffIntervalCalculator calculator = ExponentialBackoffIntervalCalculator.from(null);
-    // When-Then
+    // When
+    IntStream.range(0, 9).forEach(i -> calculator.nextReconnectInterval());
+    // Then
+    assertThat(calculator.shouldRetry()).isTrue();
+  }
+
+  @Test
+  @DisplayName("shouldRetry, from null config outside limit, should use default values returns false")
+  void shouldRetryFromNullConfigReturnsTrue() {
+    // Given
+    final ExponentialBackoffIntervalCalculator calculator = ExponentialBackoffIntervalCalculator.from(null);
+    // When
+    IntStream.range(0, 10).forEach(i -> calculator.nextReconnectInterval());
+    // Then
     assertThat(calculator.shouldRetry()).isFalse();
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -372,12 +372,13 @@ class WatchTest {
   }
 
   @Test
-  void testErrorResponse() throws InterruptedException {
+  void testErrorResponse() {
     // Given
+    client.getConfiguration().setRequestRetryBackoffLimit(0);
     server.expect()
         .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&watch=true")
         .andReturn(503, "may not be a status")
-        .once();
+        .times(2);
 
     client.pods().watch(new Watcher<Pod>() {
 


### PR DESCRIPTION
## Description
Fix #4863

- feat: default HttpClient retry logic to 100ms interval
- feat: request retry backoff limit defaults to 10

Enables the usage of the retry logic with a maximum limit of 10 attempts


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
