### PR TITLE
fix #4886: waiting for the derived apiservice to exist

### DIFF
--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/APIServiceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/APIServiceIT.java
@@ -22,8 +22,12 @@ import io.fabric8.kubernetes.api.model.APIServiceBuilder;
 import io.fabric8.kubernetes.api.model.APIServiceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +36,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class APIServiceIT {
 
   KubernetesClient client;
+
+  @BeforeEach
+  void ensureExists() {
+    Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        .until(() -> client.apiServices().withName("v1.tests.example.com").get() != null);
+  }
 
   @Test
   void get() {


### PR DESCRIPTION
## Description
It appears that the APIServiceIT test fails due to a timing issue with the creation of the derived apiservice - there can be a gap between the creation of the crd and the apiservice entry.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
