### PR TITLE
fix #5152: ensuring onClose can be called after channel closed

### DIFF
--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyWebSocket.java
@@ -142,9 +142,8 @@ public class JettyWebSocket implements WebSocket, WebSocketListener {
 
   @Override
   public void onWebSocketClose(int statusCode, String reason) {
-    if (terminated.complete(null)) {
-      listener.onClose(this, statusCode, reason);
-    }
+    terminated.complete(null);
+    listener.onClose(this, statusCode, reason);
   }
 
   @Override
@@ -160,8 +159,7 @@ public class JettyWebSocket implements WebSocket, WebSocketListener {
    */
   @Override
   public void onWebSocketError(Throwable cause) {
-    boolean completed = terminated.complete(null);
-    if (cause instanceof ClosedChannelException && (!completed || outputClosed.get())) {
+    if (cause instanceof ClosedChannelException && (outputClosed.get() || !terminated.complete(null))) {
       // TODO: Check better
       //  It appears to be a race condition in Jetty:
       // - The server sends a close frame (but we haven't received it)

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketTest.java
@@ -171,7 +171,11 @@ class JettyWebSocketTest {
     // When
     jws.onWebSocketError(new ClosedChannelException());
     // Then
-    assertThat(listener.events).isEmpty(); // onClose would normally be called later by jetty
+    assertThat(listener.events).isEmpty();
+
+    jws.onWebSocketClose(1000, "Closed");
+    assertThat(listener.events)
+        .containsOnlyKeys("onClose");
   }
 
   @Test


### PR DESCRIPTION
## Description
On more refinement to the Jetty handling

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
