### PR TITLE
fix #5035: removing initial execconfig version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #5015: executing resync as a locking operation to ensure resync event ordering
 * Fix #5020: updating the resourceVersion on a delete with finalizers
 * Fix #5033: port forwarding for clients other than okhttp needs to specify the subprotocol
+* Fix #5035: allowed client.authentication.k8s.io/v1 to work for the ExecConfig
 * fix #5036: Better websocket error handling for protocol / client enforced errors, also update frame/message limits
 * Fix #5044: disable Vert.x instance file caching
 * Fix #5059: Vert.x InputStreamReader uses an empty Buffer sentinel to avoid NPE

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -773,33 +773,28 @@ public class Config {
   protected static ExecCredential getExecCredentialFromExecConfig(ExecConfig exec, File configFile)
       throws IOException, InterruptedException {
     String apiVersion = exec.getApiVersion();
-    if ("client.authentication.k8s.io/v1alpha1".equals(apiVersion)
-        || "client.authentication.k8s.io/v1beta1".equals(apiVersion)) {
-      List<ExecEnvVar> env = exec.getEnv();
-      // TODO check behavior of tty & stdin
-      ProcessBuilder pb = new ProcessBuilder(
-          getAuthenticatorCommandFromExecConfig(exec, configFile, Utils.getSystemPathVariable()));
-      pb.redirectErrorStream(true);
-      if (env != null) {
-        Map<String, String> environment = pb.environment();
-        env.forEach(var -> environment.put(var.getName(), var.getValue()));
-      }
-      Process p = pb.start();
-      String output;
-      try (InputStream is = p.getInputStream()) {
-        output = IOHelpers.readFully(is);
-      }
-      if (p.waitFor() != 0) {
-        LOGGER.warn(output);
-      }
-      ExecCredential ec = Serialization.unmarshal(output, ExecCredential.class);
-      if (!apiVersion.equals(ec.apiVersion)) {
-        LOGGER.warn("Wrong apiVersion {} vs. {}", ec.apiVersion, apiVersion);
-      } else {
-        return ec;
-      }
-    } else { // TODO v1beta1?
-      LOGGER.warn("Unsupported apiVersion: {}", apiVersion);
+    List<ExecEnvVar> env = exec.getEnv();
+    // TODO check behavior of tty & stdin
+    ProcessBuilder pb = new ProcessBuilder(
+        getAuthenticatorCommandFromExecConfig(exec, configFile, Utils.getSystemPathVariable()));
+    pb.redirectErrorStream(true);
+    if (env != null) {
+      Map<String, String> environment = pb.environment();
+      env.forEach(var -> environment.put(var.getName(), var.getValue()));
+    }
+    Process p = pb.start();
+    String output;
+    try (InputStream is = p.getInputStream()) {
+      output = IOHelpers.readFully(is);
+    }
+    if (p.waitFor() != 0) {
+      LOGGER.warn(output);
+    }
+    ExecCredential ec = Serialization.unmarshal(output, ExecCredential.class);
+    if (!apiVersion.equals(ec.apiVersion)) {
+      LOGGER.warn("Wrong apiVersion {} vs. {}", ec.apiVersion, apiVersion);
+    } else {
+      return ec;
     }
     return null;
   }

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1
       args:
       - world
       command: ./token-generator

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-args-with-spaces
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-args-with-spaces
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1
       args:
       - "w o r l d"
       command: "./token-generator"

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-args-with-spaces-windows
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-args-with-spaces-windows
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1
       args:
       - "w o r l d"
       command: ".\\token-generator-win.bat"

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-null-args
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-null-args
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1
       args: null
       command: ./token-generator
       env:

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-win
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-win
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1
       args:
       - world
       command: ".\\token-generator-win.bat"

--- a/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-win-null-args
+++ b/kubernetes-client-api/src/test/resources/test-kubeconfig-exec-win-null-args
@@ -14,7 +14,7 @@ users:
 - name: test
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1
       args: null
       command: ".\\token-generator-win.bat"
       env:

--- a/kubernetes-client-api/src/test/resources/token-generator
+++ b/kubernetes-client-api/src/test/resources/token-generator
@@ -3,7 +3,7 @@ token=`echo $PART1 $1 | tr '[a-z]' '[A-Z]'`
 cat <<EOF
 {
   "kind": "ExecCredential",
-  "apiVersion": "client.authentication.k8s.io/v1alpha1",
+  "apiVersion": "client.authentication.k8s.io/v1",
   "spec": {},
   "status": {
     "token": "$token"

--- a/kubernetes-client-api/src/test/resources/token-generator-win.bat
+++ b/kubernetes-client-api/src/test/resources/token-generator-win.bat
@@ -25,7 +25,7 @@ CALL :upper token
 
 echo {
 echo   "kind": "ExecCredential",
-echo   "apiVersion": "client.authentication.k8s.io/v1alpha1",
+echo   "apiVersion": "client.authentication.k8s.io/v1",
 echo   "spec": {},
 echo   "status": {
 echo     "token": "%token%"


### PR DESCRIPTION
## Description
Fix #5035 

The initial version check doesn't seem necessary given that we're only trying to obtain the status token - and that schema is the same for all current version v1, v1beta1, v1alpha1.  Should a new/different schema come along, at worst we'll just report that the token is null.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
