### PR TITLE
refactor: don't expose StandardHttpHeaders internal Map

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
@@ -47,8 +47,4 @@ public class StandardHttpHeaders implements HttpHeaders {
   public Map<String, List<String>> headers() {
     return Collections.unmodifiableMap(headers);
   }
-
-  public Map<String, List<String>> getHeaders() {
-    return headers;
-  }
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestHttpResponse.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestHttpResponse.java
@@ -16,6 +16,8 @@
 package io.fabric8.kubernetes.client.http;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -29,6 +31,14 @@ public class TestHttpResponse<T> extends StandardHttpHeaders implements HttpResp
   private T body;
   private HttpRequest request;
   private HttpResponse<T> previousResponse;
+
+  public TestHttpResponse() {
+    super();
+  }
+
+  public TestHttpResponse(Map<String, List<String>> headers) {
+    super(headers);
+  }
 
   @Override
   public int code() {


### PR DESCRIPTION
## Description
refactor: don't expose StandardHttpHeaders internal Map

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
