### PR TITLE
fix: BuildConfigs.instantiateBinary().fromFile() does not time out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #4723: [java-generator] Fix a race in the use of JavaParser hitting large CRDs
 * Fix #4885: addresses a potential hang in the jdk client with exec stream reading
 * Fix #4891: address vertx not completely reading exec streams
+* Fix #4899: BuildConfigs.instantiateBinary().fromFile() does not time out
 
 #### Improvements
 * Fix #4675: adding a fully client side timeout for informer watches

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationContext.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.RequestConfig;
+import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.kubernetes.client.dsl.FieldValidateable;
 import io.fabric8.kubernetes.client.dsl.FieldValidateable.Validation;
 import io.fabric8.kubernetes.client.http.HttpClient;
@@ -117,7 +118,7 @@ public class OperationContext {
     this.forceConflicts = forceConflicts;
     this.timeout = timeout;
     this.timeoutUnit = timeoutUnit;
-    this.requestConfig = requestConfig;
+    this.requestConfig = requestConfig == null ? null : new RequestConfigBuilder(requestConfig).build();
   }
 
   private void setFieldsNot(Map<String, String[]> fieldsNot) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -737,9 +737,9 @@ public class OperationSupport {
   public RequestConfig getRequestConfig() {
     RequestConfig result = context.getRequestConfig();
     if (result == null && config != null) {
-      return config.getRequestConfig();
+      result = config.getRequestConfig();
     }
-    return new RequestConfigBuilder().build();
+    return new RequestConfigBuilder(result).build();
   }
 
   private String getContentTypeFromPatchContextOrDefault(PatchContext patchContext) {

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildIT.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.openshift;
+
+import io.fabric8.junit.jupiter.api.KubernetesTest;
+import io.fabric8.junit.jupiter.api.RequireK8sSupport;
+import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
+import io.fabric8.openshift.api.model.BuildOutputBuilder;
+import io.fabric8.openshift.api.model.BuildStrategyBuilder;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import io.fabric8.openshift.api.model.SourceBuildStrategyBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KubernetesTest(createEphemeralNamespace = false)
+@RequireK8sSupport(Build.class)
+class BuildIT {
+
+  @TempDir
+  private Path tempDir;
+  private String imageStreamName;
+  private String imageStreamTag;
+  private String buildConfigName;
+  private String buildName;
+  OpenShiftClient client;
+
+  @BeforeEach
+  void setUp() {
+    final String id = UUID.randomUUID().toString().replace("-", "");
+    imageStreamName = id + "-is";
+    imageStreamTag = imageStreamName + ":latest";
+    buildConfigName = id + "-bc";
+    buildName = id + "-s2i";
+  }
+
+  @AfterEach
+  void tearDown() {
+    client.builds().withName(buildName).withGracePeriod(0L).delete();
+    client.buildConfigs().withName(buildConfigName).withGracePeriod(0L).delete();
+    client.imageStreams().withName(imageStreamName).withGracePeriod(0L).delete();
+  }
+
+  @ParameterizedTest(name = "OpenShift build from file of size {0} bytes builds ImageStream")
+  @ValueSource(ints = {
+      1024,
+      10485760//, 314572800 // Big file to test-drive upload timeout (disabled for CI)
+  })
+  void buildImage(int archiveSize) throws IOException {
+    // Given
+    final BuildConfig buildConfig = new BuildConfigBuilder()
+        .withNewMetadata().withName(buildConfigName).endMetadata()
+        .withNewSpec()
+        .withNewSource().withType("Binary").endSource()
+        .withStrategy(new BuildStrategyBuilder()
+            .withType("Source")
+            .withSourceStrategy(new SourceBuildStrategyBuilder()
+                .withFrom(new ObjectReferenceBuilder()
+                    .withKind("DockerImage")
+                    .withName("quay.io/jkube/jkube-java:0.0.17")
+                    .build())
+                .build())
+            .build())
+        .withOutput(new BuildOutputBuilder()
+            .withTo(new ObjectReferenceBuilder()
+                .withKind("ImageStreamTag")
+                .withName(imageStreamTag)
+                .build())
+            .build())
+        .endSpec().build();
+    final ImageStream is = new ImageStreamBuilder()
+        .withNewMetadata().withName(imageStreamName).endMetadata()
+        .withNewSpec().withNewLookupPolicy().withLocal(true).endLookupPolicy().endSpec()
+        .build();
+    client.resourceList(buildConfig, is).create();
+    // When
+    final Build build = client.buildConfigs().withName(buildConfigName).instantiateBinary()
+        .fromFile(prepareTarFile(archiveSize));
+    // Then
+    client.pods().withName(build.getMetadata().getName() + "-build")
+        .waitUntilReady(60, TimeUnit.SECONDS);
+    final Pod buildPod = client.pods()
+        .waitUntilCondition(pod -> !pod.getStatus().getPhase().equals("Running"), 60, TimeUnit.SECONDS);
+    assertThat(buildPod)
+        .hasFieldOrPropertyWithValue("status.phase", "Succeeded");
+  }
+
+  private File prepareTarFile(int size) throws IOException {
+    final File tarFile = tempDir.resolve("test-" + size + ".tar").toFile();
+    try (FileOutputStream fos = new FileOutputStream(tarFile);
+        TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(fos)) {
+      tarArchiveOutputStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+      tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+      final TarArchiveEntry file = new TarArchiveEntry("deployments/file.txt");
+      file.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+      file.setSize(size);
+      tarArchiveOutputStream.putArchiveEntry(file);
+      tarArchiveOutputStream.write(new byte[(int) size]);
+      tarArchiveOutputStream.closeArchiveEntry();
+
+    }
+    return tarFile;
+  }
+}

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -61,13 +61,13 @@
       <groupId>io.fabric8</groupId>
       <artifactId>openshift-client-api</artifactId>
     </dependency>
-   
+
     <dependency>
       <groupId>com.github.mifmif</groupId>
       <artifactId>generex</artifactId>
       <version>${generex.version}</version>
     </dependency>
-    
+
     <!-- Compile Only Dependencies -->
     <dependency>
       <groupId>io.sundr</groupId>
@@ -78,7 +78,7 @@
       <groupId>io.sundr</groupId>
       <artifactId>transform-annotations</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
@@ -100,7 +100,7 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    
+
      <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client-api</artifactId>
@@ -128,14 +128,13 @@
    </dependency>
 
    <dependency>
-     <groupId>org.junit.jupiter</groupId>
-     <artifactId>junit-jupiter-migrationsupport</artifactId>
-     <scope>test</scope>
-   </dependency>
-
-   <dependency>
      <groupId>org.mockito</groupId>
      <artifactId>mockito-core</artifactId>
+     <scope>test</scope>
+   </dependency>
+   <dependency>
+     <groupId>org.assertj</groupId>
+     <artifactId>assertj-core</artifactId>
      <scope>test</scope>
    </dependency>
  </dependencies>


### PR DESCRIPTION
## Description
Fix https://github.com/eclipse/jkube/issues/2024

`BuildConfigs.instantiateBinary().fromFile()` no longer times out based on the RequestConfig default read timeout value.

This PR addresses a bug present in `OperationSupport` where the overridden settings for RequestConfig in the `OperationContext` were ignored.

The PR fixes the problem with BuildConfig by overriding the `requestTimeout` value for the context `RequestConfig` whenever a `withTimeout` value is provided in the context. It will also default the RequestConfig `requestTimeout` initial timeout to `0` which will effectively disable the client-side timeout kill we perform at `OperationSupport.waitForResult()`:

https://github.com/fabric8io/kubernetes-client/blob/d0ad0140437a22c7b04f08ed9700fbb2ffb8d73a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java#L520-L522

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
