### PR TITLE
fix #5022: adds a small amount of additional buffering to exec streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix #4477 exposing LeaderElector.release to force an elector to give up the lease
 * Fix #4935: improve HTTP client implementation selection messages
 * Fix #4975: exposing scale operations for all Resources
+* Fix #5022: adding additional buffering to ExecWatchInputStream
 * Fix #4992: Optimize Quantity parsing to avoid regex overhead
 * Fix #4998: removing the internal usage of the Serialization yaml mapper
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWatchInputStreamTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWatchInputStreamTest.java
@@ -72,7 +72,7 @@ public class ExecWatchInputStreamTest {
   @Test
   void testConsume() throws IOException {
     AtomicInteger count = new AtomicInteger();
-    ExecWatchInputStream is = new ExecWatchInputStream(() -> count.getAndIncrement());
+    ExecWatchInputStream is = new ExecWatchInputStream(() -> count.getAndIncrement(), 0);
     is.consume(Collections.singletonList(ByteBuffer.allocate(1)));
 
     assertEquals(0, is.read());
@@ -92,6 +92,21 @@ public class ExecWatchInputStreamTest {
 
     is.consume(Collections.singletonList(ByteBuffer.allocate(1)));
     readFuture.join();
+  }
+
+  @Test
+  void testConsumeBuffering() throws IOException {
+    AtomicInteger count = new AtomicInteger();
+    ExecWatchInputStream is = new ExecWatchInputStream(() -> count.getAndIncrement(), 2);
+    is.consume(Collections.singletonList(ByteBuffer.allocate(1)));
+
+    // should keep going as the amount is less than the buffer size
+    assertEquals(1, count.get());
+
+    is.consume(Collections.singletonList(ByteBuffer.allocate(1)));
+
+    // should not request as we're at the buffer limit
+    assertEquals(1, count.get());
   }
 
   @Test


### PR DESCRIPTION
## Description
Fix #5022 - for most scenarios coming from older releases with multiple exec streams, this will remove the need to proactively read them.  The additional buffering is being done as part of the consume call so sometimes this will mean that once the buffers are full, they must be drained to fill it back up again.

Ideally the user would supply a minimally blocking output stream directly to write into instead.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
