### PR TITLE
fix #4954: disabling jdk expect continue by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix #4908: using the response headers in the vertx response
 * Fix #4947: typo in HttpClient.Factory scoring system logic
 * Fix #4928: allows non-okhttp clients to handle invalid status
+* Fix #4954: disabling expect continue support by default in the jdk client
 
 #### Improvements
 * Fix #4675: adding a fully client side timeout for informer watches

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientFactory.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientFactory.java
@@ -80,4 +80,16 @@ public class JdkHttpClientFactory implements HttpClient.Factory {
         .map(ShutdownableExecutor.class::cast).ifPresent(ShutdownableExecutor::shutdownNow);
   }
 
+  /**
+   * Due to go/kubernetes bug https://github.com/golang/go/issues/57824
+   * expect continue is not supported for jdk. Override this method if you are using a
+   * kubernetes version with the fix and require this support (currently only used for
+   * submitting openshift builds)
+   *
+   * @return
+   */
+  protected boolean useExpectContinue() {
+    return false;
+  }
+
 }

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -296,7 +296,7 @@ public class JdkHttpClientImpl extends StandardHttpClient<JdkHttpClientImpl, Jdk
     }
 
     requestBuilder.uri(request.uri());
-    if (request.isExpectContinue()) {
+    if (request.isExpectContinue() && this.builder.getClientFactory().useExpectContinue()) {
       requestBuilder.expectContinue(true);
     }
     return requestBuilder;


### PR DESCRIPTION
## Description
Fixes #4954 - it appears like expect continue support is not required, at least for our minikube tests.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
