### PR TITLE
fix #4861: various changes to refine resourceVersion and replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
 * Fix #4659: The SupportTestingClient interface has been deprecated.  Please use one of the supports methods or getApiGroup to determine what is available on the api server.
 * Fix #4825: removed or deprecated/moved methods that are unrelated to the rolling timeout from ImageEditReplacePatchable.  Deprecated rollout methods for timeout and edit - future versions will not support
 * Fix #4826: removed RequestConfig upload connection and rolling timeouts.  Both were no longer used with no plans to re-introduce their usage.
+* Fix #4861: several breaking changes related to resourceVersion handling and the replace operation:
+  - replace is deprecated, you should use update instead.  If you set the resourceVersion to null it will not be optimistically locked
+  - json patch methods using an item for the diff generation such as edit or patch will no longer omit the resourceVersion in the patch.  If you want the patch to be unlocked, then set the resourceVersion to null on the item to be patched.
+  - createOrReplace is deprecated, you should use server side apply instead.
+  - internal logic to mimic an apply that modify an item prior to a json patch is deprecated - you should instead build the item to be patched off of base version, such as with the edit method.
 
 ### 6.4.1 (2023-01-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,11 @@
 * Fix #4825: removed or deprecated/moved methods that are unrelated to the rolling timeout from ImageEditReplacePatchable.  Deprecated rollout methods for timeout and edit - future versions will not support
 * Fix #4826: removed RequestConfig upload connection and rolling timeouts.  Both were no longer used with no plans to re-introduce their usage.
 * Fix #4861: several breaking changes related to resourceVersion handling and the replace operation:
-  - replace is deprecated, you should use update instead.  If you set the resourceVersion to null it will not be optimistically locked
-  - json patch methods using an item for the diff generation such as edit or patch will no longer omit the resourceVersion in the patch.  If you want the patch to be unlocked, then set the resourceVersion to null on the item to be patched.
-  - createOrReplace is deprecated, you should use server side apply instead.
-  - internal logic to mimic an apply that modify an item prior to a json patch is deprecated - you should instead build the item to be patched off of base version, such as with the edit method.
+  - `replace` is deprecated, you should use `update` instead. If you set the resourceVersion to null it will not be optimistically locked.
+  - `createOrReplace` is deprecated, you should use server side apply instead.
+  - `edit` uses now optimistic locking by default. To disable locking you should change your methods to follow this pattern: `.edit(pod -> new PodBuilder(pod).editMetadata().withResourceVersion(null)//...`
+  - JSON patch methods using an item for the diff generation such as edit or patch will no longer omit the resourceVersion in the patch.  If you want the patch to be unlocked, then set the resourceVersion to null on the item to be patched.
+  - internal logic to mimic an apply that modify an item prior to a JSON patch is deprecated - you should instead build the item to be patched off of base version, such as with the edit method.
 
 ### 6.4.1 (2023-01-31)
 

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/crud/KubernetesCrudDispatcherPatchTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/crud/KubernetesCrudDispatcherPatchTest.java
@@ -324,8 +324,7 @@ class KubernetesCrudDispatcherPatchTest {
   class ResourceVersion {
 
     @Test
-    @DisplayName("JSON patch, with different resource version, should patch the resource ---->" +
-        "Invalid Client behavior which removes the resource version from the list of operations")
+    @DisplayName("JSON patch, with different resource version, should throw conflict exception")
     void differentResourceVersionConflictEdit() {
       // Given
       client.resource(new ConfigMapBuilder()
@@ -339,7 +338,7 @@ class KubernetesCrudDispatcherPatchTest {
           .addToData("key", "changed")
           .build());
       // Then
-      assertThatThrownBy(() -> patchedCmOp.patch())
+      assertThatThrownBy(patchedCmOp::patch)
           .asInstanceOf(InstanceOfAssertFactories.type(KubernetesClientException.class))
           .hasFieldOrPropertyWithValue("code", 409)
           .extracting(KubernetesClientException::getMessage).asString()
@@ -347,7 +346,7 @@ class KubernetesCrudDispatcherPatchTest {
     }
 
     @Test
-    @DisplayName("JSON patch, with different resource version, should throw conflict exception")
+    @DisplayName("JSON patch (list of operations), with different resource version, should throw conflict exception")
     void differentResourceVersionConflict() {
       // Given
       client.resource(new ConfigMapBuilder()

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -22,7 +22,10 @@ public interface CreateOrReplaceable<T> extends Replaceable<T> {
    * fails with a HTTP_CONFLICT, it tries to replace resource.
    *
    * @return created item returned in kubernetes api response
+   *
+   * @deprecated please user {@link ServerSideApplicable#serverSideApply()} or attempt a create and edit/patch operation.
    */
+  @Deprecated
   T createOrReplace();
 
   /**

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
@@ -72,6 +72,13 @@ public interface EditReplacePatchable<T>
    * concurrent changes (between when you obtained your item and the current state) in an unexpected way.
    * <p>
    * Consider using edit, which allows for a known base, and a builder instead.
+   * <p>
+   * WARNING: For some resource types there is an attempt to make this operation more like
+   * an apply by considering implicit server side state as not being part of the patch. This behavior will be
+   * removed in future versions, you should instead construct the resource to be patched from a resource obtained
+   * from the api server or use patch method that is tolerant to missing state, or
+   * {@link ServerSideApplicable#serverSideApply()}
+   * <p>
    *
    * @param item to be patched with patched values
    * @return returns deserialized version of api server response
@@ -92,6 +99,13 @@ public interface EditReplacePatchable<T>
    * <li>{@link PatchType#SERVER_SIDE_APPLY} - will send the serialization of the item as a SERVER SIDE APPLY patch.
    * You may explicitly set the {@link PatchContext#getFieldManager()} as well to override the default.
    * </ul>
+   *
+   * WARNING: For a JSON patch and some resource types there is an attempt to make this operation more like
+   * an apply by considering implicit server side state as not being part of the patch. This behavior will be
+   * removed in future versions, you should instead construct the resource to be patched from a resource obtained
+   * from the api server or use patch method that is tolerant to missing state, or
+   * {@link ServerSideApplicable#serverSideApply()}
+   * <p>
    *
    * @param item to be patched with patched values
    * @param patchContext {@link PatchContext} for patch request
@@ -149,6 +163,13 @@ public interface EditReplacePatchable<T>
    * <p>
    * Consider using edit instead.
    *
+   * WARNING: For some resource types there is an attempt to make this operation more like
+   * an apply by considering implicit server side state as not being part of the patch. This behavior will be
+   * removed in future versions, you should instead construct the resource to be patched from a resource obtained
+   * from the api server or use patch method that is tolerant to missing state, or
+   * {@link ServerSideApplicable#serverSideApply()}
+   * <p>
+   *
    * @return returns deserialized version of api server response
    */
   T patch();
@@ -168,6 +189,13 @@ public interface EditReplacePatchable<T>
    * <li>{@link PatchType#SERVER_SIDE_APPLY} - will send the serialization of the item as a SERVER SIDE APPLY patch.
    * You may explicitly set the {@link PatchContext#getFieldManager()} as well to override the default.
    * </ul>
+   *
+   * WARNING: For a JSON patch and some resource types there is an attempt to make this operation more like
+   * an apply by considering implicit server side state as not being part of the patch. This behavior will be
+   * removed in future versions, you should instead construct the resource to be patched from a resource obtained
+   * from the api server or use patch method that is tolerant to missing state, or
+   * {@link ServerSideApplicable#serverSideApply()}
+   * <p>
    *
    * @param patchContext {@link PatchContext} for patch request
    * @return returns deserialized version of api server response

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemWritableOperation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemWritableOperation.java
@@ -62,8 +62,7 @@ public interface ItemWritableOperation<T> extends DeletableWithOptions, ItemRepl
    *
    * @param item kubernetes object
    * @return updated object
-   * @deprecated please use one of patchStatus, editStatus, or replaceStatus, or a locked replace
-   *             {@link Resource#lockResourceVersion(String)}
+   * @deprecated please use resource(item).updateStatus();
    */
   @Deprecated
   T updateStatus(T item);

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
@@ -30,14 +30,38 @@ public interface Replaceable<T> {
    * the latest resourceVersion from the server.
    *
    * @return returns deserialized version of api server response
+   *
+   * @deprecated use {@link #update()} instead
    */
+  @Deprecated
   T replace();
 
   /**
    * Similar to {@link Replaceable#replace()}, but only affects the status subresource
    *
    * @return returns deserialized version of api server response
+   *
+   * @deprecated use {@link #updateStatus()} instead
    */
+  @Deprecated
   T replaceStatus();
+
+  /**
+   * Similar to {@link Replaceable#update()}, but only affects the status subresource
+   *
+   * @return returns deserialized version of api server response
+   */
+  T updateStatus();
+
+  /**
+   * Update the server's state with the given item (PUT).
+   * <p>
+   * If the resourceVersion is on the resource, the update will be performed with optimistic locking, and may
+   * result in a conflict (409 error). If no resourceVersion is on the resource, the latest resourceVersion will
+   * be obtained from the server prior to the update call - which may still be a conflict in a rare circumstance.
+   *
+   * @return returns deserialized version of api server response
+   */
+  T update();
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -330,6 +330,7 @@ public class ResourceAdapter<T> implements Resource<T> {
     return resource.item();
   }
 
+  @Override
   public DeletableWithOptions withTimeout(long timeout, TimeUnit unit) {
     return resource.withTimeout(timeout, unit);
   }
@@ -337,6 +338,16 @@ public class ResourceAdapter<T> implements Resource<T> {
   @Override
   public DeletableWithOptions withTimeoutInMillis(long timeoutInMillis) {
     return withTimeout(timeoutInMillis, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public T update() {
+    return resource.update();
+  }
+
+  @Override
+  public T updateStatus() {
+    return resource.updateStatus();
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -1103,7 +1103,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public T updateStatus(T item) {
-    return resource(item).lockResourceVersion().replaceStatus();
+    return resource(item).updateStatus();
   }
 
   @Override
@@ -1138,6 +1138,16 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   @Override
   public ExtensibleResource<T> withTimeout(long timeout, TimeUnit unit) {
     return newInstance(context.withTimeout(timeout, unit));
+  }
+
+  @Override
+  public T updateStatus() {
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
+  }
+
+  @Override
+  public T update() {
+    throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -322,4 +322,14 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImp
     return this.withTimeout(timeoutInMillis, TimeUnit.MILLISECONDS);
   }
 
+  @Override
+  public List<HasMetadata> updateStatus() {
+    return performOperation(Resource::updateStatus);
+  }
+
+  @Override
+  public List<HasMetadata> update() {
+    return performOperation(Resource::update);
+  }
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -390,6 +390,13 @@ public class OperationSupport {
       throws InterruptedException, IOException {
     String patchForUpdate;
     if (current != null && (patchContext == null || patchContext.getPatchType() == PatchType.JSON)) {
+      if (current instanceof HasMetadata) {
+        ObjectMeta meta = ((HasMetadata) current).getMetadata();
+        if (meta != null) {
+          // include the resourceVersion in the patch if it's specified on the updated
+          meta.setResourceVersion(null);
+        }
+      }
       // we can't omit status unless this is not a status operation and we know this has a status subresource
       patchForUpdate = PatchUtils.jsonDiff(current, updated, false);
       if (patchContext == null) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PatchUtils.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PatchUtils.java
@@ -65,7 +65,6 @@ public class PatchUtils {
       m.remove("creationTimestamp");
       m.remove("deletionTimestamp");
       m.remove("generation");
-      m.remove("resourceVersion");
       m.remove("selfLink");
       m.remove("uid");
     });

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/DeploymentOperationsImpl.java
@@ -106,11 +106,6 @@ public class DeploymentOperationsImpl
   }
 
   @Override
-  public Deployment withReplicas(int count) {
-    return accept(d -> d.getSpec().setReplicas(count));
-  }
-
-  @Override
   public int getCurrentReplicas(Deployment current) {
     return current.getStatus().getReplicas();
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/ReplicaSetOperationsImpl.java
@@ -70,11 +70,6 @@ public class ReplicaSetOperationsImpl
   }
 
   @Override
-  public ReplicaSet withReplicas(int count) {
-    return accept(r -> r.getSpec().setReplicas(count));
-  }
-
-  @Override
   public RollingUpdater<ReplicaSet, ReplicaSetList> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit) {
     return new ReplicaSetRollingUpdater(context.getClient(), getNamespace(), rollingTimeUnit.toMillis(rollingTimeout),
         getRequestConfig().getLoggingInterval());

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollableScalableResourceOperation.java
@@ -26,6 +26,8 @@ import io.fabric8.kubernetes.client.dsl.Loggable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
@@ -57,7 +59,10 @@ public abstract class RollableScalableResourceOperation<T extends HasMetadata, L
     this.rollingOperationContext = context;
   }
 
-  protected abstract T withReplicas(int count);
+  protected final T withReplicas(int count) {
+    return patch(PatchContext.of(PatchType.JSON),
+        "[{\"op\": \"replace\", \"path\":\"/spec/replicas\", \"value\":" + count + "}]");
+  }
 
   protected abstract RollingUpdater<T, L> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit);
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/StatefulSetOperationsImpl.java
@@ -74,11 +74,6 @@ public class StatefulSetOperationsImpl
   }
 
   @Override
-  public StatefulSet withReplicas(int count) {
-    return accept(s -> s.getSpec().setReplicas(count));
-  }
-
-  @Override
   public RollingUpdater<StatefulSet, StatefulSetList> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit) {
     return null;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ReplicationControllerOperationsImpl.java
@@ -71,11 +71,6 @@ public class ReplicationControllerOperationsImpl extends
   }
 
   @Override
-  public ReplicationController withReplicas(int count) {
-    return accept(r -> r.getSpec().setReplicas(count));
-  }
-
-  @Override
   public RollingUpdater<ReplicationController, ReplicationControllerList> getRollingUpdater(long rollingTimeout,
       TimeUnit rollingTimeUnit) {
     return new ReplicationControllerRollingUpdater(context.getClient(), namespace, rollingTimeUnit.toMillis(rollingTimeout),

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/DeploymentOperationsImpl.java
@@ -103,11 +103,6 @@ public class DeploymentOperationsImpl
   }
 
   @Override
-  public Deployment withReplicas(int count) {
-    return accept(d -> d.getSpec().setReplicas(count));
-  }
-
-  @Override
   public int getCurrentReplicas(Deployment current) {
     return current.getStatus().getReplicas();
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/extensions/v1beta1/ReplicaSetOperationsImpl.java
@@ -72,11 +72,6 @@ public class ReplicaSetOperationsImpl
   }
 
   @Override
-  public ReplicaSet withReplicas(int count) {
-    return accept(r -> r.getSpec().setReplicas(count));
-  }
-
-  @Override
   public RollingUpdater<ReplicaSet, ReplicaSetList> getRollingUpdater(long rollingTimeout, TimeUnit rollingTimeUnit) {
     return new ReplicaSetRollingUpdater(context.getClient(), getNamespace(), rollingTimeUnit.toMillis(rollingTimeout),
         getRequestConfig().getLoggingInterval());

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/APIServiceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/APIServiceIT.java
@@ -63,7 +63,7 @@ class APIServiceIT {
   void update() {
     APIService result = client.apiServices().withName("v1.tests.example.com")
         .edit(c -> new APIServiceBuilder(c)
-            .editOrNewMetadata().addToAnnotations("foo", "bar").endMetadata()
+            .editOrNewMetadata().withResourceVersion(null).addToAnnotations("foo", "bar").endMetadata()
             .build());
     assertThat(result)
         .hasFieldOrPropertyWithValue("metadata.annotations.foo", "bar")

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ClusterRoleBindingIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ClusterRoleBindingIT.java
@@ -111,6 +111,7 @@ class ClusterRoleBindingIT {
 
     ClusterRoleBinding clusterRoleBinding = client.rbac().clusterRoleBindings().withName("read-nodes-update")
         .edit(c -> new ClusterRoleBindingBuilder(c)
+            .editMetadata().withResourceVersion(null).endMetadata()
             .editSubject(0).withName("jane-new").endSubject().build());
 
     assertNotNull(clusterRoleBinding);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ClusterRoleIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ClusterRoleIT.java
@@ -123,6 +123,7 @@ class ClusterRoleIT {
   void update() {
 
     ClusterRole clusterRole = client.rbac().clusterRoles().withName("node-reader-update").edit(c -> new ClusterRoleBuilder(c)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editRule(0).addToApiGroups(1, "extensions").endRule().build());
 
     assertNotNull(clusterRole);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ConfigMapIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ConfigMapIT.java
@@ -56,6 +56,7 @@ class ConfigMapIT {
   @Test
   void update() {
     ConfigMap configMap = client.configMaps().withName("configmap-update").edit(c -> new ConfigMapBuilder(c)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .addToData("MSSQL", "Microsoft Database").build());
 
     assertNotNull(configMap);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CronJobIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CronJobIT.java
@@ -59,9 +59,8 @@ class CronJobIT {
   void update() {
     CronJob cronJob1 = client.batch().v1beta1().cronjobs().withName("hello-update")
         .edit(c -> new CronJobBuilder(c)
-            .editSpec()
-            .withSchedule("*/1 * * * *")
-            .endSpec()
+            .editMetadata().withResourceVersion(null).endMetadata()
+            .editSpec().withSchedule("*/1 * * * *").endSpec()
             .build());
     assertEquals("*/1 * * * *", cronJob1.getSpec().getSchedule());
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
@@ -99,6 +99,7 @@ class CustomResourceDefinitionIT {
     // When
     final CustomResourceDefinition result = client.apiextensions().v1().customResourceDefinitions()
         .withName(name).edit(c -> new CustomResourceDefinitionBuilder(c)
+            .editMetadata().withResourceVersion(null).endMetadata()
             .editSpec().editOrNewNames().addToShortNames("its").endNames().endSpec().build());
     // Then
     assertThat(result.getSpec().getNames().getShortNames())

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DaemonSetIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DaemonSetIT.java
@@ -50,6 +50,7 @@ class DaemonSetIT {
   @Test
   void update() {
     DaemonSet daemonSet = client.apps().daemonSets().withName("daemonset-update").edit(c -> new DaemonSetBuilder(c)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editSpec().editTemplate().editSpec().editContainer(0)
         .withImage("quay.io/fluentd_elasticsearch/fluentd:v3.0.0")
         .endContainer().endSpec().endTemplate().endSpec()

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeploymentIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeploymentIT.java
@@ -65,7 +65,8 @@ class DeploymentIT {
   @Test
   void update() {
     Deployment deployment1 = client.apps().deployments().withName("deployment-standard")
-        .edit(d -> new DeploymentBuilder(d).editMetadata().addToAnnotations("updated", "true").endMetadata().build());
+        .edit(d -> new DeploymentBuilder(d)
+            .editMetadata().withResourceVersion(null).addToAnnotations("updated", "true").endMetadata().build());
     assertThat(deployment1).isNotNull();
     assertEquals("true", deployment1.getMetadata().getAnnotations().get("updated"));
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/IngressIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/IngressIT.java
@@ -58,7 +58,7 @@ class IngressIT {
   @Test
   void update() {
     Ingress ingress = client.network().v1().ingresses().withName("ingress-update").edit(i -> new IngressBuilder(i)
-        .editOrNewMetadata().addToAnnotations("foo", "bar").endMetadata().build());
+        .editMetadata().withResourceVersion(null).addToAnnotations("foo", "bar").endMetadata().build());
 
     assertNotNull(ingress);
     assertEquals("bar", ingress.getMetadata().getAnnotations().get("foo"));

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/NamespaceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/NamespaceIT.java
@@ -47,7 +47,7 @@ class NamespaceIT {
 
     // Update
     namespace = client.namespaces().withName("fabric8-test").edit(c -> new NamespaceBuilder(c)
-        .editOrNewMetadata().addToAnnotations("foo", "bar").endMetadata()
+        .editOrNewMetadata().withResourceVersion(null).addToAnnotations("foo", "bar").endMetadata()
         .build());
     assertNotNull(namespace);
     assertEquals("bar", namespace.getMetadata().getAnnotations().get("foo"));

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/NetworkPolicyIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/NetworkPolicyIT.java
@@ -93,7 +93,7 @@ class NetworkPolicyIT {
   void update() {
     NetworkPolicy networkPolicy = client.network().v1().networkPolicies()
         .withName("networkpolicy-update").edit(n -> new NetworkPolicyBuilder(n)
-            .editMetadata().addToLabels("bar", "foo").endMetadata()
+            .editMetadata().withResourceVersion(null).addToLabels("bar", "foo").endMetadata()
             .build());
 
     assertNotNull(networkPolicy);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodEphemeralContainersIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodEphemeralContainersIT.java
@@ -43,6 +43,7 @@ class PodEphemeralContainersIT {
     Pod pod = client.pods().withName("pod-standard")
         .ephemeralContainers()
         .edit(p -> new PodBuilder(p)
+            .editMetadata().withResourceVersion(null).endMetadata()
             .editSpec()
             .addNewEphemeralContainer()
             .withName("debugger-1")
@@ -83,6 +84,7 @@ class PodEphemeralContainersIT {
     PodResource resource = client.pods().withName("pod-standard");
     resource.ephemeralContainers()
         .edit(p -> new PodBuilder(p)
+            .editMetadata().withResourceVersion(null).endMetadata()
             .editSpec()
             .addNewEphemeralContainer()
             .withName("debugger-3")

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -105,7 +105,7 @@ class PodIT {
   @Test
   void update() {
     Pod pod1 = client.pods().withName("pod-standard").edit(p -> new PodBuilder(p)
-        .editMetadata().addToLabels("foo", "bar").endMetadata().build());
+        .editMetadata().withResourceVersion(null).addToLabels("foo", "bar").endMetadata().build());
     assertEquals("bar", pod1.getMetadata().getLabels().get("foo"));
   }
 

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodSecurityPolicyIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodSecurityPolicyIT.java
@@ -79,6 +79,7 @@ class PodSecurityPolicyIT {
 
     PodSecurityPolicy podSecurityPolicy = client.policy().v1beta1().podSecurityPolicies().withName("psp-update")
         .edit(p -> new PodSecurityPolicyBuilder(p)
+            .editMetadata().withResourceVersion(null).endMetadata()
             .editSpec().withPrivileged(true).endSpec()
             .build());
 

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ReplicaSetIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ReplicaSetIT.java
@@ -62,6 +62,7 @@ class ReplicaSetIT {
     client.apps().replicaSets().withName("replicaset-update")
         .waitUntilCondition(Objects::nonNull, 30, TimeUnit.SECONDS);
     ReplicaSet replicaset1 = client.apps().replicaSets().withName("replicaset-update").edit(r -> new ReplicaSetBuilder(r)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editSpec().withReplicas(2).endSpec().build());
     assertThat(replicaset1).isNotNull();
     assertEquals(2, replicaset1.getSpec().getReplicas().intValue());

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ResourceQuotaIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ResourceQuotaIT.java
@@ -50,7 +50,7 @@ class ResourceQuotaIT {
   @Test
   void update() {
     ResourceQuota resourceQuota = client.resourceQuotas().withName("resourcequota-update").edit(c -> new ResourceQuotaBuilder(c)
-        .editOrNewMetadata().addToAnnotations("foo", "bar").endMetadata().build());
+        .editMetadata().withResourceVersion(null).addToAnnotations("foo", "bar").endMetadata().build());
 
     assertNotNull(resourceQuota);
     assertEquals("bar", resourceQuota.getMetadata().getAnnotations().get("foo"));

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RoleBindingIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RoleBindingIT.java
@@ -108,6 +108,7 @@ class RoleBindingIT {
   void update() {
 
     RoleBinding roleBinding = client.rbac().roleBindings().withName("rb-update").edit(r -> new RoleBindingBuilder(r)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editSubject(0).withName("jane-new").endSubject().build());
 
     assertNotNull(roleBinding);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RoleIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/RoleIT.java
@@ -129,6 +129,7 @@ class RoleIT {
   void update() {
 
     Role role = client.rbac().roles().withName("role-update").edit(r -> new RoleBuilder(r)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editRule(0).addToApiGroups(1, "extensions").endRule().build());
 
     assertNotNull(role);

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/SecretIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/SecretIT.java
@@ -64,7 +64,7 @@ class SecretIT {
   @Test
   void update() {
     Secret secret1 = client.secrets().withName("secret-update").edit(s -> new SecretBuilder(s)
-        .editOrNewMetadata().addToLabels("foo", "bar").endMetadata()
+        .editMetadata().withResourceVersion(null).addToLabels("foo", "bar").endMetadata()
         .build());
     client.secrets().withName("secret-update").waitUntilCondition(Objects::nonNull, 30, TimeUnit.SECONDS);
     assertThat(secret1).isNotNull();

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceAccountIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceAccountIT.java
@@ -60,6 +60,7 @@ class ServiceAccountIT {
   @Test
   void update() {
     ServiceAccount serviceAccount1 = client.serviceAccounts().withName("sa-update").edit(s -> new ServiceAccountBuilder(s)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .addNewSecret().withName("default-token-uudp").endSecret()
         .addNewImagePullSecret().withName("myregistrykey").endImagePullSecret()
         .build());

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceIT.java
@@ -64,6 +64,7 @@ class ServiceIT {
   @Test
   void update() {
     Service svc1 = client.services().withName("service-update").edit(s -> new ServiceBuilder(s)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editSpec().addNewPort().withName("https").withProtocol("TCP").withPort(443).withTargetPort(new IntOrString(9377))
         .endPort().endSpec()
         .build());

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/StorageClassIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/StorageClassIT.java
@@ -55,7 +55,8 @@ class StorageClassIT {
   @Test
   void update() {
     StorageClass storageClass = client.storage().storageClasses().withName("storageclass-update")
-        .edit(s -> new StorageClassBuilder(s).editMetadata().addToLabels("testLabel", "testLabelValue").endMetadata().build());
+        .edit(s -> new StorageClassBuilder(s)
+            .editMetadata().withResourceVersion(null).addToLabels("testLabel", "testLabelValue").endMetadata().build());
     assertNotNull(storageClass);
     assertEquals("testLabelValue", storageClass.getMetadata().getLabels().get("testLabel"));
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
@@ -152,6 +152,7 @@ class TypedCustomResourceIT {
     await().atMost(5, TimeUnit.SECONDS)
         .until(() -> petClient.withName("pet-update").get() != null);
     Pet updatedPet = petClient.withName("pet-update").edit(pet1 -> {
+      pet1.getMetadata().setResourceVersion(null);
       pet1.getMetadata().setAnnotations(Collections.singletonMap("first", "1"));
       return pet1;
     });

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildConfigIT.java
@@ -62,6 +62,7 @@ class BuildConfigIT {
   @Test
   void update() {
     BuildConfig buildConfig1 = client.buildConfigs().withName("bc-update").edit(b -> new BuildConfigBuilder(b)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editSpec().withFailedBuildsHistoryLimit(5).endSpec().build());
     assertEquals(5, buildConfig1.getSpec().getFailedBuildsHistoryLimit().intValue());
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
@@ -61,7 +61,9 @@ class DeploymentConfigIT {
   @Test
   void update() {
     DeploymentConfig deploymentConfig1 = client.deploymentConfigs().withName("dc-update")
-        .edit(d -> new DeploymentConfigBuilder(d).editSpec().withReplicas(3).endSpec().build());
+        .edit(d -> new DeploymentConfigBuilder(d)
+            .editMetadata().withResourceVersion(null).endMetadata()
+            .editSpec().withReplicas(3).endSpec().build());
     assertThat(deploymentConfig1).isNotNull();
     assertEquals(3, deploymentConfig1.getSpec().getReplicas().intValue());
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/ImageStreamIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/ImageStreamIT.java
@@ -62,6 +62,7 @@ class ImageStreamIT {
   void update() {
     client.imageStreams().withName("is-update").waitUntilCondition(Objects::nonNull, 30, TimeUnit.SECONDS);
     ImageStream imageStream1 = client.imageStreams().withName("is-update").edit(i -> new ImageStreamBuilder(i)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editSpec().withDockerImageRepository("fabric8/s2i-java").endSpec()
         .build());
     assertThat(imageStream1).isNotNull();

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/RouteIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/RouteIT.java
@@ -62,6 +62,7 @@ class RouteIT {
   @Test
   void update() {
     final Route route = client.routes().withName("route-update").edit(r -> new RouteBuilder(r)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .editSpec().withPath("/test").endSpec().build());
     assertThat(route).isNotNull();
     assertEquals("/test", route.getSpec().getPath());

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/SecurityContextConstraintsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/SecurityContextConstraintsIT.java
@@ -97,6 +97,7 @@ class SecurityContextConstraintsIT {
   void update() {
 
     scc = client.securityContextConstraints().withName("scc-update").edit(s -> new SecurityContextConstraintsBuilder(s)
+        .editMetadata().withResourceVersion(null).endMetadata()
         .withAllowPrivilegedContainer(false)
         .build());
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -50,7 +50,8 @@ class CustomResourceCrudTest {
   void setUp() {
     KubernetesDeserializer.registerCustomKind("stable.example.com/v1", "CronTab", CronTab.class);
     cronTabCrd = client
-        .apiextensions().v1()
+        .apiextensions()
+        .v1()
         .customResourceDefinitions()
         .load(getClass().getResourceAsStream("/crontab-crd.yml"))
         .item();
@@ -133,7 +134,8 @@ class CustomResourceCrudTest {
     cronTab.setStatus(status);
 
     NonNamespaceOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
-        .resources(CronTab.class).inNamespace("test-ns");
+        .resources(CronTab.class)
+        .inNamespace("test-ns");
 
     CronTab result = cronTabClient.create(cronTab);
 
@@ -164,12 +166,14 @@ class CustomResourceCrudTest {
     assertNotNull(result.getStatus());
 
     labels.put("another", "label");
+    cronTab.getMetadata().setResourceVersion(null);
     result = cronTabClient.withName(cronTab.getMetadata().getName()).patch(cronTab);
 
     // should retain the existing
     assertNotNull(result.getStatus());
     // should have accumulated all labels
-    assertEquals(new HashSet<String>(Arrays.asList("app", "other", "another")), result.getMetadata().getLabels().keySet());
+    assertEquals(new HashSet<String>(Arrays.asList("app", "other", "another")),
+        result.getMetadata().getLabels().keySet());
 
     assertEquals(originalUid, result.getMetadata().getUid());
   }
@@ -182,7 +186,8 @@ class CustomResourceCrudTest {
     cronTab.setStatus(status);
 
     NonNamespaceOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
-        .resources(CronTab.class).inNamespace("test-ns");
+        .resources(CronTab.class)
+        .inNamespace("test-ns");
 
     CronTab result = cronTabClient.create(cronTab);
 
@@ -200,7 +205,8 @@ class CustomResourceCrudTest {
     CronTab cronTab = createCronTab("my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
 
     NonNamespaceOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
-        .resources(CronTab.class).inNamespace("test-ns");
+        .resources(CronTab.class)
+        .inNamespace("test-ns");
 
     CronTab result = cronTabClient.resource(cronTab).create();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/UpdateResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/UpdateResourceTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@EnableKubernetesMockClient
+class UpdateResourceTest {
+
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  void testResourceUpdate() {
+    server.expect()
+        .get()
+        .withPath("/api/v1/namespaces/test/pods/pod123")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
+            .withNewMetadata()
+            .withResourceVersion("12345")
+            .and()
+            .build())
+        .times(2);
+
+    server.expect()
+        .put()
+        .withPath("/api/v1/namespaces/test/pods/pod123")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
+            .withNewMetadata()
+            .withResourceVersion("12346")
+            .and()
+            .build())
+        .once();
+
+    Pod pod = client.resource(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build())
+        .update();
+    assertNotNull(pod);
+    assertEquals("12346", pod.getMetadata().getResourceVersion());
+  }
+
+  @Test
+  void testResourceConflict() {
+    server.expect()
+        .put()
+        .withPath("/api/v1/namespaces/test/pods/pod123")
+        .andReturn(HttpURLConnection.HTTP_CONFLICT, "")
+        .always();
+
+    NamespaceableResource<Pod> podResoruce = client.resource(new PodBuilder().withNewMetadata()
+        .withName("pod123")
+        .withResourceVersion("11")
+        .and()
+        .withNewSpec()
+        .and()
+        .build());
+    final KubernetesClientException result = assertThrows(KubernetesClientException.class, podResoruce::update);
+    assertEquals(409, result.getCode());
+  }
+
+  @Test
+  void testResourceUpdateStatus() {
+    server.expect()
+        .put()
+        .withPath("/api/v1/namespaces/test/pods/pod123/status")
+        .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
+            .withNewMetadata()
+            .withResourceVersion("y")
+            .and()
+            .build())
+        .once();
+
+    Pod pod = client
+        .resource(new PodBuilder().withNewMetadata()
+            .withName("pod123")
+            .withResourceVersion("x")
+            .and()
+            .withNewSpec()
+            .and()
+            .build())
+        .updateStatus();
+    assertEquals("y", pod.getMetadata().getResourceVersion());
+  }
+
+  @Test
+  void testUpdateNonExistent() {
+    Resource<ConfigMap> resource = client.resource(new ConfigMapBuilder().withNewMetadata().withName("map1").and().build());
+    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
+        resource::update);
+    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getCode());
+  }
+
+}


### PR DESCRIPTION
## Description

Closes #4861 

Introduces several breaking changes to implement what's described in #4861.

Potential concerns:
- there's no direct replacement for createOrReplace. Users are directed instead to use one of several alternatives.
- there's likely a behavioral change for people using patch methods that default to or specify the json patch type, which may require them to manually set their resourceVersions to null.  We could consider instead introducing an "unlock" method in the dsl that does this for the user - resource.unlock().{patch, update, serverSideApply} - this is generally preferable to lock as you are opting into overwriting concurrent changes.
- it will be a little confusing coming from kubectl - our update will be the same as their replace and our replace will be deprecated.

cc @manusa  @csviri

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
