### PR TITLE
fix #5233: allowing schemaswap to have a configurable level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Improvements
 * Fix #5166: Remove opinionated messages from Config's `errorMessages` and deprecate it
+* Fix #5233: Generalized SchemaSwap to allow for cycle expansion
 
 #### Dependency Upgrade
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaSwap.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaSwap.java
@@ -15,7 +15,11 @@
  */
 package io.fabric8.crd.generator.annotation;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotation that allows replacing a nested schema with one from another class.
@@ -52,4 +56,12 @@ public @interface SchemaSwap {
    * The default value of {@code void.class} causes the field to be skipped
    */
   Class<?> targetType() default void.class;
+
+  /**
+   * For fields that may include a reference cycle, how many expansions to include in the output before including the
+   * {@link #targetType()}
+   * <p>
+   * The default value of 0 replaces the field with the {@link #targetType()} without any expansion
+   */
+  int depth() default 0;
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CollectionCyclicSchemaSwap.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CollectionCyclicSchemaSwap.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.SchemaSwap;
+import io.fabric8.kubernetes.api.model.AnyType;
+import io.fabric8.kubernetes.client.CustomResource;
+
+import java.util.List;
+
+@SchemaSwap(originalType = CollectionCyclicSchemaSwap.Level.class, fieldName = "levels", targetType = AnyType.class, depth = 2)
+public class CollectionCyclicSchemaSwap extends CustomResource<CollectionCyclicSchemaSwap.Spec, Void> {
+
+  public static class Spec {
+    private MyObject myObject;
+    private List<Level> levels;
+  }
+
+  public static class Level {
+    private MyObject myObject;
+    private List<Level> levels;
+  }
+
+  public static class MyObject {
+    private int value;
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CyclicSchemaSwap.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CyclicSchemaSwap.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.SchemaSwap;
+import io.fabric8.kubernetes.client.CustomResource;
+
+import java.util.List;
+
+@SchemaSwap(originalType = CyclicSchemaSwap.Level.class, fieldName = "level", depth = 1)
+public class CyclicSchemaSwap extends CustomResource<CyclicSchemaSwap.Spec, Void> {
+
+  public static class Spec {
+    private MyObject myObject;
+    private Level root;
+    private List<Level> roots; // should not interfere with the rendering depth of level of its sibling
+  }
+
+  public static class Level {
+    private MyObject myObject;
+    private Level level;
+  }
+
+  public static class MyObject {
+    private int value;
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/NestedSchemaSwap.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/NestedSchemaSwap.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.SchemaSwap;
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class NestedSchemaSwap extends CustomResource<NestedSchemaSwap.Spec, Void> {
+
+  @SchemaSwap(originalType = End.class, fieldName = "value", targetType = String.class)
+  public static class Spec {
+    private Intermediate one;
+    private Intermediate another;
+  }
+
+  @SchemaSwap(originalType = End.class, fieldName = "value", targetType = Void.class)
+  public static class Intermediate {
+    private End one;
+  }
+
+  public static class End {
+    private int value;
+  }
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/keycloak/KeycloakRealm.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/keycloak/KeycloakRealm.java
@@ -28,8 +28,8 @@ import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 
 @Group("sample.fabric8.io")
 @Version("v1alpha1")
-@SchemaSwap(originalType = ComponentExportRepresentation.class, fieldName = "subComponents")
-@SchemaSwap(originalType = GroupRepresentation.class, fieldName = "subGroups")
+@SchemaSwap(originalType = GroupRepresentation.class, fieldName = "subGroups", depth = 10)
+@SchemaSwap(originalType = ComponentExportRepresentation.class, fieldName = "subComponents", depth = 10)
 @SchemaSwap(originalType = ScopeRepresentation.class, fieldName = "policies")
 @SchemaSwap(originalType = ScopeRepresentation.class, fieldName = "resources")
 public class KeycloakRealm extends CustomResource<RealmRepresentation, Void> implements Namespaced {

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -323,6 +323,10 @@ The CRD generator will perform the same substitution as a `SchemaFrom` annotatio
 
 The name of the field is restricted to the original `fieldName` and should be backed by a matching concrete field of the matching class. Getters, setters, and constructors are not taken into consideration.
 
+SchemaSwaps cannot currently be nested - if a more deeply nested class contains a swap for the same class and field, an exception will be thrown.
+
+The ScheamSwap annotation has an optional depth property, which is for advanced scenarios involving cyclic references.  Since CRDs cannot directly represent cycles, the depth property may be used to control an unrolling of the representation in your CRD.  A depth of 0, the default, performs the swap on the field without the originalType appearing in your CRD.  A depth of n will allow the originalType to appear in the CRD up to a nesting depth of n, with the specified field at the nth level terminated by the targetType.
+
 ### Generating `x-kubernetes-preserve-unknown-fields: true`
 
 If a field or one of its accessors is annotated with
@@ -437,7 +441,7 @@ The CRD generator will add the additional `labels`:
 | `io.fabric8.generator.annotation.Nullable`                   | The field is marked as `nullable`                                                     |
 | `io.fabric8.generator.annotation.Required`                   | The field is marked as `required`                                                     |
 | `io.fabric8.crd.generator.annotation.SchemaFrom`             | The field type for the generation is the one coming from the annotation               |
-| `io.fabric8.crd.generator.annotation.SchemaSwap`             | Same as SchemaFrom, but can be applied at any point in the class hierarchy            |
+| `io.fabric8.crd.generator.annotation.SchemaSwap`             | Similar to SchemaFrom, but can be applied at any point in the class hierarchy            |
 | `io.fabric8.crd.generator.annotation.Annotations`            | Additional `annotations` in `metadata`                                                |
 | `io.fabric8.crd.generator.annotation.Labels`                 | Additional `labels` in `metadata`                                                     |
 


### PR DESCRIPTION
## Description
Fix #5233 

Based upon https://github.com/keycloak/keycloak/issues/12725 it would be good to allow for configurable expansion depths.  Using the Any type as the terminal swap should also allow the content to be free-form under that.  I think this should eliminate the need for creating the intermidiate classes.

A couple of thoughts:
- there's still no default expansion depth, if a cycle is detected, then an exception will be thrown
- the cycle detection doesn't seem to work for non-collection properties, but at worst that just gives a stackoverflow so that could be addressed separately
- the naming or javadocs may need tweaked or examples added

cc @andreaTP 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
