### PR TITLE
fix #4662: a few cleanups and exposing more control over the discovery

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientBuilder.java
@@ -16,7 +16,6 @@
 
 package io.fabric8.kubernetes.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
@@ -49,7 +48,7 @@ public class KubernetesClientBuilder {
   private Class<KubernetesClient> clazz;
   private ExecutorSupplier executorSupplier;
   private Consumer<HttpClient.Builder> builderConsumer;
-  private KubernetesSerialization kubernetesSerialization = new KubernetesSerialization(new ObjectMapper());
+  private KubernetesSerialization kubernetesSerialization = new KubernetesSerialization();
 
   public KubernetesClientBuilder() {
     // basically the same logic as in KubernetesResourceUtil for finding list types

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.api.model.AuthInfo;
 import io.fabric8.kubernetes.api.model.NamedAuthInfo;
 import io.fabric8.kubernetes.api.model.NamedContext;
@@ -333,12 +332,12 @@ public class OpenIDConnectionUtils {
           String[] jwtParts = accessToken.split(JWT_PARTS_DELIMITER_REGEX);
           String jwtPayload = jwtParts[1];
           String jwtPayloadDecoded = new String(Base64.getDecoder().decode(jwtPayload));
-          Map<String, Object> jwtPayloadMap = Serialization.jsonMapper().readValue(jwtPayloadDecoded, Map.class);
+          Map<String, Object> jwtPayloadMap = Serialization.unmarshal(jwtPayloadDecoded, Map.class);
           int expiryTimestampInSeconds = (Integer) jwtPayloadMap.get(JWT_TOKEN_EXPIRY_TIMESTAMP_KEY);
           return Instant.ofEpochSecond(expiryTimestampInSeconds)
               .minusSeconds(TOKEN_EXPIRY_DELTA)
               .isBefore(Instant.now());
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
           return true;
         }
       }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java
@@ -204,7 +204,10 @@ public class Serialization {
    * @param type The {@link TypeReference}.
    * @param <T> Template argument denoting type
    * @return returns de-serialized object
+   *
+   * @deprecated use {@link KubernetesSerialization#unmarshal(InputStream, TypeReference)}
    */
+  @Deprecated
   public static <T> T unmarshal(InputStream is, TypeReference<T> type) {
     return kubernetesSerialization.unmarshal(is, type);
   }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReducedStateItemStoreTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReducedStateItemStoreTest.java
@@ -15,7 +15,6 @@
  */
 package io.fabric8.kubernetes.client.informers.cache;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
@@ -30,7 +29,7 @@ class ReducedStateItemStoreTest {
   @Test
   void testStoreRestore() {
     ReducedStateItemStore<Pod> store = new ReducedStateItemStore<>(ReducedStateItemStore.UID_KEY_STATE,
-        Pod.class, new KubernetesSerialization(new ObjectMapper()), "metadata.labels", "foo.bar");
+        Pod.class, new KubernetesSerialization(), "metadata.labels", "foo.bar");
 
     Pod pod = new PodBuilder().withNewSpec().endSpec().withNewMetadata().withUid("x").withName("y").addToLabels("one", "1")
         .addToLabels("two", "2").withResourceVersion("2").endMetadata().withNewStatus().endStatus().build();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/Handlers.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/Handlers.java
@@ -84,7 +84,7 @@ public final class Handlers {
       Client client) {
     // check if it's built-in
     Class<? extends KubernetesResource> clazz = client.adapt(BaseClient.class).getKubernetesSerialization()
-        .getRegisteredKind(apiVersion, kind);
+        .getRegisteredKubernetesResource(apiVersion, kind);
 
     ResourceDefinitionContext rdc = null;
     if (clazz != null) {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.impl.BaseClient;
 import io.fabric8.kubernetes.client.mock.crd.CronTab;
 import io.fabric8.kubernetes.client.mock.crd.CronTabSpec;
 import io.fabric8.kubernetes.client.mock.crd.CronTabStatus;
@@ -48,7 +47,7 @@ class CustomResourceCrudTest {
 
   @BeforeEach
   void setUp() {
-    client.adapt(BaseClient.class).getKubernetesSerialization().registerCustomKind("stable.example.com/v1", "CronTab",
+    client.getKubernetesSerialization().registerKubernetesResource("stable.example.com/v1", "CronTab",
         CronTab.class);
     cronTabCrd = client
         .apiextensions()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudWithCRDContextTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudWithCRDContextTest.java
@@ -38,7 +38,7 @@ class CustomResourceCrudWithCRDContextTest {
   @Test
   void testCreateAndGet() {
     // Given
-    client.adapt(BaseClient.class).getKubernetesSerialization().registerCustomKind("demo.fabric8.io/v1alpha1",
+    client.getKubernetesSerialization().registerKubernetesResource("demo.fabric8.io/v1alpha1",
         "EntandoBundleRelease", EntandoBundleRelease.class);
     MixedOperation<EntandoBundleRelease, EntandoBundleReleaseList, Resource<EntandoBundleRelease>> ebrClient = client
         .resources(EntandoBundleRelease.class, EntandoBundleReleaseList.class);
@@ -55,7 +55,7 @@ class CustomResourceCrudWithCRDContextTest {
   @Test
   void testCreateAndGetWithInferredContext() {
     // Given
-    client.adapt(BaseClient.class).getKubernetesSerialization().registerCustomKind("demo.fabric8.io/v1alpha1",
+    client.adapt(BaseClient.class).getKubernetesSerialization().registerKubernetesResource("demo.fabric8.io/v1alpha1",
         "EntandoBundleRelease", EntandoBundleRelease.class);
     MixedOperation<EntandoBundleRelease, KubernetesResourceList<EntandoBundleRelease>, Resource<EntandoBundleRelease>> ebrClient = client
         .resources(EntandoBundleRelease.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -42,7 +42,6 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
-import io.fabric8.kubernetes.client.impl.BaseClient;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
@@ -1166,7 +1165,7 @@ class DefaultSharedIndexInformerTest {
         r -> new WatchEvent(getAnimal("red-panda", "Carnivora", r), "ADDED"), null, null);
 
     // When
-    client.adapt(BaseClient.class).getKubernetesSerialization().registerCustomKind("jungle.example.com/v1", "Animal",
+    client.getKubernetesSerialization().registerKubernetesResource("jungle.example.com/v1", "Animal",
         CronTab.class);
     SharedIndexInformer<GenericKubernetesResource> animalSharedIndexInformer = client
         .genericKubernetesResources(animalContext)


### PR DESCRIPTION
## Description
A few naming refinements, cleanups, etc. mentioned on today's call.  While more verbose, we're more consistently using the the term KubernetesResource.

This also updates the constructor providing an objectmapper to elect to disable the classpath scanning via ServiceLoaders.  
I'm certainly open to refining this mechanism more once we be get more feedback on what's needed - in particular from Quarkus.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
