### PR TITLE
Various proxy changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #5164: [java-generator] handle more special characters in field names
 
 #### Improvements
+* Fix #1335: HttpClient Factory additionalConfig consistently applied for all client types
 
 #### Dependency Upgrade
 * Fix #4989: Upgrade Tekton Model to v0.47.0
@@ -19,6 +20,7 @@
 #### New Features
 * Fix #4184: Add utility methods for creating ConfigMap from files/directories in KubernetesResourceUtil
 * Fix #4829: Gradle Plugin for Java Generation from CRD
+* Fix #5086: Allow for supporting socks proxies via proxy urls with the socks4 or socks5 protocol.  Note that the JDK client does not support socks, and the Jetty client does not support socks5
 
 #### _**Note**_: Breaking changes
 * Fix #4911: Config/RequestConfig.scaleTimeout has been deprecated along with Scalable.scale(count, wait) and DeployableScalableResource.deployLatest(wait). withTimeout may be called before the operation to control the timeout.
@@ -29,6 +31,7 @@
 * Fix #4662: deprecated Helper.getAnnotationValue, use HasMetadata methods instead.
 * Fix #5125: support for TLSv1.3 is now enabled by default
 * Fix #5125: usage of TlsVersion.TLS_1_1, TLS_1_0, and SSL_3_0 have been deprecated
+* Fix #1335: The JDK and OkHttp clients will default to using the VM's standard configuration for proxies if an applicable proxy configuration is not found in the Kubernetes client Config
 
 ### 6.6.2 (2023-05-15)
 

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
@@ -16,10 +16,7 @@
 
 package io.fabric8.kubernetes.client.jdkhttp;
 
-import io.fabric8.kubernetes.client.http.BasicBuilder;
 import io.fabric8.kubernetes.client.http.HttpClient;
-import io.fabric8.kubernetes.client.http.HttpRequest;
-import io.fabric8.kubernetes.client.http.Interceptor;
 import io.fabric8.kubernetes.client.http.StandardHttpClientBuilder;
 import io.fabric8.kubernetes.client.http.TlsVersion;
 
@@ -64,18 +61,9 @@ class JdkHttpClientBuilderImpl
     }
     if (proxyAddress != null) {
       builder.proxy(ProxySelector.of(proxyAddress));
+      addProxyAuthInterceptor();
     } else {
       builder.proxy(java.net.http.HttpClient.Builder.NO_PROXY);
-    }
-    if (proxyAuthorization != null) {
-      this.interceptors.put("PROXY-AUTH", new Interceptor() {
-
-        @Override
-        public void before(BasicBuilder builder, HttpRequest httpRequest, RequestTags tags) {
-          builder.setHeader("Proxy-Authorization", proxyAuthorization);
-        }
-
-      });
     }
     if (preferHttp11) {
       builder.version(Version.HTTP_1_1);

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
-import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.dynamic.HttpClientTransportDynamic;
 import org.eclipse.jetty.client.http.HttpClientConnectionFactory;
 import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
@@ -79,17 +78,11 @@ public class JettyHttpClientBuilder
     sharedHttpClient.setMaxConnectionsPerDestination(MAX_CONNECTIONS);
     sharedWebSocketClient.getHttpClient().setMaxConnectionsPerDestination(MAX_CONNECTIONS);
     if (proxyAddress != null) {
-      sharedHttpClient.getProxyConfiguration().getProxies()
-          .add(new HttpProxy(new Origin.Address(proxyAddress.getHostString(), proxyAddress.getPort()), false));
+      sharedHttpClient.getProxyConfiguration()
+          .addProxy(new HttpProxy(new Origin.Address(proxyAddress.getHostString(), proxyAddress.getPort()), false));
+      addProxyAuthInterceptor();
     }
-    if (proxyAddress != null && proxyAuthorization != null) {
-      sharedHttpClient.getRequestListeners().add(new Request.Listener.Adapter() {
-        @Override
-        public void onBegin(Request request) {
-          request.headers(h -> h.put("Proxy-Authorization", proxyAuthorization));
-        }
-      });
-    }
+    clientFactory.additionalConfig(sharedHttpClient, sharedWebSocketClient);
     return new JettyHttpClient(this, sharedHttpClient, sharedWebSocketClient);
   }
 

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientFactory.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientFactory.java
@@ -15,12 +15,21 @@
  */
 package io.fabric8.kubernetes.client.jetty;
 
+import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.http.HttpClient;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 public class JettyHttpClientFactory implements HttpClient.Factory {
 
   @Override
   public JettyHttpClientBuilder newBuilder() {
     return new JettyHttpClientBuilder(this);
+  }
+
+  /**
+   * Additional configuration to be applied to the clients after the {@link Config} has been processed.
+   */
+  protected void additionalConfig(org.eclipse.jetty.client.HttpClient httpClient, WebSocketClient webSocketClient) {
+    // no default implementation
   }
 }

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactory.java
@@ -80,8 +80,6 @@ public class OkHttpClientFactory implements HttpClient.Factory {
         builderWrapper.preferHttp11();
       }
 
-      additionalConfig(httpClientBuilder);
-
       return builderWrapper;
     } catch (Exception e) {
       throw KubernetesClientException.launderThrowable(e);

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactoryTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientFactoryTest.java
@@ -20,7 +20,12 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClient.Builder;
 import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Proxy.Type;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -87,6 +92,21 @@ class OkHttpClientFactoryTest {
         .build();
     assertThat(client.getOkHttpClient().dispatcher())
         .hasFieldOrPropertyWithValue("maxRequests", 1337);
+  }
+
+  @Test
+  void proxyOverride() {
+    OkHttpClientFactory factory = new OkHttpClientFactory() {
+      @Override
+      protected void additionalConfig(Builder builder) {
+        builder.proxy(new Proxy(Type.SOCKS, InetSocketAddress.createUnresolved("foo", 1000)));
+      }
+
+    };
+
+    OkHttpClientImpl client = factory.newBuilder(Config.empty()).build();
+
+    assertEquals(Type.SOCKS, client.getOkHttpClient().proxy().type());
   }
 
 }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
@@ -25,7 +25,6 @@ import io.fabric8.kubernetes.client.http.WebSocketResponse;
 import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.UpgradeRejectedException;
@@ -47,15 +46,12 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
   private final List<VertxHttpClient<F>> derivedClients;
   private final Vertx vertx;
   private final HttpClient client;
-  private final String proxyAuthorization;
 
-  VertxHttpClient(VertxHttpClientBuilder<F> vertxHttpClientBuilder, WebClientOptions options,
-      String proxyAuthorization) {
+  VertxHttpClient(VertxHttpClientBuilder<F> vertxHttpClientBuilder, WebClientOptions options) {
     super(vertxHttpClientBuilder);
     derivedClients = Collections.synchronizedList(new ArrayList<>());
     this.vertx = vertxHttpClientBuilder.vertx;
     this.client = vertx.createHttpClient(options);
-    this.proxyAuthorization = proxyAuthorization;
   }
 
   @Override
@@ -109,11 +105,6 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
 
     if (request.getTimeout() != null) {
       options.setTimeout(request.getTimeout().toMillis());
-    }
-
-    // Proxy authorization is handled manually since the proxyAuthorization value is the actual header
-    if (proxyAuthorization != null) {
-      options.putHeader(HttpHeaders.PROXY_AUTHORIZATION, proxyAuthorization);
     }
 
     Optional.ofNullable(request.getContentType())

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.vertx;
 
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.http.StandardHttpClientBuilder;
 import io.fabric8.kubernetes.client.http.TlsVersion;
@@ -67,11 +68,11 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
       options.setFollowRedirects(followRedirects);
     }
 
-    if (this.proxyAddress != null) {
+    if (this.proxyType != HttpClient.ProxyType.DIRECT && this.proxyAddress != null) {
       ProxyOptions proxyOptions = new ProxyOptions()
           .setHost(this.proxyAddress.getHostName())
           .setPort(this.proxyAddress.getPort())
-          .setType(ProxyType.HTTP);
+          .setType(convertProxyType());
       options.setProxyOptions(proxyOptions);
       addProxyAuthInterceptor();
     }
@@ -122,6 +123,19 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
   @Override
   protected VertxHttpClientBuilder<F> newInstance(F clientFactory) {
     return new VertxHttpClientBuilder<>(clientFactory, vertx);
+  }
+
+  private ProxyType convertProxyType() {
+    switch (proxyType) {
+      case HTTP:
+        return ProxyType.HTTP;
+      case SOCKS4:
+        return ProxyType.SOCKS4;
+      case SOCKS5:
+        return ProxyType.SOCKS5;
+      default:
+        throw new KubernetesClientException("Unsupported proxy type");
+    }
   }
 
 }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -73,6 +73,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
           .setPort(this.proxyAddress.getPort())
           .setType(ProxyType.HTTP);
       options.setProxyOptions(proxyOptions);
+      addProxyAuthInterceptor();
     }
 
     final String[] protocols;
@@ -111,7 +112,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
     }
 
     // track derived clients to clean up properly
-    VertxHttpClient<F> result = new VertxHttpClient<>(this, options, proxyAddress != null ? proxyAuthorization : null);
+    VertxHttpClient<F> result = new VertxHttpClient<>(this, options);
     if (this.client != null) {
       this.client.addDerivedClient(result);
     }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
@@ -16,9 +16,11 @@
 
 package io.fabric8.kubernetes.client.vertx;
 
+import io.fabric8.kubernetes.client.Config;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystemOptions;
+import io.vertx.ext.web.client.WebClientOptions;
 
 import static io.vertx.core.spi.resolver.ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME;
 
@@ -55,5 +57,12 @@ public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http
       }
     }
     return vertx;
+  }
+
+  /**
+   * Additional configuration to be applied to the options after the {@link Config} has been processed.
+   */
+  protected void additionalConfig(WebClientOptions options) {
+    // no default implementation
   }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
@@ -30,6 +30,13 @@ import javax.net.ssl.TrustManager;
 
 public interface HttpClient extends AutoCloseable {
 
+  enum ProxyType {
+    HTTP,
+    SOCKS4,
+    SOCKS5,
+    DIRECT
+  }
+
   interface Factory {
 
     /**
@@ -114,6 +121,8 @@ public interface HttpClient extends AutoCloseable {
     Builder tlsVersions(TlsVersion... tlsVersions);
 
     Builder preferHttp11();
+
+    Builder proxyType(ProxyType type);
   }
 
   @Override

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClientBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClientBuilder.java
@@ -17,6 +17,7 @@
 package io.fabric8.kubernetes.client.http;
 
 import io.fabric8.kubernetes.client.http.HttpClient.DerivedClientBuilder;
+import io.fabric8.kubernetes.client.http.HttpClient.ProxyType;
 import io.fabric8.kubernetes.client.internal.SSLUtils;
 import lombok.Getter;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,7 @@ public abstract class StandardHttpClientBuilder<C extends HttpClient, F extends 
   protected TrustManager[] trustManagers;
   protected KeyManager[] keyManagers;
   protected LinkedHashMap<Class<?>, Object> tags = new LinkedHashMap<>();
+  protected ProxyType proxyType = ProxyType.HTTP; // for backwards compatibility if the builder is manually configured
 
   protected StandardHttpClientBuilder(F clientFactory) {
     this.clientFactory = clientFactory;
@@ -107,6 +109,12 @@ public abstract class StandardHttpClientBuilder<C extends HttpClient, F extends 
   }
 
   @Override
+  public T proxyType(ProxyType type) {
+    this.proxyType = type;
+    return (T) this;
+  }
+
+  @Override
   public T tlsVersions(TlsVersion... tlsVersions) {
     this.tlsVersions = tlsVersions;
     return (T) this;
@@ -148,6 +156,7 @@ public abstract class StandardHttpClientBuilder<C extends HttpClient, F extends 
     copy.authenticatorNone = this.authenticatorNone;
     copy.client = client;
     copy.tags = new LinkedHashMap<>(this.tags);
+    copy.proxyType = this.proxyType;
     return copy;
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClientBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClientBuilder.java
@@ -151,4 +151,17 @@ public abstract class StandardHttpClientBuilder<C extends HttpClient, F extends 
     return copy;
   }
 
+  protected void addProxyAuthInterceptor() {
+    if (proxyAuthorization != null) {
+      this.interceptors.put("PROXY-AUTH", new Interceptor() {
+
+        @Override
+        public void before(BasicBuilder builder, HttpRequest httpRequest, RequestTags tags) {
+          builder.setHeader(StandardHttpHeaders.PROXY_AUTHORIZATION, proxyAuthorization);
+        }
+
+      });
+    }
+  }
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
@@ -27,6 +27,7 @@ public class StandardHttpHeaders implements HttpHeaders {
   public static final String EXPECT = "Expect";
   public static final String EXPECT_CONTINUE = "100-continue";
   public static final String RETRY_AFTER = "Retry-After";
+  public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
 
   private final Map<String, List<String>> headers;
 


### PR DESCRIPTION
## Description

Fix #5086
Fix #1335 

- Addresses #5086 by allowing socks proxy urls to be used.  A new config HttpClient.Builder property called proxyType was added for this.  Based upon the implementations I used an enum, but you could also consider using a just a string to capture support for things like socks5h.

- There was also a bug with the vertx client and proxy support - the auth header was not being applied for websocket requests. The common interceptor was refactored and applied to vertx as well

- Addresses #1335 / #5086 by ensuring that additionalConfig can be used consistently across the client types - and applied just before the final client is built so that its changes are not overriden.  The changes also try to infer when it's okay to default the proxy configuration to whatever is supported to the client - we'll only force "no proxy" on the client when HttpConfigUtils determines our no.proxy / NO_PROXY setting is applicable.  If that seems too broad, then we'll need to introduce yet another config property.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
