### PR TITLE
fix (kubernetes-client-api) : Make Config's ExecCredential nested classes `public` (#4724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix #3805: DeletionTimestamp and Finalizer support in Mock server.
 * Fix #4644: generate CRDs in parallel and optimize code
 * Fix #4659: added a generic support(apiversion, kind) method in addition to the class based check
+* Fix #4724: Private configuration classes cause trouble with Java native (reflection)
 * Fix #4739: honor optimistic concurrency control semantics in the mock server for `PUT` and `PATCH` requests.
 * Fix #4747: migrate to SnakeYAML Engine
 * Fix #4788: moved retry logic into the standard client so that it applies to all requests, including websockets

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -858,7 +858,7 @@ public class Config {
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class ExecCredential {
+  public static final class ExecCredential {
     public String kind;
     public String apiVersion;
     public ExecCredentialSpec spec;
@@ -866,11 +866,11 @@ public class Config {
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class ExecCredentialSpec {
+  public static final class ExecCredentialSpec {
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class ExecCredentialStatus {
+  public static final class ExecCredentialStatus {
     public String token;
     // TODO clientCertificateData, clientKeyData, expirationTimestamp
   }


### PR DESCRIPTION
## Description
Part of #4724 

Expose these nested config classes so that they can be used in reflection.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
