### PR TITLE
refactor: reduce StandardHttpClient retry complexity

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpHeaders.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.http;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public interface HttpHeaders {
 
@@ -35,5 +36,21 @@ public interface HttpHeaders {
    * @return the Map of Headers and their list of values.
    */
   Map<String, List<String>> headers();
+
+  /**
+   * Return the header as a single string value
+   *
+   * @return will be null if the header is unset
+   */
+  default String header(String key) {
+    List<String> headers = headers(key);
+    if (headers.size() == 1) {
+      return headers.get(0);
+    }
+    if (headers.isEmpty()) {
+      return null;
+    }
+    return headers.stream().collect(Collectors.joining(","));
+  }
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
@@ -191,8 +191,8 @@ public abstract class StandardHttpClient<C extends HttpClient, F extends HttpCli
         });
   }
 
-  private long retryAfterMillis(HttpResponse<?> httpResponse) {
-    String retryAfter = httpResponse.header("Retry-After");
+  static long retryAfterMillis(HttpResponse<?> httpResponse) {
+    String retryAfter = httpResponse.header(StandardHttpHeaders.RETRY_AFTER);
     if (retryAfter != null) {
       try {
         return Integer.parseInt(retryAfter) * 1000L;

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
@@ -26,6 +26,7 @@ public class StandardHttpHeaders implements HttpHeaders {
   public static final String CONTENT_LENGTH = "Content-Length";
   public static final String EXPECT = "Expect";
   public static final String EXPECT_CONTINUE = "100-continue";
+  public static final String RETRY_AFTER = "Retry-After";
 
   private final Map<String, List<String>> headers;
 
@@ -45,5 +46,9 @@ public class StandardHttpHeaders implements HttpHeaders {
   @Override
   public Map<String, List<String>> headers() {
     return Collections.unmodifiableMap(headers);
+  }
+
+  public Map<String, List<String>> getHeaders() {
+    return headers;
   }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/AsyncUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/AsyncUtils.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class AsyncUtils {
+
+  private AsyncUtils() {
+  }
+
+  /**
+   * Returns the provided {@link CompletableFuture} that will complete exceptionally with a {@link TimeoutException}
+   * if the provided {@link Duration} timeout period is exceeded.
+   *
+   * @param future the future to add a timeout to.
+   * @param timeout the timeout duration.
+   * @return the provided future with a timeout.
+   * @param <T> the result type returned by the future.
+   */
+  public static <T> CompletableFuture<T> withTimeout(CompletableFuture<T> future, Duration timeout) {
+    if (timeout != null && timeout.toMillis() > 0) {
+      final Future<?> scheduled = Utils.schedule(Runnable::run, () -> future.completeExceptionally(new TimeoutException()),
+          timeout.toMillis(), TimeUnit.MILLISECONDS);
+      future.whenComplete((v, t) -> scheduled.cancel(true));
+    }
+    return future;
+  }
+
+  /**
+   * Returns a new {@link CompletableFuture} that will complete once the action provided by the action supplier completes.
+   * The action will be retried with an exponential backoff using the {@link ExponentialBackoffIntervalCalculator} as
+   * long as the {@link ShouldRetry} predicate returns true.
+   * Each action retrieval retry will time out after the provided timeout {@link Duration}.
+   * 
+   * @param action the action supplier.
+   * @param onCancel consumes the intermediate result in case the returned future is cancelled or each time the action is
+   *        retried.
+   * @param timeout the timeout duration.
+   * @param retryIntervalCalculator the retry interval calculator.
+   * @param shouldRetry the predicate to compute if the action is to be retried.
+   * @return a new {@link CompletableFuture} that will complete once the action provided by the action supplier completes.
+   * @param <T> the result type returned by the future.
+   */
+  public static <T> CompletableFuture<T> retryWithExponentialBackoff(Supplier<CompletableFuture<T>> action,
+      Consumer<T> onCancel, Duration timeout, ExponentialBackoffIntervalCalculator retryIntervalCalculator,
+      ShouldRetry<T> shouldRetry) {
+    final CompletableFuture<T> result = new CompletableFuture<>();
+    retryWithExponentialBackoff(result, action, onCancel, timeout, retryIntervalCalculator, shouldRetry);
+    return result;
+  }
+
+  private static <T> void retryWithExponentialBackoff(CompletableFuture<T> result, Supplier<CompletableFuture<T>> action,
+      Consumer<T> onCancel, Duration timeout, ExponentialBackoffIntervalCalculator retryIntervalCalculator,
+      ShouldRetry<T> shouldRetry) {
+    withTimeout(action.get(), timeout).whenComplete((r, t) -> {
+      if (retryIntervalCalculator.shouldRetry() && !result.isDone()) {
+        final long retryInterval = retryIntervalCalculator.nextReconnectInterval();
+        if (shouldRetry.shouldRetry(r, t, retryInterval)) {
+          if (r != null) {
+            onCancel.accept(r);
+          }
+          Utils.schedule(Runnable::run,
+              () -> retryWithExponentialBackoff(result, action, onCancel, timeout, retryIntervalCalculator, shouldRetry),
+              retryInterval, TimeUnit.MILLISECONDS);
+          return;
+        }
+      }
+      if (t != null) {
+        result.completeExceptionally(t);
+      } else if (!result.complete(r)) {
+        onCancel.accept(r);
+      }
+    });
+  }
+
+  @FunctionalInterface
+  public interface ShouldRetry<T> {
+    boolean shouldRetry(T result, Throwable exception, long retryInterval);
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -221,6 +222,8 @@ class StandardHttpClientTest {
         });
 
     Awaitility.await().atMost(10, TimeUnit.SECONDS).until(consumeFuture::isDone);
+    assertThatThrownBy(consumeFuture::get)
+        .isInstanceOf(ExecutionException.class).hasCauseInstanceOf(TimeoutException.class);
   }
 
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -121,7 +121,7 @@ class StandardHttpClientTest {
         .build();
 
     IntStream.range(0, 3).forEach(i -> client.expect(".*", new IOException("Unreachable!")));
-    client.expect(".*", new TestHttpResponse<AsyncBody>().withCode(500));
+    client.expect(".*", new TestHttpResponse<AsyncBody>().withCode(403));
 
     CompletableFuture<HttpResponse<AsyncBody>> consumeFuture = client.consumeBytes(
         client.newHttpRequestBuilder().uri("http://localhost").build(),
@@ -132,7 +132,7 @@ class StandardHttpClientTest {
     long start = System.currentTimeMillis();
 
     // should ultimately error with the final 500
-    assertEquals(500, consumeFuture.get().code());
+    assertEquals(403, consumeFuture.get().code());
     long stop = System.currentTimeMillis();
 
     // should take longer than the delay
@@ -172,7 +172,7 @@ class StandardHttpClientTest {
         .withRequestRetryBackoffLimit(3)
         .withRequestRetryBackoffInterval(50).build())
         .build();
-    final WebSocketResponse error = new WebSocketResponse(new WebSocketUpgradeResponse(null, 500, null), new IOException());
+    final WebSocketResponse error = new WebSocketResponse(new WebSocketUpgradeResponse(null, 500), new IOException());
     IntStream.range(0, 2).forEach(i -> client.wsExpect(".*", error));
     client.wsExpect(".*", new WebSocketResponse(new WebSocketUpgradeResponse(null), mock(WebSocket.class)));
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/AsyncUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/AsyncUtilsTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.utils;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static io.fabric8.kubernetes.client.utils.AsyncUtils.retryWithExponentialBackoff;
+import static io.fabric8.kubernetes.client.utils.AsyncUtils.withTimeout;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AsyncUtilsTest {
+
+  @Test
+  @DisplayName("withTimeout, future is cancelled when timeout is exceeded")
+  void withTimeout_timeout() {
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+    withTimeout(future, Duration.ofMillis(1));
+    assertThatThrownBy(() -> future.get(100, TimeUnit.MILLISECONDS))
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(TimeoutException.class);
+  }
+
+  @Test
+  @DisplayName("withTimeout, future is completed before timeout is exceeded")
+  void withTimeout_completes() throws Exception {
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+    withTimeout(future, Duration.ofMillis(100));
+    Utils.schedule(Runnable::run, () -> future.complete(null), 1, TimeUnit.MILLISECONDS);
+    assertThat(future.get(100, TimeUnit.MILLISECONDS)).isNull();
+  }
+
+  @Test
+  @DisplayName("withTimeout, timeout=0, future remains intact")
+  void withTimeout_notApplicable() {
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+    withTimeout(future, Duration.ofMillis(0));
+    assertThat(future.getNow(null)).isNull();
+  }
+
+  @Test
+  @DisplayName("withTimeout, timeout>0, future has alternative Timeout result")
+  void withTimeout_applicableTimeout() {
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+    withTimeout(future, Duration.ofMillis(1));
+    Awaitility.await().atMost(Duration.ofMillis(101)).until(future::isDone);
+    assertThatThrownBy(() -> future.getNow(null))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(TimeoutException.class);
+  }
+
+  @Test
+  @DisplayName("retryWithExponentialBackoff, action is timed out")
+  void retryWithExponentialBackoff_timeout() {
+    // Given
+    final Supplier<CompletableFuture<Void>> action = CompletableFuture::new;
+    final CompletableFuture<Void> onCancel = new CompletableFuture<>();
+    final ExponentialBackoffIntervalCalculator retryIntervalCalculator = new ExponentialBackoffIntervalCalculator(1, 1);
+    final AsyncUtils.ShouldRetry<Void> shouldRetry = (v, t, retryInterval) -> true;
+    // When
+    final CompletableFuture<Void> result = retryWithExponentialBackoff(action, onCancel::complete, Duration.ofMillis(1),
+        retryIntervalCalculator, shouldRetry);
+    // Then
+    assertThatThrownBy(() -> result.get(100000, TimeUnit.MILLISECONDS))
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(TimeoutException.class);
+    assertThat(onCancel).isNotDone();
+  }
+
+  @Test
+  @DisplayName("retryWithExponentialBackoff, with no retry, should invoke onCancel on action completion with cancelled future")
+  void retryWithExponentialBackoff_withCancelledFuture_onCancel() {
+    // Given
+    final CompletableFuture<Void> action = new CompletableFuture<>();
+    final Supplier<CompletableFuture<Void>> actionSupplier = () -> action;
+    final CompletableFuture<Void> onCancel = new CompletableFuture<>();
+    final ExponentialBackoffIntervalCalculator retryIntervalCalculator = new ExponentialBackoffIntervalCalculator(1, 0);
+    final AsyncUtils.ShouldRetry<Void> shouldRetry = (v, t, retryInterval) -> false;
+    // When
+    final CompletableFuture<Void> result = retryWithExponentialBackoff(actionSupplier, onCancel::complete,
+        Duration.ofMillis(100), retryIntervalCalculator, shouldRetry);
+    result.cancel(false);
+    action.complete(null);
+    // Then
+    assertThat(onCancel)
+        .isDone()
+        .isCompleted()
+        .isNotCancelled();
+  }
+
+  @Test
+  @DisplayName("retryWithExponentialBackoff, with retry, should invoke onCancel on action completion before retrying")
+  void retryWithExponentialBackoff_withCompletedResult_onCancel() throws Exception {
+    // Given
+    final CompletableFuture<Boolean> action = new CompletableFuture<>();
+    final Supplier<CompletableFuture<Boolean>> actionSupplier = () -> action;
+    final CompletableFuture<Boolean> onCancel = new CompletableFuture<>();
+    final ExponentialBackoffIntervalCalculator retryIntervalCalculator = new ExponentialBackoffIntervalCalculator(1, 1);
+    final AsyncUtils.ShouldRetry<Boolean> shouldRetry = (v, t, retryInterval) -> true;
+    // When
+    CompletableFuture<Boolean> result = retryWithExponentialBackoff(actionSupplier, onCancel::complete,
+        Duration.ofMillis(100), retryIntervalCalculator, shouldRetry);
+    action.complete(true);
+    result.get(150, TimeUnit.MILLISECONDS);
+    // Then
+    assertThat(onCancel)
+        .isDone()
+        .isCompleted()
+        .isNotCancelled();
+  }
+
+  @Test
+  @DisplayName("retryWithExponentialBackoff, with no retry, should complete future on action completion")
+  void retryWithExponentialBackoff_complete() {
+    // Given
+    final CompletableFuture<Void> action = new CompletableFuture<>();
+    final Supplier<CompletableFuture<Void>> actionSupplier = () -> action;
+    final CompletableFuture<Void> onCancel = new CompletableFuture<>();
+    final ExponentialBackoffIntervalCalculator retryIntervalCalculator = new ExponentialBackoffIntervalCalculator(1, 0);
+    final AsyncUtils.ShouldRetry<Void> shouldRetry = (v, t, retryInterval) -> false;
+    // When
+    final CompletableFuture<Void> result = retryWithExponentialBackoff(actionSupplier, onCancel::complete,
+        Duration.ofMillis(100), retryIntervalCalculator, shouldRetry);
+    action.complete(null);
+    // Then
+    assertThat(onCancel).isNotDone();
+    assertThat(result).isDone().isCompletedWithValue(null);
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -274,11 +274,11 @@ class PodTest {
         .andReturn(200, new PodBuilder().build())
         .once();
     server.expect()
-        .withPath("/api/v1/namespaces/ns1/pods/pod3/eviction")
+        .withPath("/api/v1/namespaces/ns1/pods/pod-429/eviction")
         .andReturn(PodOperationsImpl.HTTP_TOO_MANY_REQUESTS, new PodBuilder().build())
         .once();
     server.expect()
-        .withPath("/api/v1/namespaces/ns1/pods/pod3/eviction")
+        .withPath("/api/v1/namespaces/ns1/pods/pod-429/eviction")
         .andReturn(200, new PodBuilder().build())
         .once();
     server.expect()
@@ -296,11 +296,8 @@ class PodTest {
     deleted = client.pods().inNamespace("ns1").withName("pod2").evict();
     assertTrue(deleted);
 
-    // too many requests
-    deleted = client.pods().inNamespace("ns1").withName("pod3").evict();
-    assertFalse(deleted);
-
-    deleted = client.pods().inNamespace("ns1").withName("pod3").evict();
+    // too many requests - automatically retries
+    deleted = client.pods().inNamespace("ns1").withName("pod-429").evict();
     assertTrue(deleted);
 
     // unhandled error


### PR DESCRIPTION
## Description
refactor: reduce StandardHttpClient retry complexity
- Abstracts the retryWithExponentialBackoff method so that it can be reused
- Provides specific testing for all scenarios

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
