### PR TITLE
fix #5020: updating the resourceVersion on delete with finalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #4985: triggering the immediate cleanup of the okhttp idle task
 * fix #5002: Jetty response completion accounts for header processing
 * Fix #5009: addressing issue with serialization of wrapped polymophic types
+* Fix #5020: updating the resourceVersion on a delete with finalizers
 
 #### Improvements
 * Fix #4434: Update CronJobIT to use `batch/v1` CronJob instead

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesCrudDispatcher.java
@@ -214,6 +214,7 @@ public class KubernetesCrudDispatcher extends CrudDispatcher implements Kubernet
     if (!resource.isMarkedForDeletion()) {
       // Mark the resource as deleted, but don't remove it yet (wait for finalizer-removal).
       resource.getMetadata().setDeletionTimestamp(LocalDateTime.now().toString());
+      resource.getMetadata().setResourceVersion(String.valueOf(requestResourceVersion()));
       String updatedResource = Serialization.asJson(resource);
       processEvent(path, pathAttributes, oldAttributes, resource, updatedResource);
       return;

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/crud/KubernetesCrudDispatcherFinalizerTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/crud/KubernetesCrudDispatcherFinalizerTest.java
@@ -60,8 +60,7 @@ class KubernetesCrudDispatcherFinalizerTest {
   private Owl createOwlWithFinalizer(String owlName) {
     final Owl owl = new Owl();
     owl.setMetadata(new ObjectMetaBuilder().withName(owlName).withFinalizers("test-finalizer").build());
-    client.resources(Owl.class).resource(owl).create();
-    return owl;
+    return client.resources(Owl.class).resource(owl).create();
   }
 
   @Test
@@ -96,6 +95,7 @@ class KubernetesCrudDispatcherFinalizerTest {
     String deletionTimestamp1 = owl1.getMetadata().getDeletionTimestamp();
     assertNotNull(deletionTimestamp1);
     assertDoesNotThrow(() -> DateTimeFormatter.ISO_DATE_TIME.parse(deletionTimestamp1));
+    assertNotEquals(initialOwl.getMetadata().getResourceVersion(), owl1.getMetadata().getResourceVersion());
 
     // When the owl is deleted a second time:
     client.resources(Owl.class).resource(owl1).delete();


### PR DESCRIPTION
## Description
Addresses #5020 - the resourveVersion needs updated when the deletionTimestamp is set.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
