### PR TITLE
test : Update CronJobIT to use batch/v1 CronJob instead(#4434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * fix #5002: Jetty response completion accounts for header processing
 
 #### Improvements
+* Fix #4434: Update CronJobIT to use `batch/v1` CronJob instead
 * Fix #4477 exposing LeaderElector.release to force an elector to give up the lease
 * Fix #4975: exposing scale operations for all Resources
 * Fix #4992: Optimize Quantity parsing to avoid regex overhead

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CronJobIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CronJobIT.java
@@ -18,9 +18,9 @@ package io.fabric8.kubernetes;
 
 import io.fabric8.junit.jupiter.api.LoadKubernetesManifests;
 import io.fabric8.junit.jupiter.api.RequireK8sSupport;
-import io.fabric8.kubernetes.api.model.batch.v1beta1.CronJob;
-import io.fabric8.kubernetes.api.model.batch.v1beta1.CronJobBuilder;
-import io.fabric8.kubernetes.api.model.batch.v1beta1.CronJobList;
+import io.fabric8.kubernetes.api.model.batch.v1.CronJob;
+import io.fabric8.kubernetes.api.model.batch.v1.CronJobBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.CronJobList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.jupiter.api.Test;
 
@@ -37,27 +37,27 @@ class CronJobIT {
 
   @Test
   void load() {
-    CronJob aCronJob = client.batch().v1beta1().cronjobs().load(getClass().getResourceAsStream("/test-cronjob.yml")).item();
+    CronJob aCronJob = client.batch().v1().cronjobs().load(getClass().getResourceAsStream("/test-cronjob.yml")).item();
     assertNotNull(aCronJob);
     assertEquals("hello", aCronJob.getMetadata().getName());
   }
 
   @Test
   void get() {
-    CronJob cronJob1 = client.batch().v1beta1().cronjobs().withName("hello-get").get();
+    CronJob cronJob1 = client.batch().v1().cronjobs().withName("hello-get").get();
     assertThat(cronJob1).isNotNull();
   }
 
   @Test
   void list() {
-    CronJobList cronJobList = client.batch().v1beta1().cronjobs().list();
+    CronJobList cronJobList = client.batch().v1().cronjobs().list();
     assertNotNull(cronJobList);
     assertTrue(cronJobList.getItems().size() >= 1);
   }
 
   @Test
   void update() {
-    CronJob cronJob1 = client.batch().v1beta1().cronjobs().withName("hello-update")
+    CronJob cronJob1 = client.batch().v1().cronjobs().withName("hello-update")
         .edit(c -> new CronJobBuilder(c)
             .editMetadata().withResourceVersion(null).endMetadata()
             .editSpec().withSchedule("*/1 * * * *").endSpec()
@@ -67,6 +67,6 @@ class CronJobIT {
 
   @Test
   void delete() {
-    assertTrue(client.batch().v1beta1().cronjobs().withName("hello-delete").delete().size() == 1);
+    assertTrue(client.batch().v1().cronjobs().withName("hello-delete").delete().size() == 1);
   }
 }

--- a/kubernetes-itests/src/test/resources/cronjob-it.yml
+++ b/kubernetes-itests/src/test/resources/cronjob-it.yml
@@ -15,7 +15,7 @@
 #
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello-get
@@ -34,7 +34,7 @@ spec:
                 - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello-list
@@ -53,7 +53,7 @@ spec:
                 - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello-update
@@ -72,7 +72,7 @@ spec:
                 - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello-delete


### PR DESCRIPTION
## Description
Fix #4434 

Update CronJobIT to use `io.fabric8.kubernetes.api.model.batch.v1.CronJob` instead.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
