### PR TITLE
fix: prevent runtime issues when running with Vert.x HTTP client in native mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * fix #5036: Better websocket error handling for protocol / client enforced errors, also update frame/message limits
 * Fix #5044: disable Vert.x instance file caching
 * Fix #5059: Vert.x InputStreamReader uses an empty Buffer sentinel to avoid NPE
+* Fix #5085: Vert.x HTTP Client InputStreamReadStream works in Native mode
 
 #### Improvements
 * Fix #4434: Update CronJobIT to use `batch/v1` CronJob instead

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/InputStreamReadStream.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/InputStreamReadStream.java
@@ -30,10 +30,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class InputStreamReadStream implements ReadStream<Buffer> {
 
-  private static final Buffer END_SENTINEL = Buffer.buffer();
   private static final int CHUNK_SIZE = 2048;
   private static final int MAX_DEPTH = 8;
 
+  private final Buffer endSentinel;
   private final VertxHttpRequest vertxHttpRequest;
   private final InputStream is;
   private final HttpClientRequest request;
@@ -46,6 +46,7 @@ class InputStreamReadStream implements ReadStream<Buffer> {
     this.vertxHttpRequest = vertxHttpRequest;
     this.is = is;
     this.request = request;
+    endSentinel = Buffer.buffer();
   }
 
   @Override
@@ -72,7 +73,7 @@ class InputStreamReadStream implements ReadStream<Buffer> {
     }
     if (handler != null) {
       inboundBuffer.handler(buff -> {
-        if (buff == END_SENTINEL) {
+        if (buff == endSentinel) {
           if (endHandler != null) {
             endHandler.handle(null);
           }
@@ -133,7 +134,7 @@ class InputStreamReadStream implements ReadStream<Buffer> {
             // Full
           }
         } else {
-          inboundBuffer.write(END_SENTINEL);
+          inboundBuffer.write(endSentinel);
         }
       } else {
         if (exceptionHandler != null) {


### PR DESCRIPTION
## Description
fix: prevent runtime issues when running with Vert.x HTTP client in native mode

/cc @metacosm @geoand 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
