### PR TITLE
feat: generic HttpLoggingInterceptor

### DIFF
--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -72,6 +72,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -235,7 +235,7 @@ public class JdkHttpClientImpl extends StandardHttpClient<JdkHttpClientImpl, Jdk
       return;
     }
     builder.getClientFactory().closeHttpClient(this);
-    // help with default cleanup, which is based upon garbarge collection
+    // help with default cleanup, which is based upon garbage collection
     this.httpClient = null;
   }
 
@@ -252,7 +252,7 @@ public class JdkHttpClientImpl extends StandardHttpClient<JdkHttpClientImpl, Jdk
     BodyHandler<AsyncBody> handlerAdapter = new BodyHandlerAdapter(subscriber, handler);
 
     return this.getHttpClient().sendAsync(requestBuilder(request).build(), handlerAdapter)
-        .thenApply(r -> new JdkHttpResponseImpl<AsyncBody>(r, r.body()));
+        .thenApply(r -> new JdkHttpResponseImpl<>(r, r.body()));
   }
 
   java.net.http.HttpRequest.Builder requestBuilder(StandardHttpRequest request) {

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpLoggingInterceptorTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpLoggingInterceptorTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JdkHttpLoggingInterceptorTest extends AbstractHttpLoggingInterceptorTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JdkHttpClientFactory();
+  }
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
@@ -136,7 +136,7 @@ public class JettyHttpClient extends StandardHttpClient<JettyHttpClient, JettyHt
       Listener listener) {
     try {
       jettyWs.start();
-      HttpRequest request = standardWebSocketBuilder.asHttpRequest();
+      final HttpRequest request = standardWebSocketBuilder.asHttpRequest();
       final ClientUpgradeRequest cur = new ClientUpgradeRequest();
       if (Utils.isNotNullOrEmpty(standardWebSocketBuilder.getSubprotocol())) {
         cur.setSubProtocols(standardWebSocketBuilder.getSubprotocol());
@@ -152,15 +152,14 @@ public class JettyHttpClient extends StandardHttpClient<JettyHttpClient, JettyHt
           .whenComplete((s, ex) -> {
             if (ex != null) {
               if (ex instanceof CompletionException && ex.getCause() instanceof UpgradeException) {
-                future.complete(
-                    new WebSocketResponse(webSocket, JettyWebSocket.toHandshakeException((UpgradeException) ex.getCause())));
+                future.complete(JettyWebSocket.toWebSocketResponse(request, webSocket, (UpgradeException) ex.getCause()));
               } else if (ex instanceof UpgradeException) {
-                future.complete(new WebSocketResponse(webSocket, JettyWebSocket.toHandshakeException((UpgradeException) ex)));
+                future.complete(JettyWebSocket.toWebSocketResponse(request, webSocket, (UpgradeException) ex));
               } else {
                 future.completeExceptionally(ex);
               }
             } else {
-              future.complete(new WebSocketResponse(webSocket, null));
+              future.complete(JettyWebSocket.toWebSocketResponse(request, webSocket, s));
             }
           });
       return future;

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpLoggingInterceptorTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpLoggingInterceptorTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class JettyHttpLoggingInterceptorTest extends AbstractHttpLoggingInterceptorTest {
+
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+}

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
@@ -19,10 +19,8 @@ package io.fabric8.kubernetes.client.okhttp;
 import io.fabric8.kubernetes.client.http.StandardHttpClientBuilder;
 import okhttp3.Authenticator;
 import okhttp3.ConnectionSpec;
-import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
-import okhttp3.logging.HttpLoggingInterceptor;
 
 import java.net.Proxy;
 import java.util.Arrays;
@@ -106,16 +104,6 @@ class OkHttpClientBuilderImpl
       builder.cache(null);
     }
     OkHttpClient client = builder.build();
-    if (this.forStreaming) {
-      // If we set the HttpLoggingInterceptor's logging level to Body (as it is by default), it does
-      // not let us stream responses from the server.
-      for (Interceptor i : client.networkInterceptors()) {
-        if (i instanceof HttpLoggingInterceptor) {
-          HttpLoggingInterceptor interceptor = (HttpLoggingInterceptor) i;
-          interceptor.setLevel(HttpLoggingInterceptor.Level.BASIC);
-        }
-      }
-    }
 
     return new OkHttpClientImpl(client, this);
   }

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
@@ -22,9 +22,6 @@ import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
-import okhttp3.logging.HttpLoggingInterceptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -71,13 +68,6 @@ public class OkHttpClientFactory implements HttpClient.Factory {
 
       if (config.isTrustCerts() || config.isDisableHostnameVerification()) {
         httpClientBuilder.hostnameVerifier((s, sslSession) -> true);
-      }
-
-      Logger reqLogger = LoggerFactory.getLogger(HttpLoggingInterceptor.class);
-      if (reqLogger.isTraceEnabled()) {
-        HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
-        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-        httpClientBuilder.addNetworkInterceptor(loggingInterceptor);
       }
 
       if (config.getWebsocketPingInterval() > 0) {

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -411,11 +411,12 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
   @Override
   public CompletableFuture<WebSocketResponse> buildWebSocketDirect(StandardWebSocketBuilder standardWebSocketBuilder,
       Listener listener) {
-    Request.Builder requestBuilder = requestBuilder(standardWebSocketBuilder.asHttpRequest());
+    final StandardHttpRequest fabric8Request = standardWebSocketBuilder.asHttpRequest();
+    Request.Builder requestBuilder = requestBuilder(fabric8Request);
     if (standardWebSocketBuilder.getSubprotocol() != null) {
       requestBuilder.header("Sec-WebSocket-Protocol", standardWebSocketBuilder.getSubprotocol());
     }
-    return OkHttpWebSocketImpl.buildAsync(httpClient, requestBuilder.build(), listener);
+    return OkHttpWebSocketImpl.buildAsync(httpClient, fabric8Request, requestBuilder.build(), listener);
   }
 
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpHttpLoggingInterceptorTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpHttpLoggingInterceptorTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.okhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class OkHttpHttpLoggingInterceptorTest extends AbstractHttpLoggingInterceptorTest {
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new OkHttpClientFactory();
+  }
+}

--- a/httpclient-vertx/pom.xml
+++ b/httpclient-vertx/pom.xml
@@ -73,6 +73,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
@@ -16,13 +16,13 @@
 package io.fabric8.kubernetes.client.vertx;
 
 import io.fabric8.kubernetes.client.http.AsyncBody;
-import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.StandardHttpClient;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import io.fabric8.kubernetes.client.http.StandardWebSocketBuilder;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketResponse;
+import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpHeaders;
@@ -35,11 +35,11 @@ import io.vertx.ext.web.client.WebClientOptions;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+
+import static io.fabric8.kubernetes.client.vertx.VertxHttpRequest.toHeadersMap;
 
 public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpClient.Factory>
     extends StandardHttpClient<VertxHttpClient<F>, F, VertxHttpClientBuilder<F>> {
@@ -71,59 +71,27 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
       options.setSubProtocols(Collections.singletonList(standardWebSocketBuilder.getSubprotocol()));
     }
 
-    StandardHttpRequest request = standardWebSocketBuilder.asHttpRequest();
+    final StandardHttpRequest request = standardWebSocketBuilder.asHttpRequest();
 
     request.headers().entrySet().stream()
         .forEach(e -> e.getValue().stream().forEach(v -> options.addHeader(e.getKey(), v)));
     options.setAbsoluteURI(request.uri().toString());
 
-    CompletableFuture<WebSocketResponse> response = new CompletableFuture<WebSocketResponse>();
+    CompletableFuture<WebSocketResponse> response = new CompletableFuture<>();
 
     client
         .webSocket(options)
         .onSuccess(ws -> {
           VertxWebSocket ret = new VertxWebSocket(ws, listener);
           ret.init();
-          response.complete(new WebSocketResponse(ret, null));
+          response.complete(new WebSocketResponse(new WebSocketUpgradeResponse(request, ret), null));
         }).onFailure(t -> {
           if (t instanceof UpgradeRejectedException) {
             UpgradeRejectedException handshake = (UpgradeRejectedException) t;
-            response.complete(new WebSocketResponse(null,
-                new io.fabric8.kubernetes.client.http.WebSocketHandshakeException(new HttpResponse<String>() {
-                  @Override
-                  public int code() {
-                    return handshake.getStatus();
-                  }
-
-                  @Override
-                  public String body() {
-                    return handshake.getBody().toString();
-                  }
-
-                  @Override
-                  public HttpRequest request() {
-                    throw new UnsupportedOperationException();
-                  }
-
-                  @Override
-                  public Optional<HttpResponse<?>> previousResponse() {
-                    return Optional.empty();
-                  }
-
-                  @Override
-                  public List<String> headers(String s) {
-                    return handshake.getHeaders().getAll(s);
-                  }
-
-                  @Override
-                  public Map<String, List<String>> headers() {
-                    Map<String, List<String>> headers = new LinkedHashMap<>();
-                    handshake.getHeaders().names().forEach(name -> {
-                      headers.put(name, handshake.getHeaders().getAll(name));
-                    });
-                    return headers;
-                  }
-                })));
+            final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(
+                request, handshake.getStatus(), toHeadersMap(handshake.getHeaders()), null);
+            response.complete(new WebSocketResponse(upgradeResponse,
+                new io.fabric8.kubernetes.client.http.WebSocketHandshakeException(upgradeResponse)));
           }
           response.completeExceptionally(t);
         });

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
@@ -150,7 +150,7 @@ class VertxHttpRequest {
 
   static Map<String, List<String>> toHeadersMap(MultiMap multiMap) {
     Map<String, List<String>> headers = new LinkedHashMap<>();
-    multiMap.names().stream().forEach(k -> headers.put(k, multiMap.getAll(k)));
+    multiMap.names().forEach(k -> headers.put(k, multiMap.getAll(k)));
     return headers;
   }
 

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpLoggingInterceptorTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpLoggingInterceptorTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.vertx;
+
+import io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest;
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+@SuppressWarnings("java:S2187")
+public class VertxHttpLoggingInterceptorTest extends AbstractHttpLoggingInterceptorTest {
+
+  @Override
+  protected HttpClient.Factory getHttpClientFactory() {
+    return new VertxHttpClientFactory();
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/AsyncBody.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/AsyncBody.java
@@ -45,5 +45,12 @@ public interface AsyncBody {
   interface Consumer<T> {
     void consume(T value, AsyncBody asyncBody) throws Exception;
 
+    default <U> U unwrap(Class<U> target) {
+      if (this.getClass().equals(target)) {
+        return (U) this;
+      }
+      return null;
+    }
+
   }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/BufferUtil.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/BufferUtil.java
@@ -16,6 +16,9 @@
 package io.fabric8.kubernetes.client.http;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -70,4 +73,24 @@ public class BufferUtil {
     buffer.position(position);
     return clone;
   }
+
+  /**
+   * Very rudimentary method to check if the provided ByteBuffer contains text.
+   * 
+   * @return true if the buffer contains text, false otherwise.
+   */
+  public static boolean isPlainText(ByteBuffer originalBuffer) {
+    if (originalBuffer == null) {
+      return false;
+    }
+    final ByteBuffer buffer = copy(originalBuffer);
+    final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+    try {
+      decoder.decode(buffer);
+      return true;
+    } catch (CharacterCodingException ex) {
+      return false;
+    }
+  }
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpLoggingInterceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpLoggingInterceptor.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.kubernetes.client.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+public class HttpLoggingInterceptor implements Interceptor {
+
+  private final HttpLogger httpLogger;
+  private final Map<UUID, DeferredLoggingConsumer> activeConsumers;
+
+  public HttpLoggingInterceptor() {
+    this(LoggerFactory.getLogger(HttpLoggingInterceptor.class));
+  }
+
+  public HttpLoggingInterceptor(Logger logger) {
+    this.httpLogger = new HttpLogger(logger);
+    activeConsumers = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public AsyncBody.Consumer<List<ByteBuffer>> consumer(AsyncBody.Consumer<List<ByteBuffer>> consumer, HttpRequest request) {
+    final DeferredLoggingConsumer interceptedConsumer = new DeferredLoggingConsumer(httpLogger, request, consumer,
+        () -> activeConsumers.remove(request.id()));
+    activeConsumers.put(request.id(), interceptedConsumer);
+    return interceptedConsumer;
+  }
+
+  @Override
+  public void after(HttpRequest request, HttpResponse<?> response) {
+    if (response instanceof WebSocketUpgradeResponse) {
+      httpLogger.logWsStart();
+      httpLogger.logRequest(request);
+      httpLogger.logResponse(response);
+      httpLogger.logWsEnd();
+    } else {
+      activeConsumers.computeIfPresent(request.id(), (id, consumer) -> {
+        consumer.originalResponse.set(response);
+        if (response.body() instanceof AsyncBody) {
+          consumer.processAsyncBody((AsyncBody) response.body());
+        }
+        return consumer;
+      });
+    }
+  }
+
+  private static final class DeferredLoggingConsumer
+      implements AsyncBody.Consumer<List<ByteBuffer>>, BiConsumer<Void, Throwable> {
+
+    private final HttpLogger httpLogger;
+    private final HttpRequest originalRequest;
+    private final AsyncBody.Consumer<List<ByteBuffer>> originalConsumer;
+    private final Runnable cleanUp;
+    private final AtomicReference<HttpResponse<?>> originalResponse;
+    private final AtomicBoolean asyncBodyDoneProcessed;
+    private final Queue<ByteBuffer> responseBody;
+
+    public DeferredLoggingConsumer(HttpLogger httpLogger, HttpRequest originalRequest,
+        AsyncBody.Consumer<List<ByteBuffer>> originalConsumer, Runnable cleanUp) {
+      this.httpLogger = httpLogger;
+      this.originalRequest = originalRequest;
+      this.originalConsumer = originalConsumer;
+      this.cleanUp = cleanUp;
+      originalResponse = new AtomicReference<>();
+      asyncBodyDoneProcessed = new AtomicBoolean(false);
+      responseBody = new ConcurrentLinkedQueue<>();
+    }
+
+    @Override
+    public void consume(List<ByteBuffer> value, AsyncBody asyncBody) throws Exception {
+      // TODO: Should try to detect if the body is text or not? (HttpLoggingInterceptor.isPlainText)
+      value.stream().map(BufferUtil::copy).forEach(responseBody::add); // Potential leak
+      originalConsumer.consume(value, asyncBody);
+    }
+
+    @Override
+    public void accept(Void v, Throwable throwable) {
+      httpLogger.logStart();
+      httpLogger.logRequest(originalRequest);
+      if (originalResponse.get() != null) {
+        httpLogger.logResponse(originalResponse.get());
+        httpLogger.logResponseBody(responseBody);
+      }
+      httpLogger.logEnd();
+      responseBody.clear();
+      cleanUp.run();
+    }
+
+    /**
+     * Registers the asyncBody.done() callback.
+     * 
+     * @param asyncBody the AsyncBody instance to register the callback on the done() future.
+     */
+    private void processAsyncBody(AsyncBody asyncBody) {
+      if (asyncBodyDoneProcessed.compareAndSet(false, true)) {
+        asyncBody.done().whenComplete(this);
+      }
+    }
+  }
+
+  private static final class HttpLogger {
+    private final Logger logger;
+
+    private HttpLogger(Logger logger) {
+      this.logger = logger;
+    }
+
+    void logRequest(HttpRequest request) {
+      if (logger.isTraceEnabled() && request != null) {
+        logger.trace("> {} {}", request.method(), request.uri());
+        request.headers().forEach((h, vv) -> vv.forEach(v -> logger.trace("> {}: {}", h, v)));
+        if (!Utils.isNullOrEmpty(request.bodyString())) {
+          logger.trace(request.bodyString());
+        }
+      }
+    }
+
+    void logResponse(HttpResponse<?> response) {
+      if (logger.isTraceEnabled() && response != null) {
+        logger.trace("< {} {}", response.code(), response.message());
+        response.headers().forEach((h, vv) -> vv.forEach(v -> logger.trace("< {}: {}", h, v)));
+      }
+    }
+
+    void logResponseBody(Queue<ByteBuffer> responseBody) {
+      if (logger.isTraceEnabled() && responseBody != null) {
+        final StringBuilder bodyString = new StringBuilder();
+        while (!responseBody.isEmpty()) {
+          bodyString.append(StandardCharsets.UTF_8.decode(responseBody.poll()));
+        }
+        if (bodyString.length() > 0) {
+          logger.trace(bodyString.toString());
+        }
+      }
+    }
+
+    void logStart() {
+      if (logger.isTraceEnabled()) {
+        logger.trace("-HTTP START-");
+      }
+    }
+
+    void logEnd() {
+      if (logger.isTraceEnabled()) {
+        logger.trace("-HTTP END-");
+      }
+    }
+
+    void logWsStart() {
+      if (logger.isTraceEnabled()) {
+        logger.trace("-WS START-");
+      }
+    }
+
+    void logWsEnd() {
+      if (logger.isTraceEnabled()) {
+        logger.trace("-WS END-");
+      }
+    }
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpRequest.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpRequest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public interface HttpRequest extends HttpHeaders {
@@ -97,6 +98,13 @@ public interface HttpRequest extends HttpHeaders {
       throw new RuntimeException(e);
     }
   }
+
+  /**
+   * The unique id for this HTTP request, used for logging and debugging
+   * 
+   * @return a UUID.
+   */
+  UUID id();
 
   URI uri();
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpStatusMessage.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpStatusMessage.java
@@ -31,7 +31,7 @@ public class HttpStatusMessage {
   static {
     // informational
     entry(100, "Continue");
-    entry(101, "Switching Protocol");
+    entry(101, "Switching Protocols");
     entry(102, "Processing");
     entry(103, "Early Hints");
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
@@ -45,7 +45,7 @@ public interface Interceptor {
    * @param request the original request sent to the server.
    * @param response the response received from the server.
    */
-  default void after(HttpRequest request, HttpResponse<?> response) {
+  default void after(HttpRequest request, HttpResponse<?> response, AsyncBody.Consumer<List<ByteBuffer>> consumer) {
 
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
@@ -42,9 +42,10 @@ public interface Interceptor {
    * <p>
    * Should be used to analyze response codes and headers, original response shouldn't be altered.
    *
+   * @param request the original request sent to the server.
    * @param response the response received from the server.
    */
-  default void after(HttpResponse<?> response) {
+  default void after(HttpRequest request, HttpResponse<?> response) {
 
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClientBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClientBuilder.java
@@ -19,6 +19,7 @@ package io.fabric8.kubernetes.client.http;
 import io.fabric8.kubernetes.client.http.HttpClient.DerivedClientBuilder;
 import io.fabric8.kubernetes.client.internal.SSLUtils;
 import lombok.Getter;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -54,6 +55,10 @@ public abstract class StandardHttpClientBuilder<C extends HttpClient, F extends 
 
   protected StandardHttpClientBuilder(F clientFactory) {
     this.clientFactory = clientFactory;
+    // TODO: Find better place or solution
+    if (LoggerFactory.getLogger(HttpLoggingInterceptor.class).isTraceEnabled()) {
+      interceptors.put("HttpLogging", new HttpLoggingInterceptor());
+    }
   }
 
   @Override

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpRequest.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpRequest.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Standard representation of a request. HttpClient implementations need to handle the special fields,
@@ -84,6 +85,7 @@ public class StandardHttpRequest extends StandardHttpHeaders implements HttpRequ
 
   }
 
+  private final UUID id;
   private final URI uri;
   private final String method;
   private final String contentType;
@@ -100,24 +102,24 @@ public class StandardHttpRequest extends StandardHttpHeaders implements HttpRequ
    * @param bodyString
    */
   public StandardHttpRequest(Map<String, List<String>> headers, URI uri, String method, String bodyString) {
-    super(headers);
-    this.uri = uri;
-    this.method = method;
-    this.bodyString = bodyString;
-    expectContinue = false;
-    this.body = null;
-    this.contentType = null;
+    this(headers, uri, method, bodyString, null, false, null);
   }
 
   StandardHttpRequest(Map<String, List<String>> headers, URI uri, String method, String bodyString,
       BodyContent body, boolean expectContinue, String contentType) {
     super(headers);
+    this.id = UUID.randomUUID();
     this.uri = uri;
     this.method = method;
     this.bodyString = bodyString;
     this.body = body;
     this.expectContinue = expectContinue;
     this.contentType = contentType;
+  }
+
+  @Override
+  public UUID id() {
+    return id;
   }
 
   @Override

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketHandshakeException.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketHandshakeException.java
@@ -20,18 +20,18 @@ import java.io.IOException;
 
 public final class WebSocketHandshakeException extends IOException {
 
-  private final transient HttpResponse<?> response;
+  private final transient WebSocketUpgradeResponse response;
 
-  public WebSocketHandshakeException(HttpResponse<?> response) {
+  public WebSocketHandshakeException(WebSocketUpgradeResponse response) {
     this.response = response;
   }
 
   /**
    * Get the response, which includes the code of failure.
-   * 
+   *
    * @return the response, never null
    */
-  public HttpResponse<?> getResponse() {
+  public WebSocketUpgradeResponse getResponse() {
     return response;
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketResponse.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketResponse.java
@@ -16,16 +16,20 @@
 
 package io.fabric8.kubernetes.client.http;
 
+import java.util.Objects;
+
 /*
  * TODO: this may not be the best way to do this - in general
  * instead we create a response to hold them both
+ * manusa: We can remove this class and replace with separate WebSocketUpgradeResponse|WebSocketHandshakeException handled by the future
  */
 public class WebSocketResponse {
-  public WebSocketResponse(WebSocket w, WebSocketHandshakeException wshse) {
-    this.webSocket = w;
+  final WebSocketUpgradeResponse webSocketUpgradeResponse;
+  final WebSocketHandshakeException wshse;
+
+  public WebSocketResponse(WebSocketUpgradeResponse webSocketUpgradeResponse, WebSocketHandshakeException wshse) {
+    this.webSocketUpgradeResponse = Objects.requireNonNull(webSocketUpgradeResponse);
     this.wshse = wshse;
   }
 
-  WebSocket webSocket;
-  WebSocketHandshakeException wshse;
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketUpgradeResponse.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketUpgradeResponse.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class WebSocketUpgradeResponse extends StandardHttpHeaders implements HttpResponse<Void> {
+
+  private final HttpRequest httpRequest;
+  private final int code;
+  private final WebSocket webSocket;
+
+  public WebSocketUpgradeResponse(HttpRequest httpRequest, WebSocket webSocket) {
+    this(httpRequest, 101, new LinkedHashMap<>(), webSocket);
+  }
+
+  public WebSocketUpgradeResponse(HttpRequest httpRequest, int code, WebSocket webSocket) {
+    this(httpRequest, code, new LinkedHashMap<>(), webSocket);
+  }
+
+  public WebSocketUpgradeResponse(HttpRequest httpRequest, int code, Map<String, List<String>> headers, WebSocket webSocket) {
+    super(headers);
+    this.httpRequest = httpRequest;
+    this.code = code;
+    this.webSocket = webSocket;
+  }
+
+  @Override
+  public int code() {
+    return code;
+  }
+
+  @Override
+  public Void body() {
+    return null;
+  }
+
+  @Override
+  public HttpRequest request() {
+    return httpRequest;
+  }
+
+  @Override
+  public Optional<HttpResponse<?>> previousResponse() {
+    return Optional.empty();
+  }
+
+  public WebSocket getWebSocket() {
+    return webSocket;
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.mockwebserver.DefaultMockServer;
+import io.fabric8.mockwebserver.utils.ResponseProviders;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractHttpLoggingInterceptorTest {
+
+  private static DefaultMockServer server;
+  private Logger logger;
+  private InOrder inOrder;
+  private HttpClient httpClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  @BeforeEach
+  void setUp() {
+    logger = mock(Logger.class);
+    inOrder = Mockito.inOrder(logger);
+    when(logger.isTraceEnabled()).thenReturn(true);
+    httpClient = getHttpClientFactory().newBuilder()
+        .addOrReplaceInterceptor("loggingInterceptor", new HttpLoggingInterceptor(logger))
+        .build();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  @Test
+  @DisplayName("HTTP request URI is logged")
+  public void httpRequestUriLogged() throws Exception {
+    server.expect().withPath("/request-uri")
+        .andReturn(200, "This is the response body")
+        .always();
+    httpClient.sendAsync(httpClient.newHttpRequestBuilder()
+        .uri(server.url("/request-uri"))
+        .build(), String.class).get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    inOrder.verify(logger)
+        .trace(eq("> {} {}"), eq("GET"), argThat((URI uri) -> uri.toString().endsWith("/request-uri")));
+    inOrder.verify(logger).trace("-HTTP END-");
+  }
+
+  @Test
+  @DisplayName("HTTP request headers are logged")
+  public void httpRequestHeadersLogged() throws Exception {
+    server.expect().withPath("/request-headers")
+        .andReturn(200, "This is the response body")
+        .always();
+    httpClient.sendAsync(httpClient.newHttpRequestBuilder()
+        .header("test-type", "header-test")
+        .uri(server.url("/request-headers"))
+        .build(), String.class).get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    inOrder.verify(logger).trace("> {}: {}", "test-type", "header-test");
+    inOrder.verify(logger).trace("-HTTP END-");
+  }
+
+  @Test
+  @DisplayName("HTTP request body is logged")
+  public void httpRequestBodyLogged() throws Exception {
+    server.expect().withPath("/request-body")
+        .andReturn(200, "This is the response body")
+        .always();
+    httpClient.sendAsync(httpClient.newHttpRequestBuilder()
+        .uri(server.url("/request-body"))
+        .method("POST", "test/plain", "This is the request body")
+        .build(), String.class).get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    inOrder.verify(logger).trace("This is the request body");
+    inOrder.verify(logger).trace("-HTTP END-");
+  }
+
+  @Test
+  @DisplayName("HTTP response status is logged")
+  public void httpResponseStatusLogged() throws Exception {
+    server.expect().withPath("/response-status")
+        .andReturn(200, "This is the response body")
+        .always();
+    httpClient.sendAsync(httpClient.newHttpRequestBuilder()
+        .uri(server.url("/response-status"))
+        .build(), String.class).get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    inOrder.verify(logger).trace("< {} {}", 200, "OK");
+    inOrder.verify(logger).trace("-HTTP END-");
+  }
+
+  @Test
+  @DisplayName("HTTP response headers are logged")
+  public void httpResponseHeadersLogged() throws Exception {
+    server.expect().withPath("/response-headers")
+        .andReply(ResponseProviders.of(204, "", Collections.singletonMap("test-type", "response-header-test")))
+        .always();
+    httpClient.sendAsync(httpClient.newHttpRequestBuilder()
+        .uri(server.url("/response-headers"))
+        .build(), String.class).get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    inOrder.verify(logger).trace(eq("< {} {}"), anyInt(), anyString());
+    inOrder.verify(logger).trace("< {}: {}", "test-type", "response-header-test");
+    inOrder.verify(logger).trace("-HTTP END-");
+  }
+
+  @Test
+  @DisplayName("HTTP response body is logged")
+  public void httpResponseBodyLogged() throws Exception {
+    server.expect().withPath("/response-body")
+        .andReturn(200, "This is the response body")
+        .always();
+    httpClient.sendAsync(httpClient.newHttpRequestBuilder()
+        .uri(server.url("/response-body"))
+        .build(), String.class).get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    inOrder.verify(logger).trace(eq("< {} {}"), anyInt(), anyString());
+    inOrder.verify(logger).trace("This is the response body");
+    inOrder.verify(logger).trace("-HTTP END-");
+  }
+
+  @Test
+  @DisplayName("WS request URI is logged")
+  public void wsRequestUriLogged() throws Exception {
+    server.expect().withPath("/ws-request-uri")
+        .andUpgradeToWebSocket()
+        .open().done().always();
+    httpClient.newWebSocketBuilder()
+        .uri(URI.create(server.url("/ws-request-uri")))
+        .buildAsync(new WebSocket.Listener() {
+        })
+        .get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-WS START-");
+    inOrder.verify(logger)
+        .trace(eq("> {} {}"), eq("GET"), argThat((URI uri) -> uri.toString().endsWith("/ws-request-uri")));
+    inOrder.verify(logger).trace("-WS END-");
+  }
+
+  @Test
+  @DisplayName("WS request headers are logged")
+  public void wsRequestHeadersLogged() throws Exception {
+    server.expect().withPath("/ws-request-headers")
+        .andUpgradeToWebSocket()
+        .open().done().always();
+    httpClient.newWebSocketBuilder()
+        .header("test-type", "ws-header-test")
+        .uri(URI.create(server.url("/ws-request-headers")))
+        .buildAsync(new WebSocket.Listener() {
+        })
+        .get(10, TimeUnit.SECONDS);
+    verify(logger, timeout(1000L)).trace("-WS END-");
+    inOrder.verify(logger).trace("-WS START-");
+    inOrder.verify(logger).trace("> {}: {}", "test-type", "ws-header-test");
+    inOrder.verify(logger).trace("-WS END-");
+  }
+
+  @Test
+  @DisplayName("WS response status is logged")
+  public void wsResponseStatusLogged() throws Exception {
+    server.expect().withPath("/ws-response-status")
+        .andUpgradeToWebSocket()
+        .open().done().always();
+    httpClient.newWebSocketBuilder()
+        .uri(URI.create(server.url("/ws-response-status")))
+        .buildAsync(new WebSocket.Listener() {
+        })
+        .get(10, TimeUnit.SECONDS);
+    inOrder.verify(logger, timeout(1000L)).trace("-WS START-");
+    inOrder.verify(logger).trace("< {} {}", 101, "Switching Protocols");
+    inOrder.verify(logger).trace("-WS END-");
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
@@ -49,6 +49,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractHttpLoggingInterceptorTest {
@@ -92,7 +93,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
     httpClient.sendAsync(httpClient.newHttpRequestBuilder()
         .uri(server.url("/request-uri"))
         .build(), String.class).get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    verify(logger, timeout(1000L)).trace("-HTTP END-");
+    inOrder.verify(logger).trace("-HTTP START-");
     inOrder.verify(logger)
         .trace(eq("> {} {}"), eq("GET"), argThat((URI uri) -> uri.toString().endsWith("/request-uri")));
     inOrder.verify(logger).trace("-HTTP END-");
@@ -108,7 +110,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
         .header("test-type", "header-test")
         .uri(server.url("/request-headers"))
         .build(), String.class).get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    verify(logger, timeout(1000L)).trace("-HTTP END-");
+    inOrder.verify(logger).trace("-HTTP START-");
     inOrder.verify(logger).trace("> {}: {}", "test-type", "header-test");
     inOrder.verify(logger).trace("-HTTP END-");
   }
@@ -123,7 +126,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
         .uri(server.url("/request-body"))
         .method("POST", "test/plain", "This is the request body")
         .build(), String.class).get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    verify(logger, timeout(1000L)).trace("-HTTP END-");
+    inOrder.verify(logger).trace("-HTTP START-");
     inOrder.verify(logger).trace("This is the request body");
     inOrder.verify(logger).trace("-HTTP END-");
   }
@@ -137,7 +141,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
     httpClient.sendAsync(httpClient.newHttpRequestBuilder()
         .uri(server.url("/response-status"))
         .build(), String.class).get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    verify(logger, timeout(1000L)).trace("-HTTP END-");
+    inOrder.verify(logger).trace("-HTTP START-");
     inOrder.verify(logger).trace("< {} {}", 200, "OK");
     inOrder.verify(logger).trace("-HTTP END-");
   }
@@ -151,7 +156,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
     httpClient.sendAsync(httpClient.newHttpRequestBuilder()
         .uri(server.url("/response-headers"))
         .build(), String.class).get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    verify(logger, timeout(1000L)).trace("-HTTP END-");
+    inOrder.verify(logger).trace("-HTTP START-");
     inOrder.verify(logger).trace(eq("< {} {}"), anyInt(), anyString());
     inOrder.verify(logger).trace("< {}: {}", "test-type", "response-header-test");
     inOrder.verify(logger).trace("-HTTP END-");
@@ -166,7 +172,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
     httpClient.sendAsync(httpClient.newHttpRequestBuilder()
         .uri(server.url("/response-body"))
         .build(), String.class).get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    verify(logger, timeout(1000L)).trace("-HTTP END-");
+    inOrder.verify(logger).trace("-HTTP START-");
     inOrder.verify(logger).trace(eq("< {} {}"), anyInt(), anyString());
     inOrder.verify(logger).trace("This is the response body");
     inOrder.verify(logger).trace("-HTTP END-");
@@ -193,7 +200,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
     httpClient.sendAsync(httpClient.newHttpRequestBuilder()
         .uri(server.url("/binary-response-body"))
         .build(), String.class).get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-HTTP START-");
+    verify(logger, timeout(1000L)).trace("-HTTP END-");
+    inOrder.verify(logger).trace("-HTTP START-");
     inOrder.verify(logger).trace(eq("< {} {}"), anyInt(), anyString());
     inOrder.verify(logger, times(1)).trace(anyString()); // only -HTTP END- was logged
     inOrder.verifyNoMoreInteractions();

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.http;
 
+import io.fabric8.kubernetes.client.http.AsyncBody.Consumer;
 import io.fabric8.mockwebserver.DefaultMockServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -272,7 +273,7 @@ public abstract class AbstractInterceptorTest {
     final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
         .addOrReplaceInterceptor("after", new Interceptor() {
           @Override
-          public void after(HttpRequest request, HttpResponse<?> response) {
+          public void after(HttpRequest request, HttpResponse<?> response, Consumer<List<ByteBuffer>> consumer) {
             responseFuture.complete(response);
           }
         });
@@ -299,7 +300,7 @@ public abstract class AbstractInterceptorTest {
     final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
         .addOrReplaceInterceptor("after", new Interceptor() {
           @Override
-          public void after(HttpRequest request, HttpResponse<?> response) {
+          public void after(HttpRequest request, HttpResponse<?> response, Consumer<List<ByteBuffer>> consumer) {
             responseFuture.complete(response);
           }
         });

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -272,7 +272,7 @@ public abstract class AbstractInterceptorTest {
     final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
         .addOrReplaceInterceptor("after", new Interceptor() {
           @Override
-          public void after(HttpResponse<?> response) {
+          public void after(HttpRequest request, HttpResponse<?> response) {
             responseFuture.complete(response);
           }
         });
@@ -299,7 +299,7 @@ public abstract class AbstractInterceptorTest {
     final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
         .addOrReplaceInterceptor("after", new Interceptor() {
           @Override
-          public void after(HttpResponse<?> response) {
+          public void after(HttpRequest request, HttpResponse<?> response) {
             responseFuture.complete(response);
           }
         });

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -54,7 +54,7 @@ class StandardHttpClientTest {
 
     // cancel the future before the websocket response
     future.cancel(true);
-    client.getWsFutures().get(0).complete(new WebSocketResponse(ws, null));
+    client.getWsFutures().get(0).complete(new WebSocketResponse(new WebSocketUpgradeResponse(null, 101, ws), null));
 
     // ensure that the ws has been closed
     Mockito.verify(ws).sendClose(1000, null);
@@ -176,9 +176,10 @@ class StandardHttpClientTest {
         });
 
     client.getWsFutures().get(0)
-        .completeExceptionally(new WebSocketHandshakeException(new TestHttpResponse<AsyncBody>().withCode(500)));
+        .completeExceptionally(new WebSocketHandshakeException(new WebSocketUpgradeResponse(null, 500, null)));
     client.getWsFutures().add(client.getWsFutures().get(0));
-    client.getWsFutures().add(CompletableFuture.completedFuture((new WebSocketResponse(ws, null))));
+    client.getWsFutures()
+        .add(CompletableFuture.completedFuture((new WebSocketResponse(new WebSocketUpgradeResponse(null, ws), null))));
 
     future.get(2, TimeUnit.MINUTES);
 


### PR DESCRIPTION
## Description

Relates to (should fix):
- https://github.com/eclipse/jkube/issues/1950
- https://github.com/eclipse/jkube/issues/2000

**PoC** to replace the OkHttp-specific `HttpLoggingInterceptor` with a Fabric8-specific implementation that works across all of our `HttpClient`s.

The `HttpLoggingInterceptor` implementation is following a deferred approach. This means that the messages are only logged once the server responds and the response is completely processed by the client. This allows to log the request (and its body), the response, and the response body in a neat and grouped way. Other alternatives can be considered.

The `Interceptor` interface `after` method had to be further modified (on top of changes already provided in #5025), to allow to uniquely identify the original requests. HttpClients freely copy the original request to propagate it around which prevents keeping a consistent identifier (HttpRequests are copied either to propagate them, or to start new ones)

Additional changes had to be completed in the WebSocket handling in order to allow to fully intercept and log the HTTP upgrade requests and responses. We should look into completely removing the `WebSocketResponse` wrapper class in the future.

Some questions/topics
- Do we prefer the neat and sorted deferred logging, or shall we consider immediate logging instead?
- Log format is similar to that provided by cURL, but can likely be improved
- Does this look good in general? should we keep moving in this direction?

I'll continue by implementing tests and addressing any comments once I get some feedback about this.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
