### PR TITLE
fix #5015: executing resync as a locked operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #4993: Quantity class should have @JsonIgnore on the additionalProperties parameter
 * fix #5002: Jetty response completion accounts for header processing
 * Fix #5009: addressing issue with serialization of wrapped polymorphic types
+* Fix #5015: executing resync as a locking operation to ensure resync event ordering
 * Fix #5020: updating the resourceVersion on a delete with finalizers
 * Fix #5033: port forwarding for clients other than okhttp needs to specify the subprotocol
 * Fix #5044: disable Vert.x instance file caching

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/CacheImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/CacheImpl.java
@@ -396,4 +396,8 @@ public class CacheImpl<T extends HasMetadata> implements Cache<T> {
     return items.isFullState();
   }
 
+  public Object getLockObject() {
+    return this;
+  }
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
@@ -130,8 +130,11 @@ public class ProcessorStore<T extends HasMetadata> implements SyncableStore<T> {
 
   @Override
   public void resync() {
-    this.cache.list()
-        .forEach(i -> this.processor.distribute(new ProcessorListener.UpdateNotification<>(i, i), true));
+    // lock to ensure the ordering wrt other events
+    synchronized (cache.getLockObject()) {
+      this.cache.list()
+          .forEach(i -> this.processor.distribute(new ProcessorListener.UpdateNotification<>(i, i), true));
+    }
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/SharedProcessor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/SharedProcessor.java
@@ -56,6 +56,10 @@ public class SharedProcessor<T> {
   }
 
   public SharedProcessor(Executor executor, String informerDescription) {
+    // serialexecutors are by default unbounded, we expect this behavior here
+    // because resync may flood the executor with events for large caches
+    // if we ever need to limit the queue size, we have to revisit the
+    // resync locking behavior
     this.executor = new SerialExecutor(executor);
     this.informerDescription = informerDescription;
   }


### PR DESCRIPTION
## Description
Addresses the concern from #5015 by making resync a locked operation.  It is safe to do this because all of the resync events will get queued, so it's not a blocking operation as long as the underlying executor is not direct.  The only time the executor is backed by direct execution is for our internal informers, which do not use resync.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
