### PR TITLE
fix #4826: refining / deprecating rollout logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 #### _**Note**_: Breaking changes
 * Fix #4659: The SupportTestingClient interface has been deprecated.  Please use one of the supports methods or getApiGroup to determine what is available on the api server.
+* Fix #4825: removed or deprecated/moved methods that are unrelated to the rolling timeout from ImageEditReplacePatchable.  Deprecated rollout methods for timeout and edit - future versions will not support
 
 ### 6.4.1 (2023-01-31)
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ImageEditReplacePatchable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ImageEditReplacePatchable.java
@@ -16,30 +16,34 @@
 package io.fabric8.kubernetes.client.dsl;
 
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
-public interface ImageEditReplacePatchable<T> extends EditReplacePatchable<T> {
-
-  /**
-   * Update existing container image(s) of resources
-   *
-   * @param containerToImageMap Map with keys as container name and value as image
-   * @return updated resource
-   */
-  T updateImage(Map<String, String> containerToImageMap);
+/**
+ * @deprecated will be removed in future versions
+ */
+@Deprecated
+public interface ImageEditReplacePatchable<T> extends ImageUpdateable<T> {
 
   /**
-   * Update existing container image of single container resource
+   * Edit the context or current item and apply the result to trigger a rollout. It is resource dependent how the
+   * new resource is applied.
    *
-   * @param image image to be updated
-   * @return updated resource
+   * @param function
+   * @return
+   *
+   * @deprecated client managed rollouts will be removed in future versions
    */
-  T updateImage(String image);
+  @Deprecated
+  T edit(UnaryOperator<T> function);
 
   /**
    * Mark the provided resource as paused
    *
    * @return updated resource
+   *
+   * @deprecated should be called prior to the timeout method
    */
+  @Deprecated
   T pause();
 
   /**
@@ -47,21 +51,44 @@ public interface ImageEditReplacePatchable<T> extends EditReplacePatchable<T> {
    * By resuming a resource, we allow it to be reconciled again.
    *
    * @return updated resource
+   *
+   * @deprecated should be called prior to the timeout method
    */
+  @Deprecated
   T resume();
 
   /**
    * Restart a resource. Resource will be rollout restarted.
    *
    * @return updated resource
+   *
+   * @deprecated should be called prior to the timeout method
    */
+  @Deprecated
   T restart();
 
   /**
    * Rollback to previous rollout.
    *
    * @return updated resource
+   *
+   * @deprecated should be called prior to the timeout method
    */
+  @Deprecated
   T undo();
+
+  /**
+   * @deprecated should be called prior to the rolling method
+   */
+  @Deprecated
+  @Override
+  T updateImage(Map<String, String> containerToImageMap);
+
+  /**
+   * @deprecated should be called prior to the rolling method
+   */
+  @Deprecated
+  @Override
+  T updateImage(String image);
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ImageUpdateable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ImageUpdateable.java
@@ -13,15 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.fabric8.kubernetes.client.dsl;
 
-import io.fabric8.kubernetes.api.model.Status;
-import io.fabric8.kubernetes.api.model.extensions.DeploymentRollback;
+import java.util.Map;
 
-public interface RollableScalableResource<T> extends ScalableResource<T>, ImageUpdateable<T> {
+public interface ImageUpdateable<T> {
 
-  TimeoutImageEditReplacePatchable<T> rolling();
+  /**
+   * Update existing container image(s) of resources
+   *
+   * @param containerToImageMap Map with keys as container name and value as image
+   * @return updated resource
+   */
+  T updateImage(Map<String, String> containerToImageMap);
 
-  Status rollback(DeploymentRollback deploymentRollback);
+  /**
+   * Update existing container image of single container resource
+   *
+   * @param image image to be updated
+   * @return updated resource
+   */
+  T updateImage(String image);
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TimeoutImageEditReplacePatchable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TimeoutImageEditReplacePatchable.java
@@ -18,12 +18,63 @@ package io.fabric8.kubernetes.client.dsl;
 
 import java.util.concurrent.TimeUnit;
 
+// TODO should be renamed when deprecations are removed
 public interface TimeoutImageEditReplacePatchable<T> extends
     Timeoutable, ImageEditReplacePatchable<T> {
 
+  /**
+   * Sets the timeout for each pod scaling operation during the rollout
+   * <p>
+   * Applies only to ReplicaSets and ReplicationControllers
+   *
+   * @deprecated client managed rollouts will be removed in future versions
+   */
+  @Deprecated
   @Override
   ImageEditReplacePatchable<T> withTimeout(long timeout, TimeUnit unit);
 
+  /**
+   * Sets the timeout for each pod scaling operation during the rollout
+   * <p>
+   * Applies only to ReplicaSets and ReplicationControllers
+   *
+   * @deprecated client managed rollouts will be removed in future versions
+   */
+  @Deprecated
   @Override
   ImageEditReplacePatchable<T> withTimeoutInMillis(long timeoutInMillis);
+
+  /**
+   * Mark the provided resource as paused
+   *
+   * @return updated resource
+   */
+  @Override
+  T pause();
+
+  /**
+   * Resume a paused resource. Paused resources will not be reconciled by a controller.
+   * By resuming a resource, we allow it to be reconciled again.
+   *
+   * @return updated resource
+   */
+  @Override
+  T resume();
+
+  /**
+   * Restart a resource. Resource will be rollout restarted.
+   *
+   * @return updated resource
+   */
+  @Override
+  T restart();
+
+  /**
+   * Rollback to previous rollout.
+   *
+   * @return updated resource
+   */
+  @Override
+  T undo();
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
@@ -70,26 +70,6 @@ public class ReplicaSetOperationsImpl
   }
 
   @Override
-  public ReplicaSet pause() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" pausing is not supported");
-  }
-
-  @Override
-  public ReplicaSet resume() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" resuming is not supported");
-  }
-
-  @Override
-  public ReplicaSet restart() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" restarting is not supported");
-  }
-
-  @Override
-  public ReplicaSet undo() {
-    throw new UnsupportedOperationException("no rollbacker has been implemented for \"" + get().getKind() + "\"");
-  }
-
-  @Override
   public ReplicaSet withReplicas(int count) {
     return accept(r -> r.getSpec().setReplicas(count));
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetRollingUpdater.java
@@ -28,10 +28,6 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 
 class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList> {
 
-  ReplicaSetRollingUpdater(Client client, String namespace) {
-    super(client, namespace);
-  }
-
   ReplicaSetRollingUpdater(Client client, String namespace, long rollingTimeoutMillis, long loggingIntervalMillis) {
     super(client, namespace, rollingTimeoutMillis, loggingIntervalMillis);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
@@ -26,8 +26,6 @@ import io.fabric8.kubernetes.client.dsl.Loggable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
-import io.fabric8.kubernetes.client.dsl.base.PatchContext;
-import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
@@ -136,32 +134,13 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
 
   @Override
   public T edit(UnaryOperator<T> function) {
-    if (!rollingOperationContext.isRolling()) {
+    RollingUpdater<T, L> rollingUpdater = getRollingUpdater(context.getTimeout(), context.getTimeoutUnit());
+    if (!rollingOperationContext.isRolling() || rollingUpdater == null) {
       return super.edit(function);
     }
-    try {
-      T oldObj = getItemOrRequireFromServer();
-      T newObj = function.apply(Serialization.clone(oldObj));
-      return getRollingUpdater(context.getTimeout(), context.getTimeoutUnit()).rollUpdate(oldObj, newObj);
-    } catch (Exception e) {
-      throw KubernetesClientException.launderThrowable(e);
-    }
-  }
-
-  @Override
-  public T replace(T t) {
-    if (!rollingOperationContext.isRolling()) {
-      return super.replace(t);
-    }
-    return getRollingUpdater(context.getTimeout(), context.getTimeoutUnit()).rollUpdate(getItemOrRequireFromServer(), t);
-  }
-
-  @Override
-  public T patch(PatchContext patchContext, T item) {
-    if (!rollingOperationContext.isRolling() || patchContext == null || patchContext.getPatchType() != PatchType.JSON) {
-      return super.patch(patchContext, item);
-    }
-    return getRollingUpdater(context.getTimeout(), context.getTimeoutUnit()).rollUpdate(getItemOrRequireFromServer(), item);
+    T oldObj = getItemOrRequireFromServer();
+    T newObj = function.apply(Serialization.clone(oldObj));
+    return rollingUpdater.rollUpdate(oldObj, newObj);
   }
 
   public abstract RollableScalableResourceOperation<T, L, R> newInstance(PodOperationContext context,
@@ -256,6 +235,26 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
   @Override
   public RollableScalableResourceOperation<T, L, R> withTimeoutInMillis(long timeoutInMillis) {
     return withTimeout(timeoutInMillis, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public T pause() {
+    throw new KubernetesClientException(context.getPlural() + " pausing is not supported");
+  }
+
+  @Override
+  public T resume() {
+    throw new KubernetesClientException(context.getPlural() + " resuming is not supported");
+  }
+
+  @Override
+  public T restart() {
+    throw new KubernetesClientException(context.getPlural() + " restarting is not supported");
+  }
+
+  @Override
+  public T undo() {
+    throw new KubernetesClientException(context.getPlural() + " undo is not supported");
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
@@ -58,8 +57,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class RollingUpdater<T extends HasMetadata, L> {
   public static final String DEPLOYMENT_KEY = "deployment";
 
-  private static final Long DEFAULT_ROLLING_TIMEOUT = 15 * 60 * 1000L; // 15 mins
-
   private static final Long DEFAULT_SERVER_GC_WAIT_TIMEOUT = 60 * 1000L; // 60 seconds
 
   private static final transient Logger LOG = LoggerFactory.getLogger(RollingUpdater.class);
@@ -68,10 +65,6 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
   protected final String namespace;
   private final long rollingTimeoutMillis;
   private final long loggingIntervalMillis;
-
-  protected RollingUpdater(Client client, String namespace) {
-    this(client, namespace, DEFAULT_ROLLING_TIMEOUT, Config.DEFAULT_LOGGING_INTERVAL);
-  }
 
   protected RollingUpdater(Client client, String namespace, long rollingTimeoutMillis, long loggingIntervalMillis) {
     this.client = client;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
@@ -145,16 +145,6 @@ public class StatefulSetOperationsImpl
   }
 
   @Override
-  public StatefulSet pause() {
-    throw new KubernetesClientException("not supported");
-  }
-
-  @Override
-  public StatefulSet resume() {
-    throw new KubernetesClientException("not supported");
-  }
-
-  @Override
   public StatefulSet restart() {
     return RollingUpdater.restart(this);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
@@ -143,26 +143,6 @@ public class ReplicationControllerOperationsImpl extends
     return PodOperationUtil.watchLog(doGetLog(), out);
   }
 
-  @Override
-  public ReplicationController pause() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" pausing is not supported");
-  }
-
-  @Override
-  public ReplicationController resume() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" resuming is not supported");
-  }
-
-  @Override
-  public ReplicationController restart() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" restarting is not supported");
-  }
-
-  @Override
-  public ReplicationController undo() {
-    throw new UnsupportedOperationException("no rollbacker has been implemented for \"" + get().getKind() + "\"");
-  }
-
   static Map<String, String> getReplicationControllerPodLabels(ReplicationController replicationController) {
     Map<String, String> labels = new HashMap<>();
     if (replicationController != null && replicationController.getSpec() != null

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerRollingUpdater.java
@@ -29,10 +29,6 @@ import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
 
 class ReplicationControllerRollingUpdater extends RollingUpdater<ReplicationController, ReplicationControllerList> {
 
-  ReplicationControllerRollingUpdater(Client client, String namespace) {
-    super(client, namespace);
-  }
-
   ReplicationControllerRollingUpdater(Client client, String namespace, long rollingTimeoutMillis, long loggingIntervalMillis) {
     super(client, namespace, rollingTimeoutMillis, loggingIntervalMillis);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
@@ -72,26 +72,6 @@ public class ReplicaSetOperationsImpl
   }
 
   @Override
-  public ReplicaSet pause() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" pausing is not supported");
-  }
-
-  @Override
-  public ReplicaSet resume() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" resuming is not supported");
-  }
-
-  @Override
-  public ReplicaSet restart() {
-    throw new UnsupportedOperationException(context.getPlural() + " \"" + name + "\" restarting is not supported");
-  }
-
-  @Override
-  public ReplicaSet undo() {
-    throw new UnsupportedOperationException("no rollbacker has been implemented for \"" + get().getKind() + "\"");
-  }
-
-  @Override
   public ReplicaSet withReplicas(int count) {
     return accept(r -> r.getSpec().setReplicas(count));
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetRollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetRollingUpdater.java
@@ -29,10 +29,6 @@ import io.fabric8.kubernetes.client.dsl.internal.apps.v1.RollingUpdater;
 
 class ReplicaSetRollingUpdater extends RollingUpdater<ReplicaSet, ReplicaSetList> {
 
-  ReplicaSetRollingUpdater(Client client, String namespace) {
-    super(client, namespace);
-  }
-
   ReplicaSetRollingUpdater(Client client, String namespace, long rollingTimeoutMillis, long loggingIntervalMillis) {
     super(client, namespace, rollingTimeoutMillis, loggingIntervalMillis);
   }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -18,7 +18,6 @@ package io.fabric8.kubernetes.client.mock;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -47,7 +46,6 @@ import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -64,17 +62,31 @@ class DeploymentTest {
 
   @Test
   void testList() {
-    server.expect().withPath("/apis/apps/v1/namespaces/test/deployments").andReturn(200, new DeploymentListBuilder().build())
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/test/deployments")
+        .andReturn(200, new DeploymentListBuilder().build())
         .once();
-    server.expect().withPath("/apis/apps/v1/namespaces/ns1/deployments").andReturn(200, new DeploymentListBuilder()
-        .addNewItem().and()
-        .addNewItem().and().build()).once();
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments")
+        .andReturn(200, new DeploymentListBuilder()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .build())
+        .once();
 
-    server.expect().withPath("/apis/apps/v1/deployments").andReturn(200, new DeploymentListBuilder()
-        .addNewItem().and()
-        .addNewItem().and()
-        .addNewItem()
-        .and().build()).once();
+    server.expect()
+        .withPath("/apis/apps/v1/deployments")
+        .andReturn(200, new DeploymentListBuilder()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .build())
+        .once();
 
     DeploymentList deploymentList = client.apps().deployments().list();
     assertNotNull(deploymentList);
@@ -94,17 +106,23 @@ class DeploymentTest {
     server.expect()
         .withPath("/apis/apps/v1/namespaces/test/deployments?labelSelector="
             + Utils.toUrlEncoded("key1=value1,key2=value2,key3=value3"))
-        .andReturn(200, new DeploymentListBuilder().build()).always();
+        .andReturn(200, new DeploymentListBuilder().build())
+        .always();
     server.expect()
-        .withPath("/apis/apps/v1/namespaces/test/deployments?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2"))
+        .withPath(
+            "/apis/apps/v1/namespaces/test/deployments?labelSelector=" + Utils.toUrlEncoded("key1=value1,key2=value2"))
         .andReturn(200, new DeploymentListBuilder()
-            .addNewItem().and()
-            .addNewItem().and()
-            .addNewItem().and()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
+            .addNewItem()
+            .and()
             .build())
         .once();
 
-    DeploymentList deploymentList = client.apps().deployments()
+    DeploymentList deploymentList = client.apps()
+        .deployments()
         .withLabel("key1", "value1")
         .withLabel("key2", "value2")
         .withLabel("key3", "value3")
@@ -113,7 +131,8 @@ class DeploymentTest {
     assertNotNull(deploymentList);
     assertEquals(0, deploymentList.getItems().size());
 
-    deploymentList = client.apps().deployments()
+    deploymentList = client.apps()
+        .deployments()
         .withLabel("key1", "value1")
         .withLabel("key2", "value2")
         .list();
@@ -124,10 +143,14 @@ class DeploymentTest {
 
   @Test
   void testGet() {
-    server.expect().withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
-        .andReturn(200, new DeploymentBuilder().build()).once();
-    server.expect().withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2")
-        .andReturn(200, new DeploymentBuilder().build()).once();
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
+        .andReturn(200, new DeploymentBuilder().build())
+        .once();
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2")
+        .andReturn(200, new DeploymentBuilder().build())
+        .once();
 
     Deployment deployment = client.apps().deployments().withName("deployment1").get();
     assertNotNull(deployment);
@@ -196,17 +219,26 @@ class DeploymentTest {
         .endStatus()
         .build();
 
-    server.expect().withPath("/apis/apps/v1/namespaces/test/deployments/deployment1").andReturn(200, deployment1).once();
-    server.expect().withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
-        .andReturn(200, new DeploymentBuilder(deployment1).editSpec().withReplicas(0).endSpec().build()).times(5);
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
+        .andReturn(200, deployment1)
+        .once();
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
+        .andReturn(200, new DeploymentBuilder(deployment1).editSpec().withReplicas(0).endSpec().build())
+        .times(5);
 
-    server.expect().withPath("/apis/apps/v1/namespaces/test/replicasets?labelSelector=key1%3Dvalue1")
-        .andReturn(200, new ReplicaSetListBuilder().addToItems(replicaSet1).build()).once();
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/test/replicasets?labelSelector=key1%3Dvalue1")
+        .andReturn(200, new ReplicaSetListBuilder().addToItems(replicaSet1).build())
+        .once();
     server.expect().withPath("/apis/apps/v1/namespaces/test/replicasets/rs1").andReturn(200, replicaSet1).once();
 
     server.expect().withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2").andReturn(200, deployment2).once();
-    server.expect().withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2")
-        .andReturn(200, new DeploymentBuilder(deployment2).editSpec().withReplicas(0).endSpec().build()).times(5);
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2")
+        .andReturn(200, new DeploymentBuilder(deployment2).editSpec().withReplicas(0).endSpec().build())
+        .times(5);
 
     boolean deleted = client.apps().deployments().withName("deployment1").delete().size() == 1;
     assertTrue(deleted);
@@ -250,15 +282,21 @@ class DeploymentTest {
         .endStatus()
         .build();
 
-    Deployment deployment3 = new DeploymentBuilder().withNewMetadata().withName("deployment3").withNamespace("any")
+    Deployment deployment3 = new DeploymentBuilder().withNewMetadata()
+        .withName("deployment3")
+        .withNamespace("any")
         .endMetadata()
         .withNewSpec()
         .withReplicas(1)
         .endSpec()
         .build();
 
-    server.expect().withPath("/apis/apps/v1/namespaces/test/deployments/deployment1").andReturn(200, deployment1).once();
-    server.expect().withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
+        .andReturn(200, deployment1)
+        .once();
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
         .andReturn(200, new DeploymentBuilder(deployment1)
             .editStatus()
             .withReplicas(0)
@@ -268,7 +306,8 @@ class DeploymentTest {
         .times(5);
 
     server.expect().withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2").andReturn(200, deployment2).once();
-    server.expect().withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2")
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment2")
         .andReturn(200, new DeploymentBuilder(deployment2)
             .editStatus()
             .withReplicas(0)
@@ -286,24 +325,31 @@ class DeploymentTest {
 
   @Test
   void testDeleteWithNamespaceMismatch() {
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata().withName("deployment1").withNamespace("test")
+    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+        .withName("deployment1")
+        .withNamespace("test")
         .endMetadata()
         .withNewSpec()
         .withReplicas(1)
         .endSpec()
         .build();
     NonNamespaceOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deployOp = client.apps()
-        .deployments().inNamespace("test1");
+        .deployments()
+        .inNamespace("test1");
 
     assertTrue(deployOp.delete(deployment1).isEmpty());
   }
 
   @Test
   void testCreateWithNameMismatch() {
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata().withName("deployment1").withNamespace("test").and()
+    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+        .withName("deployment1")
+        .withNamespace("test")
+        .and()
         .build();
     RollableScalableResource<Deployment> deployOp = client
-        .apps().deployments()
+        .apps()
+        .deployments()
         .inNamespace("test1")
         .withName("mydeployment1");
     assertThrows(KubernetesClientException.class, () -> deployOp.create(deployment1));
@@ -330,7 +376,9 @@ class DeploymentTest {
         .endStrategy()
         .withMinReadySeconds(5)
         .withNewTemplate()
-        .withNewMetadata().withLabels(Collections.singletonMap("service", "http-server")).endMetadata()
+        .withNewMetadata()
+        .withLabels(Collections.singletonMap("service", "http-server"))
+        .endMetadata()
         .withNewSpec()
         .addToContainers(new ContainerBuilder()
             .withName("nginx")
@@ -343,16 +391,17 @@ class DeploymentTest {
         .endSpec()
         .build();
 
-    server.expect().withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment1").andReturn(200, deployment).always();
-    server.expect().withPath("/api/v1/namespaces/ns1/pods?labelSelector=service%3Dhttp-server")
-        .andReturn(200, new KubernetesListBuilder().build()).once();
-    server.expect().post().withPath("/apis/apps/v1/namespaces/ns1/deployments").andReturn(201, deployment).times(2);
+    server.expect()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deployment1")
+        .andReturn(200, deployment)
+        .always();
 
-    client.apps().deployments().inNamespace("ns1")
+    client.apps()
+        .deployments()
+        .inNamespace("ns1")
         .withName("deployment1")
         .rolling()
-        .withTimeout(5, TimeUnit.MINUTES)
-        .updateImage("");
+        .edit(d -> new DeploymentBuilder(d).editSpec().withReplicas(2).endSpec().build());
   }
 
   @Test
@@ -378,7 +427,8 @@ class DeploymentTest {
 
     server.expect()
         .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1")
-        .andReturn(200, serverDeployment).once();
+        .andReturn(200, serverDeployment)
+        .once();
 
     List<HasMetadata> resources = client.resourceList(clientDeployment).get();
 
@@ -400,14 +450,19 @@ class DeploymentTest {
   @Test
   void testScaleGet() {
     Scale scaleObj = new ScaleBuilder()
-        .withNewMetadata().addToLabels("foo", "bar").endMetadata()
-        .withNewSpec().withReplicas(Integer.parseInt("2")).endSpec()
+        .withNewMetadata()
+        .addToLabels("foo", "bar")
+        .endMetadata()
+        .withNewSpec()
+        .withReplicas(Integer.parseInt("2"))
+        .endSpec()
         .build();
 
     server.expect()
         .get()
         .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1/scale")
-        .andReturn(200, scaleObj).once();
+        .andReturn(200, scaleObj)
+        .once();
 
     Scale scaleResponse = client.apps().deployments().inNamespace("test").withName("deployment1").scale();
     assertEquals("bar", scaleResponse.getMetadata().getLabels().get("foo"));
@@ -416,14 +471,19 @@ class DeploymentTest {
   @Test
   void testScaleUpdate() {
     Scale scaleObj = new ScaleBuilder()
-        .withNewMetadata().addToLabels("foo", "bar").endMetadata()
-        .withNewSpec().withReplicas(Integer.parseInt("2")).endSpec()
+        .withNewMetadata()
+        .addToLabels("foo", "bar")
+        .endMetadata()
+        .withNewSpec()
+        .withReplicas(Integer.parseInt("2"))
+        .endSpec()
         .build();
 
     server.expect()
         .put()
         .withPath("/apis/apps/v1/namespaces/test/deployments/deployment1/scale")
-        .andReturn(200, scaleObj).once();
+        .andReturn(200, scaleObj)
+        .once();
 
     Scale scaleResponse = client.apps().deployments().inNamespace("test").withName("deployment1").scale(scaleObj);
     assertEquals("bar", scaleResponse.getMetadata().getLabels().get("foo"));
@@ -431,14 +491,18 @@ class DeploymentTest {
 
   @Test
   void testCreate() {
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata().withName("deployment1").withNamespace("test")
+    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+        .withName("deployment1")
+        .withNamespace("test")
         .endMetadata()
         .withNewSpec()
         .withReplicas(1)
         .endSpec()
         .build();
 
-    server.expect().post().withPath("/apis/apps/v1/namespaces/test/deployments")
+    server.expect()
+        .post()
+        .withPath("/apis/apps/v1/namespaces/test/deployments")
         .andReturn(200, deployment1)
         .once();
 
@@ -452,19 +516,34 @@ class DeploymentTest {
   void testRolloutUpdateSingleImage() throws InterruptedException {
     // Given
     String imageToUpdate = "nginx:latest";
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
-    server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .times(3);
+    server.expect()
+        .patch()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
         .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder()
-            .editSpec().editTemplate().editSpec().editContainer(0)
+            .editSpec()
+            .editTemplate()
+            .editSpec()
+            .editContainer(0)
             .withImage(imageToUpdate)
-            .endContainer().endSpec().endTemplate().endSpec()
+            .endContainer()
+            .endSpec()
+            .endTemplate()
+            .endSpec()
             .build())
         .once();
 
     // When
-    Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
-        .rolling().updateImage(imageToUpdate);
+    Deployment deployment = client.apps()
+        .deployments()
+        .inNamespace("ns1")
+        .withName("deploy1")
+        .rolling()
+        .updateImage(imageToUpdate);
 
     // Then
     assertNotNull(deployment);
@@ -479,19 +558,34 @@ class DeploymentTest {
   void testRolloutUpdateImage() throws InterruptedException {
     // Given
     Map<String, String> containerToImageMap = Collections.singletonMap("nginx", "nginx:latest");
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
-    server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .times(3);
+    server.expect()
+        .patch()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
         .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder()
-            .editSpec().editTemplate().editSpec().editContainer(0)
+            .editSpec()
+            .editTemplate()
+            .editSpec()
+            .editContainer(0)
             .withImage(containerToImageMap.get("nginx"))
-            .endContainer().endSpec().endTemplate().endSpec()
+            .endContainer()
+            .endSpec()
+            .endTemplate()
+            .endSpec()
             .build())
         .once();
 
     // When
-    Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
-        .rolling().updateImage(containerToImageMap);
+    Deployment deployment = client.apps()
+        .deployments()
+        .inNamespace("ns1")
+        .withName("deploy1")
+        .rolling()
+        .updateImage(containerToImageMap);
 
     // Then
     assertNotNull(deployment);
@@ -506,14 +600,24 @@ class DeploymentTest {
   @DisplayName("Should pause resource")
   void testRolloutPause() throws InterruptedException {
     // Given
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
-    server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .times(3);
+    server.expect()
+        .patch()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .once();
 
     // When
-    Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
-        .rolling().pause();
+    Deployment deployment = client.apps()
+        .deployments()
+        .inNamespace("ns1")
+        .withName("deploy1")
+        .rolling()
+        .pause();
 
     // Then
     RecordedRequest recordedRequest = server.getLastRequest();
@@ -525,14 +629,24 @@ class DeploymentTest {
   @DisplayName("Should resume rollout")
   void testRolloutResume() throws InterruptedException {
     // Given
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
-    server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .times(3);
+    server.expect()
+        .patch()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .once();
 
     // When
-    Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
-        .rolling().resume();
+    Deployment deployment = client.apps()
+        .deployments()
+        .inNamespace("ns1")
+        .withName("deploy1")
+        .rolling()
+        .resume();
 
     // Then
     RecordedRequest recordedRequest = server.getLastRequest();
@@ -545,14 +659,24 @@ class DeploymentTest {
   @DisplayName("Should restart rollout")
   void testRolloutRestart() throws InterruptedException {
     // Given
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
-    server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .times(3);
+    server.expect()
+        .patch()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .once();
 
     // When
-    Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
-        .rolling().restart();
+    Deployment deployment = client.apps()
+        .deployments()
+        .inNamespace("ns1")
+        .withName("deploy1")
+        .rolling()
+        .restart();
 
     // Then
     RecordedRequest recordedRequest = server.getLastRequest();
@@ -572,7 +696,9 @@ class DeploymentTest {
         .endMetadata()
         .withNewSpec()
         .withReplicas(0)
-        .withNewSelector().addToMatchLabels("app", "nginx").endSelector()
+        .withNewSelector()
+        .addToMatchLabels("app", "nginx")
+        .endSelector()
         .withNewTemplate()
         .withNewMetadata()
         .addToAnnotations("kubectl.kubernetes.io/restartedAt", "2020-06-08T11:52:50.022")
@@ -583,7 +709,9 @@ class DeploymentTest {
         .addNewContainer()
         .withName("nginx")
         .withImage("nginx:perl")
-        .addNewPort().withContainerPort(80).endPort()
+        .addNewPort()
+        .withContainerPort(80)
+        .endPort()
         .endContainer()
         .endSpec()
         .endTemplate()
@@ -596,7 +724,9 @@ class DeploymentTest {
         .endMetadata()
         .withNewSpec()
         .withReplicas(1)
-        .withNewSelector().addToMatchLabels("app", "nginx").endSelector()
+        .withNewSelector()
+        .addToMatchLabels("app", "nginx")
+        .endSelector()
         .withNewTemplate()
         .withNewMetadata()
         .addToAnnotations("kubectl.kubernetes.io/restartedAt", "2020-06-08T11:52:50.022")
@@ -607,25 +737,39 @@ class DeploymentTest {
         .addNewContainer()
         .withName("nginx")
         .withImage("nginx:1.19")
-        .addNewPort().withContainerPort(80).endPort()
+        .addNewPort()
+        .withContainerPort(80)
+        .endPort()
         .endContainer()
         .endSpec()
         .endTemplate()
         .endSpec()
         .build();
 
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=" + Utils.toUrlEncoded("app=nginx"))
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=" + Utils.toUrlEncoded("app=nginx"))
         .andReturn(HttpURLConnection.HTTP_OK,
             new ReplicaSetListBuilder().withItems(replicaSetRevision1, replicaSetRevision2).build())
         .once();
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).times(3);
-    server.expect().patch().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
-        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build()).once();
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .times(3);
+    server.expect()
+        .patch()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+        .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
+        .once();
 
     // When
-    Deployment deployment = client.apps().deployments().inNamespace("ns1").withName("deploy1")
-        .rolling().undo();
+    Deployment deployment = client.apps()
+        .deployments()
+        .inNamespace("ns1")
+        .withName("deploy1")
+        .rolling()
+        .undo();
 
     // Then
     RecordedRequest recordedRequest = server.getLastRequest();
@@ -642,20 +786,30 @@ class DeploymentTest {
         Collections.singletonMap("app", "nginx"), "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4");
     Pod deployPod = createMockPod("1", "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4", "deploy1-hk9nf",
         Collections.singletonMap("controller-uid", "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4"));
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
         .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
         .always();
 
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
         .andReturn(HttpURLConnection.HTTP_OK, new ReplicaSetListBuilder().withItems(replicaSet).build())
         .once();
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets/deploy1-hk9nf")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/replicasets/deploy1-hk9nf")
         .andReturn(HttpURLConnection.HTTP_OK, replicaSet)
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=app%3Dnginx")
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/ns1/pods?labelSelector=app%3Dnginx")
         .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder().withItems(deployPod).build())
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/deploy1-hk9nf/log?pretty=false")
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/ns1/pods/deploy1-hk9nf/log?pretty=false")
         .andReturn(HttpURLConnection.HTTP_OK, "hello")
         .once();
 
@@ -671,29 +825,41 @@ class DeploymentTest {
   void testDeploymentGetLogMultiContainer() {
     // Given
     ReplicaSet replicaSet = createMockReplicaSet("deploy-multi1", "93b8b619-731a-435a-bcb0-4b0c19f07f2f",
-        "multi-container-deploy-5dfdf5ddfc", Collections.singletonMap("app", "nginx"), "f9ed6d37-9256-44aa-93b0-4af70e046348");
+        "multi-container-deploy-5dfdf5ddfc", Collections.singletonMap("app", "nginx"),
+        "f9ed6d37-9256-44aa-93b0-4af70e046348");
     Pod deployPod = createMockPod("multi-container-deploy-5dfdf5ddfc", "f9ed6d37-9256-44aa-93b0-4af70e046348",
         "multi-container-deploy-5dfdf5ddfc-r6q4j",
         Collections.singletonMap("controller-uid", "f9ed6d37-9256-44aa-93b0-4af70e046348"));
 
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy-multi1")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy-multi1")
         .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().editMetadata()
             .withName("deploy-multi1")
             .withUid("93b8b619-731a-435a-bcb0-4b0c19f07f2f")
-            .endMetadata().build())
+            .endMetadata()
+            .build())
         .always();
 
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
         .andReturn(HttpURLConnection.HTTP_OK, new ReplicaSetListBuilder().withItems(replicaSet).build())
         .once();
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets/multi-container-deploy-5dfdf5ddfc")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/replicasets/multi-container-deploy-5dfdf5ddfc")
         .andReturn(HttpURLConnection.HTTP_OK, replicaSet)
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=app%3Dnginx")
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/ns1/pods?labelSelector=app%3Dnginx")
         .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder().withItems(deployPod).build())
         .once();
-    server.expect().get()
-        .withPath("/api/v1/namespaces/ns1/pods/multi-container-deploy-5dfdf5ddfc-r6q4j/log?pretty=false&container=container1")
+    server.expect()
+        .get()
+        .withPath(
+            "/api/v1/namespaces/ns1/pods/multi-container-deploy-5dfdf5ddfc-r6q4j/log?pretty=false&container=container1")
         .andReturn(HttpURLConnection.HTTP_OK, "hello")
         .once();
 
@@ -713,20 +879,30 @@ class DeploymentTest {
         Collections.singletonMap("app", "nginx"), "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4");
     Pod deployPod = createMockPod("1", "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4", "deploy1-hk9nf",
         Collections.singletonMap("controller-uid", "3Dc4c8746c-94fd-47a7-ac01-11047c0323b4"));
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/deployments/deploy1")
         .andReturn(HttpURLConnection.HTTP_OK, createDeploymentBuilder().build())
         .always();
 
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/replicasets?labelSelector=app%3Dnginx")
         .andReturn(HttpURLConnection.HTTP_OK, new ReplicaSetListBuilder().withItems(replicaSet).build())
         .once();
-    server.expect().get().withPath("/apis/apps/v1/namespaces/ns1/replicasets/deploy1-hk9nf")
+    server.expect()
+        .get()
+        .withPath("/apis/apps/v1/namespaces/ns1/replicasets/deploy1-hk9nf")
         .andReturn(HttpURLConnection.HTTP_OK, replicaSet)
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=app%3Dnginx")
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/ns1/pods?labelSelector=app%3Dnginx")
         .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder().withItems(deployPod).build())
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/pods/deploy1-hk9nf/log?pretty=false&timestamps=true")
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/ns1/pods/deploy1-hk9nf/log?pretty=false&timestamps=true")
         .andReturn(HttpURLConnection.HTTP_OK, "hello")
         .once();
 
@@ -752,12 +928,16 @@ class DeploymentTest {
         .addToMatchLabels("app", "nginx")
         .endSelector()
         .withNewTemplate()
-        .withNewMetadata().addToLabels("app", "nginx").endMetadata()
+        .withNewMetadata()
+        .addToLabels("app", "nginx")
+        .endMetadata()
         .withNewSpec()
         .addNewContainer()
         .withName("nginx")
         .withImage("nginx:1.7.9")
-        .addNewPort().withContainerPort(80).endPort()
+        .addNewPort()
+        .withContainerPort(80)
+        .endPort()
         .endContainer()
         .endSpec()
         .endTemplate()
@@ -799,7 +979,8 @@ class DeploymentTest {
             .withName(replicaSetName)
             .withUid(replicaSetUid)
             .build())
-        .withName(name).addToLabels(labels)
+        .withName(name)
+        .addToLabels(labels)
         .endMetadata()
         .build();
   }


### PR DESCRIPTION
## Description

Fix #4826

In looking at #4826 it was clear that #4140 was incomplete.  ImageEditReplacePatchable is problematic in several ways - kubectl no longer provides the ability to have client side rollouts of replicasets and replicationcontrollers, so I'm proposing to deprecate the whole interface and the timeout related methods - at this also means there's no reason to keep the rollingTimeout RequestConfig option.  Beyond that the design of the interface leaves access to methods that are unrelated to rollout after timeout is called - to this end instead on inheriting from EditReplacePatchable, a narrower ImageUpdateable has been added and the only method that was actually implemented as respecting the rollout, edit, has been moved up to the ImageEditReplacePatchable interface.

To keep conflicts at a minimum I'll update this pr after the RequestConfig refinement goes in.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
