### PR TITLE
fix #5033: allow port-forward to work with other clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * fix #5002: Jetty response completion accounts for header processing
 * Fix #5009: addressing issue with serialization of wrapped polymophic types
 * Fix #5020: updating the resourceVersion on a delete with finalizers
+* Fix #5033: port forwarding for clients other than okhttp needs to specify the subprotocol
 
 #### Improvements
 * Fix #4434: Update CronJobIT to use `batch/v1` CronJob instead

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
@@ -173,6 +173,7 @@ public class PortForwarderWebsocket implements PortForwarder {
     CompletableFuture<WebSocket> socket = client
         .newWebSocketBuilder()
         .uri(URI.create(URLUtils.join(resourceBaseUrl.toString(), "portforward?ports=" + port)))
+        .subprotocol("v4.channel.k8s.io")
         .buildAsync(listener);
 
     socket.whenComplete((w, t) -> {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListener.java
@@ -117,9 +117,8 @@ public class PortForwarderWebsocketListener implements WebSocket.Listener {
       closeBothWays(webSocket, 1002, PROTOCOL_ERROR);
     } else if (channel == 1) {
       // Error channel
-      // TODO: read the error
       KubernetesClientException e = new KubernetesClientException(
-          String.format("Received an error from the remote socket"));
+          String.format("Received an error from the remote socket %s", ExecWebSocketListener.toString(buffer)));
       serverThrowables.add(e);
       logger.debug("Server error", e);
       closeForwarder();

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
@@ -31,6 +32,7 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.IOHelpers;
 import io.fabric8.kubernetes.client.utils.InputStreamPumper;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,6 +46,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.SocketException;
+import java.net.URL;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -442,6 +448,42 @@ class PodIT {
     assertEquals(pod1.getKind(), fromServerPod.getKind());
     assertEquals(namespace.getMetadata().getName(), fromServerPod.getMetadata().getNamespace());
     assertEquals(pod1.getMetadata().getName(), fromServerPod.getMetadata().getName());
+  }
+
+  @Test
+  void portForward() throws IOException, InterruptedException {
+    client.pods().withName("nginx").waitUntilReady(POD_READY_WAIT_IN_MILLIS, TimeUnit.SECONDS);
+    LocalPortForward portForward = client.pods().withName("nginx").portForward(80);
+    boolean failed = false;
+    try (SocketChannel channel = SocketChannel.open()) {
+
+      int localPort = portForward.getLocalPort();
+
+      URL url = new URL("http://localhost:" + localPort);
+
+      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+      InputStream content = (InputStream) conn.getContent();
+
+      // make sure we got data, should be the welcome page
+      assertTrue(content.read() != -1);
+
+      content.close();
+    } catch (SocketException e) {
+      failed = true;
+    } finally {
+      portForward.close();
+    }
+
+    if (failed) {
+      // not all kube versions nor runtimes can to port forwarding - the nodes need socat installed
+      portForward.getServerThrowables().stream()
+          .filter(t -> !t.getMessage().contains("unable to do port forwarding: socat not found")).findFirst()
+          .ifPresent(Assertions::fail);
+    } else {
+      assertThat(portForward.getServerThrowables()).isEmpty();
+    }
+    assertThat(portForward.getClientThrowables()).isEmpty();
   }
 
 }

--- a/kubernetes-itests/src/test/resources/pod-it.yml
+++ b/kubernetes-itests/src/test/resources/pod-it.yml
@@ -56,3 +56,14 @@ spec:
       command: ["timeout", "-s", "SIGKILL", "36000", "sh", "-i"]
       stdin: true
       tty: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
## Description
Fix #5033 - other clients need an explicit subprotocol.  Added an integration test as well.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
