### PR TITLE
fix #4998: removing the usage of the yaml mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@
 #### Improvements
 * Fix #4477 exposing LeaderElector.release to force an elector to give up the lease
 * Fix #4992: Optimize Quantity parsing to avoid regex overhead
+* Fix #4998: removing the internal usage of the Serialization yaml mapper
 
 #### Dependency Upgrade
 
 #### New Features
 
 #### _**Note**_: Breaking changes
+* Fix #4998: Serialization.yamlMapper and Serialization.clearYamlMapper have been deprecated
 
 ### 6.5.1 (2023-03-20)
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.AuthInfo;
 import io.fabric8.kubernetes.api.model.Cluster;
 import io.fabric8.kubernetes.api.model.Config;
@@ -26,6 +25,8 @@ import io.fabric8.kubernetes.api.model.NamedContext;
 import io.fabric8.kubernetes.client.utils.Serialization;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 
@@ -39,13 +40,11 @@ public class KubeConfigUtils {
   }
 
   public static Config parseConfig(File file) throws IOException {
-    ObjectMapper mapper = Serialization.yamlMapper();
-    return mapper.readValue(file, Config.class);
+    return Serialization.unmarshal(new FileInputStream(file), Config.class);
   }
 
-  public static Config parseConfigFromString(String contents) throws IOException {
-    ObjectMapper mapper = Serialization.yamlMapper();
-    return mapper.readValue(contents, Config.class);
+  public static Config parseConfigFromString(String contents) {
+    return Serialization.unmarshal(contents, Config.class);
   }
 
   /**
@@ -158,6 +157,8 @@ public class KubeConfigUtils {
    * @throws IOException in case of failure while writing to file
    */
   public static void persistKubeConfigIntoFile(Config kubeConfig, String kubeConfigPath) throws IOException {
-    Serialization.yamlMapper().writeValue(new File(kubeConfigPath), kubeConfig);
+    try (FileWriter writer = new FileWriter(kubeConfigPath)) {
+      writer.write(Serialization.asYaml(kubeConfig));
+    }
   }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/IOHelpers.java
@@ -74,15 +74,11 @@ public class IOHelpers {
     return true;
   }
 
-  public static String convertYamlToJson(String yaml) throws IOException {
-    ObjectMapper yamlReader = Serialization.yamlMapper();
-    Object obj = yamlReader.readValue(yaml, Object.class);
-
-    ObjectMapper jsonWriter = Serialization.jsonMapper();
-    return jsonWriter.writeValueAsString(obj);
+  public static String convertYamlToJson(String yaml) {
+    return Serialization.asJson(Serialization.unmarshal(yaml, Object.class));
   }
 
-  public static String convertToJson(String jsonOrYaml) throws IOException {
+  public static String convertToJson(String jsonOrYaml) {
     if (isJSONValid(jsonOrYaml)) {
       return jsonOrYaml;
     }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -467,6 +467,20 @@ class SerializationTest {
   }
 
   @Test
+  void testArrayAsYaml() {
+    // Given
+    String[] value = new String[] { "x", "y" };
+
+    // When
+    String yaml = Serialization.asYaml(value);
+
+    // Then
+    assertThat(yaml).isEqualTo("---\n"
+        + "- \"x\"\n"
+        + "- \"y\"\n");
+  }
+
+  @Test
   void testAnyTypeSerialization() {
     // Given
     AnyType value = new AnyType("x");


### PR DESCRIPTION
## Description
Fixes #4998 by pulling some code from #4662

There is some customization of the yaml output needed to match what jackson is doing - primarily quoting values, but not keys.   The only special case is that the y/n abbreviations as not recognized by snake yaml by default.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
