### PR TITLE
fix #5141: remove junit5 junit-jupiter-migrationsupport dependency from codebase

### DIFF
--- a/extensions/camel-k/model-v1/pom.xml
+++ b/extensions/camel-k/model-v1/pom.xml
@@ -68,11 +68,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/extensions/camel-k/model-v1alpha1/pom.xml
+++ b/extensions/camel-k/model-v1alpha1/pom.xml
@@ -75,11 +75,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <scope>provided</scope>

--- a/extensions/certmanager/client/pom.xml
+++ b/extensions/certmanager/client/pom.xml
@@ -92,11 +92,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/extensions/certmanager/model-v1/pom.xml
+++ b/extensions/certmanager/model-v1/pom.xml
@@ -72,11 +72,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/certmanager/model-v1alpha2/pom.xml
+++ b/extensions/certmanager/model-v1alpha2/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/certmanager/model-v1alpha3/pom.xml
+++ b/extensions/certmanager/model-v1alpha3/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/certmanager/model-v1beta1/pom.xml
+++ b/extensions/certmanager/model-v1beta1/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/chaosmesh/model/pom.xml
+++ b/extensions/chaosmesh/model/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-agent/pom.xml
+++ b/extensions/open-cluster-management/model-agent/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-apps/pom.xml
+++ b/extensions/open-cluster-management/model-apps/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-cluster/pom.xml
+++ b/extensions/open-cluster-management/model-cluster/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-discovery/pom.xml
+++ b/extensions/open-cluster-management/model-discovery/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-observability/pom.xml
+++ b/extensions/open-cluster-management/model-observability/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-operator/pom.xml
+++ b/extensions/open-cluster-management/model-operator/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-placementruleapps/pom.xml
+++ b/extensions/open-cluster-management/model-placementruleapps/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-policy/pom.xml
+++ b/extensions/open-cluster-management/model-policy/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/open-cluster-management/model-search/pom.xml
+++ b/extensions/open-cluster-management/model-search/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/service-catalog/model/pom.xml
+++ b/extensions/service-catalog/model/pom.xml
@@ -63,11 +63,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/tekton/model-triggers-v1alpha1/pom.xml
+++ b/extensions/tekton/model-triggers-v1alpha1/pom.xml
@@ -68,11 +68,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/extensions/tekton/model-triggers-v1beta1/pom.xml
+++ b/extensions/tekton/model-triggers-v1beta1/pom.xml
@@ -68,11 +68,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/extensions/tekton/model-v1/pom.xml
+++ b/extensions/tekton/model-v1/pom.xml
@@ -66,11 +66,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <scope>provided</scope>

--- a/extensions/tekton/model-v1alpha1/pom.xml
+++ b/extensions/tekton/model-v1alpha1/pom.xml
@@ -66,11 +66,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <scope>provided</scope>

--- a/extensions/tekton/model-v1beta1/pom.xml
+++ b/extensions/tekton/model-v1beta1/pom.xml
@@ -68,11 +68,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/extensions/tekton/tests/pom.xml
+++ b/extensions/tekton/tests/pom.xml
@@ -53,12 +53,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>

--- a/extensions/verticalpodautoscaler/model-v1/pom.xml
+++ b/extensions/verticalpodautoscaler/model-v1/pom.xml
@@ -68,11 +68,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/extensions/volumesnapshot/model/pom.xml
+++ b/extensions/volumesnapshot/model/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/HttpBodyStreamTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/HttpBodyStreamTest.java
@@ -24,9 +24,9 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.StreamResetException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,8 +34,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpBodyStreamTest {
 
@@ -44,7 +44,7 @@ public class HttpBodyStreamTest {
   private volatile Handler<HttpServerRequest> requestHandler;
   private HttpClient.Factory clientFactory = new VertxHttpClientFactory();
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     vertx = Vertx.vertx();
     server = vertx.createHttpServer().requestHandler(req -> {
@@ -58,7 +58,7 @@ public class HttpBodyStreamTest {
     server.listen(8080).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
     vertx.close().toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
   }

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/HttpBodyStreamTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/HttpBodyStreamTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class HttpBodyStreamTest {
+class HttpBodyStreamTest {
 
   private Vertx vertx;
   private HttpServer server;
@@ -64,7 +64,7 @@ public class HttpBodyStreamTest {
   }
 
   @Test
-  public void testStreamFlowControl() throws Exception {
+  void testStreamFlowControl() throws Exception {
 
     AtomicInteger bytesSent = new AtomicInteger();
     AtomicInteger data = new AtomicInteger('A');
@@ -106,7 +106,7 @@ public class HttpBodyStreamTest {
   }
 
   @Test
-  public void testStreamError() throws Exception {
+  void testStreamError() throws Exception {
 
     requestHandler = req -> {
     };
@@ -135,7 +135,7 @@ public class HttpBodyStreamTest {
   }
 
   @Test
-  public void testStackOverflow() throws Exception {
+  void testStackOverflow() throws Exception {
 
     requestHandler = req -> {
       AtomicInteger size = new AtomicInteger();

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
@@ -25,16 +25,16 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SelfSignedCertificate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SslTest {
 
@@ -44,7 +44,7 @@ public class SslTest {
   private HttpClient.Factory clientFactory = new VertxHttpClientFactory();
   private TrustManager[] trustManagers;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     SelfSignedCertificate cert = SelfSignedCertificate.create();
     vertx = Vertx.vertx();
@@ -64,7 +64,7 @@ public class SslTest {
     trustManagers = tmf.getTrustManagers();
   }
 
-  @After
+  @AfterEach
   public void after() throws Exception {
     vertx.close().toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
   }

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
@@ -36,7 +36,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SslTest {
+class SslTest {
 
   private Vertx vertx;
   private HttpServer server;
@@ -70,7 +70,7 @@ public class SslTest {
   }
 
   @Test
-  public void testGet() throws Exception {
+  void testGet() throws Exception {
     requestHandler = req -> {
       req.response().end("OK");
     };

--- a/junit/kubernetes-server-mock/pom.xml
+++ b/junit/kubernetes-server-mock/pom.xml
@@ -49,12 +49,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>

--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -197,11 +197,6 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.client.http.TlsVersion;
 import io.fabric8.kubernetes.client.lib.FileSystem;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -40,9 +39,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -394,7 +393,7 @@ class ConfigTest {
     Config config = new Config();
     assertNotNull(config);
     assertEquals("http://somehost:80/", config.getMasterUrl());
-    Assertions.assertNull(config.getNamespace());
+    assertNull(config.getNamespace());
   }
 
   @Test

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -39,13 +39,13 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReducedStateItemStoreTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReducedStateItemStoreTest.java
@@ -20,9 +20,9 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ReducedStateItemStoreTest {
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReducedStateItemStoreTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/ReducedStateItemStoreTest.java
@@ -20,8 +20,8 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ReducedStateItemStoreTest {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/KubernetesVersionPriorityTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/KubernetesVersionPriorityTest.java
@@ -22,10 +22,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KubernetesVersionPriorityTest {
+class KubernetesVersionPriorityTest {
 
   @Test
-  public void should_version_with_highest_priority() {
+  void should_version_with_highest_priority() {
     // given
     String highest = "v10";
     List<String> versions = Arrays.asList(

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/KubernetesVersionPriorityTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/KubernetesVersionPriorityTest.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.kubernetes.client.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/PodStatusUtilTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/PodStatusUtilTest.java
@@ -18,7 +18,7 @@ package io.fabric8.kubernetes.client.utils;
 
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/PodStatusUtilTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/PodStatusUtilTest.java
@@ -31,7 +31,7 @@ import static io.fabric8.kubernetes.client.utils.PodMockUtils.containerStatus;
 import static io.fabric8.kubernetes.client.utils.PodMockUtils.pod;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PodStatusUtilTest {
+class PodStatusUtilTest {
 
   private ContainerStatus runningReady = containerStatus(
       true,
@@ -41,7 +41,7 @@ public class PodStatusUtilTest {
           containerStateRunning()));
 
   @Test
-  public void isRunning_should_return_true_if_pod_is_in_phase_running() {
+  void isRunning_should_return_true_if_pod_is_in_phase_running() {
     // given
     Pod pod = pod("starwars")
         .status("Running", "<Darth Vader has lost its sabre>")
@@ -53,7 +53,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_true_if_pod_has_reason_running() {
+  void isRunning_should_return_true_if_pod_has_reason_running() {
     // given
     Pod pod = pod("anakin")
         .status("<transition to the dark side>", "Running")
@@ -65,7 +65,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_false_if_pod_has_deletion_Timestamp() {
+  void isRunning_should_return_false_if_pod_has_deletion_Timestamp() {
     // given
     Pod pod = pod("some pod")
         .status("", "")
@@ -78,7 +78,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_false_if_pod_is_initializing() {
+  void isRunning_should_return_false_if_pod_is_initializing() {
     // given
     Pod pod = pod("some pod")
         .setInitializing()
@@ -90,7 +90,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isInitializing_should_return_false_if_pod_has_no_initContainerStatus() {
+  void isInitializing_should_return_false_if_pod_has_no_initContainerStatus() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -103,7 +103,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isInitializing_should_return_true_if_pod_has_initContainerStatus_without_state() {
+  void isInitializing_should_return_true_if_pod_has_initContainerStatus_without_state() {
     // given
     Pod pod = pod("some pod")
         .initContainerStatus()
@@ -115,7 +115,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isInitializing_should_return_true_if_pod_has_initContainerStatus_without_terminated_value_nor_waiting_value() {
+  void isInitializing_should_return_true_if_pod_has_initContainerStatus_without_terminated_value_nor_waiting_value() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -130,7 +130,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isInitializing_should_return_true_if_pod_has_initContainerStatus_without_terminated_value_but_waiting_value() {
+  void isInitializing_should_return_true_if_pod_has_initContainerStatus_without_terminated_value_but_waiting_value() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -150,7 +150,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isInitializing_should_return_false_if_pod_has_initContainerStatus_without_terminated_value_but_waiting_value_PodInitializing() {
+  void isInitializing_should_return_false_if_pod_has_initContainerStatus_without_terminated_value_but_waiting_value_PodInitializing() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -170,7 +170,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isInitializing_should_return_false_if_pod_has_initContainerStatus_with_state_with_exit_code_0() {
+  void isInitializing_should_return_false_if_pod_has_initContainerStatus_with_state_with_exit_code_0() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -190,7 +190,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_true_if_pod_has_containerStatus_ready_and_running() {
+  void isRunning_should_return_true_if_pod_has_containerStatus_ready_and_running() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -204,7 +204,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_false_if_pod_has_containerStatus_ready_but_not_running() {
+  void isRunning_should_return_false_if_pod_has_containerStatus_ready_but_not_running() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -221,7 +221,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_true_if_pod_has_running_container_and_another_that_is_completed_and_ready_condition_is_true() {
+  void isRunning_should_return_true_if_pod_has_running_container_and_another_that_is_completed_and_ready_condition_is_true() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -246,7 +246,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_false_if_pod_has_running_container_and_another_that_is_completed_and_ready_condition_is_false() {
+  void isRunning_should_return_false_if_pod_has_running_container_and_another_that_is_completed_and_ready_condition_is_false() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -269,7 +269,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void isRunning_should_return_true_if_pod_has_running_container_and_another_that_is_terminated_for_other_reason_than_completed() {
+  void isRunning_should_return_true_if_pod_has_running_container_and_another_that_is_terminated_for_other_reason_than_completed() {
     // given
     Pod pod = pod("some pod")
         .statusBuilder()
@@ -292,7 +292,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void getContainersStatuses_should_return_all_containers() {
+  void getContainersStatuses_should_return_all_containers() {
     // given
     ContainerStatus waitingReady = containerStatus(
         true,
@@ -324,7 +324,7 @@ public class PodStatusUtilTest {
   }
 
   @Test
-  public void getContainersStatuses_should_return_emptyList_if_pod_has_no_status() {
+  void getContainersStatuses_should_return_emptyList_if_pod_has_no_status() {
     // given
     Pod pod = pod("some pod")
         .build();

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -127,11 +127,6 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -27,8 +27,8 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
@@ -32,8 +32,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WatchConnectionManagerTest {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManagerTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/HandlersTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/HandlersTest.java
@@ -22,11 +22,10 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HandlersTest {
 
@@ -50,10 +49,10 @@ public class HandlersTest {
     BaseClient mock = Mockito.mock(BaseClient.class, Mockito.RETURNS_SELF);
     Mockito.when(mock.adapt(BaseClient.class).getHandlers()).thenReturn(handlers);
 
-    assertThat(handlers.get(new MyPod(), null).operation(mock, null), Matchers.instanceOf(MyPodOperationsImpl.class));
+    assertThat(handlers.get(new MyPod(), null).operation(mock, null)).isInstanceOf(MyPodOperationsImpl.class);
 
     handlers.unregister(MyPod.class);
 
-    assertThat(handlers.get(new MyPod(), null).operation(mock, null), Matchers.instanceOf(HasMetadataOperationsImpl.class));
+    assertThat(handlers.get(new MyPod(), null).operation(mock, null)).isInstanceOf(HasMetadataOperationsImpl.class);
   }
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/HandlersTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/impl/HandlersTest.java
@@ -26,7 +26,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HandlersTest {
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelperTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelperTest.java
@@ -27,7 +27,7 @@ import java.net.HttpURLConnection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.UnaryOperator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/OptionalDependencyWrapperTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/OptionalDependencyWrapperTest.java
@@ -19,8 +19,8 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.junit.jupiter.api.Test;
 
 import static io.fabric8.kubernetes.client.utils.internal.OptionalDependencyWrapper.wrapRunWithOptionalDependency;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OptionalDependencyWrapperTest {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/OptionalDependencyWrapperTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/OptionalDependencyWrapperTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.fabric8.kubernetes.client.utils.internal.OptionalDependencyWrapper.wrapRunWithOptionalDependency;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OptionalDependencyWrapperTest {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/OptionalDependencyWrapperTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/OptionalDependencyWrapperTest.java
@@ -19,8 +19,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.junit.jupiter.api.Test;
 
 import static io.fabric8.kubernetes.client.utils.internal.OptionalDependencyWrapper.wrapRunWithOptionalDependency;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OptionalDependencyWrapperTest {
@@ -30,7 +29,7 @@ class OptionalDependencyWrapperTest {
     final boolean result = wrapRunWithOptionalDependency(() -> true,
         "I have no optional dependencies");
 
-    assertThat(result, equalTo(true));
+    assertThat(result).isEqualTo(true);
   }
 
   @Test
@@ -40,7 +39,7 @@ class OptionalDependencyWrapperTest {
           throw new NoClassDefFoundError("com.1337.invalid.IDontExist");
         }, "IDontExist class is provided by some optional package"));
 
-    assertThat(exception.getMessage(), equalTo(
-        "IDontExist class is provided by some optional package, an optional dependency. To use this functionality you must explicitly add this dependency to the classpath."));
+    assertThat(exception.getMessage()).isEqualTo(
+        "IDontExist class is provided by some optional package, an optional dependency. To use this functionality you must explicitly add this dependency to the classpath.");
   }
 }

--- a/kubernetes-examples/pom.xml
+++ b/kubernetes-examples/pom.xml
@@ -71,12 +71,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>compile</scope>

--- a/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/SettableBeanPropertyDelegateTest.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/SettableBeanPropertyDelegateTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;

--- a/kubernetes-model-generator/pom.xml
+++ b/kubernetes-model-generator/pom.xml
@@ -120,11 +120,6 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
@@ -39,9 +39,9 @@ import org.junit.jupiter.api.Test;
 import java.net.HttpURLConnection;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import java.net.HttpURLConnection;
 import java.util.List;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentV1beta1Test.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentV1beta1Test.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentV1beta1Test.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentV1beta1Test.java
@@ -33,9 +33,9 @@ import org.junit.jupiter.api.Test;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @EnableKubernetesMockClient
 class DeploymentV1beta1Test {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -43,9 +43,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient(https = false)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
@@ -35,9 +35,9 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
@@ -35,7 +35,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -46,7 +46,6 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.mockwebserver.internal.WebSocketMessage;
 import okio.ByteString;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -718,7 +717,7 @@ class PodTest {
         .always();
 
     Pod result = client.pods().withName("pod1").waitUntilReady(10, TimeUnit.SECONDS);
-    Assert.assertEquals("2", result.getMetadata().getResourceVersion());
+    assertEquals("2", result.getMetadata().getResourceVersion());
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
@@ -25,7 +25,7 @@ import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableKubernetesMockClient

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
@@ -25,8 +25,8 @@ import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @EnableKubernetesMockClient
 class RequestConfigTest {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -40,7 +40,6 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -288,7 +287,7 @@ class ResourceTest {
 
       }
     });
-    Assert.assertTrue(latch.await(5000, MILLISECONDS));
+    assertTrue(latch.await(5000, MILLISECONDS));
     watch.close();
   }
 
@@ -318,7 +317,7 @@ class ResourceTest {
         .always();
 
     Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
-    Assert.assertTrue(Readiness.isPodReady(p));
+    assertTrue(Readiness.isPodReady(p));
   }
 
   /**
@@ -371,7 +370,7 @@ class ResourceTest {
         .always();
 
     Pod p = client.pods().withName("pod1").waitUntilReady(10, SECONDS);
-    Assert.assertTrue(Readiness.isPodReady(p));
+    assertTrue(Readiness.isPodReady(p));
   }
 
   @Test
@@ -490,7 +489,7 @@ class ResourceTest {
         .once();
 
     Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
-    Assert.assertTrue(Readiness.isPodReady(p));
+    assertTrue(Readiness.isPodReady(p));
   }
 
   @Test
@@ -535,7 +534,7 @@ class ResourceTest {
         .once();
 
     Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
-    Assert.assertTrue(Readiness.isPodReady(p));
+    assertTrue(Readiness.isPodReady(p));
   }
 
   @Test
@@ -554,7 +553,7 @@ class ResourceTest {
     list(ready);
 
     Pod p = client.resource(noReady).waitUntilReady(10, SECONDS);
-    Assert.assertTrue(Readiness.isPodReady(p));
+    assertTrue(Readiness.isPodReady(p));
   }
 
   @Test
@@ -653,7 +652,7 @@ class ResourceTest {
     NamespaceableResource<Pod> resource = client.resource(noReady);
     resource.create();
     Pod p = resource.waitUntilReady(10, SECONDS);
-    Assert.assertTrue(Readiness.isPodReady(p));
+    assertTrue(Readiness.isPodReady(p));
   }
 
   @Test

--- a/openshift-client-api/pom.xml
+++ b/openshift-client-api/pom.xml
@@ -160,12 +160,6 @@
    </dependency>
 
    <dependency>
-     <groupId>org.junit.jupiter</groupId>
-     <artifactId>junit-jupiter-migrationsupport</artifactId>
-     <scope>test</scope>
-   </dependency>
-
-   <dependency>
      <groupId>org.mockito</groupId>
      <artifactId>mockito-core</artifactId>
      <scope>test</scope>

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/impl/OpenShiftExtensionAdapterTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/impl/OpenShiftExtensionAdapterTest.java
@@ -18,7 +18,7 @@ package io.fabric8.openshift.client.impl;
 
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class OpenShiftExtensionAdapterTest {
@@ -29,14 +29,14 @@ class OpenShiftExtensionAdapterTest {
         .withMasterUrl("http://host1:80")
         .build();
 
-    Assert.assertFalse(OpenShiftClientImpl.hasCustomOpenShiftUrl(config));
+    Assertions.assertFalse(OpenShiftClientImpl.hasCustomOpenShiftUrl(config));
 
     config = new OpenShiftConfigBuilder()
         .withMasterUrl("http://host1:80")
         .withOpenShiftUrl("http://host2:80/oapi/v1")
         .build();
 
-    Assert.assertTrue(OpenShiftClientImpl.hasCustomOpenShiftUrl(config));
+    Assertions.assertTrue(OpenShiftClientImpl.hasCustomOpenShiftUrl(config));
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -841,12 +841,6 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>

--- a/uberjar/pom.xml
+++ b/uberjar/pom.xml
@@ -249,11 +249,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
+++ b/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
@@ -15,11 +15,10 @@
  */
 package io.fabric8.kubernetes.clnt;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Document;
 
 import java.io.BufferedOutputStream;
@@ -46,8 +45,8 @@ class UberJarTest {
   private static final String JAR_SUFFIX = ".jar";
   private static final String ARTIFACT_ID = "kubernetes-openshift-uberjar";
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  public File tempDir;
 
   @Test
   @DisplayName("UberJar should be generated and should contain necessary files")
@@ -59,7 +58,7 @@ class UberJarTest {
 
     // When
     File uberJar = new File(uberJarFilePath);
-    File jarExtractedDir = folder.newFolder("extractedJar");
+    File jarExtractedDir = new File(tempDir, "extractedJar");
     unzip(uberJar.getAbsolutePath(), jarExtractedDir.getAbsolutePath());
 
     // Then
@@ -99,7 +98,7 @@ class UberJarTest {
 
     // When
     File uberJarVersioned = new File(versionedJarFilePath);
-    File jarExtractedDir = folder.newFolder("extractedJar");
+    File jarExtractedDir = new File(tempDir, "extractedJar");
     unzip(uberJarVersioned.getAbsolutePath(), jarExtractedDir.getAbsolutePath());
 
     // Then

--- a/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
+++ b/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
@@ -15,9 +15,9 @@
  */
 package io.fabric8.kubernetes.clnt;
 
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 
 import java.io.BufferedOutputStream;

--- a/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
+++ b/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
@@ -15,9 +15,9 @@
  */
 package io.fabric8.kubernetes.clnt;
 
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 
 import java.io.BufferedOutputStream;

--- a/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
+++ b/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
@@ -18,7 +18,6 @@ package io.fabric8.kubernetes.clnt;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.w3c.dom.Document;
 
 import java.io.BufferedOutputStream;
@@ -37,7 +36,6 @@ import javax.xml.xpath.XPathFactory;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableRuleMigrationSupport
 class UberJarTest {
   private static final String OUTPUT_DIR = System.getProperty("user.dir") + File.separator + "target";
   private static final File pomFile = new File(System.getProperty("user.dir") + File.separator + "pom.xml");


### PR DESCRIPTION
## Description

Fixes #5141 

<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fixing issue #5141, removing `junit-jupiter-migrationsupport` and migrating various junit4 references to junit5
- Removed all references to `junit-jupiter-migrationsupport` from various `pom.xml` files (total 36)
- Modified `UberJarTest` to use `@TempDir` instead of rules.
- Migrated most `org.junit.Assert` references to the newer `org.junit.jupiter.api.Assertions`
- Migrated 2 tests from the older `org.junit.After` / Before / Test to the newer `org.junit.jupiter.api.AfterEach` / BeforeEach / Test

The only thing pending is the `org.junit.Test` and `org.junit.Assert` refernces remaining in karaf\itests which I couldn't complete.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
