### PR TITLE
ci: prevent builds from running when changes in documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'ide-config/**'
+      - '**.md'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,10 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'ide-config/**'
+      - '**.md'
   schedule:
     - cron: '0 1 * * *' # Every day at 1
 

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -21,6 +21,10 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'ide-config/**'
+      - '**.md'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -24,6 +24,10 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'ide-config/**'
+      - '**.md'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -24,6 +24,10 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'ide-config/**'
+      - '**.md'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,6 +22,10 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'ide-config/**'
+      - '**.md'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.


### PR DESCRIPTION
## Description
ci: prevent builds from running when changes in documentation

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
