### PR TITLE
fix #4885: addressing a potential hang with jdk streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix #4818: [java-generator] Escape `*/` in generated JavaDocs
 * Fix #4823: (java-generator) handle special characters in field names
 * Fix #4723: [java-generator] Fix a race in the use of JavaParser hitting large CRDs
+* Fix #4885: addresses a potential hang in the jdk client with exec stream reading
 
 #### Improvements
 * Fix #3805: DeletionTimestamp and Finalizer support in Mock server.

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.jdkhttp;
 
 import io.fabric8.kubernetes.client.http.AsyncBody;
 import io.fabric8.kubernetes.client.http.AsyncBody.Consumer;
+import io.fabric8.kubernetes.client.http.BufferUtil;
 import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.StandardHttpClient;
@@ -51,6 +52,7 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static io.fabric8.kubernetes.client.http.StandardHttpHeaders.CONTENT_TYPE;
 
@@ -86,7 +88,9 @@ public class JdkHttpClientImpl extends StandardHttpClient<JdkHttpClientImpl, Jdk
 
         @Override
         public void onNext(List<ByteBuffer> item) {
-          bodySubscriber.onNext(item);
+          // there doesn't seem to be a guarantee that the buffer won't be modified by the caller
+          // after passing it in, so we'll create a copy
+          bodySubscriber.onNext(item.stream().map(BufferUtil::copy).collect(Collectors.toList()));
         }
 
         @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWatchInputStream.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWatchInputStream.java
@@ -86,7 +86,7 @@ public class ExecWatchInputStream extends InputStream {
 
         currentBuffer = buffers.poll();
 
-        if (currentBuffer == null) {
+        if (currentBuffer == null && !complete) {
           try {
             buffers.wait();
           } catch (InterruptedException e) {


### PR DESCRIPTION
## Description

Fix #4885

Addresses PodIT hanging failure with jdk by checking for complete prior to waiting - the issue is that the request for more with jdk will be executed in the calling thread which already holds the lock and can modify the complete flag prior to the wait.

There are also some failures on the JobIT log - but I have not been able to reproduce that.  There are a couple of changes here to help with that logic in general - one is better localize when more is requested.  That should be done inline with the processing call, rather than in a completion handler because it looks like they can be executed in parallel.  The other is that I don't see now anywhere in the jdk client that guarantees the supplied buffers won't change after be passed to consume.  Since we already handled that case with jetty we should do the same here.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
