### PR TITLE
[chore] Remove deprecated configuration options from java-generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 #### _**Note**_: Breaking changes
 
+* Fix #4875: Removed unused options from the java-generator
+
 ### 6.5.1 (2023-03-20)
 
 #### Bugs

--- a/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
+++ b/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
@@ -55,29 +55,9 @@ public class GenerateJavaSources implements Runnable {
   @Option(names = { "-enum-uppercase", "--enum-uppercase" }, description = "Uppercase the enum values", required = false)
   Boolean uppercaseEnum = null;
 
-  @Deprecated
-  @Option(names = { "-prefix-strategy",
-      "--prefix-strategy" }, description = "The prefix strategy to be used", required = false, hidden = true)
-  String prefixStrategy = null;
-
-  @Deprecated
-  @Option(names = { "-suffix-strategy",
-      "--suffix-strategy" }, description = "The suffix strategy to be used", required = false, hidden = true)
-  String suffixStrategy = null;
-
-  @Deprecated
-  @Option(names = { "-always-preserve-unknown",
-      "--always-preserve-unknown" }, description = "Always preserve unknown fields in the generated classes", required = false, hidden = true)
-  Boolean alwaysPreserveUnkownFields = null;
-
   @Option(names = { "-add-extra-annotations",
       "--add-extra-annotations" }, description = "Add extra lombok and sundrio annotation to the generated classes", required = false)
   Boolean addExtraAnnotations = null;
-
-  @Deprecated
-  @Option(names = { "-code-structure",
-      "--code-structure" }, description = "Generate classes using a specific layout", required = false, hidden = true)
-  String codeStructure = null;
 
   @Option(names = { "-skip-generated-annotations",
       "--skip-generated-annotations" }, description = "Skip emitting the @javax.annotation.processing.Generated annotation on the generated sources", required = false, hidden = true)
@@ -89,17 +69,10 @@ public class GenerateJavaSources implements Runnable {
 
   @Override
   public void run() {
-    final Config.Prefix pSt = (prefixStrategy != null) ? Config.Prefix.valueOf(prefixStrategy) : null;
-    final Config.Suffix sSt = (suffixStrategy != null) ? Config.Suffix.valueOf(suffixStrategy) : null;
-    final Config.CodeStructure structure = (codeStructure != null) ? Config.CodeStructure.valueOf(codeStructure) : null;
     final Boolean noGeneratedAnnotations = (skipGeneratedAnnotations != null) ? skipGeneratedAnnotations : false;
     final Config config = new Config(
         uppercaseEnum,
-        pSt,
-        sSt,
-        alwaysPreserveUnkownFields,
         addExtraAnnotations,
-        structure,
         !noGeneratedAnnotations,
         packageOverrides);
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/CRGeneratorRunner.java
@@ -60,24 +60,17 @@ public class CRGeneratorRunner {
 
       AbstractJSONSchema2Pojo specGenerator = null;
 
-      String prefix = crName;
-      if (config.getPrefixStrategy() == Config.Prefix.NEVER) {
-        prefix = "";
-      }
-
       JSONSchemaProps spec = crdv.getSchema().getOpenAPIV3Schema().getProperties().get("spec");
       if (spec != null) {
-        String suffix = (config.getSuffixStrategy() != Config.Suffix.NEVER) ? "Spec" : "";
         specGenerator = AbstractJSONSchema2Pojo.fromJsonSchema(
-            "spec", spec, pkg, prefix, suffix, config);
+            crName + "Spec", spec, pkg, config);
       }
 
       AbstractJSONSchema2Pojo statusGenerator = null;
       JSONSchemaProps status = crdv.getSchema().getOpenAPIV3Schema().getProperties().get("status");
       if (status != null) {
-        String suffix = (config.getSuffixStrategy() != Config.Suffix.NEVER) ? "Status" : "";
         statusGenerator = AbstractJSONSchema2Pojo.fromJsonSchema(
-            "status", status, pkg, prefix, suffix, config);
+            crName + "Status", status, pkg, config);
       }
 
       AbstractJSONSchema2Pojo crGenerator = new JCRObject(
@@ -86,8 +79,8 @@ public class CRGeneratorRunner {
           group,
           version,
           scope,
-          prefix + "Spec",
-          prefix + "Status",
+          crName + "Spec",
+          crName + "Status",
           specGenerator != null,
           statusGenerator != null,
           crdv.getStorage(),

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
@@ -24,71 +24,26 @@ import java.util.Map;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 public class Config {
-  public enum CodeStructure {
-    FLAT,
-    PACKAGE_NESTED,
-  }
-
-  public enum Prefix {
-    TOP_LEVEL,
-    ALWAYS,
-    NEVER,
-  }
-
-  public enum Suffix {
-    TOP_LEVEL,
-    ALWAYS,
-    NEVER,
-  }
-
   private static final boolean DEFAULT_UPPERCASE_ENUM = true;
-  private static final Prefix DEFAULT_PREFIX_STRATEGY = Prefix.TOP_LEVEL;
-  private static final Suffix DEFAULT_SUFFIX_STRATEGY = Suffix.TOP_LEVEL;
-  private static final boolean DEFAULT_ALWAYS_PRESERVE_FIELDS = false;
   private static final boolean DEFAULT_ADD_EXTRA_ANNOTATIONS = false;
-  private static final CodeStructure DEFAULT_CODE_STRUCTURE = CodeStructure.PACKAGE_NESTED;
   private static final boolean DEFAULT_ADD_GENERATED_ANNOTATIONS = true;
   private static final Map<String, String> DEFAULT_PACKAGE_OVERRIDES = new HashMap<>();
 
   private Boolean uppercaseEnums = DEFAULT_UPPERCASE_ENUM;
-  @Deprecated
-  private Prefix prefixStrategy = DEFAULT_PREFIX_STRATEGY;
-  @Deprecated
-  private Suffix suffixStrategy = DEFAULT_SUFFIX_STRATEGY;
-  @Deprecated
-  private Boolean alwaysPreserveUnknownFields = DEFAULT_ALWAYS_PRESERVE_FIELDS;
   private Boolean objectExtraAnnotations = DEFAULT_ADD_EXTRA_ANNOTATIONS;
-  @Deprecated
-  private CodeStructure structure = DEFAULT_CODE_STRUCTURE;
   private Boolean generatedAnnotations = DEFAULT_ADD_GENERATED_ANNOTATIONS;
   private Map<String, String> packageOverrides = DEFAULT_PACKAGE_OVERRIDES;
 
   public Config(
       Boolean uppercaseEnums,
-      Prefix prefixStrategy,
-      Suffix suffixStrategy,
-      Boolean alwaysPreserveUnknownFields,
       Boolean objectExtraAnnotations,
-      CodeStructure structure,
       Boolean generatedAnnotations,
       Map<String, String> packageOverrides) {
     if (uppercaseEnums != null) {
       this.uppercaseEnums = uppercaseEnums;
     }
-    if (prefixStrategy != null) {
-      this.prefixStrategy = prefixStrategy;
-    }
-    if (suffixStrategy != null) {
-      this.suffixStrategy = suffixStrategy;
-    }
-    if (alwaysPreserveUnknownFields != null) {
-      this.alwaysPreserveUnknownFields = alwaysPreserveUnknownFields;
-    }
     if (objectExtraAnnotations != null) {
       this.objectExtraAnnotations = objectExtraAnnotations;
-    }
-    if (structure != null) {
-      this.structure = structure;
     }
     if (generatedAnnotations != null) {
       this.generatedAnnotations = generatedAnnotations;
@@ -102,28 +57,10 @@ public class Config {
     return (uppercaseEnums == null) ? DEFAULT_UPPERCASE_ENUM : uppercaseEnums;
   }
 
-  public Prefix getPrefixStrategy() {
-    return (prefixStrategy == null) ? DEFAULT_PREFIX_STRATEGY : prefixStrategy;
-  }
-
-  public Suffix getSuffixStrategy() {
-    return (suffixStrategy == null) ? DEFAULT_SUFFIX_STRATEGY : suffixStrategy;
-  }
-
-  public boolean isAlwaysPreserveUnknownFields() {
-    return (alwaysPreserveUnknownFields == null)
-        ? DEFAULT_ALWAYS_PRESERVE_FIELDS
-        : alwaysPreserveUnknownFields;
-  }
-
   public boolean isObjectExtraAnnotations() {
     return (objectExtraAnnotations == null)
         ? DEFAULT_ADD_EXTRA_ANNOTATIONS
         : objectExtraAnnotations;
-  }
-
-  public CodeStructure getCodeStructure() {
-    return (structure == null) ? DEFAULT_CODE_STRUCTURE : structure;
   }
 
   public boolean isGeneratedAnnotations() {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -147,16 +147,12 @@ public abstract class AbstractJSONSchema2Pojo {
       String key,
       JSONSchemaProps prop,
       String parentPkg,
-      String classPrefix,
-      String classSuffix,
       Config config) {
     Function<JavaNameAndType, AbstractJSONSchema2Pojo> fromJsonSchema = javaNameAndType -> fromJsonSchema(
         key,
         javaNameAndType,
         prop,
         parentPkg,
-        classPrefix,
-        classSuffix,
         config);
     String type = prop.getType();
     if (Boolean.TRUE.equals(prop.getXKubernetesIntOrString())) {
@@ -220,8 +216,6 @@ public abstract class AbstractJSONSchema2Pojo {
       JavaNameAndType nt,
       JSONSchemaProps prop,
       String parentPkg,
-      String classPrefix,
-      String classSuffix,
       Config config) {
     final boolean isNullable = Boolean.TRUE.equals(prop.getNullable());
     switch (nt.getType()) {
@@ -243,8 +237,6 @@ public abstract class AbstractJSONSchema2Pojo {
                 key,
                 prop.getItems().getSchema(),
                 parentPkg,
-                classPrefix,
-                classSuffix,
                 config),
             config,
             prop.getDescription(),
@@ -256,8 +248,6 @@ public abstract class AbstractJSONSchema2Pojo {
                 key,
                 prop.getAdditionalProperties().getSchema(),
                 parentPkg,
-                classPrefix,
-                classSuffix,
                 config),
             config,
             prop.getDescription(),
@@ -271,8 +261,6 @@ public abstract class AbstractJSONSchema2Pojo {
             prop.getProperties(),
             prop.getRequired(),
             preserveUnknownFields,
-            classPrefix,
-            classSuffix,
             config,
             prop.getDescription(),
             isNullable,

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -55,11 +55,10 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
       Map<String, JSONSchemaProps> fields,
       List<String> required,
       boolean preserveUnknownFields,
-      String classPrefix,
-      String classSuffix,
       Config config,
       String description,
-      final boolean isNullable, JsonNode defaultValue) {
+      final boolean isNullable,
+      JsonNode defaultValue) {
     super(config, description, isNullable, defaultValue, null);
     this.required = new HashSet<>(Optional.ofNullable(required).orElse(Collections.emptyList()));
     this.fields = new HashMap<>();
@@ -67,41 +66,22 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
 
     this.pkg = (pkg == null) ? "" : pkg.trim();
     String pkgPrefix = (this.pkg.isEmpty()) ? this.pkg : this.pkg + ".";
-    String clazzPrefix = (classPrefix == null) ? "" : classPrefix.trim();
-    String clazzSuffix = (classSuffix == null
-        || type.toLowerCase(Locale.ROOT)
-            .endsWith(classSuffix.toLowerCase(Locale.ROOT)))
-                ? ""
-                : classSuffix.trim();
     String upperCasedClassName = type.substring(0, 1).toUpperCase() + type.substring(1);
-    this.className = AbstractJSONSchema2Pojo.sanitizeString(
-        clazzPrefix + upperCasedClassName + clazzSuffix);
+    this.className = AbstractJSONSchema2Pojo.sanitizeString(upperCasedClassName);
     this.type = pkgPrefix + this.className;
 
     if (fields == null) {
       // no fields
     } else {
-      String nextPackagePath = null;
-      switch (config.getCodeStructure()) {
-        case FLAT:
-          nextPackagePath = this.pkg;
-          break;
-        case PACKAGE_NESTED:
-          nextPackagePath = pkgPrefix + AbstractJSONSchema2Pojo.packageName(this.className);
-          break;
-      }
+      String nextPackagePath = pkgPrefix + AbstractJSONSchema2Pojo.packageName(this.className);
 
       for (Map.Entry<String, JSONSchemaProps> field : fields.entrySet()) {
-        String nextPrefix = (config.getPrefixStrategy() == Config.Prefix.ALWAYS) ? classPrefix : "";
-        String nextSuffix = (config.getSuffixStrategy() == Config.Suffix.ALWAYS) ? classSuffix : "";
         this.fields.put(
             field.getKey(),
             AbstractJSONSchema2Pojo.fromJsonSchema(
                 field.getKey(),
                 field.getValue(),
                 nextPackagePath,
-                nextPrefix,
-                nextSuffix,
                 config));
       }
     }
@@ -270,7 +250,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
       }
     }
 
-    if (this.preserveUnknownFields || config.isAlwaysPreserveUnknownFields()) {
+    if (this.preserveUnknownFields) {
       ClassOrInterfaceType mapType = new ClassOrInterfaceType()
           .setName(Keywords.JAVA_UTIL_MAP)
           .setTypeArguments(

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/ApprovalTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/ApprovalTest.java
@@ -39,7 +39,7 @@ class ApprovalTest {
     return Stream.of(
         Arguments.of("testCrontabCrd", "crontab-crd.yml", "CronTab", "CrontabJavaCr", new Config()),
         Arguments.of("testCrontabExtraAnnotationsCrd", "crontab-crd.yml", "CronTab", "CrontabJavaExtraAnnotationsCr",
-            new Config(null, null, null, null, Boolean.TRUE, null, true, new HashMap<>())),
+            new Config(null, true, null, new HashMap<>())),
         Arguments.of("testKeycloakCrd", "keycloak-crd.yml", "Keycloak", "KeycloakJavaCr", new Config()),
         Arguments.of("testJokeCrd", "jokerequests-crd.yml", "JokeRequest", "JokeRequestJavaCr", new Config()),
         Arguments.of("testAkkaMicroservicesCrd", "akka-microservices-crd.yml", "AkkaMicroservice", "AkkaMicroserviceJavaCr",

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/CompilationTest.java
@@ -50,7 +50,6 @@ class CompilationTest {
   @BeforeEach
   void setUp() {
     config = Config.builder()
-        .structure(Config.CodeStructure.PACKAGE_NESTED)
         .generatedAnnotations(false)
         .build();
   }
@@ -89,30 +88,11 @@ class CompilationTest {
   }
 
   @Test
-  void crontabCRDCompilesWithFlatPackage() throws Exception {
-    // Arrange
-    File crd = getCRD("crontab-crd.yml");
-    config = config.toBuilder()
-        .structure(Config.CodeStructure.FLAT)
-        .build();
-
-    // Act
-    new FileJavaGenerator(config, crd).run(tempDir);
-    Compilation compilation = javac().compile(getSources(tempDir));
-
-    // Assert
-    assertTrue(compilation.errors().isEmpty());
-    assertEquals(3, compilation.sourceFiles().size());
-    assertEquals(Compilation.Status.SUCCESS, compilation.status());
-  }
-
-  @Test
-  void testCrontabCRDCompilesWithExtraAnnotationsAndUnknownFields() throws Exception {
+  void testCrontabCRDCompilesWithExtraAnnotations() throws Exception {
     // Arrange
     File crd = getCRD("crontab-crd.yml");
     config = config.toBuilder()
         .objectExtraAnnotations(true)
-        .alwaysPreserveUnknownFields(true)
         .build();
 
     // Act

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/ConfigTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/ConfigTest.java
@@ -25,14 +25,10 @@ class ConfigTest {
 
   @Test
   void defaultValuesWithAllArgsConstructor() {
-    final Config result = new Config(null, null, null, null, null, null, null, null);
+    final Config result = new Config(null, null, null, null);
     assertThat(result)
         .returns(true, Config::isUppercaseEnums)
-        .returns(Config.Prefix.TOP_LEVEL, Config::getPrefixStrategy)
-        .returns(Config.Suffix.TOP_LEVEL, Config::getSuffixStrategy)
-        .returns(false, Config::isAlwaysPreserveUnknownFields)
         .returns(false, Config::isObjectExtraAnnotations)
-        .returns(Config.CodeStructure.PACKAGE_NESTED, Config::getCodeStructure)
         .returns(true, Config::isGeneratedAnnotations)
         .returns(new HashMap<>(), Config::getPackageOverrides);
   }
@@ -42,11 +38,7 @@ class ConfigTest {
     final Config result = new Config();
     assertThat(result)
         .returns(true, Config::isUppercaseEnums)
-        .returns(Config.Prefix.TOP_LEVEL, Config::getPrefixStrategy)
-        .returns(Config.Suffix.TOP_LEVEL, Config::getSuffixStrategy)
-        .returns(false, Config::isAlwaysPreserveUnknownFields)
         .returns(false, Config::isObjectExtraAnnotations)
-        .returns(Config.CodeStructure.PACKAGE_NESTED, Config::getCodeStructure)
         .returns(true, Config::isGeneratedAnnotations)
         .returns(new HashMap<>(), Config::getPackageOverrides);
   }
@@ -56,11 +48,7 @@ class ConfigTest {
     final Config result = Config.builder().build();
     assertThat(result)
         .returns(true, Config::isUppercaseEnums)
-        .returns(Config.Prefix.TOP_LEVEL, Config::getPrefixStrategy)
-        .returns(Config.Suffix.TOP_LEVEL, Config::getSuffixStrategy)
-        .returns(false, Config::isAlwaysPreserveUnknownFields)
         .returns(false, Config::isObjectExtraAnnotations)
-        .returns(Config.CodeStructure.PACKAGE_NESTED, Config::getCodeStructure)
         .returns(true, Config::isGeneratedAnnotations)
         .returns(new HashMap<>(), Config::getPackageOverrides);
   }

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -294,8 +294,7 @@ class GeneratorTest {
         null,
         null,
         false,
-        "",
-        "", defaultConfig,
+        defaultConfig,
         null,
         Boolean.FALSE,
         null);
@@ -310,32 +309,6 @@ class GeneratorTest {
   }
 
   @Test
-  void testEmptyObjectWithSuffix() {
-    // Arrange
-    Config config = new Config(null, null, Config.Suffix.ALWAYS, null, null, null, true, new HashMap<>());
-    JObject obj = new JObject(
-        "v1alpha1",
-        "t",
-        null,
-        null,
-        false,
-        "",
-        "MySuffix",
-        config,
-        null,
-        Boolean.FALSE,
-        null);
-
-    // Act
-    GeneratorResult res = obj.generateJava();
-
-    // Assert
-    assertEquals("v1alpha1.TMySuffix", obj.getType());
-    assertEquals(1, res.getTopLevelClasses().size());
-    assertEquals("TMySuffix", res.getTopLevelClasses().get(0).getName());
-  }
-
-  @Test
   void testEmptyObjectWithoutNamespace() {
     // Arrange
     JObject obj = new JObject(
@@ -344,8 +317,6 @@ class GeneratorTest {
         null,
         null,
         false,
-        "",
-        "",
         defaultConfig,
         null,
         Boolean.FALSE,
@@ -373,8 +344,6 @@ class GeneratorTest {
         props,
         null,
         false,
-        "",
-        "",
         defaultConfig,
         null,
         Boolean.FALSE,
@@ -409,8 +378,6 @@ class GeneratorTest {
         props,
         req,
         false,
-        "",
-        "",
         defaultConfig,
         null,
         Boolean.FALSE,
@@ -433,21 +400,17 @@ class GeneratorTest {
         new HashMap<>(),
         new ArrayList<>(),
         false,
-        "",
-        "",
         defaultConfig,
         null,
         Boolean.FALSE,
         null);
-    Config config = new Config(null, null, Config.Suffix.ALWAYS, null, null, null, false, new HashMap<>());
+    Config config = new Config(null, null, false, new HashMap<>());
     JObject obj2 = new JObject(
         "v1alpha1",
         "t",
         new HashMap<>(),
         new ArrayList<>(),
         false,
-        "",
-        "",
         config,
         null,
         Boolean.FALSE,
@@ -516,7 +479,7 @@ class GeneratorTest {
     JEnum enu = new JEnum(
         "t",
         enumValues,
-        new Config(false, null, null, null, null, null, true, new HashMap<>()),
+        new Config(false, null, null, new HashMap<>()),
         null,
         Boolean.FALSE,
         null);
@@ -547,8 +510,6 @@ class GeneratorTest {
             null,
             null,
             false,
-            "",
-            "",
             defaultConfig,
             null,
             Boolean.FALSE,
@@ -577,8 +538,6 @@ class GeneratorTest {
             null,
             null,
             false,
-            "",
-            "",
             defaultConfig,
             null,
             Boolean.FALSE,
@@ -610,8 +569,6 @@ class GeneratorTest {
         props,
         null,
         false,
-        "",
-        "",
         defaultConfig,
         null,
         Boolean.FALSE,
@@ -634,66 +591,6 @@ class GeneratorTest {
   }
 
   @Test
-  void testObjectOfObjectsWithTopLevelPrefix() {
-    // Arrange
-    Config config = new Config(null, Config.Prefix.TOP_LEVEL, null, null, null, null, true, new HashMap<>());
-    Map<String, JSONSchemaProps> props = new HashMap<>();
-    JSONSchemaProps newObj = new JSONSchemaProps();
-    newObj.setType("object");
-    props.put("o1", newObj);
-    JObject obj = new JObject(
-        null,
-        "t",
-        props,
-        null,
-        false,
-        "My",
-        "",
-        config,
-        null,
-        Boolean.FALSE,
-        null);
-
-    // Act
-    GeneratorResult res = obj.generateJava();
-
-    // Assert
-    assertEquals(2, res.getTopLevelClasses().size());
-    assertEquals("O1", res.getTopLevelClasses().get(0).getName());
-    assertEquals("MyT", res.getTopLevelClasses().get(1).getName());
-  }
-
-  @Test
-  void testObjectOfObjectsWithAlwaysPrefix() {
-    // Arrange
-    Config config = new Config(null, Config.Prefix.ALWAYS, null, null, null, null, true, new HashMap<>());
-    Map<String, JSONSchemaProps> props = new HashMap<>();
-    JSONSchemaProps newObj = new JSONSchemaProps();
-    newObj.setType("object");
-    props.put("o1", newObj);
-    JObject obj = new JObject(
-        null,
-        "t",
-        props,
-        null,
-        false,
-        "My",
-        "",
-        config,
-        null,
-        Boolean.FALSE,
-        null);
-
-    // Act
-    GeneratorResult res = obj.generateJava();
-
-    // Assert
-    assertEquals(2, res.getTopLevelClasses().size());
-    assertEquals("MyO1", res.getTopLevelClasses().get(0).getName());
-    assertEquals("MyT", res.getTopLevelClasses().get(1).getName());
-  }
-
-  @Test
   void testObjectWithPreservedFields() {
     // Arrange
     JObject obj = new JObject(
@@ -702,8 +599,6 @@ class GeneratorTest {
         null,
         null,
         true,
-        "",
-        "",
         defaultConfig,
         null,
         Boolean.FALSE,
@@ -735,8 +630,6 @@ class GeneratorTest {
         props,
         null,
         false,
-        "",
-        "",
         defaultConfig,
         null,
         Boolean.FALSE,
@@ -768,7 +661,7 @@ class GeneratorTest {
     nonNullableObj.setNullable(Boolean.FALSE);
     props.put("o2", nonNullableObj);
 
-    JObject obj = new JObject(null, "t", props, null, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(null, "t", props, null, false, defaultConfig, null, Boolean.FALSE, null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -823,7 +716,7 @@ class GeneratorTest {
     newObj2.setProperties(obj2Props);
     props.put("o1", newObj1);
     props.put("o2", newObj2);
-    JObject obj = new JObject("v1alpha1", "t", props, null, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject("v1alpha1", "t", props, null, false, defaultConfig, null, Boolean.FALSE, null);
 
     // Act
     GeneratorResult res = obj.generateJava();
@@ -878,7 +771,7 @@ class GeneratorTest {
     objWithoutDefaultValues.setType("object");
     props.put("o2", objWithoutDefaultValues);
 
-    JObject obj = new JObject(null, "t", props, null, false, "", "", defaultConfig, null, Boolean.FALSE, null);
+    JObject obj = new JObject(null, "t", props, null, false, defaultConfig, null, Boolean.FALSE, null);
 
     // Act
     GeneratorResult res = obj.generateJava();

--- a/java-generator/it/src/it/cert-manager/expected/Auth.expected
+++ b/java-generator/it/src/it/cert-manager/expected/Auth.expected
@@ -1,4 +1,4 @@
-package io.cert_manager.v1;
+package io.cert_manager.v1.issuerspec.vault;
 
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
 @com.fasterxml.jackson.annotation.JsonPropertyOrder({"appRole","kubernetes","tokenSecretRef"})
@@ -28,13 +28,13 @@ public class Auth implements io.fabric8.kubernetes.api.model.KubernetesResource 
     @com.fasterxml.jackson.annotation.JsonProperty("appRole")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private io.cert_manager.v1.AppRole appRole;
+    private io.cert_manager.v1.issuerspec.vault.auth.AppRole appRole;
 
-    public io.cert_manager.v1.AppRole getAppRole() {
+    public io.cert_manager.v1.issuerspec.vault.auth.AppRole getAppRole() {
         return appRole;
     }
 
-    public void setAppRole(io.cert_manager.v1.AppRole appRole) {
+    public void setAppRole(io.cert_manager.v1.issuerspec.vault.auth.AppRole appRole) {
         this.appRole = appRole;
     }
 
@@ -44,13 +44,13 @@ public class Auth implements io.fabric8.kubernetes.api.model.KubernetesResource 
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetes")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private io.cert_manager.v1.Kubernetes kubernetes;
+    private io.cert_manager.v1.issuerspec.vault.auth.Kubernetes kubernetes;
 
-    public io.cert_manager.v1.Kubernetes getKubernetes() {
+    public io.cert_manager.v1.issuerspec.vault.auth.Kubernetes getKubernetes() {
         return kubernetes;
     }
 
-    public void setKubernetes(io.cert_manager.v1.Kubernetes kubernetes) {
+    public void setKubernetes(io.cert_manager.v1.issuerspec.vault.auth.Kubernetes kubernetes) {
         this.kubernetes = kubernetes;
     }
 
@@ -60,31 +60,13 @@ public class Auth implements io.fabric8.kubernetes.api.model.KubernetesResource 
     @com.fasterxml.jackson.annotation.JsonProperty("tokenSecretRef")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("TokenSecretRef authenticates with Vault by presenting a token.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private io.cert_manager.v1.TokenSecretRef tokenSecretRef;
+    private io.cert_manager.v1.issuerspec.vault.auth.TokenSecretRef tokenSecretRef;
 
-    public io.cert_manager.v1.TokenSecretRef getTokenSecretRef() {
+    public io.cert_manager.v1.issuerspec.vault.auth.TokenSecretRef getTokenSecretRef() {
         return tokenSecretRef;
     }
 
-    public void setTokenSecretRef(io.cert_manager.v1.TokenSecretRef tokenSecretRef) {
+    public void setTokenSecretRef(io.cert_manager.v1.issuerspec.vault.auth.TokenSecretRef tokenSecretRef) {
         this.tokenSecretRef = tokenSecretRef;
-    }
-
-    @com.fasterxml.jackson.annotation.JsonIgnore()
-    private java.util.Map<String, Object> additionalProperties = new java.util.HashMap<>();
-
-    @com.fasterxml.jackson.annotation.JsonAnyGetter()
-    public java.util.Map<String, Object> getAdditionalProperties() {
-        return additionalProperties;
-    }
-
-    @com.fasterxml.jackson.annotation.JsonAnySetter()
-    public void setAdditionalProperties(java.util.Map<String, Object> additionalProperties) {
-        this.additionalProperties = additionalProperties;
-    }
-
-    @com.fasterxml.jackson.annotation.JsonAnySetter()
-    public void setAdditionalProperty(java.lang.String key, java.lang.Object value) {
-        this.additionalProperties.put(key, value);
     }
 }

--- a/java-generator/it/src/it/cert-manager/pom.xml
+++ b/java-generator/it/src/it/cert-manager/pom.xml
@@ -76,10 +76,7 @@
         </executions>
         <configuration>
           <source>src/main/resources/</source>
-          <codeStructure>FLAT</codeStructure>
           <extraAnnotations>true</extraAnnotations>
-          <alwaysPreserveUnknown>true</alwaysPreserveUnknown>
-          <suffixStrategy>TOP_LEVEL</suffixStrategy>
           <generatedAnnotations>false</generatedAnnotations>
         </configuration>
       </plugin>

--- a/java-generator/it/src/it/cert-manager/verify.groovy
+++ b/java-generator/it/src/it/cert-manager/verify.groovy
@@ -21,7 +21,7 @@ assertEquals(
     .getText("UTF-8")
     .replace("\r\n", "\n")
     .trim(),
-  new File(basedir, "/target/generated-sources/java/io/cert_manager/v1/Auth.java")
+  new File(basedir, "/target/generated-sources/java/io/cert_manager/v1/issuerspec/vault/Auth.java")
     .getText("UTF-8")
     .replace("\r\n", "\n")
     .trim()

--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -74,22 +74,6 @@ public class JavaGeneratorMojo extends AbstractMojo {
   Boolean enumUppercase = null;
 
   /**
-   * *DEPRECATED* The prefix strategy for name mangling
-   *
-   */
-  @Deprecated
-  @Parameter(property = "fabric8.java-generator.prefix-strategy", required = false)
-  Config.Prefix prefixStrategy = null;
-
-  /**
-   * *DEPRECATED* The suffix strategy for name mangling
-   *
-   */
-  @Deprecated
-  @Parameter(property = "fabric8.java-generator.suffix-strategy", required = false)
-  Config.Suffix suffixStrategy = null;
-
-  /**
    * *DEPRECATED* Always inject additional properties in the generated classes
    *
    */
@@ -103,14 +87,6 @@ public class JavaGeneratorMojo extends AbstractMojo {
    */
   @Parameter(property = "fabric8.java-generator.extra-annotations", required = false)
   Boolean extraAnnotations = null;
-
-  /**
-   * *DEPRECATED* The code structure to be used when generating java sources
-   *
-   */
-  @Deprecated
-  @Parameter(property = "fabric8.java-generator.code-structure", required = false)
-  protected Config.CodeStructure codeStructure = null;
 
   /**
    * *advanced* Emit the @javax.annotation.processing.Generated annotation on the generated sources
@@ -130,11 +106,7 @@ public class JavaGeneratorMojo extends AbstractMojo {
   public void execute() throws MojoExecutionException {
     final Config config = Config.builder()
         .uppercaseEnums(enumUppercase)
-        .prefixStrategy(prefixStrategy)
-        .suffixStrategy(suffixStrategy)
-        .alwaysPreserveUnknownFields(alwaysPreserveUnknown)
         .objectExtraAnnotations(extraAnnotations)
-        .structure(codeStructure)
         .generatedAnnotations(generatedAnnotations)
         .packageOverrides(packageOverrides)
         .build();


### PR DESCRIPTION
## Description

Fix #4875 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
