### PR TITLE
set bignumbermode when creating tar for upload to pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.8-SNAPSHOT
 
 #### Bugs
+* Fix #5186: Support for Pod uploads with big numbers
 * Fix #5298: Prevent requests needing authentication from causing a 403 response
 * Fix #5221: Empty kube config file causes NPE
 * Fix #5281: Ensure the KubernetesCrudDispatcher's backing map is accessed w/lock

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestStandardHttpClientFactory.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestStandardHttpClientFactory.java
@@ -18,6 +18,8 @@ package io.fabric8.kubernetes.client.http;
 import lombok.Getter;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class TestStandardHttpClientFactory implements HttpClient.Factory {
 
@@ -32,4 +34,21 @@ public class TestStandardHttpClientFactory implements HttpClient.Factory {
   public final TestStandardHttpClient getInstance(int index) {
     return instances.toArray(new TestStandardHttpClient[0])[index];
   }
+
+  public final Stream<TestStandardHttpClientFactory> times(int iterations) {
+    return IntStream.range(0, iterations).mapToObj(i -> this);
+  }
+
+  public final void expect(String pathRegex, int statusCode) {
+    instances.forEach(c -> c.expect(pathRegex, statusCode));
+  }
+
+  public final void expect(String pathRegex, int statusCode, String body) {
+    instances.forEach(c -> c.expect(pathRegex, statusCode, body));
+  }
+
+  public final void expect(String pathRegex, int statusCode, byte[] body) {
+    instances.forEach(c -> c.expect(pathRegex, statusCode, body));
+  }
+
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -141,6 +141,7 @@ public class PodUpload {
     boolean uploaded = upload(operation, fileName, os -> {
       try (final TarArchiveOutputStream tar = new TarArchiveOutputStream(os)) {
         tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+        tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
         processor.process(tar);
       }
     });

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/UploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/UploadTest.java
@@ -1,0 +1,408 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.behavior;
+
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.CopyOrReadable;
+import io.fabric8.kubernetes.client.dsl.internal.uploadable.PodUpload;
+import io.fabric8.kubernetes.client.http.StandardHttpRequest;
+import io.fabric8.kubernetes.client.http.StandardWebSocketBuilder;
+import io.fabric8.kubernetes.client.http.TestStandardHttpClient;
+import io.fabric8.kubernetes.client.http.TestStandardHttpClientFactory;
+import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.http.WebSocketResponse;
+import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Pod Upload Behavior")
+class UploadTest {
+
+  private TestStandardHttpClientFactory factory;
+  private KubernetesClient client;
+  private TestStandardHttpClient httpClient;
+
+  @BeforeEach
+  void setUp() {
+    factory = new TestStandardHttpClientFactory();
+    client = new KubernetesClientBuilder().withHttpClientFactory(factory).build();
+    httpClient = factory.getInstances().iterator().next();
+  }
+
+  @Test
+  @DisplayName("With non-existent source path, should throw exception")
+  void uploadInvalidSourcePathShouldThrowException(@TempDir Path pathToUpload) {
+    // Given
+    final CopyOrReadable podUpload = client.pods().inNamespace("namespace").withName("pod")
+        .file("/target/location");
+    final Path nonExistentPath = pathToUpload.resolve("non-existent");
+    // When - Then
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> podUpload.upload(nonExistentPath))
+        .withMessage("Provided arguments are not valid (file, directory, path)");
+  }
+
+  @Test
+  @DisplayName("With valid source file and Pod with no containers, should throw exception")
+  void uploadInvalidTargetPodThrowException(@TempDir Path pathToUpload) throws IOException {
+    // Given
+    factory.expect("/api/v1/namespaces/namespace/pods", 200, "{\"metadata\": {}}");
+    factory.expect("/api/v1/namespaces/namespace/pods/valid-source", 200, "{\"metadata\": {}}");
+    final CopyOrReadable podUpload = client.pods().inNamespace("namespace").withName("valid-source")
+        .file("/target/location");
+    final Path validPath = Files.createFile(pathToUpload.resolve("file.txt"));
+    // When - Then
+    assertThatThrownBy(() -> podUpload.upload(validPath))
+        .isInstanceOf(KubernetesClientException.class)
+        .hasMessage("Pod has no containers!");
+  }
+
+  @Test
+  @DisplayName("With failed upload, attempts to delete temp file")
+  void uploadFailureDeletesTemp() {
+    // Given
+    final WebSocket webSocket = mock(WebSocket.class);
+    when(webSocket.send(any())).thenReturn(true);
+    final TestStandardHttpClient.WsFutureProvider future = (s, l) -> {
+      l.onOpen(webSocket);
+      l.onMessage(webSocket, ByteBuffer.wrap("\u0003 ".getBytes(StandardCharsets.UTF_8))); // exit
+      return CompletableFuture.completedFuture(new WebSocketResponse(new WebSocketUpgradeResponse(null), webSocket));
+    };
+    // Upload
+    // Delete
+    factory.times(2).forEach(i -> {
+      informPodReady("failure-pod");
+      httpClient.wsExpect("/api/v1/namespaces/.+/pods/failure-pod/exec", future);
+    });
+    // When
+    client.pods().inNamespace("default").withName("failure-pod").file("/target/location")
+        .upload(new File(Objects.requireNonNull(PodUpload.class.getResource("/upload/upload-sample.txt")).getFile()).toPath());
+    // Then
+    assertThat(httpClient.getRecordedBuildWebSocketDirects())
+        .element(1)
+        .extracting(TestStandardHttpClient.RecordedBuildWebSocketDirect::getStandardWebSocketBuilder)
+        .extracting(StandardWebSocketBuilder::asHttpRequest)
+        .extracting(StandardHttpRequest::uri)
+        .extracting(URI::getQuery).asString()
+        .contains("command=rm /tmp/fabric8-");
+  }
+
+  @Nested
+  @DisplayName("Successful")
+  class Success {
+
+    private ScheduledExecutorService executorService;
+
+    private WebSocket webSocket;
+    private Path toUpload;
+
+    @BeforeEach
+    void setUp() {
+      executorService = Executors.newSingleThreadScheduledExecutor();
+      final AtomicInteger tarByteCount = new AtomicInteger(0);
+      webSocket = mock(WebSocket.class);
+      when(webSocket.send(any())).thenAnswer(i -> {
+        tarByteCount.addAndGet(i.<ByteBuffer> getArgument(0).remaining() - 1);
+        return true;
+      });
+      final TestStandardHttpClient.WsFutureProvider future = (s, l) -> {
+        l.onOpen(webSocket);
+        if (s.asHttpRequest().uri().getQuery().contains("command=wc -c")) {
+          l.onMessage(webSocket, ByteBuffer.wrap(("\u0001" + tarByteCount.get() + "\n").getBytes(StandardCharsets.UTF_8)));
+        }
+        // Needs a short delay to be able to process the previous message (TODO: this should be fixed in the production code)
+        executorService.schedule(() -> l.onMessage(webSocket, exitZeroEvent()), 100, TimeUnit.MILLISECONDS);
+        return CompletableFuture.completedFuture(new WebSocketResponse(new WebSocketUpgradeResponse(null), webSocket));
+      };
+      // Upload
+      // Word Count
+      // Extract Tar
+      factory.times(3).forEach(i -> {
+        informPodReady("success-pod");
+        httpClient.wsExpect("/api/v1/namespaces/.+/pods/success-pod/exec", future);
+      });
+    }
+
+    @AfterEach
+    void tearDown() {
+      executorService.shutdownNow();
+    }
+
+    @Nested
+    @DisplayName("File")
+    class SingleFile {
+
+      @BeforeEach
+      void setUp() {
+        toUpload = new File(Objects.requireNonNull(PodUpload.class.getResource("/upload/upload-sample.txt"))
+            .getFile()).toPath();
+      }
+
+      @Test
+      @DisplayName("upload, returns true")
+      void uploadReturnsTrue() {
+        // When
+        final boolean result = client.pods().inNamespace("default").withName("success-pod").file("/target/location")
+            .upload(toUpload);
+        // Then
+        assertThat(result).isTrue();
+      }
+
+      @Test
+      @DisplayName("creates temp directory and pipes compressed file in server")
+      void createsTempDirectoryAndPipesFileInServer() {
+        // When
+        client.pods().inNamespace("default").withName("success-pod").file("/target/location")
+            .upload(toUpload);
+        // Then
+        assertThat(httpClient.getRecordedBuildWebSocketDirects())
+            .element(0)
+            .extracting(TestStandardHttpClient.RecordedBuildWebSocketDirect::getStandardWebSocketBuilder)
+            .extracting(StandardWebSocketBuilder::asHttpRequest)
+            .extracting(StandardHttpRequest::uri)
+            .extracting(URI::getQuery).asString()
+            .contains("command=mkdir -p '/tmp' && cat - > '/tmp/fabric8-");
+      }
+
+      @Test
+      @DisplayName("verifies uploaded tar size in server")
+      void verifiesUploadedTarSize() {
+        // When
+        client.pods().inNamespace("default").withName("success-pod").file("/target/location")
+            .upload(toUpload);
+        // Then
+        assertThat(httpClient.getRecordedBuildWebSocketDirects())
+            .element(1)
+            .extracting(TestStandardHttpClient.RecordedBuildWebSocketDirect::getStandardWebSocketBuilder)
+            .extracting(StandardWebSocketBuilder::asHttpRequest)
+            .extracting(StandardHttpRequest::uri)
+            .extracting(URI::getQuery).asString()
+            .contains("command=wc -c < '/tmp/fabric8-");
+      }
+
+      @Test
+      @DisplayName("extracts tar with file to final location in server")
+      void extractsTar() {
+        // When
+        client.pods().inNamespace("default").withName("success-pod").file("/target-dir/location")
+            .upload(toUpload);
+        // Then
+        assertThat(httpClient.getRecordedBuildWebSocketDirects())
+            .element(2)
+            .extracting(TestStandardHttpClient.RecordedBuildWebSocketDirect::getStandardWebSocketBuilder)
+            .extracting(StandardWebSocketBuilder::asHttpRequest)
+            .extracting(StandardHttpRequest::uri)
+            .extracting(URI::getQuery).asString()
+            .matches(
+                ".+command=mkdir -p '/target-dir'; tar -C '/target-dir' -xmf /tmp/fabric8-.+\\.tar; e=\\$\\?; rm /tmp/fabric8-.+");
+      }
+
+      @Nested
+      @DisplayName("Tar compression")
+      class TarCompression {
+
+        private ArgumentCaptor<ByteBuffer> sendCaptor;
+
+        @BeforeEach
+        void setUp() {
+          sendCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        }
+
+        @Test
+        @DisplayName("Creates a valid Tar archive from file")
+        void validTarArchive() throws Exception {
+          // When
+          client.pods().inNamespace("default").withName("success-pod").file("/target-dir/file-name.txt")
+              .upload(toUpload);
+          // Then
+          verify(webSocket).send(sendCaptor.capture());
+          // First byte is the WebSocket Flag (0) (discard it)
+          final byte[] tarBytes = new byte[sendCaptor.getValue().remaining() - 1];
+          System.arraycopy(sendCaptor.getValue().array(), 1, tarBytes, 0, tarBytes.length);
+          final TarArchiveInputStream tar = new TarArchiveInputStream(new ByteArrayInputStream(tarBytes));
+          assertThat(tar.getNextTarEntry())
+              .hasFieldOrPropertyWithValue("name", "file-name.txt")
+              .hasFieldOrPropertyWithValue("size", toUpload.toFile().length());
+        }
+
+        @Test
+        @DisplayName("Long file names supported (POSIX)")
+        void longFileNamesSupported() throws Exception {
+          // Given
+          final String longFileName = String.format("long-file%-100s.txt", "-");
+          // When
+          client.pods().inNamespace("default").withName("success-pod")
+              .file("/target-dir/" + longFileName)
+              .upload(toUpload);
+          // Then
+          verify(webSocket).send(sendCaptor.capture());
+          // First byte is the WebSocket Flag (0) (discard it)
+          final byte[] tarBytes = new byte[sendCaptor.getValue().remaining() - 1];
+          System.arraycopy(sendCaptor.getValue().array(), 1, tarBytes, 0, tarBytes.length);
+          final TarArchiveInputStream tar = new TarArchiveInputStream(new ByteArrayInputStream(tarBytes));
+          assertThat(tar.getNextTarEntry())
+              .hasFieldOrPropertyWithValue("name", longFileName);
+        }
+
+        @Test
+        @DisplayName("Big numbers supported (POSIX)")
+        void bigNumbersSupported(@TempDir Path tempDir) throws Exception {
+          // When
+          final Path toUploadWithModifiedDate = Files.copy(toUpload, tempDir.resolve("upload-sample.txt"));
+          toUploadWithModifiedDate.toFile().setLastModified(9999999999999L); // Would trigger IllegalArgumentException: last modification time '9999999999' is too big ( > 8589934591 ).
+          client.pods().inNamespace("default").withName("success-pod").file("/target-dir/file-name.txt")
+              .upload(toUploadWithModifiedDate);
+          // Then
+          verify(webSocket).send(sendCaptor.capture());
+          // First byte is the WebSocket Flag (0) (discard it)
+          final byte[] tarBytes = new byte[sendCaptor.getValue().remaining() - 1];
+          System.arraycopy(sendCaptor.getValue().array(), 1, tarBytes, 0, tarBytes.length);
+          final TarArchiveInputStream tar = new TarArchiveInputStream(new ByteArrayInputStream(tarBytes));
+          assertThat(tar.getNextTarEntry())
+              .hasFieldOrPropertyWithValue("name", "file-name.txt")
+              .hasFieldOrPropertyWithValue("lastModifiedTime", FileTime.fromMillis(9999999999999L));
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("Directory")
+    class Directory {
+
+      @BeforeEach
+      void setUp() {
+        toUpload = new File(Objects.requireNonNull(PodUpload.class.getResource("/upload_long"))
+            .getFile()).toPath();
+        assertThat(toUpload).isDirectory();
+      }
+
+      @Test
+      @DisplayName("upload, returns true")
+      void uploadReturnsTrue() {
+        // When
+        final boolean result = client.pods().inNamespace("default").withName("success-pod").dir("/target/location")
+            .upload(toUpload);
+        // Then
+        assertThat(result).isTrue();
+      }
+
+      @Test
+      @DisplayName("creates temp directory and pipes compressed directory in server")
+      void createsTempDirectoryAndPipesDirInServer() {
+        // When
+        client.pods().inNamespace("default").withName("success-pod").dir("/target/location")
+            .upload(toUpload);
+        // Then
+        assertThat(httpClient.getRecordedBuildWebSocketDirects())
+            .element(0)
+            .extracting(TestStandardHttpClient.RecordedBuildWebSocketDirect::getStandardWebSocketBuilder)
+            .extracting(StandardWebSocketBuilder::asHttpRequest)
+            .extracting(StandardHttpRequest::uri)
+            .extracting(URI::getQuery).asString()
+            .contains("command=mkdir -p '/tmp' && cat - > '/tmp/fabric8-");
+      }
+
+      @Test
+      @DisplayName("verifies uploaded tar size in server")
+      void verifiesUploadedTarSize() {
+        // When
+        client.pods().inNamespace("default").withName("success-pod").dir("/target/location")
+            .upload(toUpload);
+        // Then
+        assertThat(httpClient.getRecordedBuildWebSocketDirects())
+            .element(1)
+            .extracting(TestStandardHttpClient.RecordedBuildWebSocketDirect::getStandardWebSocketBuilder)
+            .extracting(StandardWebSocketBuilder::asHttpRequest)
+            .extracting(StandardHttpRequest::uri)
+            .extracting(URI::getQuery).asString()
+            .contains("command=wc -c < '/tmp/fabric8-");
+      }
+
+      @Test
+      @DisplayName("extracts tar with file to final location in server")
+      void extractsTar() {
+        // When
+        client.pods().inNamespace("default").withName("success-pod").dir("/target-dir/location")
+            .upload(toUpload);
+        // Then
+        assertThat(httpClient.getRecordedBuildWebSocketDirects())
+            .element(2)
+            .extracting(TestStandardHttpClient.RecordedBuildWebSocketDirect::getStandardWebSocketBuilder)
+            .extracting(StandardWebSocketBuilder::asHttpRequest)
+            .extracting(StandardHttpRequest::uri)
+            .extracting(URI::getQuery).asString()
+            .matches(
+                ".+command=mkdir -p '/target-dir/location'; tar -C '/target-dir/location' -xmf /tmp/fabric8-.+\\.tar; e=\\$\\?; rm /tmp/fabric8-.+");
+      }
+
+    }
+
+  }
+
+  private ByteBuffer exitZeroEvent() {
+    final Status success = new StatusBuilder().withStatus("Success").build();
+    return ByteBuffer.wrap(("\u0003" + client.getKubernetesSerialization().asJson(success)).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private void informPodReady(String podName) {
+    final PodList podReadyList = new PodListBuilder()
+        .withNewMetadata().endMetadata()
+        .addNewItem()
+        .withNewMetadata().withName(podName).endMetadata()
+        .withNewSpec().addNewContainer().withName(podName).endContainer().endSpec()
+        .withNewStatus().addNewCondition().withType("Ready").withStatus("True").endCondition().endStatus()
+        .endItem()
+        .build();
+    factory.expect("/api/v1/namespaces/.+/pods",
+        200, client.getKubernetesSerialization().asJson(podReadyList));
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -15,82 +15,19 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.uploadable;
 
-import io.fabric8.kubernetes.client.dsl.TtyExecErrorable;
-import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import io.fabric8.kubernetes.client.utils.InputStreamPumper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PodUploadTest {
-
-  private PodOperationsImpl operation;
-
-  @FunctionalInterface
-  public interface PodUploadTester<R> {
-    R apply() throws IOException, InterruptedException;
-  }
-
-  @BeforeEach
-  void setUp() {
-    this.operation = Mockito.mock(PodOperationsImpl.class, Mockito.RETURNS_DEEP_STUBS);
-  }
-
-  @Test
-  @DisplayName("With invalid parameters, should throw exception")
-  void uploadInvalidParametersShouldThrowException(@TempDir Path pathToUpload) {
-    final Path nonExistentPath = pathToUpload.resolve("non-existent");
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> PodUpload.upload(operation, nonExistentPath))
-        .withMessage("Provided arguments are not valid (file, directory, path)");
-  }
-
-  @Test
-  void upload_withFile_shouldUploadFile() throws IOException, InterruptedException {
-    final Path toUpload = new File(PodUpload.class.getResource("/upload/upload-sample.txt").getFile())
-        .toPath();
-    uploadFileAndVerify(() -> PodUpload.upload(operation, toUpload), false, 2560);
-  }
-
-  @Test
-  void uploadFileData_whenByteArrayInputStreamProvided_shouldUploadFile() throws IOException, InterruptedException {
-    InputStream inputStream = new ByteArrayInputStream("test data".getBytes());
-    uploadFileAndVerify(() -> PodUpload.uploadFileData(operation, inputStream), true, 9);
-  }
-
-  @Test
-  void upload_withDirectory_shouldUploadDirectory() throws Exception {
-    final Path toUpload = new File(PodUpload.class.getResource("/upload").getFile())
-        .toPath();
-    uploadDirectoryAndVerify(() -> PodUpload.upload(operation, toUpload), 2560);
-  }
-
-  @Test
-  void upload_withDirectoryAndLongFileNames_shouldUploadDirectory() throws Exception {
-    final Path toUpload = new File(PodUpload.class.getResource("/upload_long").getFile())
-        .toPath();
-    uploadDirectoryAndVerify(() -> PodUpload.upload(operation, toUpload), 5120);
-  }
 
   @Test
   void transferTo() throws Exception {
@@ -104,92 +41,41 @@ class PodUploadTest {
     assertThat(copiedStream).hasValue("I'LL BE COPIED");
   }
 
-  @Test
-  void createExecCommandForUpload_withFileInRootPath_shouldCreateValidExecCommandForUpload() {
-    // When
-    String result = PodUpload.createExecCommandForUpload("/cp.log");
-    // Then
-    assertThat(result).isEqualTo("mkdir -p '/' && cat - > '/cp.log'");
-  }
-
-  @Test
-  void createExecCommandForUpload_withNormalFile_shouldCreateValidExecCommandForUpload() {
-    // When
-    String result = PodUpload.createExecCommandForUpload("/tmp/foo/cp.log");
-    // Then
-    assertThat(result).isEqualTo("mkdir -p '/tmp/foo' && cat - > '/tmp/foo/cp.log'");
-  }
-
-  @Test
-  void createExecCommandForUpload_withSingleQuoteInPath() {
-    // When
-    String result = PodUpload.createExecCommandForUpload("/tmp/fo'o/cp.log");
-    // Then
-    assertThat(result).isEqualTo("mkdir -p '/tmp/fo\'\\'\'o' && cat - > '/tmp/fo\'\\'\'o/cp.log'");
-  }
-
-  @Test
-  void createExecCommandForUpload_withMultipleSingleQuotesInPath() {
-    // When
-    String result = PodUpload.createExecCommandForUpload("/tmp/f'o'o/c'p.log");
-    // Then
-    assertThat(result).isEqualTo("mkdir -p '/tmp/f\'\\'\'o\'\\'\'o' && cat - > '/tmp/f\'\\'\'o\'\\'\'o/c\'\\'\'p.log'");
-  }
-
-  void uploadFileAndVerify(PodUploadTester<Boolean> fileUploadMethodToTest, boolean stream, long size)
-      throws IOException, InterruptedException {
-    Mockito.when(this.operation.getContext().getFile()).thenReturn("/mock/file");
-    if (!stream) {
-      verifyTar(fileUploadMethodToTest, size, "/mock");
-      return;
+  @Nested
+  @DisplayName("createExecCommandForUpload")
+  class CreateExecCommand {
+    @Test
+    void withFileInRootPath_shouldCreateValidExecCommandForUpload() {
+      // When
+      String result = PodUpload.createExecCommandForUpload("/cp.log");
+      // Then
+      assertThat(result).isEqualTo("mkdir -p '/' && cat - > '/cp.log'");
     }
-    Mockito.when(this.operation.writingOutput(Mockito.any())).then((Answer<TtyExecErrorable>) invocation -> {
-      OutputStream out = invocation.getArgument(0);
-      out.write((size + "\n").getBytes(StandardCharsets.UTF_8));
-      return operation;
-    });
-    boolean result = fileUploadMethodToTest.apply();
-    assertThat(result).isTrue();
 
-    ArgumentCaptor<String[]> captorUpload = ArgumentCaptor.forClass(String[].class);
-    Mockito.verify(operation.redirectingInput().terminateOnError(), Mockito.times(1)).exec(captorUpload.capture());
-    assertEquals("mkdir -p '/mock' && cat - > '/mock/file'", captorUpload.getValue()[2]);
+    @Test
+    void withNormalFile_shouldCreateValidExecCommandForUpload() {
+      // When
+      String result = PodUpload.createExecCommandForUpload("/tmp/foo/cp.log");
+      // Then
+      assertThat(result).isEqualTo("mkdir -p '/tmp/foo' && cat - > '/tmp/foo/cp.log'");
+    }
 
-    ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
-    Mockito.verify(operation, Mockito.times(1)).exec(captor.capture());
-    assertEquals("wc -c < '/mock/file'", captor.getValue()[2]);
-  }
+    //
+    @Test
+    void withSingleQuoteInPath() {
+      // When
+      String result = PodUpload.createExecCommandForUpload("/tmp/fo'o/cp.log");
+      // Then
+      assertThat(result).isEqualTo("mkdir -p '/tmp/fo\'\\'\'o' && cat - > '/tmp/fo\'\\'\'o/cp.log'");
+    }
 
-  private void uploadDirectoryAndVerify(PodUploadTester<Boolean> directoryUpload, long size)
-      throws IOException, InterruptedException {
-    Mockito.when(this.operation.getContext().getDir()).thenReturn("/mock/dir");
-    verifyTar(directoryUpload, size, "/mock/dir");
-  }
-
-  private void verifyTar(PodUploadTester<Boolean> directoryUpload, long size, String dir)
-      throws IOException, InterruptedException {
-    Mockito.when(this.operation.writingOutput(Mockito.any())).then((Answer<TtyExecErrorable>) invocation -> {
-      OutputStream out = invocation.getArgument(0);
-      out.write((size + "\n").getBytes(StandardCharsets.UTF_8));
-      return operation;
-    });
-    boolean result = directoryUpload.apply();
-    assertThat(result).isTrue();
-
-    ArgumentCaptor<String[]> captorUpload = ArgumentCaptor.forClass(String[].class);
-    Mockito.verify(operation.redirectingInput().terminateOnError(), Mockito.times(1)).exec(captorUpload.capture());
-    assertTrue(captorUpload.getValue()[2].startsWith("mkdir -p '/tmp' && cat - > '/tmp/fabric8-"));
-
-    ArgumentCaptor<String[]> captorCount = ArgumentCaptor.forClass(String[].class);
-    Mockito.verify(operation, Mockito.times(1)).exec(captorCount.capture());
-    assertTrue(captorCount.getValue()[2].startsWith("wc -c < '/tmp/fabric8-"));
-
-    ArgumentCaptor<String[]> captorExtract = ArgumentCaptor.forClass(String[].class);
-    Mockito.verify(operation.redirectingInput()).exec(captorExtract.capture());
-
-    String extractCommand = captorExtract.getValue()[2];
-    assertTrue(extractCommand.startsWith(String.format("mkdir -p '%1$s'; tar -C '%1$s' -xmf /tmp/fabric8-", dir)),
-        extractCommand);
+    @Test
+    void withMultipleSingleQuotesInPath() {
+      // When
+      String result = PodUpload.createExecCommandForUpload("/tmp/f'o'o/c'p.log");
+      // Then
+      assertThat(result).isEqualTo("mkdir -p '/tmp/f\'\\'\'o\'\\'\'o' && cat - > '/tmp/f\'\\'\'o\'\\'\'o/c\'\\'\'p.log'");
+    }
   }
 
 }

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsTimeoutTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/internal/build/BuildConfigOperationsTimeoutTest.java
@@ -17,9 +17,6 @@
 package io.fabric8.openshift.client.dsl.internal.build;
 
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.http.AsyncBody;
-import io.fabric8.kubernetes.client.http.TestAsyncBody;
-import io.fabric8.kubernetes.client.http.TestHttpResponse;
 import io.fabric8.kubernetes.client.http.TestStandardHttpClient;
 import io.fabric8.kubernetes.client.http.TestStandardHttpClientFactory;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -29,10 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,14 +45,8 @@ class BuildConfigOperationsTimeoutTest {
   @Test
   void buildConfigHasZeroTimeout() {
     // Given
-    factory.getInstance(1)
-        .expect("/apis/build.openshift.io/v1/namespaces/.+/buildconfigs/foo/instantiatebinary", (r, c) -> {
-          final AsyncBody body = new TestAsyncBody();
-          c.consume(
-              Collections.singletonList(ByteBuffer.wrap(("{\"metadata\": {},\"items\":[]}").getBytes(StandardCharsets.UTF_8))),
-              body);
-          return CompletableFuture.completedFuture(new TestHttpResponse<AsyncBody>().withCode(200).withBody(body));
-        });
+    factory.expect("/apis/build.openshift.io/v1/namespaces/.+/buildconfigs/foo/instantiatebinary",
+        200, "{\"metadata\": {},\"items\":[]}");
     // When
     client.buildConfigs().inNamespace("default").withName("foo").instantiateBinary()
         .fromInputStream(new ByteArrayInputStream("bar".getBytes(StandardCharsets.UTF_8)));
@@ -73,6 +61,5 @@ class BuildConfigOperationsTimeoutTest {
         .extracting("timeout")
         .asInstanceOf(InstanceOfAssertFactories.DURATION)
         .hasSeconds(0);
-    ;
   }
 }


### PR DESCRIPTION
## Description

Set bignumbermode when creating tar files for uploading to pod.

Bignumbermode is required to support large UIDs, which are commonly used on e.g. Openshift.

Integration tests already do the same thing:
https://github.com/fabric8io/kubernetes-client/blob/f6ea58c62e818a53f6c261a1c7a9549c138c8d88/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildIT.java#L125

## Type of change

Bugfix, to avoid this type of error:
```
Caused by: java.lang.IllegalArgumentException: user id '1000990000' is too big ( > 2097151 ).
	at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.failForBigNumber(TarArchiveOutputStream.java:406)
	at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.failForBigNumber(TarArchiveOutputStream.java:400)
	at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.failForBigNumbers(TarArchiveOutputStream.java:418)
	at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.putArchiveEntry(TarArchiveOutputStream.java:592)
	at io.fabric8.kubernetes.client.dsl.internal.uploadable.PodUpload.addFileToTar(PodUpload.java:178)
```

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

