### PR TITLE
fix: OkHttpClientFactory.additionalConfig can be used to override the default OkHttp Dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #4832: NO_PROXY can match cidr with bit suffix <10
 * Fix #4851: adding buffer cloning to ensure buffers cannot be modified after sending
 * Fix #4794: improving the semantics of manually calling informer stop
+* Fix #4797: OkHttpClientFactory.additionalConfig can be used to override the default OkHttp Dispatcher
 * Fix #4798: fix leader election release on cancel
 * Fix #4815: (java-generator) create target download directory if it doesn't exist
 * Fix #4846: allowed for pod read / copy operations to distinguish when the target doesn't exist

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
@@ -19,7 +19,6 @@ package io.fabric8.kubernetes.client.okhttp;
 import io.fabric8.kubernetes.client.http.StandardHttpClientBuilder;
 import okhttp3.Authenticator;
 import okhttp3.ConnectionSpec;
-import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -36,7 +35,7 @@ import static okhttp3.ConnectionSpec.CLEARTEXT;
 class OkHttpClientBuilderImpl
     extends StandardHttpClientBuilder<OkHttpClientImpl, OkHttpClientFactory, OkHttpClientBuilderImpl> {
 
-  private okhttp3.OkHttpClient.Builder builder;
+  private final okhttp3.OkHttpClient.Builder builder;
 
   public OkHttpClientBuilderImpl(OkHttpClientFactory clientFactory, okhttp3.OkHttpClient.Builder builder) {
     super(clientFactory);
@@ -81,8 +80,7 @@ class OkHttpClientBuilderImpl
     }
     if (tlsVersions != null) {
       ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-          .tlsVersions(Arrays.asList(tlsVersions)
-              .stream()
+          .tlsVersions(Arrays.stream(tlsVersions)
               .map(tls -> okhttp3.TlsVersion.valueOf(tls.name()))
               .toArray(okhttp3.TlsVersion[]::new))
           .build();
@@ -91,14 +89,6 @@ class OkHttpClientBuilderImpl
     if (preferHttp11) {
       builder.protocols(Collections.singletonList(Protocol.HTTP_1_1));
     }
-    Dispatcher dispatcher = new Dispatcher();
-    // websockets and long running http requests count against this and eventually starve
-    // the work that can be done
-    dispatcher.setMaxRequests(Integer.MAX_VALUE);
-    // long running http requests count against this and eventually exhaust
-    // the work that can be done
-    dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
-    builder.dispatcher(dispatcher);
     return derivedBuild(builder);
   }
 

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ public class OkHttpClientFactory implements HttpClient.Factory {
    * Subclasses may use this to apply a base configuration to the builder
    */
   protected OkHttpClient.Builder newOkHttpClientBuilder() {
-    return new OkHttpClient.Builder();
+    return new OkHttpClient.Builder().dispatcher(initDispatcher());
   }
 
   /**
@@ -106,6 +107,17 @@ public class OkHttpClientFactory implements HttpClient.Factory {
    */
   protected boolean shouldDisableHttp2() {
     return System.getProperty("java.version", "").startsWith("1.8");
+  }
+
+  protected Dispatcher initDispatcher() {
+    Dispatcher dispatcher = new Dispatcher();
+    // websockets and long-running http requests count against this and eventually starve
+    // the work that can be done
+    dispatcher.setMaxRequests(Integer.MAX_VALUE);
+    // long-running http requests count against this and eventually exhaust
+    // the work that can be done
+    dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
+    return dispatcher;
   }
 
 }


### PR DESCRIPTION
## Description

Fix #4797 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
