### PR TITLE
fix #5214: explicitly omitting nulls by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.8-SNAPSHOT
 
 #### Bugs
+* Fix #5214: null values are omitted by default, which means custom resources by in large won't need JsonIncludes annotations.  The only time that is required is when null is to be preserved via @JsonInclude(value = Include.ALWAYS) on the relevant field.
 * Fix #5218: No export for `io.fabric8.tekton.triggers.internal.knative.pkg.apis.duck.v1beta1` in tekton v1beta1 triggers model
 * Fix #5224: Ensuring jetty sets the User-Agent header
 * Fix #4225: Enum fields written in generated crd yaml

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1859,6 +1859,10 @@ import io.fabric8.kubernetes.model.annotation.Version;
 public class CronTab extends CustomResource<CronTabSpec, CronTabStatus> implements Namespaced {
 }
 ```
+
+**Note:** Null values in your custom resource will be omitted by default by the client or when directly using KubernetesSerialization, or the static Serialization methods.  If you have a situation where a null value
+must be present in the serialized form, then mark the field with @JsonInclude(value = Include.ALWAYS).
+
 You can find other helper classes related to `CronTab` in our [tests](https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/crd). For now, we can proceed with it's common usage examples:
 
 - Get Instance of client for our `CustomResource`:

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
@@ -16,6 +16,8 @@
 
 package io.fabric8.kubernetes.client.utils;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationConfig;
@@ -89,6 +91,8 @@ public class KubernetesSerialization {
   protected void configureMapper(ObjectMapper mapper) {
     mapper.registerModules(new JavaTimeModule(), unmatchedFieldTypeModule);
     mapper.disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
+    // omit null fields, but keep null map values
+    mapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(Include.NON_NULL, Include.ALWAYS));
     HandlerInstantiator instanciator = mapper.getDeserializationConfig().getHandlerInstantiator();
     mapper.setConfig(mapper.getDeserializationConfig().with(new HandlerInstantiator() {
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.utils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -76,6 +77,27 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SerializationTest {
+
+  static class WithNull {
+    @JsonInclude(value = Include.ALWAYS)
+    public Integer field;
+  }
+
+  static class WithoutNull {
+    public Integer field;
+  }
+
+  @Test
+  void testNullSerialization() throws Exception {
+    assertEquals("---\nfield: null\n", Serialization.asYaml(new WithNull()));
+    assertEquals("{\"field\":null}", Serialization.asJson(new WithNull()));
+    assertEquals("--- {}\n", Serialization.asYaml(new WithoutNull()));
+    assertEquals("{}", Serialization.asJson(new WithoutNull()));
+    // map null values should be preserved
+    Map<String, String> map = new HashMap<>();
+    map.put("key", null);
+    assertEquals("{\"key\":null}", Serialization.asJson(map));
+  }
 
   @Test
   void unmarshalCRDWithSchema() throws Exception {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/PatchUtilsTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/PatchUtilsTest.java
@@ -57,4 +57,16 @@ class PatchUtilsTest {
         PatchUtils.jsonDiff(rc1, rc2, false, new KubernetesSerialization()));
   }
 
+  @Test
+  void testDiffRemove() {
+    ReplicationController rc1 = new ReplicationControllerBuilder().withNewStatus().withFullyLabeledReplicas(1).endStatus()
+        .withNewMetadata().withName("x").endMetadata().build();
+
+    ReplicationController rc2 = new ReplicationControllerBuilder(rc1).withStatus(null).build();
+
+    assertEquals(
+        "[{\"op\":\"remove\",\"path\":\"/status\"}]",
+        PatchUtils.jsonDiff(rc1, rc2, false, new KubernetesSerialization()));
+  }
+
 }


### PR DESCRIPTION
## Description

Resolves the discussion on #5214 - we'll treat the 6.6 / 6.7 behavior as a regression and switch to explicitly omitting nulls by default.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
