### PR TITLE
Fix: Vert.x HttpClient stackoverflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #4960: NPE in OpenIDConnectionUtils if `idp-certificate-authority-data` absent in auth-provider config
+* Fix #4981: Prevent StackOverflowError in Vert.x HttpClient caused by fast InputStream buffer extraction
 
 #### Improvements
 * Fix #4970: OpenShiftOAuthInterceptor should not refresh on `403` response code


### PR DESCRIPTION
Authored by @vietj

Relates to https://github.com/quarkusio/quarkus/issues/31872

The implementation of the InputStream to ReadStream adapter can sometimes do a stack overflow when the InputStream buffer extraction on a worker thread is faster than the event-loop. We should guard against this recursion and trampoline when the reads starts to pile (8).