### PR TITLE
fix #4908: using the response headers in the vertx response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix #4885: addresses a potential hang in the jdk client with exec stream reading
 * Fix #4891: address vertx not completely reading exec streams
 * Fix #4899: BuildConfigs.instantiateBinary().fromFile() does not time out
+* Fix #4908: using the response headers in the vertx response
 
 #### Improvements
 * Fix #4675: adding a fully client side timeout for informer watches

--- a/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
+++ b/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
@@ -186,13 +186,15 @@ class OkHttpClientTest {
   @ParameterizedTest(name = "{index}: {0}")
   @ValueSource(classes = { String.class, byte[].class, Reader.class, InputStream.class })
   void supportedResponseBodyTypes(Class<?> type) throws Exception {
-    String value = new String(new byte[16384]);
+    int length = 16384;
+    String value = new String(new byte[length]);
     server.expect().withPath("/type").andReturn(200, value).always();
     final HttpResponse<?> result = client.getHttpClient()
         .sendAsync(client.getHttpClient().newHttpRequestBuilder()
             .uri(URI.create(client.getConfiguration().getMasterUrl() + "type")).build(), type)
         .get(10, TimeUnit.SECONDS);
     assertThat(result)
+        .satisfies(r -> assertThat(r.headers("Content-Length")).first().isEqualTo(String.valueOf(length)))
         .satisfies(r -> assertThat(r.body()).isInstanceOf(type))
         .satisfies(r -> assertThat(r.bodyString()).isEqualTo(value));
   }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
@@ -154,7 +154,7 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
       options.putHeader(io.vertx.core.http.HttpHeaders.EXPECT, io.vertx.core.http.HttpHeaders.CONTINUE);
     }
 
-    return new VertxHttpRequest(vertx, options, request.body()).consumeBytes(this.client, consumer);
+    return new VertxHttpRequest(vertx, options, request).consumeBytes(this.client, consumer);
   }
 
   void addDerivedClient(VertxHttpClient<F> client) {

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
@@ -19,7 +19,9 @@ package io.fabric8.kubernetes.client.vertx;
 import io.fabric8.kubernetes.client.http.AsyncBody;
 import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.kubernetes.client.http.StandardHttpHeaders;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest;
+import io.fabric8.kubernetes.client.http.StandardHttpRequest.BodyContent;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -30,7 +32,6 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.core.streams.ReadStream;
 
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -40,36 +41,49 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-class VertxHttpRequest implements HttpRequest {
+class VertxHttpRequest {
+
+  private static final class VertxHttpResponse extends StandardHttpHeaders implements HttpResponse<AsyncBody> {
+    private final AsyncBody result;
+    private final HttpClientResponse resp;
+    private final HttpRequest request;
+
+    private VertxHttpResponse(AsyncBody result, HttpClientResponse resp, HttpRequest request) {
+      super(toHeadersMap(resp.headers()));
+      this.result = result;
+      this.resp = resp;
+      this.request = request;
+    }
+
+    @Override
+    public int code() {
+      return resp.statusCode();
+    }
+
+    @Override
+    public AsyncBody body() {
+      return result;
+    }
+
+    @Override
+    public HttpRequest request() {
+      return request;
+    }
+
+    @Override
+    public Optional<HttpResponse<?>> previousResponse() {
+      return Optional.empty();
+    }
+  }
 
   final Vertx vertx;
   private final RequestOptions options;
-  private final StandardHttpRequest.BodyContent body;
+  private StandardHttpRequest request;
 
-  public VertxHttpRequest(Vertx vertx, RequestOptions options, StandardHttpRequest.BodyContent body) {
+  public VertxHttpRequest(Vertx vertx, RequestOptions options, StandardHttpRequest request) {
     this.vertx = vertx;
     this.options = options;
-    this.body = body;
-  }
-
-  @Override
-  public URI uri() {
-    return URI.create(options.getURI());
-  }
-
-  @Override
-  public String method() {
-    return options.getMethod().name();
-  }
-
-  @Override
-  public String bodyString() {
-    return body.toString();
-  }
-
-  @Override
-  public List<String> headers(String key) {
-    return options.getHeaders().getAll(key);
+    this.request = request;
   }
 
   public CompletableFuture<HttpResponse<AsyncBody>> consumeBytes(HttpClient client,
@@ -106,42 +120,11 @@ class VertxHttpRequest implements HttpRequest {
           result.done().completeExceptionally(e);
         }
       }).endHandler(end -> result.done().complete(null));
-      return new HttpResponse<AsyncBody>() {
-
-        @Override
-        public List<String> headers(String key) {
-          return VertxHttpRequest.this.headers().get(key);
-        }
-
-        @Override
-        public Map<String, List<String>> headers() {
-          return VertxHttpRequest.this.headers();
-        }
-
-        @Override
-        public int code() {
-          return resp.statusCode();
-        }
-
-        @Override
-        public AsyncBody body() {
-          return result;
-        }
-
-        @Override
-        public HttpRequest request() {
-          return VertxHttpRequest.this;
-        }
-
-        @Override
-        public Optional<HttpResponse<?>> previousResponse() {
-          return Optional.empty();
-        }
-
-      };
+      return new VertxHttpResponse(result, resp, request);
     };
     return client.request(options).compose(request -> {
       Future<HttpClientResponse> fut;
+      BodyContent body = this.request.body();
       if (body != null) {
         if (body instanceof StandardHttpRequest.StringBodyContent) {
           Buffer buffer = Buffer.buffer(((StandardHttpRequest.StringBodyContent) body).getContent());
@@ -163,12 +146,6 @@ class VertxHttpRequest implements HttpRequest {
       }
       return fut.map(responseHandler);
     }).toCompletionStage().toCompletableFuture();
-  }
-
-  @Override
-  public Map<String, List<String>> headers() {
-    MultiMap multiMap = options.getHeaders();
-    return toHeadersMap(multiMap);
   }
 
   static Map<String, List<String>> toHeadersMap(MultiMap multiMap) {


### PR DESCRIPTION
## Description

Fix #4908 

Minor change to the vertx logic to expose the proper response headers.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
