### PR TITLE
fix #4891: removing the backpressure for close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix #4823: (java-generator) handle special characters in field names
 * Fix #4723: [java-generator] Fix a race in the use of JavaParser hitting large CRDs
 * Fix #4885: addresses a potential hang in the jdk client with exec stream reading
+* Fix #4891: address vertx not completely reading exec streams
 
 #### Improvements
 * Fix #4675: adding a fully client side timeout for informer watches

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
@@ -126,7 +126,6 @@ public class JettyWebSocket implements WebSocket, WebSocketListener {
   @Override
   public void onWebSocketClose(int statusCode, String reason) {
     closed.set(true);
-    backPressure();
     listener.onClose(this, statusCode, reason);
   }
 

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
@@ -155,7 +155,6 @@ class OkHttpWebSocketImpl implements WebSocket {
 
       @Override
       public void onClosing(okhttp3.WebSocket webSocket, int code, String reason) {
-        awaitMoreRequest();
         listener.onClose(new OkHttpWebSocketImpl(webSocket, this::request), code, reason);
       }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
@@ -33,7 +33,7 @@ public interface WebSocket {
 
     /**
      * Called once the full text message has been built. {@link WebSocket#request()} must
-     * be called to receive more messages or onClose.
+     * be called to receive more messages.
      */
     default void onMessage(WebSocket webSocket, String text) {
       webSocket.request();
@@ -41,7 +41,7 @@ public interface WebSocket {
 
     /**
      * Called once the full binary message has been built. {@link WebSocket#request()} must
-     * be called to receive more messages or onClose.
+     * be called to receive more messages.
      */
     default void onMessage(WebSocket webSocket, ByteBuffer bytes) {
       webSocket.request();
@@ -49,7 +49,8 @@ public interface WebSocket {
 
     /**
      * Called when the remote input closes. It's a terminal event, calls to {@link WebSocket#request()}
-     * do nothing after this.
+     * do nothing after this. Some {@link HttpClient} implementations will require {@link WebSocket#request()}
+     * to be called to calling onClose.
      */
     default void onClose(WebSocket webSocket, int code, String reason) {
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
@@ -182,9 +182,13 @@ public class PortForwarderWebsocket implements PortForwarder {
     });
 
     return new PortForward() {
+      private final AtomicBoolean closed = new AtomicBoolean();
+
       @Override
       public void close() {
-        socket.cancel(true);
+        if (!closed.compareAndSet(false, true)) {
+          return;
+        }
         socket.whenComplete((w, t) -> {
           if (w != null) {
             listener.closeBothWays(w, 1001, "User closing");

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListener.java
@@ -197,15 +197,17 @@ public class PortForwarderWebsocketListener implements WebSocket.Listener {
   }
 
   private void closeForwarder() {
-    alive.set(false);
-    if (in != null) {
-      Utils.closeQuietly(in);
-    }
-    if (out != null && out != in) {
-      Utils.closeQuietly(out);
-    }
-    pumperService.shutdownNow();
-    serialExecutor.shutdownNow();
+    serialExecutor.execute(() -> {
+      alive.set(false);
+      if (in != null) {
+        Utils.closeQuietly(in);
+      }
+      if (out != null && out != in) {
+        Utils.closeQuietly(out);
+      }
+      pumperService.shutdownNow();
+      serialExecutor.shutdownNow();
+    });
   }
 
   private static void pipe(ReadableByteChannel in, WebSocket webSocket, BooleanSupplier isAlive)

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.dsl.internal;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.utils.CommonThreadPool;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -122,8 +123,8 @@ class PortForwarderWebsocketListenerTest {
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
     listener.onClose(webSocket, 1337, "Test ended");
     // Then
+    Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> !in.isOpen());
     assertThat(listener.getServerThrowables()).isEmpty();
-    assertThat(in.isOpen()).isFalse();
     assertThat(out.isOpen()).isFalse();
   }
 
@@ -159,6 +160,7 @@ class PortForwarderWebsocketListenerTest {
     listener.onMessage(webSocket, "SKIP 1");
     // Then
     verify(webSocket, timeout(10_000)).sendClose(1002, "Protocol error");
+    await().atMost(10, TimeUnit.SECONDS).until(() -> !listener.isAlive());
     assertThat(outputContent.toString()).isEmpty();
     assertThat(listener.errorOccurred()).isTrue();
     assertThat(listener.getServerThrowables()).isNotEmpty();
@@ -208,6 +210,7 @@ class PortForwarderWebsocketListenerTest {
       listener.onMessage(webSocket, "SKIP 1");
       // Then
       verify(webSocket, timeout(10_000)).sendClose(1002, "Protocol error");
+      await().atMost(10, TimeUnit.SECONDS).until(() -> !listener.isAlive());
       assertThat(outputContent.toString()).isEmpty();
       assertThat(listener.errorOccurred()).isTrue();
       assertThat(listener.getServerThrowables().iterator().next().getMessage())

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -83,6 +83,7 @@ class PodUploadTest {
     BaseClient client = mock(BaseClient.class, Mockito.RETURNS_SELF);
     Mockito.when(client.adapt(BaseClient.class).getExecutor()).thenReturn(CommonThreadPool.get());
     Config config = mock(Config.class, Mockito.RETURNS_DEEP_STUBS);
+    when(config.getRequestConfig().getUploadRequestTimeout()).thenReturn(10);
     when(config.getMasterUrl()).thenReturn("https://openshift.com:8443");
     when(config.getNamespace()).thenReturn("default");
     when(client.getConfiguration()).thenReturn(config);


### PR DESCRIPTION
## Description
Fixes #4891.  The WebSocket interface borrowed from the jdk implementation a requirement of calling request before seeing onClose.  However that requirement was not implemented in the vertx httpclient.  Rather than add backpressure there, a similar fix was added as was done in #4885 - which is if we are doing async handling of onMessage that we'll queue the handling of onClose until after the message processing has completed.  That makes things consistent between asyncbody and websockets.  The jdk implementation will be the only one that requires request to be called to deliver onClose.

Neither this fix nor #4885 explain the issue seen with websocket writes and containerd kube runtimes.  Still not sure what is going on there.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
