### PR TITLE
(temp) Support for JsonTypeInfo annotations in UnmatchedFieldTypeModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #4963: Openshift Client return 403 when use websocket
 * Fix #4985: triggering the immediate cleanup of the okhttp idle task
 * fix #5002: Jetty response completion accounts for header processing
+* Fix #5009: addressing issue with serialization of wrapped polymophic types
 
 #### Improvements
 * Fix #4434: Update CronJobIT to use `batch/v1` CronJob instead

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationWrappedPolymorphicTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationWrappedPolymorphicTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.utils;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SerializationWrappedPolymorphicTest {
+
+  @Group("example.com")
+  @Version("v1alpha1")
+  static class TestCR extends CustomResource<TestCR.TestCRSpec, Void> implements Namespaced {
+
+    @JsonDeserialize(using = JsonDeserializer.None.class)
+    static class TestCRSpec implements KubernetesResource {
+
+      @JsonIgnore
+      private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+      private List<Child> children = new ArrayList<>();
+
+      public List<Child> getChildren() {
+        return children;
+      }
+
+      public void setChildren(List<Child> children) {
+        this.children = children;
+      }
+
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+      }
+
+      @JsonAnySetter
+      public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+      }
+    }
+
+    @Override
+    protected TestCRSpec initSpec() {
+      return new TestCRSpec();
+    }
+  }
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+  @JsonSubTypes({ //
+      @JsonSubTypes.Type(FooChild.class), //
+      @JsonSubTypes.Type(BarChild.class), //
+  })
+  @JsonDeserialize(using = JsonDeserializer.None.class)
+  interface Child extends KubernetesResource {
+  }
+
+  @JsonTypeName("foo")
+  @Data
+  static class FooChild implements Child {
+    private String name;
+  }
+
+  @JsonTypeName("bar")
+  @Data
+  static class BarChild implements Child {
+    private String file;
+  }
+
+  @Test
+  void testPolyRoundTrip() {
+    TestCR original = new TestCR();
+    FooChild foo = new FooChild();
+    foo.setName("alice");
+    BarChild bar = new BarChild();
+    bar.setFile("bob");
+    original.getSpec().setChildren(Arrays.asList(foo, bar));
+    String json = Serialization.asJson(original);
+    assertThat(json).isEqualTo(
+        "{\"apiVersion\":\"example.com/v1alpha1\",\"kind\":\"TestCR\",\"metadata\":{},\"spec\":{\"children\":[{\"foo\":{\"name\":\"alice\"}},{\"bar\":{\"file\":\"bob\"}}]}}");
+    TestCR deserialized = Serialization.unmarshal(json, TestCR.class);
+    assertEquals(deserialized.getSpec().getChildren(), original.getSpec().getChildren());
+  }
+
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationWrappedPolymorphicTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationWrappedPolymorphicTest.java
@@ -51,7 +51,7 @@ class SerializationWrappedPolymorphicTest {
     static class TestCRSpec implements KubernetesResource {
 
       @JsonIgnore
-      private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+      private final Map<String, Object> additionalProperties = new HashMap<>();
 
       private List<Child> children = new ArrayList<>();
 

--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/BeanPropertyWriterDelegate.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/BeanPropertyWriterDelegate.java
@@ -16,8 +16,10 @@
 package io.fabric8.kubernetes.model.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,5 +70,20 @@ public class BeanPropertyWriterDelegate extends BeanPropertyWriter {
       logger.warn("Value in field '{}' ignored in favor of value in additionalProperties ({}) for {}",
           delegate.getName(), valueInAnyGetter, bean.getClass().getName());
     }
+  }
+
+  @Override
+  public void assignNullSerializer(JsonSerializer<Object> nullSer) {
+    delegate.assignNullSerializer(nullSer);
+  }
+
+  @Override
+  public void assignSerializer(JsonSerializer<Object> ser) {
+    delegate.assignSerializer(ser);
+  }
+
+  @Override
+  public void assignTypeSerializer(TypeSerializer typeSer) {
+    delegate.assignTypeSerializer(typeSer);
   }
 }


### PR DESCRIPTION
## Description

Fix #5009 

Temporary alternative to #5010 until Istio issues get fixed or gets superseded by #4662

Support for JsonTypeInfo annotations in UnmatchedFieldTypeModule

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
