### PR TITLE
fix #5088: adding a few more test timeouts

### DIFF
--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -333,13 +333,12 @@ public class JdkHttpClientImpl extends StandardHttpClient<JdkHttpClientImpl, Jdk
       if (t instanceof java.net.http.WebSocketHandshakeException) {
         final java.net.http.HttpResponse<?> jdkResponse = ((java.net.http.WebSocketHandshakeException) t).getResponse();
         final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(
-            request, jdkResponse.statusCode(), jdkResponse.headers().map(), fabric8WebSocket);
-        response.complete(new WebSocketResponse(upgradeResponse,
-            new io.fabric8.kubernetes.client.http.WebSocketHandshakeException(upgradeResponse).initCause(t)));
+            request, jdkResponse.statusCode(), jdkResponse.headers().map());
+        response.complete(new WebSocketResponse(upgradeResponse, t));
       } else if (t != null) {
         response.completeExceptionally(t);
       } else {
-        response.complete(new WebSocketResponse(new WebSocketUpgradeResponse(request, fabric8WebSocket), null));
+        response.complete(new WebSocketResponse(new WebSocketUpgradeResponse(request), fabric8WebSocket));
       }
     });
 

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
@@ -152,9 +152,9 @@ public class JettyHttpClient extends StandardHttpClient<JettyHttpClient, JettyHt
           .whenComplete((s, ex) -> {
             if (ex != null) {
               if (ex instanceof CompletionException && ex.getCause() instanceof UpgradeException) {
-                future.complete(JettyWebSocket.toWebSocketResponse(request, webSocket, (UpgradeException) ex.getCause()));
+                future.complete(JettyWebSocket.toWebSocketResponse(request, (UpgradeException) ex.getCause()));
               } else if (ex instanceof UpgradeException) {
-                future.complete(JettyWebSocket.toWebSocketResponse(request, webSocket, (UpgradeException) ex));
+                future.complete(JettyWebSocket.toWebSocketResponse(request, (UpgradeException) ex));
               } else {
                 future.completeExceptionally(ex);
               }

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.http.BufferUtil;
 import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.WebSocket;
-import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
 import io.fabric8.kubernetes.client.http.WebSocketResponse;
 import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
 import org.eclipse.jetty.websocket.api.Session;
@@ -166,18 +165,16 @@ public class JettyWebSocket implements WebSocket, WebSocketListener {
     }
   }
 
-  static WebSocketResponse toWebSocketResponse(HttpRequest httpRequest, WebSocket ws, UpgradeException ex) {
+  static WebSocketResponse toWebSocketResponse(HttpRequest httpRequest, UpgradeException ex) {
     final WebSocketUpgradeResponse webSocketUpgradeResponse = new WebSocketUpgradeResponse(httpRequest,
-        ex.getResponseStatusCode(), ws);
-    final WebSocketHandshakeException handshakeException = new WebSocketHandshakeException(webSocketUpgradeResponse)
-        .initCause(ex);
-    return new WebSocketResponse(webSocketUpgradeResponse, handshakeException);
+        ex.getResponseStatusCode());
+    return new WebSocketResponse(webSocketUpgradeResponse, ex);
   }
 
   static WebSocketResponse toWebSocketResponse(HttpRequest httpRequest, WebSocket ws, Session session) {
     final UpgradeResponse jettyUpgradeResponse = session.getUpgradeResponse();
     final WebSocketUpgradeResponse fabric8UpgradeResponse = new WebSocketUpgradeResponse(
-        httpRequest, jettyUpgradeResponse.getStatusCode(), jettyUpgradeResponse.getHeaders(), ws);
-    return new WebSocketResponse(fabric8UpgradeResponse, null);
+        httpRequest, jettyUpgradeResponse.getStatusCode(), jettyUpgradeResponse.getHeaders());
+    return new WebSocketResponse(fabric8UpgradeResponse, ws);
   }
 }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
@@ -84,14 +84,13 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
         .onSuccess(ws -> {
           VertxWebSocket ret = new VertxWebSocket(ws, listener);
           ret.init();
-          response.complete(new WebSocketResponse(new WebSocketUpgradeResponse(request, ret), null));
+          response.complete(new WebSocketResponse(new WebSocketUpgradeResponse(request), ret));
         }).onFailure(t -> {
           if (t instanceof UpgradeRejectedException) {
             UpgradeRejectedException handshake = (UpgradeRejectedException) t;
             final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(
-                request, handshake.getStatus(), toHeadersMap(handshake.getHeaders()), null);
-            response.complete(new WebSocketResponse(upgradeResponse,
-                new io.fabric8.kubernetes.client.http.WebSocketHandshakeException(upgradeResponse)));
+                request, handshake.getStatus(), toHeadersMap(handshake.getHeaders()));
+            response.complete(new WebSocketResponse(upgradeResponse, handshake));
           }
           response.completeExceptionally(t);
         });

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketResponse.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketResponse.java
@@ -19,17 +19,24 @@ package io.fabric8.kubernetes.client.http;
 import java.util.Objects;
 
 /*
- * TODO: this may not be the best way to do this - in general
- * instead we create a response to hold them both
- * manusa: We can remove this class and replace with separate WebSocketUpgradeResponse|WebSocketHandshakeException handled by the future
+ * manusa: We may be able to remove this class and replace with separate WebSocketUpgradeResponse|WebSocketHandshakeException handled by the future
+ * but we can't yet as there isn't a composable form of handle
  */
 public class WebSocketResponse {
   final WebSocketUpgradeResponse webSocketUpgradeResponse;
-  final WebSocketHandshakeException wshse;
+  final Throwable throwable;
+  final WebSocket webSocket;
 
-  public WebSocketResponse(WebSocketUpgradeResponse webSocketUpgradeResponse, WebSocketHandshakeException wshse) {
+  public WebSocketResponse(WebSocketUpgradeResponse webSocketUpgradeResponse, Throwable throwable) {
     this.webSocketUpgradeResponse = Objects.requireNonNull(webSocketUpgradeResponse);
-    this.wshse = wshse;
+    this.throwable = Objects.requireNonNull(throwable);
+    this.webSocket = null;
+  }
+
+  public WebSocketResponse(WebSocketUpgradeResponse webSocketUpgradeResponse, WebSocket webSocket) {
+    this.webSocketUpgradeResponse = Objects.requireNonNull(webSocketUpgradeResponse);
+    this.webSocket = Objects.requireNonNull(webSocket);
+    this.throwable = null;
   }
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketUpgradeResponse.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/WebSocketUpgradeResponse.java
@@ -24,21 +24,19 @@ public class WebSocketUpgradeResponse extends StandardHttpHeaders implements Htt
 
   private final HttpRequest httpRequest;
   private final int code;
-  private final WebSocket webSocket;
 
-  public WebSocketUpgradeResponse(HttpRequest httpRequest, WebSocket webSocket) {
-    this(httpRequest, 101, new LinkedHashMap<>(), webSocket);
+  public WebSocketUpgradeResponse(HttpRequest httpRequest) {
+    this(httpRequest, 101, new LinkedHashMap<>());
   }
 
-  public WebSocketUpgradeResponse(HttpRequest httpRequest, int code, WebSocket webSocket) {
-    this(httpRequest, code, new LinkedHashMap<>(), webSocket);
+  public WebSocketUpgradeResponse(HttpRequest httpRequest, int code) {
+    this(httpRequest, code, new LinkedHashMap<>());
   }
 
-  public WebSocketUpgradeResponse(HttpRequest httpRequest, int code, Map<String, List<String>> headers, WebSocket webSocket) {
+  public WebSocketUpgradeResponse(HttpRequest httpRequest, int code, Map<String, List<String>> headers) {
     super(headers);
     this.httpRequest = httpRequest;
     this.code = code;
-    this.webSocket = webSocket;
   }
 
   @Override
@@ -61,7 +59,4 @@ public class WebSocketUpgradeResponse extends StandardHttpHeaders implements Htt
     return Optional.empty();
   }
 
-  public WebSocket getWebSocket() {
-    return webSocket;
-  }
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
@@ -218,7 +218,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
         .buildAsync(new WebSocket.Listener() {
         })
         .get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-WS START-");
+    verify(logger, timeout(1000L)).trace("-WS END-");
+    inOrder.verify(logger).trace("-WS START-");
     inOrder.verify(logger)
         .trace(eq("> {} {}"), eq("GET"), argThat((URI uri) -> uri.toString().endsWith("/ws-request-uri")));
     inOrder.verify(logger).trace("-WS END-");
@@ -253,7 +254,8 @@ public abstract class AbstractHttpLoggingInterceptorTest {
         .buildAsync(new WebSocket.Listener() {
         })
         .get(10, TimeUnit.SECONDS);
-    inOrder.verify(logger, timeout(1000L)).trace("-WS START-");
+    verify(logger, timeout(1000L)).trace("-WS END-");
+    inOrder.verify(logger).trace("-WS START-");
     inOrder.verify(logger).trace("< {} {}", 101, "Switching Protocols");
     inOrder.verify(logger).trace("-WS END-");
   }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -54,7 +54,7 @@ class StandardHttpClientTest {
 
     // cancel the future before the websocket response
     future.cancel(true);
-    client.getWsFutures().get(0).complete(new WebSocketResponse(new WebSocketUpgradeResponse(null, 101, ws), null));
+    client.getWsFutures().get(0).complete(new WebSocketResponse(new WebSocketUpgradeResponse(null, 101), ws));
 
     // ensure that the ws has been closed
     Mockito.verify(ws).sendClose(1000, null);
@@ -176,10 +176,10 @@ class StandardHttpClientTest {
         });
 
     client.getWsFutures().get(0)
-        .completeExceptionally(new WebSocketHandshakeException(new WebSocketUpgradeResponse(null, 500, null)));
+        .complete(new WebSocketResponse(new WebSocketUpgradeResponse(null, 500, null), new IOException()));
     client.getWsFutures().add(client.getWsFutures().get(0));
     client.getWsFutures()
-        .add(CompletableFuture.completedFuture((new WebSocketResponse(new WebSocketUpgradeResponse(null, ws), null))));
+        .add(CompletableFuture.completedFuture(new WebSocketResponse(new WebSocketUpgradeResponse(null), ws)));
 
     future.get(2, TimeUnit.MINUTES);
 


### PR DESCRIPTION
## Description

Fix #5088

Changed a couple of test expectations to look for the last message first.

Also changed the WebSocketResponse to clearly be either the WebSocket or an exception.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
