### PR TITLE
fix #2718 minor changes related to readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### New Features
 
 #### _**Note**_: Breaking changes
+* Fix #2718: KubernetesResourceUtil.isResourceReady was deprecated.  Use 
 
 ### 6.7.0 (2023-06-01)
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Resource.java
@@ -53,6 +53,12 @@ public interface Resource<T> extends
 
   /**
    * Check if the resource is ready. If no readiness check exists, this is just an existence check.
+   * <p>
+   * Note: for resources other than Node, Deployment, ReplicaSet, StatefulSet, Pod, ReplicationController, and DeploymentConfig
+   * readiness is simply an existence check.
+   * <p>
+   * Also note this obtains the latest version of the resource from the server even if the context item
+   * is present.
    *
    * @return true if the resource exists and is ready.
    */

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Waitable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Waitable.java
@@ -20,6 +20,13 @@ import java.util.function.Predicate;
 
 public interface Waitable<T, P> {
 
+  /**
+   * For resources other than Node, Deployment, ReplicaSet, StatefulSet, Pod, ReplicationController, and DeploymentConfig
+   * readiness is simply an existence check.
+   * <br>
+   * Consider using the more general {@link #waitUntilCondition(Predicate, long, TimeUnit)} when dealing with
+   * more complex situations or other types.
+   */
   T waitUntilReady(long amount, TimeUnit timeUnit);
 
   /**

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -398,7 +398,10 @@ public class KubernetesResourceUtil {
    *
    * @param item item which needs to be checked
    * @return boolean value indicating it's status
+   *
+   * @deprecated use client.resource(item).isReady() or Readiness.getInstance().isReady(item) instead
    */
+  @Deprecated
   public static boolean isResourceReady(HasMetadata item) {
     return Readiness.getInstance().isReady(item);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -33,7 +33,6 @@ import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRec
 import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.Waitable;
-import io.fabric8.kubernetes.client.readiness.Readiness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +71,8 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImp
 
   @Override
   public List<HasMetadata> waitUntilReady(final long amount, final TimeUnit timeUnit) {
-    return waitUntilCondition(resource -> Objects.nonNull(resource) && getReadiness().isReady(resource), amount, timeUnit);
+    return waitUntilCondition(resource -> Objects.nonNull(resource) && context.getConfig().getReadiness().isReady(resource),
+        amount, timeUnit);
   }
 
   List<HasMetadata> getItems() {
@@ -228,10 +228,6 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImp
   public ListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> withPropagationPolicy(
       DeletionPropagation propagationPolicy) {
     return newInstance(context.withPropagationPolicy(propagationPolicy));
-  }
-
-  protected Readiness getReadiness() {
-    return Readiness.getInstance();
   }
 
   protected List<HasMetadata> asHasMetadata(Object item) {


### PR DESCRIPTION
## Description
Addresses #2718 by expanding the javadocs around readiness

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
