### PR TITLE
fix: RequestConfig is propagated to derived HttpClient instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.7-SNAPSHOT
 
 #### Bugs
+Fix #5121: RequestConfig is propagated to derived HttpClient instances
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ListOptions;
 import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.HttpResponse;
@@ -72,6 +73,7 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
       final ListOptions listOptions, final Watcher<T> watcher, final int reconnectInterval, final int reconnectLimit,
       long websocketTimeout) throws MalformedURLException {
     super(watcher, baseOperation, listOptions, reconnectLimit, reconnectInterval, () -> client.newBuilder()
+        .tag(new RequestConfigBuilder(baseOperation.getRequestConfig()).withRequestTimeout(0).build())
         .readTimeout(websocketTimeout, TimeUnit.MILLISECONDS)
         .build());
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.dsl.internal;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.http.AsyncBody;
 import io.fabric8.kubernetes.client.http.HttpClient;
@@ -48,6 +49,7 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
     super(
         watcher, baseOperation, listOptions, reconnectLimit, reconnectInterval,
         () -> client.newBuilder()
+            .tag(new RequestConfigBuilder(baseOperation.getRequestConfig()).withRequestTimeout(0).build())
             .readTimeout(0, TimeUnit.MILLISECONDS)
             .forStreaming()
             .build());

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -140,7 +140,7 @@ public class DeploymentConfigOperationsImpl
       // In case of DeploymentConfig we directly get logs at DeploymentConfig Url, but we need to wait for Pods
       waitUntilDeploymentConfigPodBecomesReady(get());
       URL url = getResourceLogUrl(true);
-      final LogWatchCallback callback = new LogWatchCallback(out, this.context.getExecutor());
+      final LogWatchCallback callback = new LogWatchCallback(out, context);
       return callback.callAndWait(this.httpClient, url);
     } catch (Throwable t) {
       throw KubernetesClientException.launderThrowable(forOperationType("watchLog"), t);

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImpl.java
@@ -261,6 +261,7 @@ public class BuildConfigOperationsImpl
   protected Build submitToApiServer(InputStream inputStream, long contentLength) {
     try {
       HttpClient newClient = this.httpClient.newBuilder()
+          .tag(getOperationContext().getRequestConfig())
           .readTimeout(getOperationContext().getTimeout(), getOperationContext().getTimeoutUnit())
           .writeTimeout(getOperationContext().getTimeout(), getOperationContext().getTimeoutUnit())
           .build();

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
@@ -134,7 +134,7 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
       // In case of Build we directly get logs at Build Url, but we need to wait for Pods
       waitUntilBuildPodBecomesReady(get());
       URL url = new URL(URLUtils.join(getResourceUrl().toString(), getLogParameters() + "&follow=true"));
-      final LogWatchCallback callback = new LogWatchCallback(out, this.context.getExecutor());
+      final LogWatchCallback callback = new LogWatchCallback(out, context);
       return callback.callAndWait(this.httpClient, url);
     } catch (IOException t) {
       throw KubernetesClientException.launderThrowable(forOperationType("watchLog"), t);

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/impl/OpenShiftClientImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/impl/OpenShiftClientImpl.java
@@ -699,8 +699,10 @@ public class OpenShiftClientImpl extends KubernetesClientImpl
   protected void setDerivedFields() {
     OpenShiftConfig wrapped = OpenShiftConfig.wrap(config);
     this.config = wrapped;
-    HttpClient.DerivedClientBuilder builder = httpClient.newBuilder().authenticatorNone();
+    HttpClient.DerivedClientBuilder builder = httpClient.newBuilder();
     this.httpClient = builder
+        .authenticatorNone()
+        .tag(config.getRequestConfig())
         .addOrReplaceInterceptor(TokenRefreshInterceptor.NAME,
             new OpenShiftOAuthInterceptor(httpClient, wrapped))
         .build();

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftOAuthInterceptor.java
@@ -138,6 +138,7 @@ public class OpenShiftOAuthInterceptor implements Interceptor {
 
   private CompletableFuture<String> authorize() {
     HttpClient.DerivedClientBuilder builder = client.newBuilder();
+    builder.tag(config.getRequestConfig());
     builder.addOrReplaceInterceptor(TokenRefreshInterceptor.NAME, null);
     HttpClient clone = builder.build();
 

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImplTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsImplTest.java
@@ -55,6 +55,7 @@ class BuildConfigOperationsImplTest {
     when(response.uri()).thenReturn(URI.create("https://localhost:8443/"));
 
     when(httpClient.newBuilder()
+        .tag(any())
         .readTimeout(anyLong(), any())
         .writeTimeout(anyLong(), any())
         .build()).thenReturn(httpClient);


### PR DESCRIPTION
## Description

Fixes #5121 

fix: RequestConfig is propagated to derived HttpClient instances

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
