### PR TITLE
Added example for Resource Typed API vs. Resource Typeless API to doc/CHEATSHEET.md

### DIFF
--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -2012,7 +2012,7 @@ public class SparkOperatorResource extends GenericKubernetesResource implements 
 
 Usage with Resource Typed API by `SparkOperatorResource`
 ```
-kubernetesClient.resources(SparkOperatorResource.class).inNamespace("myNamespace)...
+kubernetesClient.resources(SparkOperatorResource.class).inNamespace("myNamespace")...
 ```
 
 Resource Typeless API:
@@ -2030,7 +2030,7 @@ public static ResourceDefinitionContext getResourceDefinitionContext() {
 
 Usage with Resource Typeless API:
 ```
-kubernetesClient.genericKubernetesResources(getResourceDefinitionContext()).inNamespace("myNamespace)...
+kubernetesClient.genericKubernetesResources(getResourceDefinitionContext()).inNamespace("myNamespace")...
 ```
 
 ### CertificateSigningRequest

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -39,6 +39,7 @@ This document contains common usages of different resources using Fabric8 Kubern
   * [CustomResourceDefinition](#customresourcedefinition)
   * [Resource Typed API](#resource-typed-api)
   * [Resource Typeless API](#resource-typeless-api)
+  * [Resource Typed API vs. Resource Typeless API](#resource-typed-api-vs-resource-typeless-api)
   * [CertificateSigningRequest](#certificatesigningrequest)
   * [SharedInformers](#sharedinformers)
   * [List Options](#list-options)

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -2017,15 +2017,15 @@ kubernetesClient.resources(SparkOperatorResource.class).inNamespace("myNamespace
 
 Resource Typeless API:
 ```
-    public static ResourceDefinitionContext getResourceDefinitionContext() {
-        return new ResourceDefinitionContext.Builder()
-                .withGroup("sparkoperator.k8s.io")
-                .withPlural("sparkapps")
-                .withVersion("v1beta2")
-                .withKind("SparkApplication")
-                .withNamespaced(true)
-                .build();
-    }
+public static ResourceDefinitionContext getResourceDefinitionContext() {
+    return new ResourceDefinitionContext.Builder()
+            .withGroup("sparkoperator.k8s.io")
+            .withPlural("sparkapps")
+            .withVersion("v1beta2")
+            .withKind("SparkApplication")
+            .withNamespaced(true)
+            .build();
+}
 ```
 
 Usage with Resource Typeless API:

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1909,6 +1909,41 @@ cronTabClient.inNamespace("default").watch(new Watcher<CronTab>() {
    }
 });
 ```
+### Resource Typed API vs. Resource Typeless API
+Following examples demonstrate how to define the same context for custom resources in two different ways by example of the spark operator.
+
+Resource Typed API:
+```
+@Group("sparkoperator.k8s.io")
+@Plural("sparkapps")
+@Version("v1beta2")
+@Kind("SparkApplication")
+public class SparkOperatorResource extends GenericKubernetesResource implements Namespaced { ... }
+```
+
+Usage with Resource Typed API by `SparkOperatorResource`
+```
+kubernetesClient.resources(SparkOperatorResource.class).inNamespace("myNamespace)...
+```
+
+Resource Typeless API:
+```
+    public static ResourceDefinitionContext getResourceDefinitionContext() {
+        return new ResourceDefinitionContext.Builder()
+                .withGroup("sparkoperator.k8s.io")
+                .withPlural("sparkapps")
+                .withVersion("v1beta2")
+                .withKind("SparkApplication")
+                .withNamespaced(true)
+                .build();
+    }
+```
+
+Usage with Resource Typeless API:
+```
+kubernetesClient.genericKubernetesResources(getResourceDefinitionContext()).inNamespace("myNamespace)...
+```
+
 
 ### Resource Typeless API
 If you don't need or want to use a strongly typed client, the Kubernetes Client also provides a typeless/raw API to handle your resources in form of GenericKubernetesResource.  GenericKubernetesResource implements HasMetadata and provides the rest of its fields via a map. In most circumstances the client can infer the necessary details about your type from the api server, this includes:

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1910,41 +1910,6 @@ cronTabClient.inNamespace("default").watch(new Watcher<CronTab>() {
    }
 });
 ```
-### Resource Typed API vs. Resource Typeless API
-Following examples demonstrate how to define the same context for custom resources in two different ways by example of the spark operator.
-
-Resource Typed API:
-```
-@Group("sparkoperator.k8s.io")
-@Plural("sparkapps")
-@Version("v1beta2")
-@Kind("SparkApplication")
-public class SparkOperatorResource extends GenericKubernetesResource implements Namespaced { ... }
-```
-
-Usage with Resource Typed API by `SparkOperatorResource`
-```
-kubernetesClient.resources(SparkOperatorResource.class).inNamespace("myNamespace)...
-```
-
-Resource Typeless API:
-```
-    public static ResourceDefinitionContext getResourceDefinitionContext() {
-        return new ResourceDefinitionContext.Builder()
-                .withGroup("sparkoperator.k8s.io")
-                .withPlural("sparkapps")
-                .withVersion("v1beta2")
-                .withKind("SparkApplication")
-                .withNamespaced(true)
-                .build();
-    }
-```
-
-Usage with Resource Typeless API:
-```
-kubernetesClient.genericKubernetesResources(getResourceDefinitionContext()).inNamespace("myNamespace)...
-```
-
 
 ### Resource Typeless API
 If you don't need or want to use a strongly typed client, the Kubernetes Client also provides a typeless/raw API to handle your resources in form of GenericKubernetesResource.  GenericKubernetesResource implements HasMetadata and provides the rest of its fields via a map. In most circumstances the client can infer the necessary details about your type from the api server, this includes:
@@ -2031,6 +1996,41 @@ client.genericKubernetesResources(crdContext).inNamespace(namespace).watch(new W
     }
 });
 closeLatch.await(10, TimeUnit.MINUTES);
+```
+
+### Resource Typed API vs. Resource Typeless API
+Following examples demonstrate how to define the same context for custom resources in two different ways by example of the spark operator.
+
+Resource Typed API:
+```
+@Group("sparkoperator.k8s.io")
+@Plural("sparkapps")
+@Version("v1beta2")
+@Kind("SparkApplication")
+public class SparkOperatorResource extends GenericKubernetesResource implements Namespaced { ... }
+```
+
+Usage with Resource Typed API by `SparkOperatorResource`
+```
+kubernetesClient.resources(SparkOperatorResource.class).inNamespace("myNamespace)...
+```
+
+Resource Typeless API:
+```
+    public static ResourceDefinitionContext getResourceDefinitionContext() {
+        return new ResourceDefinitionContext.Builder()
+                .withGroup("sparkoperator.k8s.io")
+                .withPlural("sparkapps")
+                .withVersion("v1beta2")
+                .withKind("SparkApplication")
+                .withNamespaced(true)
+                .build();
+    }
+```
+
+Usage with Resource Typeless API:
+```
+kubernetesClient.genericKubernetesResources(getResourceDefinitionContext()).inNamespace("myNamespace)...
 ```
 
 ### CertificateSigningRequest


### PR DESCRIPTION
## Description
added a section demonstrating same context configuration by Resource Typed API vs. Resource Typeless API

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

