### PR TITLE
fix #5091 reverting to byte[] simple requests

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestHttpResponse.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestHttpResponse.java
@@ -15,8 +15,6 @@
  */
 package io.fabric8.kubernetes.client.http;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -84,8 +82,8 @@ public class TestHttpResponse<T> extends StandardHttpHeaders implements HttpResp
     return this;
   }
 
-  public static TestHttpResponse<InputStream> from(int code, String body) {
-    return new TestHttpResponse<InputStream>().withCode(code)
-        .withBody(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+  public static TestHttpResponse<byte[]> from(int code, String body) {
+    return new TestHttpResponse<byte[]>().withCode(code)
+        .withBody(body.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -44,6 +44,7 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -564,11 +565,11 @@ public class OperationSupport {
     VersionUsageUtils.log(this.resourceT, this.apiGroupVersion);
     HttpRequest request = requestBuilder.build();
 
-    return client.sendAsync(request, InputStream.class).thenApply(response -> {
+    return client.sendAsync(request, byte[].class).thenApply(response -> {
       try {
         assertResponseCode(request, response);
         if (type != null && type.getType() != null) {
-          return Serialization.unmarshal(response.body(), type);
+          return Serialization.unmarshal(new ByteArrayInputStream(response.body()), type);
         } else {
           return null;
         }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/DryRunTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/DryRunTest.java
@@ -35,7 +35,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +58,7 @@ class DryRunTest {
     builders = new ArrayList<>();
     this.mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
     Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
-    when(mockClient.sendAsync(any(), Mockito.eq(InputStream.class)))
+    when(mockClient.sendAsync(any(), Mockito.eq(byte[].class)))
         .thenReturn(CompletableFuture.completedFuture(TestHttpResponse.from(200,
             "{\"kind\":\"Pod\", \"apiVersion\":\"v1\"}")));
     kubernetesClient = new KubernetesClientImpl(mockClient, config);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/PatchTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/PatchTest.java
@@ -35,7 +35,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
@@ -60,7 +59,7 @@ class PatchTest {
     // TODO: fully mocking makes this logic more difficult and basically copied in other tests, we may want to rely on an actual implementation instead
     builders = new ArrayList<>();
     this.mockClient = Mockito.mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);
-    when(mockClient.sendAsync(any(), Mockito.eq(InputStream.class)))
+    when(mockClient.sendAsync(any(), Mockito.eq(byte[].class)))
         .thenReturn(CompletableFuture.completedFuture(TestHttpResponse.from(200, "{}")));
     Config config = new ConfigBuilder().withMasterUrl("https://localhost:8443/").build();
     kubernetesClient = new KubernetesClientImpl(mockClient, config);
@@ -119,8 +118,8 @@ class PatchTest {
   @Test
   void testPatchThrowExceptionWhenResourceNotFound() {
     // Given
-    when(mockClient.sendAsync(any(), Mockito.eq(InputStream.class)))
-        .thenReturn(CompletableFuture.completedFuture(new TestHttpResponse<InputStream>().withCode(404)));
+    when(mockClient.sendAsync(any(), Mockito.eq(byte[].class)))
+        .thenReturn(CompletableFuture.completedFuture(new TestHttpResponse<byte[]>().withCode(404)));
 
     // When
     PodResource podResource = kubernetesClient.pods()

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImplTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImplTest.java
@@ -28,7 +28,6 @@ import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -107,9 +106,9 @@ class BuildConfigOperationsImplTest {
 
     // When
     ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
-    CompletableFuture<HttpResponse<InputStream>> future = new CompletableFuture<>();
+    CompletableFuture<HttpResponse<byte[]>> future = new CompletableFuture<>();
     future.completeExceptionally(new IOException());
-    when(httpClient.sendAsync(any(), eq(InputStream.class))).thenReturn(future);
+    when(httpClient.sendAsync(any(), eq(byte[].class))).thenReturn(future);
 
     KubernetesClientException exception = assertThrows(KubernetesClientException.class,
         () -> impl.submitToApiServer(inputStream, 0));
@@ -128,11 +127,11 @@ class BuildConfigOperationsImplTest {
       };
     };
 
-    HttpResponse<InputStream> response = mock(HttpResponse.class, Mockito.CALLS_REAL_METHODS);
+    HttpResponse<byte[]> response = mock(HttpResponse.class, Mockito.CALLS_REAL_METHODS);
     when(response.code()).thenReturn(200);
-    when(response.body()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    when(response.body()).thenReturn(new byte[0]);
 
-    when(httpClient.sendAsync(any(), eq(InputStream.class))).thenReturn(CompletableFuture.completedFuture(response));
+    when(httpClient.sendAsync(any(), eq(byte[].class))).thenReturn(CompletableFuture.completedFuture(response));
     impl.submitToApiServer(new ByteArrayInputStream(new byte[0]), 0);
 
     Mockito.verify(response, Mockito.times(1)).body();


### PR DESCRIPTION
## Description

Fix #5091 

Partially reverts #5064

We can't use `InputStream` yet for the parsing logic as thenApply will potentially use the io thread that needs to be free to deliver results.  We would need a non-blocking parser, or to first wait / return the operation to the calling thread before processing (but that doesn't quite line up to the current usage).

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
