### PR TITLE
Optimize Quantity.parse to avoid regex overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Improvements
 * Fix #4477 exposing LeaderElector.release to force an elector to give up the lease
+* Fix #4992: Optimize Quantity parsing to avoid regex overhead
 
 #### Dependency Upgrade
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -293,6 +293,9 @@ public class Quantity implements Serializable {
         case 'T':
         case 'P':
           return i;
+        default:
+          //noinspection UnnecessaryContinue - satisfy Sonar
+          continue;
       }
     }
     return quantityAsString.length();

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
@@ -88,6 +88,7 @@ public class QuantityTest {
   public void testExponents() {
     assertEquals("129000000", Quantity.getAmountInBytes(new Quantity("129e6")).toString());
     assertEquals("129000000", Quantity.getAmountInBytes(new Quantity("129e+6")).toString());
+    assertEquals("1234567890", Quantity.getAmountInBytes(new Quantity("1234567890")).toString());
     assertEquals("8192", Quantity.getAmountInBytes(new Quantity("8Ki")).toString());
     assertEquals("7340032", Quantity.getAmountInBytes(new Quantity("7Mi")).toString());
     assertEquals("6442450944", Quantity.getAmountInBytes(new Quantity("6Gi")).toString());
@@ -131,6 +132,7 @@ public class QuantityTest {
   public void testExponent() {
     assertEquals("10000", Quantity.getAmountInBytes(new Quantity("1e4")).toString());
     assertEquals("2000000000", Quantity.getAmountInBytes(new Quantity("2E9")).toString());
+    assertEquals("2000000000000", Quantity.getAmountInBytes(new Quantity("2E12")).toString());
   }
 
   @Test
@@ -150,6 +152,7 @@ public class QuantityTest {
     assertEquals("1Ki", new Quantity("1Ki").toString());
     assertEquals("32Mi", new Quantity("32Mi").toString());
     assertEquals("1e3", new Quantity("1e3").toString());
+    assertEquals("1e10", new Quantity("1e10").toString());
     assertEquals("1e-3", new Quantity("1e-3").toString());
     assertEquals("100k", new Quantity("100k").toString());
     assertEquals("100001m", new Quantity("100001m").toString());
@@ -165,6 +168,7 @@ public class QuantityTest {
     assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity()));
     assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity("4MiB")));
     assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity("4megabyte")));
+    assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity("4c")));
   }
 
   @Test
@@ -192,5 +196,6 @@ public class QuantityTest {
     assertEquals(3, Quantity.indexOfUnit("123K"));
     assertEquals(1, Quantity.indexOfUnit("1e3"));
     assertEquals(4, Quantity.indexOfUnit("123 K"));
+    assertEquals(4, Quantity.indexOfUnit("123c"));
   }
 }

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuantityTest {
   private final ObjectMapper mapper = new ObjectMapper();
@@ -163,5 +165,32 @@ public class QuantityTest {
     assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity()));
     assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity("4MiB")));
     assertThrows(IllegalArgumentException.class, () -> Quantity.getAmountInBytes(new Quantity("4megabyte")));
+  }
+
+  @Test
+  @DisplayName("Test containsAtLeastOneDigit method")
+  public void testContainsAtLeastOneDigit() {
+    assertTrue(Quantity.containsAtLeastOneDigit("0"));
+    assertTrue(Quantity.containsAtLeastOneDigit(".1"));
+    assertTrue(Quantity.containsAtLeastOneDigit(".1e2"));
+    assertTrue(Quantity.containsAtLeastOneDigit("1.2e3"));
+    assertTrue(Quantity.containsAtLeastOneDigit("-1K"));
+
+    assertFalse(Quantity.containsAtLeastOneDigit(""));
+    assertFalse(Quantity.containsAtLeastOneDigit("e"));
+    assertFalse(Quantity.containsAtLeastOneDigit("Mi"));
+  }
+
+  @Test
+  @DisplayName("Test indexOfUnit method")
+  public void testIndexOfUnit() {
+    assertEquals(0, Quantity.indexOfUnit(""));
+    assertEquals(1, Quantity.indexOfUnit("0"));
+    assertEquals(1, Quantity.indexOfUnit("1"));
+    assertEquals(3, Quantity.indexOfUnit("123"));
+    assertEquals(2, Quantity.indexOfUnit("12Mi"));
+    assertEquals(3, Quantity.indexOfUnit("123K"));
+    assertEquals(1, Quantity.indexOfUnit("1e3"));
+    assertEquals(4, Quantity.indexOfUnit("123 K"));
   }
 }


### PR DESCRIPTION
## Description
Optimize `Quantity.parse` to avoid regex overhead. While reviewing some JFR profiles from a service using fabric8.io k8s client, I noticed some significant allocations and CPU time spent parsing quantities using regex from interacting with k8s APIs. We can avoid some of these overheads by simplifying the parsing to identify when and where to split quantity and units.

![image](https://user-images.githubusercontent.com/54594/227241735-2b165930-0442-458a-bf53-06a4a265df4c.png)
![image](https://user-images.githubusercontent.com/54594/227241803-884e5f7d-fe9e-443e-a30e-cffc398db1d7.png)
![image](https://user-images.githubusercontent.com/54594/227253876-a9ca5265-e9c4-4a4e-8e46-e8c7eacb18a3.png)


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
