### PR TITLE
fix #4888: narrowing where the 0 resourceVersion is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix #4823: (java-generator) handle special characters in field names
 * Fix #4723: [java-generator] Fix a race in the use of JavaParser hitting large CRDs
 * Fix #4885: addresses a potential hang in the jdk client with exec stream reading
+* Fix #4888: narrowing where the 0 initial list resourceVersion is used for informers - in particular if a limit is set or initialState is used, then we should not use 0.  Additionally for the informOnCondition / wait methods we'll also not use 0 - it's not expected that the user should test any state prior to the latest.
 * Fix #4891: address vertx not completely reading exec streams
 * Fix #4899: BuildConfigs.instantiateBinary().fromFile() does not time out
 * Fix #4908: using the response headers in the vertx response

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -902,6 +902,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     // create an informer that supplies the tester with events and empty list handling
     SharedIndexInformer<T> informer = this.createInformer(0, Runnable::run);
 
+    informer.initialState(Stream.empty());
+
     // prevent unnecessary watches and handle closure
     future.whenComplete((r, t) -> informer.stop());
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -155,6 +155,7 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
 
       if (initialState != null) {
         initialState.forEach(indexer::put);
+        reflector.usingInitialState();
       }
     }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -253,7 +253,7 @@ class InformTest {
         .build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=0")
+        .withPath("/api/v1/namespaces/test/pods?labelSelector=my-label")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().withItems(pod1).build())
         .once();
@@ -320,7 +320,7 @@ class InformTest {
         .build();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?limit=1&resourceVersion=0")
+        .withPath("/api/v1/namespaces/test/pods?limit=1")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata()
                 .withResourceVersion("2")
@@ -337,7 +337,8 @@ class InformTest {
         .once();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?resourceVersion=2&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath(
+            "/api/v1/namespaces/test/pods?resourceVersion=2&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()
@@ -387,7 +388,8 @@ class InformTest {
         .once();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath(
+            "/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()
@@ -453,7 +455,8 @@ class InformTest {
         .once();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath(
+            "/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -705,7 +705,7 @@ class PodTest {
 
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=0")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
         .andReturn(200, notReady)
         .once();
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
@@ -208,7 +208,7 @@ class ReplicaSetTest {
 
     // list for waiting
     server.expect()
-        .withPath("/apis/apps/v1/namespaces/test/replicasets?fieldSelector=metadata.name%3Drepl1&resourceVersion=0")
+        .withPath("/apis/apps/v1/namespaces/test/replicasets?fieldSelector=metadata.name%3Drepl1")
         .andReturn(200,
             new ReplicaSetListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
         .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
@@ -212,7 +212,7 @@ class ReplicationControllerTest {
 
     // list for waiting
     server.expect()
-        .withPath("/api/v1/namespaces/test/replicationcontrollers?fieldSelector=metadata.name%3Drepl1&resourceVersion=0")
+        .withPath("/api/v1/namespaces/test/replicationcontrollers?fieldSelector=metadata.name%3Drepl1")
         .andReturn(200,
             new ReplicationControllerListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
         .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -159,12 +159,12 @@ public class ResourceListTest {
   void testCreateOrReplaceWithDeleteExisting() throws Exception {
     server.expect().delete().withPath("/api/v1/namespaces/ns1/services/my-service").andReturn(HTTP_OK, service).once();
     server.expect().delete().withPath("/api/v1/namespaces/ns1/configmaps/my-configmap").andReturn(HTTP_OK, configMap).once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dmy-service&resourceVersion=0")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dmy-service")
         .andReturn(HTTP_OK,
             new KubernetesListBuilder().withNewMetadata().endMetadata().build())
         .once();
     server.expect().get()
-        .withPath("/api/v1/namespaces/ns1/configmaps?fieldSelector=metadata.name%3Dmy-configmap&resourceVersion=0")
+        .withPath("/api/v1/namespaces/ns1/configmaps?fieldSelector=metadata.name%3Dmy-configmap")
         .andReturn(HTTP_OK,
             new KubernetesListBuilder().withNewMetadata().endMetadata().build())
         .once();
@@ -202,8 +202,8 @@ public class ResourceListTest {
         .anyMatch(c -> "True".equals(c.getStatus()));
 
     // The pods are never ready if you request them directly.
-    ResourceTest.list(server, noReady1, "0");
-    ResourceTest.list(server, noReady2, "0");
+    ResourceTest.list(server, noReady1, null);
+    ResourceTest.list(server, noReady2, null);
 
     server.expect().get().withPath(
         "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
@@ -247,8 +247,8 @@ public class ResourceListTest {
         .anyMatch(c -> "True".equals(c.getStatus()));
 
     // The pods are never ready if you request them directly.
-    ResourceTest.list(server, noReady1, "0");
-    ResourceTest.list(server, noReady2, "0");
+    ResourceTest.list(server, noReady1, null);
+    ResourceTest.list(server, noReady2, null);
 
     Status gone = new StatusBuilder()
         .withCode(HTTP_GONE)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -327,7 +327,7 @@ class ResourceTest {
    * @param pod
    */
   private void list(Pod pod) {
-    list(server, pod, "0");
+    list(server, pod, null);
   }
 
   static void list(KubernetesMockServer server, Pod pod, String resourceVersion) {
@@ -355,7 +355,7 @@ class ResourceTest {
     // and again so that "periodicWatchUntilReady" successfully begins
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=0")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
         .andReturn(200, noReady)
         .times(2);
 
@@ -715,7 +715,7 @@ class ResourceTest {
   void testWaitNullDoesntExist() throws InterruptedException {
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=0")
+        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1")
         .andReturn(200,
             new PodListBuilder().withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
@@ -210,11 +210,11 @@ class ServiceTest {
             .addToPorts(new EndpointPortBuilder().withPort(8443).build())
             .build())
         .build();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/endpoints?fieldSelector=metadata.name%3Dsvc1&resourceVersion=0")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/endpoints?fieldSelector=metadata.name%3Dsvc1")
         .andReturn(HttpURLConnection.HTTP_OK,
             new EndpointsListBuilder().withItems(endpoint).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();
-    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dsvc1&resourceVersion=0")
+    server.expect().get().withPath("/api/v1/namespaces/ns1/services?fieldSelector=metadata.name%3Dsvc1")
         .andReturn(HttpURLConnection.HTTP_OK,
             new ServiceListBuilder().withItems(svc1).withNewMetadata().withResourceVersion("1").endMetadata().build())
         .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -250,7 +250,7 @@ public class StatefulSetTest {
 
     // list for waiting
     server.expect()
-        .withPath("/apis/apps/v1/namespaces/test/statefulsets?fieldSelector=metadata.name%3Drepl1&resourceVersion=0")
+        .withPath("/apis/apps/v1/namespaces/test/statefulsets?fieldSelector=metadata.name%3Drepl1")
         .andReturn(200,
             new StatefulSetListBuilder().withItems(scaled).withMetadata(new ListMetaBuilder().build()).build())
         .always();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -406,7 +406,7 @@ class DeploymentConfigTest {
         .endStatus().build();
     server.expect().get()
         .withPath(
-            "/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs?fieldSelector=metadata.name%3Ddc1&resourceVersion=0")
+            "/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs?fieldSelector=metadata.name%3Ddc1")
         .andReturn(HttpURLConnection.HTTP_OK,
             new DeploymentConfigListBuilder().withItems(deploymentConfig).withMetadata(new ListMeta()).build())
         .always();


### PR DESCRIPTION
## Description

Fix #4888

Narrowing the usage of 0 initial resourceVersion.  We don't want to do this if:
- there's a limit specified as it will be ignored by the api server.
- there's initialState specified, since we don't know what the initial resourceVersion is.  While things will be eventually consistent, it's best not to have any misleading events
- we're doing some version of a wait or informOnCondition - as we saw with a couple integration tests that needed their conditions adjusted after this change, it can be unexpected that you are testing state from before the call is made - that is you create an resource, then make a waitOnCondition call and initially it appears that the resource doesn't exists.

This will mean that only direct usage of an informer will default to the 0/cached initial listing.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
