### PR TITLE
fix #4985: triggering the cleanup of the idle task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #4963: Openshift Client return 403 when use websocket
+* Fix #4985: triggering the immediate cleanup of the okhttp idle task
 
 #### Improvements
 * Fix #4477 exposing LeaderElector.release to force an elector to give up the lease


### PR DESCRIPTION
## Description

Fix #4985 

A thread is held per connectionpool to clean idle connections on https://github.com/quarkusio/quarkus/issues/18973 we noticed that this is holding a quarkus classloader that eventually run tests out of memory.  There seems to be only two ways to address this immediately:
1. trigger the cleanup when the pool is empty with a notification that will wake up the job and let it exit.  This is of course not a full fledged part of their api and does change between versions, such that we have to get a hold of a different object.  This is the initial proposal.
2. Add logic that will provide more control over the idle timeout on the ConnectionPool - those are arguments to the pool constructor that can then be provided to the okhttp client builder.  However I'm not sure there's a good value we can always set, it seems like it would be dependent upon whether you were running in such a way as to expect lots of client creation.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
