### PR TITLE
fix #5224: ensuring jetty sets the default user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #5218: No export for `io.fabric8.tekton.triggers.internal.knative.pkg.apis.duck.v1beta1` in tekton v1beta1 triggers model
+* Fix #5224: Ensuring jetty sets the User-Agent header
 
 #### Improvements
 

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpConfiguredClientTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpConfiguredClientTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.jdkhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractConfiguredClientTest;
+import io.fabric8.kubernetes.client.http.HttpClient.Factory;
+
+class JdkHttpConfiguredClientTest extends AbstractConfiguredClientTest {
+
+  @Override
+  protected Factory getHttpClientFactory() {
+    return new JdkHttpClientFactory();
+  }
+
+}

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
@@ -102,7 +102,7 @@ public class JettyHttpClient extends StandardHttpClient<JettyHttpClient, JettyHt
     if (originalRequest.getTimeout() != null) {
       jettyRequest.timeout(originalRequest.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
     }
-    jettyRequest.headers(m -> request.headers().forEach((k, l) -> l.forEach(v -> m.add(k, v))));
+    jettyRequest.headers(m -> request.headers().forEach(m::put));
 
     final var contentType = Optional.ofNullable(request.getContentType());
 

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyConfiguredClientTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyConfiguredClientTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.jetty;
+
+import io.fabric8.kubernetes.client.http.AbstractConfiguredClientTest;
+import io.fabric8.kubernetes.client.http.HttpClient.Factory;
+
+class JettyConfiguredClientTest extends AbstractConfiguredClientTest {
+
+  @Override
+  protected Factory getHttpClientFactory() {
+    return new JettyHttpClientFactory();
+  }
+
+}

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpConfiguredClientTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpConfiguredClientTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.okhttp;
+
+import io.fabric8.kubernetes.client.http.AbstractConfiguredClientTest;
+import io.fabric8.kubernetes.client.http.HttpClient.Factory;
+
+class OkHttpConfiguredClientTest extends AbstractConfiguredClientTest {
+
+  @Override
+  protected Factory getHttpClientFactory() {
+    return new OkHttpClientFactory();
+  }
+
+}

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpConfiguredClientTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpConfiguredClientTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.vertx;
+
+import io.fabric8.kubernetes.client.http.AbstractConfiguredClientTest;
+import io.fabric8.kubernetes.client.http.HttpClient.Factory;
+
+class VertxHttpConfiguredClientTest extends AbstractConfiguredClientTest {
+
+  @Override
+  protected Factory getHttpClientFactory() {
+    return new VertxHttpClientFactory();
+  }
+
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractConfiguredClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractConfiguredClientTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.mockwebserver.DefaultMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractConfiguredClientTest {
+
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    server = new DefaultMockServer(false);
+    server.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  private HttpClient clientWithDefaultConfiguration() {
+    return getHttpClientFactory().newBuilder(Config.empty()).build();
+  }
+
+  @Test
+  public void userAgentTest() throws Exception {
+    try (final HttpClient client = clientWithDefaultConfiguration()) {
+      server.expect().withPath("/consume-bytes")
+          .andReturn(200, "This is the response body as bytes")
+          .always();
+      client.sendAsync(client.newHttpRequestBuilder().uri(server.url("/consume-bytes")).build(), String.class).get(10L,
+          TimeUnit.SECONDS);
+      // ensure that the header interceptor is applied
+      assertThat(server.getLastRequest().getHeader("User-Agent")).startsWith("fabric8-kubernetes-client");
+    }
+  }
+
+}


### PR DESCRIPTION
## Description

Fix #5224 

Jetty needs to overwrite, rather than append headers because it sets the user-agent by default.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
