### PR TITLE
fix #4477 #4965: LeaderElector release public / crud mock compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 #### Improvements
+* Fix #4477 exposing LeaderElector.release to force an elector to give up the lease
 
 #### Dependency Upgrade
 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -19,6 +19,7 @@ package io.fabric8.kubernetes.client.server.mock;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
@@ -98,7 +99,8 @@ public class KubernetesMockServerExtension
     EnableKubernetesMockClient a = testClass.getAnnotation(EnableKubernetesMockClient.class);
     final Map<ServerRequest, Queue<ServerResponse>> responses = new HashMap<>();
     mock = a.crud()
-        ? new KubernetesMockServer(new Context(), new MockWebServer(), responses, new KubernetesMixedDispatcher(responses),
+        ? new KubernetesMockServer(new Context(Serialization.jsonMapper()), new MockWebServer(), responses,
+            new KubernetesMixedDispatcher(responses),
             a.https())
         : new KubernetesMockServer(a.https());
     mock.init();

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/ConfigMapLock.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/ConfigMapLock.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.extended.leaderelection.resourcelock;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.slf4j.Logger;
@@ -58,10 +59,10 @@ public class ConfigMapLock extends ResourceLock<ConfigMap> {
   }
 
   @Override
-  protected ConfigMap toResource(LeaderElectionRecord leaderElectionRecord, ObjectMeta meta) {
-    return new ConfigMapBuilder().withMetadata(meta).editMetadata()
-        .addToAnnotations(LEADER_ELECTION_RECORD_ANNOTATION_KEY, Serialization.asJson(leaderElectionRecord))
-        .endMetadata()
+  protected ConfigMap toResource(LeaderElectionRecord leaderElectionRecord, ObjectMetaBuilder meta) {
+    return new ConfigMapBuilder()
+        .withMetadata(
+            meta.addToAnnotations(LEADER_ELECTION_RECORD_ANNOTATION_KEY, Serialization.asJson(leaderElectionRecord)).build())
         .build();
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaderElectionRecord.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaderElectionRecord.java
@@ -17,12 +17,9 @@ package io.fabric8.kubernetes.client.extended.leaderelection.resourcelock;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 
-import java.io.Serializable;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -35,7 +32,6 @@ import java.util.Objects;
  * @see <a href=
  *      "https://github.com/kubernetes/client-go/blob/1aa326d7304eba6aedc8c89daad615cc7499d1f7/tools/leaderelection/resourcelock/interface.go">leaderelection/resourcelock/interface.go</a>
  */
-@AllArgsConstructor
 @Builder(toBuilder = true)
 public class LeaderElectionRecord {
 
@@ -46,8 +42,6 @@ public class LeaderElectionRecord {
   @JsonFormat(timezone = "UTC", pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
   private final ZonedDateTime renewTime;
   private final int leaderTransitions;
-  @JsonIgnore
-  private transient Serializable version;
 
   @JsonCreator
   public LeaderElectionRecord(
@@ -82,14 +76,6 @@ public class LeaderElectionRecord {
     return leaderTransitions;
   }
 
-  public Serializable getVersion() {
-    return version;
-  }
-
-  public void setVersion(Serializable version) {
-    this.version = version;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o)
@@ -101,13 +87,12 @@ public class LeaderElectionRecord {
         Objects.equals(holderIdentity, that.holderIdentity) &&
         Objects.equals(leaseDuration, that.leaseDuration) &&
         Objects.equals(acquireTime, that.acquireTime) &&
-        Objects.equals(renewTime, that.renewTime) &&
-        Objects.equals(version, that.version);
+        Objects.equals(renewTime, that.renewTime);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(holderIdentity, leaseDuration, acquireTime, renewTime, leaderTransitions, version);
+    return Objects.hash(holderIdentity, leaseDuration, acquireTime, renewTime, leaderTransitions);
   }
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaseLock.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/LeaseLock.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.extended.leaderelection.resourcelock;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.coordination.v1.Lease;
 import io.fabric8.kubernetes.api.model.coordination.v1.LeaseBuilder;
 
@@ -39,8 +40,8 @@ public class LeaseLock extends ResourceLock<Lease> {
   }
 
   @Override
-  protected Lease toResource(LeaderElectionRecord leaderElectionRecord, ObjectMeta meta) {
-    return new LeaseBuilder().withMetadata(meta)
+  protected Lease toResource(LeaderElectionRecord leaderElectionRecord, ObjectMetaBuilder meta) {
+    return new LeaseBuilder().withMetadata(meta.build())
         .withNewSpec()
         .withHolderIdentity(leaderElectionRecord.getHolderIdentity())
         .withLeaseDurationSeconds((int) leaderElectionRecord.getLeaseDuration().get(ChronoUnit.SECONDS))

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/ResourceLock.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extended/leaderelection/resourcelock/ResourceLock.java
@@ -77,7 +77,7 @@ public abstract class ResourceLock<T extends HasMetadata> implements Lock {
   protected abstract LeaderElectionRecord toRecord(T resource);
 
   protected ObjectMetaBuilder getObjectMeta(String version) {
-    return new ObjectMetaBuilder(meta).withResourceVersion((String) version);
+    return new ObjectMetaBuilder(meta).withResourceVersion(version);
   }
 
   /**

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElectorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/extended/leaderelection/LeaderElectorTest.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
+import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -55,8 +56,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class LeaderElectorTest {
-
-  final static AtomicReference<LeaderElectionRecord> activeLer = new AtomicReference<>(null);
 
   @Test
   void runShouldAbortAfterRenewDeadlineExpired() throws Exception {
@@ -114,17 +113,14 @@ class LeaderElectorTest {
   @Test
   void shouldReleaseWhenCanceled() throws Exception {
     // Given
-    final LeaderElectionConfig lec = mockLeaderElectionConfiguration();
+    AtomicReference<LeaderElectionRecord> activeLer = new AtomicReference<>();
+    final LeaderElectionConfig lec = mockLeaderElectionConfiguration(activeLer);
     final CountDownLatch signal = new CountDownLatch(1);
     final Lock mockedLock = lec.getLock();
     when(lec.isReleaseOnCancel()).thenReturn(true);
     doAnswer(invocation -> {
       LeaderElectionRecord leaderRecord = invocation.getArgument(1, LeaderElectionRecord.class);
-      if (!activeLer.get().getVersion().equals(leaderRecord.getVersion())) {
-        throw new KubernetesClientException("Wrong");
-      }
-      activeLer.set(leaderRecord.toBuilder()
-          .version(String.valueOf(Integer.parseInt(String.valueOf(leaderRecord.getVersion())) + 1)).build());
+      activeLer.set(leaderRecord);
       signal.countDown();
       return null;
     }).when(mockedLock).update(any(), any());
@@ -138,7 +134,6 @@ class LeaderElectorTest {
     // Then
     Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> Utils.isNullOrEmpty(activeLer.get().getHolderIdentity()));
     assertEquals(0, activeLer.get().getLeaderTransitions());
-    assertEquals("3", activeLer.get().getVersion());
 
     // create a new elector, they are no good after a single use
     leaderElector = new LeaderElector(mock(NamespacedKubernetesClient.class), lec, CommonThreadPool.get());
@@ -147,6 +142,44 @@ class LeaderElectorTest {
 
     // there should be a transition
     assertEquals(1, activeLer.get().getLeaderTransitions());
+  }
+
+  @Test
+  void shouldRelease() throws Exception {
+    // Given
+    AtomicReference<LeaderElectionRecord> activeLer = new AtomicReference<>();
+    final LeaderElectionConfig lec = mockLeaderElectionConfiguration(activeLer);
+    final CountDownLatch signal = new CountDownLatch(1);
+    final Lock mockedLock = lec.getLock();
+    doAnswer(invocation -> {
+      LeaderElectionRecord leaderRecord = invocation.getArgument(1, LeaderElectionRecord.class);
+      activeLer.set(leaderRecord);
+      signal.countDown();
+      return null;
+    }).when(mockedLock).update(any(), any());
+
+    // When
+    LeaderElector leaderElector = new LeaderElector(mock(NamespacedKubernetesClient.class), lec, CommonThreadPool.get());
+    CompletableFuture<?> started = leaderElector.start();
+    assertTrue(signal.await(10, TimeUnit.SECONDS));
+
+    Mockito.verify(lec.getLeaderCallbacks(), times(1)).onStartLeading();
+
+    leaderElector.release();
+
+    // ensure that release cause us to stop leading
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+      Mockito.verify(lec.getLeaderCallbacks()).onStopLeading();
+      return true;
+    });
+
+    // we haven't stopped, so we'll re-acquire
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+      Mockito.verify(lec.getLeaderCallbacks(), times(2)).onStartLeading();
+      return true;
+    });
+
+    started.cancel(true);
   }
 
   @Test
@@ -231,9 +264,7 @@ class LeaderElectorTest {
   void loopCancel() throws Exception {
     // Given
     AtomicInteger count = new AtomicInteger();
-    CompletableFuture<?> cf = loop(completion -> {
-      count.getAndIncrement();
-    }, () -> 10L, CommonThreadPool.get());
+    CompletableFuture<?> cf = loop(completion -> count.getAndIncrement(), () -> 10L, CommonThreadPool.get());
     // When
     Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> count.get() >= 1);
 
@@ -281,7 +312,12 @@ class LeaderElectorTest {
     assertTrue(result.toMillis() > 1000L);
   }
 
-  private static LeaderElectionConfig mockLeaderElectionConfiguration() throws Exception {
+  private LeaderElectionConfig mockLeaderElectionConfiguration() throws Exception {
+    return mockLeaderElectionConfiguration(new AtomicReference<>());
+  }
+
+  private LeaderElectionConfig mockLeaderElectionConfiguration(AtomicReference<LeaderElectionRecord> activeLer)
+      throws Exception {
     final LeaderElectionConfig lec = mock(LeaderElectionConfig.class, Answers.RETURNS_DEEP_STUBS);
     when(lec.getLeaseDuration()).thenReturn(Duration.ofSeconds(2L));
     when(lec.getRenewDeadline()).thenReturn(Duration.ofSeconds(1L));
@@ -291,7 +327,7 @@ class LeaderElectorTest {
     when(mockedLock.get(any())).thenReturn(null).thenAnswer(invocation -> activeLer.get());
     doAnswer(invocation -> {
       LeaderElectionRecord leaderRecord = invocation.getArgument(1, LeaderElectionRecord.class);
-      activeLer.set(leaderRecord.toBuilder().version("1").build());
+      activeLer.set(leaderRecord);
       return null;
     }).when(mockedLock).create(any(), any());
     return lec;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionCrudTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.ConfigMapLock;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.fabric8.kubernetes.client.mock.LeaderElectionTest.testAndAssertSingleLeader;
+
+@EnableKubernetesMockClient(crud = true)
+@DisplayName("LeaderElection runs on Kubernetes Mock Server in CRUD mode")
+class LeaderElectionCrudTest {
+
+  KubernetesClient client;
+
+  @Test
+  void singleLeaderConfigMapLockTest() throws Exception {
+    testAndAssertSingleLeader(client, "lead-config-map-crud",
+        new ConfigMapLock("namespace", "name", "lead-config-map-crud"));
+
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(crud = true)
 public class LeaderElectionTest {
 
   KubernetesMockServer server;
@@ -82,6 +82,11 @@ public class LeaderElectionTest {
         .andReturn(200, null)
         .once();
     // When - Then
+    testAndAssertSingleLeader("lead-config-map",
+        new ConfigMapLock("namespace", "name", "lead-config-map"));
+
+    // verify crud mock behavior
+    server.clearExpectations();
     testAndAssertSingleLeader("lead-config-map",
         new ConfigMapLock("namespace", "name", "lead-config-map"));
   }


### PR DESCRIPTION
## Description

Fix #4477
Fix #4965 

Address #4477 and #4965 - in looking at 4477, I decided to address 4965 as well, but together as to avoid conflicts.  The only major changes here are:
* use merge instead of strategic merge.  This may only be an issue in an extreme corner case - the user specifies a finalizer or ownerReference in the meta provided to the lock configuration, and wants to modify the configmap or lease after the fact to add other finalizers or ownerRefereneces.  Because of the merge, those will be removed.
* moved the version off of the LeaderElectionRecord - in reviewing the go implementation they've introduced a couple of new lock types such that the version is not properly a construct of the record, but of the lock.  Because we're doing a patch we don't really use the whole record yet, just the resource version.
* expose the release method for use by someone who wants to force the LeaderElector to give up their leadership.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
