### PR TITLE
fix #4924: handles non-okhttp clients with invalid watch status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix #4899: BuildConfigs.instantiateBinary().fromFile() does not time out
 * Fix #4908: using the response headers in the vertx response
 * Fix #4947: typo in HttpClient.Factory scoring system logic
+* Fix #4928: allows non-okhttp clients to handle invalid status
 
 #### Improvements
 * Fix #4675: adding a fully client side timeout for informer watches

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -651,10 +651,12 @@ public class OperationSupport {
         String bodyString = response.bodyString();
         if (Utils.isNotNullOrEmpty(bodyString)) {
           Status status = JSON_MAPPER.readValue(bodyString, Status.class);
-          if (status.getCode() == null) {
-            status = new StatusBuilder(status).withCode(statusCode).build();
+          if (status != null) {
+            if (status.getCode() == null) {
+              status = new StatusBuilder(status).withCode(statusCode).build();
+            }
+            return status;
           }
-          return status;
         }
       } catch (IOException e) {
         // ignored

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.PodStatusBuilder;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -41,6 +43,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @EnableKubernetesMockClient(crud = true)
 class PodExecTest {
 
+  private static PodStatus READY = new PodStatusBuilder().addNewCondition().withType("Ready").withStatus("True").endCondition()
+      .build();
+
   private KubernetesMockServer server;
   private KubernetesClient client;
 
@@ -52,7 +57,7 @@ class PodExecTest {
   @Test
   @DisplayName("With no containers, should throw exception")
   void withNoContainers() {
-    client.pods().resource(new PodBuilder().withNewMetadata().withName("no-containers").endMetadata().build())
+    client.pods().resource(new PodBuilder().withNewMetadata().withName("no-containers").endMetadata().withStatus(READY).build())
         .createOrReplace();
     final PodResource pr = client.pods().withName("no-containers");
     assertThatThrownBy(() -> pr.exec("sh", "-c", "echo Greetings Professor Falken"))
@@ -68,7 +73,7 @@ class PodExecTest {
         .addNewContainer()
         .withName("the-single-container")
         .endContainer()
-        .endSpec()
+        .endSpec().withStatus(READY)
         .build())
         .createOrReplace();
     server.expect()
@@ -92,7 +97,7 @@ class PodExecTest {
         .addNewContainer()
         .withName("the-single-container")
         .endContainer()
-        .endSpec()
+        .endSpec().withStatus(READY)
         .build())
         .createOrReplace();
     final ContainerResource cr = client.pods().withName("single-container").inContainer("non-existent");
@@ -108,7 +113,7 @@ class PodExecTest {
         .addNewContainer()
         .withName("the-first-container")
         .endContainer()
-        .endSpec()
+        .endSpec().withStatus(READY)
         .build())
         .createOrReplace();
     PodResource op = client.pods().withName("name");
@@ -126,7 +131,7 @@ class PodExecTest {
         .addNewContainer()
         .withName("the-second-container")
         .endContainer()
-        .endSpec()
+        .endSpec().withStatus(READY)
         .build())
         .createOrReplace();
     server.expect()
@@ -153,7 +158,7 @@ class PodExecTest {
         .addNewContainer()
         .withName("the-second-container")
         .endContainer()
-        .endSpec()
+        .endSpec().withStatus(READY)
         .build())
         .createOrReplace();
     server.expect()


### PR DESCRIPTION
## Description

In trying to run the other clients against the kubernetes-tests, WatchTest had a failure - responding with 200, null was actually providing the literal "null" result.  This is not seen by the okhttp logic because it doesn't provide the response to websocket request exceptions, but we do for the other client types.  Treating this as a status creates a null value and ensuing NPE - but that is swallowed by the current exception handling.  These changes make everything appropriately defensive.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
