### PR TITLE
fix (kubernetes-client-api) : Remove opinionated messages from Config's `errorMessages` and deprecate it (#5166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #5224: Ensuring jetty sets the User-Agent header
 
 #### Improvements
+* Fix #5166: Remove opinionated messages from Config's `errorMessages` and deprecate it
 
 #### Dependency Upgrade
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -220,6 +220,10 @@ public class Config {
   private String userAgent = "fabric8-kubernetes-client/" + Version.clientVersion();
   private TlsVersion[] tlsVersions = new TlsVersion[] { TlsVersion.TLS_1_3, TlsVersion.TLS_1_2 };
 
+  /**
+   * @deprecated Use Kubernetes Status directly for extracting error messages.
+   */
+  @Deprecated
   private Map<Integer, String> errorMessages = new HashMap<>();
 
   /**
@@ -551,9 +555,6 @@ public class Config {
           String serviceTokenCandidate = new String(Files.readAllBytes(saTokenPathFile.toPath()));
           LOGGER.debug("Found service account token at: [{}].", saTokenPathLocation);
           config.setAutoOAuthToken(serviceTokenCandidate);
-          String txt = "Configured service account doesn't have access. Service account may have been revoked.";
-          config.getErrorMessages().put(401, "Unauthorized! " + txt);
-          config.getErrorMessages().put(403, "Forbidden!" + txt);
           return true;
         } catch (IOException e) {
           // No service account token available...
@@ -758,10 +759,6 @@ public class Config {
               }
             }
           }
-
-          config.getErrorMessages().put(401, "Unauthorized! Token may have expired! Please log-in again.");
-          config.getErrorMessages().put(403,
-              "Forbidden! User " + (currentContext != null ? currentContext.getUser() : "") + " doesn't have permission.");
         }
         return true;
       }
@@ -1150,6 +1147,11 @@ public class Config {
     this.requestConfig.setWatchReconnectLimit(watchReconnectLimit);
   }
 
+  /**
+   * @deprecated Use Kubernetes status messages directly
+   * @return map of error codes to message mappings
+   */
+  @Deprecated
   @JsonProperty("errorMessages")
   public Map<Integer, String> getErrorMessages() {
     return errorMessages;

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -645,6 +645,7 @@ class ConfigTest {
 
     assertEquals(120, config.getMaxConcurrentRequests());
     assertEquals(20, config.getMaxConcurrentRequestsPerHost());
+    assertThat(config.getErrorMessages()).isEmpty();
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupportTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupportTest.java
@@ -138,6 +138,22 @@ class OperationSupportTest {
   }
 
   @Test
+  @DisplayName("assertResponse, with client error, should throw exception with server response body")
+  void assertResponseCodeClientErrorAndStatus() throws Exception {
+    // Given
+    final HttpRequest request = new StandardHttpRequest.Builder().method("GET", null, null).uri(new URI("https://example.com"))
+        .build();
+    final HttpResponse<String> response = new TestHttpResponse<String>().withCode(400)
+        .withBody("{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"status\":\"Failure\",\"code\":400,\"message\":\"Invalid\"}");
+    // When
+    final KubernetesClientException result = assertThrows(KubernetesClientException.class,
+        () -> operationSupport.assertResponseCode(request, response));
+    // Then
+    assertThat(result)
+        .hasMessageContaining("Failure executing: GET at: https://example.com. Message: Invalid. Received status: Status(");
+  }
+
+  @Test
   void getResourceURL() throws MalformedURLException {
     assertThat(operationSupport.getResourceUrl()).hasToString("https://kubernetes.default.svc/api/v1");
 


### PR DESCRIPTION
## Description
Fix #5166 

+ Remove opinionated status code to message mappings from Config
+ Deprecate Config.errorMessages field in favor of kubernetes status
+ Update OperationSupport to only rely on Kubernetes status for error messages



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
