### PR TITLE
fix #4988: ensuring the previous response is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #4793: (java-generator) Fix broken POJO generation when two schema properties collide into a single field name
 * Fix #4963: Openshift Client return 403 when use websocket
 * Fix #4985: triggering the immediate cleanup of the okhttp idle task
+* Fix #4988: Ensuring that previous requests are closed before retry
 * fix #5002: Jetty response completion accounts for header processing
 * Fix #5009: addressing issue with serialization of wrapped polymophic types
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
@@ -145,6 +145,7 @@ public abstract class StandardHttpClient<C extends HttpClient, F extends HttpCli
                 LOG.debug("HTTP operation on url: {} should be retried as the response code was {}, retrying after {} millis",
                     uri, code, retryInterval);
                 retry = true;
+                cancel.accept(response);
               }
             } else if (throwable instanceof IOException) {
               LOG.debug(String.format("HTTP operation on url: %s should be retried after %d millis because of IOException",


### PR DESCRIPTION
## Description

Fix #4988 

The prior location of the retry code did not require explicit closure because it was on top of consuming the the whole auto-closed response.  Now that it's been moved, we have to account for the closure before issuing the retry.

@manusa @rohanKanojia should we put in reference tracking cleanup as a fail safe?

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
