### PR TITLE
fix #5102: accounting for null replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.7-SNAPSHOT
 
 #### Bugs
+* Fix #5102: wait on scale to 0 was not completing
 
 #### Improvements
 

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeploymentIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DeploymentIT.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.client.readiness.Readiness;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,6 +79,9 @@ class DeploymentIT {
     assertEquals(5, deployment1.getStatus().getReplicas());
     deployment1 = client.apps().deployments().withName("deployment-standard").scale(1, true);
     assertEquals(1, deployment1.getStatus().getReplicas());
+    // ensure scale to 0 as some replica fields can flip to null
+    deployment1 = client.apps().deployments().withName("deployment-standard").scale(0, true);
+    assertEquals(0, Optional.ofNullable(deployment1.getStatus().getReplicas()).orElse(0));
 
     // will only work on clusters older than 1.16
     if (client.supports(io.fabric8.kubernetes.api.model.extensions.Deployment.class)) {


### PR DESCRIPTION
## Description
Fixes the scale logic to be to wait on scale to 0.  Porting from the go implementation it wasn't obvious that the replica fields could be null as nil would be 0.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
