### PR TITLE
fix #5036: addressing the handling of non-connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #5015: executing resync as a locking operation to ensure resync event ordering
 * Fix #5020: updating the resourceVersion on a delete with finalizers
 * Fix #5033: port forwarding for clients other than okhttp needs to specify the subprotocol
+* fix #5036: Better websocket error handling for protocol / client enforced errors, also update frame/message limits
 * Fix #5044: disable Vert.x instance file caching
 * Fix #5059: Vert.x InputStreamReader uses an empty Buffer sentinel to avoid NPE
 

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkWebSocketImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkWebSocketImpl.java
@@ -82,7 +82,7 @@ class JdkWebSocketImpl implements WebSocket {
 
     @Override
     public void onError(java.net.http.WebSocket webSocket, Throwable error) {
-      listener.onError(new JdkWebSocketImpl(queueSize, webSocket), error);
+      listener.onError(new JdkWebSocketImpl(queueSize, webSocket), error, false);
     }
 
     @Override

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -39,6 +39,8 @@ public class JettyHttpClientBuilder
     extends StandardHttpClientBuilder<JettyHttpClient, JettyHttpClientFactory, JettyHttpClientBuilder> {
 
   private static final int MAX_CONNECTIONS = Integer.MAX_VALUE;
+  // the default for etcd seems to be 3 MB, but we'll default to unlimited to have the same behavior across clients
+  private static final int MAX_WS_MESSAGE_SIZE = Integer.MAX_VALUE;
 
   public JettyHttpClientBuilder(JettyHttpClientFactory clientFactory) {
     super(clientFactory);
@@ -62,6 +64,10 @@ public class JettyHttpClientBuilder
     }
     HttpClient sharedHttpClient = new HttpClient(newTransport(sslContextFactory, preferHttp11));
     WebSocketClient sharedWebSocketClient = new WebSocketClient(new HttpClient(newTransport(sslContextFactory, preferHttp11)));
+    sharedWebSocketClient.setMaxBinaryMessageSize(MAX_WS_MESSAGE_SIZE);
+    // the api-server does not seem to fragment messages, so the frames can be very large
+    sharedWebSocketClient.setMaxFrameSize(MAX_WS_MESSAGE_SIZE);
+    sharedWebSocketClient.setMaxTextMessageSize(MAX_WS_MESSAGE_SIZE);
     sharedWebSocketClient.setIdleTimeout(Duration.ZERO);
     if (connectTimeout != null) {
       sharedHttpClient.setConnectTimeout(connectTimeout.toMillis());

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.websocket.api.WebSocketListener;
 import org.eclipse.jetty.websocket.api.WriteCallback;
 import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
@@ -147,7 +148,7 @@ public class JettyWebSocket implements WebSocket, WebSocketListener {
       // - Jetty throws a ClosedChannelException
       return;
     }
-    listener.onError(this, cause);
+    listener.onError(this, cause, cause instanceof IOException);
   }
 
   private void backPressure() {

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
@@ -258,8 +258,8 @@ class JettyWebSocketTest {
     }
 
     @Override
-    public void onError(WebSocket webSocket, Throwable error) {
-      events.put("onError", new Object[] { error });
+    public void onError(WebSocket webSocket, Throwable error, boolean connectionError) {
+      events.put("onError", new Object[] { error, connectionError });
     }
   }
 }

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
@@ -90,7 +90,7 @@ class OkHttpWebSocketImpl implements WebSocket {
             future.completeExceptionally(t);
           }
         } else {
-          listener.onError(new OkHttpWebSocketImpl(webSocket, this::request), t);
+          listener.onError(new OkHttpWebSocketImpl(webSocket, this::request), t, true);
         }
       }
 

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -36,6 +36,8 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
     extends StandardHttpClientBuilder<VertxHttpClient<F>, F, VertxHttpClientBuilder<F>> {
 
   private static final int MAX_CONNECTIONS = 8192;
+  // the default for etcd seems to be 3 MB, but we'll default to unlimited to have the same behavior across clients
+  private static final int MAX_WS_MESSAGE_SIZE = Integer.MAX_VALUE;
 
   final Vertx vertx;
 
@@ -51,6 +53,9 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
     options.setMaxPoolSize(MAX_CONNECTIONS);
     options.setMaxWebSockets(MAX_CONNECTIONS);
     options.setIdleTimeoutUnit(TimeUnit.SECONDS);
+    // the api-server does not seem to fragment messages, so the frames can be very large
+    options.setMaxWebSocketFrameSize(MAX_WS_MESSAGE_SIZE);
+    options.setMaxWebSocketMessageSize(MAX_WS_MESSAGE_SIZE);
 
     if (this.connectTimeout != null) {
       options.setConnectTimeout((int) this.connectTimeout.toMillis());

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocket.java
@@ -24,7 +24,7 @@ public interface WebSocket {
 
   /**
    * Callback methods for websocket events. The methods are
-   * guaranteed to be called serially - except for {@link #onError(WebSocket, Throwable)}
+   * guaranteed to be called serially - except for {@link Listener#onError(WebSocket, Throwable, boolean)}
    */
   interface Listener {
 
@@ -59,7 +59,7 @@ public interface WebSocket {
      * Called when an error has occurred. It's a terminal event, calls to {@link WebSocket#request()}
      * do nothing after this.
      */
-    default void onError(WebSocket webSocket, Throwable error) {
+    default void onError(WebSocket webSocket, Throwable error, boolean connectionError) {
     }
 
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -261,7 +261,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
   }
 
   @Override
-  public void onError(WebSocket webSocket, Throwable t) {
+  public void onError(WebSocket webSocket, Throwable t, boolean connectionError) {
     closed.set(true);
     HttpResponse<?> response = null;
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocket.java
@@ -178,7 +178,7 @@ public class PortForwarderWebsocket implements PortForwarder {
 
     socket.whenComplete((w, t) -> {
       if (t != null) {
-        listener.onError(w, t);
+        listener.onError(w, t, true);
       }
     });
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListener.java
@@ -159,7 +159,7 @@ public class PortForwarderWebsocketListener implements WebSocket.Listener {
   }
 
   @Override
-  public void onError(WebSocket webSocket, Throwable t) {
+  public void onError(WebSocket webSocket, Throwable t, boolean connectionError) {
     logger.debug("{}: Throwable received from websocket", LOG_PREFIX, t);
     if (alive.get()) {
       serverThrowables.add(t);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -119,7 +119,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
         if (ready) {
           // if we're not ready yet, that means we're waiting on the future and there's
           // no need to invoke the reconnect logic
-          listener.onError(w, t);
+          listener.onError(w, t, true);
         }
         throw KubernetesClientException.launderThrowable(t);
       }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatcherWebSocketListener.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import org.slf4j.Logger;
@@ -42,9 +43,13 @@ class WatcherWebSocketListener<T extends HasMetadata> implements WebSocket.Liste
   }
 
   @Override
-  public void onError(WebSocket webSocket, Throwable t) {
-    logger.debug("WebSocket error received", t);
-    manager.scheduleReconnect(state);
+  public void onError(WebSocket webSocket, Throwable t, boolean connectionError) {
+    if (connectionError) {
+      logger.debug("WebSocket error received", t);
+      manager.scheduleReconnect(state);
+    } else {
+      manager.close(new WatcherException("Could not process websocket message", t));
+    }
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -383,7 +383,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
         .buildAsync(execWebSocketListener);
     startedFuture.whenComplete((w, t) -> {
       if (t != null) {
-        execWebSocketListener.onError(w, t);
+        execWebSocketListener.onError(w, t, true);
       }
     });
     Utils.waitUntilReadyOrFail(startedFuture, getRequestConfig().getWebsocketTimeout(), TimeUnit.MILLISECONDS);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -95,7 +95,7 @@ class ExecWebSocketListenerTest {
   void testCheckErrorHasErrorFromFailureShouldThrowException() {
     ExecWebSocketListener listener = new ExecWebSocketListener(new PodOperationContext());
 
-    listener.onError(null, new IOException("here"));
+    listener.onError(null, new IOException("here"), true);
 
     assertThrows(KubernetesClientException.class, () -> listener.checkError());
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
@@ -108,7 +108,7 @@ class PortForwarderWebsocketListenerTest {
   @Test
   void onError_shouldStoreExceptionAndCloseChannels() {
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
-    listener.onError(webSocket, new RuntimeException("Server error"));
+    listener.onError(webSocket, new RuntimeException("Server error"), true);
     // Then
     assertThat(listener.getServerThrowables())
         .singleElement()


### PR DESCRIPTION
## Description
Addresses the additional concerns raised in #5036

This still needs to increase or allow setting the relevant limits in vertx and jetty.

cc @vietj 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
