### PR TITLE
fix #5238: Preserve folder structure again in PodUpload.upload()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #4225: Enum fields written in generated crd yaml
 * Fix #5236: using scale v1beta1 compatible logic for DeploymentConfig
 * Fix #5235: Vert.x doesn't need to track derived HttpClients - prevents leakage
+* Fix #5238: Preserve folder structure again in PodUpload.upload()
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -33,7 +33,6 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -54,11 +53,11 @@ public class PodUpload {
 
     if (Utils.isNotNullOrEmpty(operation.getContext().getFile()) && pathToUpload.toFile().isFile()) {
       return uploadTar(operation, getDirectoryFromFile(operation),
-          tar -> addFileToTar(null, new File(operation.getContext().getFile()).getName(), pathToUpload.toFile(), tar));
+          tar -> addFileToTar(new File(operation.getContext().getFile()).getName(), pathToUpload.toFile(), tar));
     } else if (Utils.isNotNullOrEmpty(operation.getContext().getDir()) && pathToUpload.toFile().isDirectory()) {
       return uploadTar(operation, operation.getContext().getDir(), tar -> {
         for (File file : pathToUpload.toFile().listFiles()) {
-          addFileToTar(null, file.getName(), file, tar);
+          addFileToTar(file.getName(), file, tar);
         }
       });
     }
@@ -173,17 +172,16 @@ public class PodUpload {
     return String.format("mkdir -p %1$s; tar -C %1$s -xmf %2$s; e=$?; rm %2$s; exit $e", shellQuote(directory), tar);
   }
 
-  private static void addFileToTar(String rootTarPath, String fileName, File file, TarArchiveOutputStream tar)
+  private static void addFileToTar(String fileName, File file, TarArchiveOutputStream tar)
       throws IOException {
-    String dirRootPath = Optional.ofNullable(rootTarPath).orElse("") + TAR_PATH_DELIMITER + fileName;
-    tar.putArchiveEntry(new TarArchiveEntry(file, dirRootPath));
+    tar.putArchiveEntry(new TarArchiveEntry(file, fileName));
     if (file.isFile()) {
       Files.copy(file.toPath(), tar);
       tar.closeArchiveEntry();
     } else if (file.isDirectory()) {
       tar.closeArchiveEntry();
       for (File fileInDirectory : file.listFiles()) {
-        addFileToTar(dirRootPath, fileInDirectory.getName(), fileInDirectory, tar);
+        addFileToTar(fileName + TAR_PATH_DELIMITER + fileInDirectory.getName(), fileInDirectory, tar);
       }
     }
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -175,13 +175,13 @@ public class PodUpload {
 
   private static void addFileToTar(String rootTarPath, String fileName, File file, TarArchiveOutputStream tar)
       throws IOException {
-    tar.putArchiveEntry(new TarArchiveEntry(file, fileName));
+    String dirRootPath = Optional.ofNullable(rootTarPath).orElse("") + TAR_PATH_DELIMITER + fileName;
+    tar.putArchiveEntry(new TarArchiveEntry(file, dirRootPath));
     if (file.isFile()) {
       Files.copy(file.toPath(), tar);
       tar.closeArchiveEntry();
     } else if (file.isDirectory()) {
       tar.closeArchiveEntry();
-      String dirRootPath = Optional.ofNullable(rootTarPath).orElse("") + TAR_PATH_DELIMITER + fileName;
       for (File fileInDirectory : file.listFiles()) {
         addFileToTar(dirRootPath, fileInDirectory.getName(), fileInDirectory, tar);
       }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
@@ -144,13 +143,10 @@ class PodUploadTest {
       verifyTar(fileUploadMethodToTest, size, "/mock");
       return;
     }
-    Mockito.when(this.operation.writingOutput(Mockito.any())).then(new Answer<TtyExecErrorable>() {
-      @Override
-      public TtyExecErrorable answer(InvocationOnMock invocation) throws Throwable {
-        OutputStream out = (OutputStream) invocation.getArgument(0);
-        out.write((size + "\n").getBytes(StandardCharsets.UTF_8));
-        return operation;
-      }
+    Mockito.when(this.operation.writingOutput(Mockito.any())).then((Answer<TtyExecErrorable>) invocation -> {
+      OutputStream out = invocation.getArgument(0);
+      out.write((size + "\n").getBytes(StandardCharsets.UTF_8));
+      return operation;
     });
     boolean result = fileUploadMethodToTest.apply();
     assertThat(result).isTrue();
@@ -172,13 +168,10 @@ class PodUploadTest {
 
   private void verifyTar(PodUploadTester<Boolean> directoryUpload, long size, String dir)
       throws IOException, InterruptedException {
-    Mockito.when(this.operation.writingOutput(Mockito.any())).then(new Answer<TtyExecErrorable>() {
-      @Override
-      public TtyExecErrorable answer(InvocationOnMock invocation) throws Throwable {
-        OutputStream out = (OutputStream) invocation.getArgument(0);
-        out.write((size + "\n").getBytes(StandardCharsets.UTF_8));
-        return operation;
-      }
+    Mockito.when(this.operation.writingOutput(Mockito.any())).then((Answer<TtyExecErrorable>) invocation -> {
+      OutputStream out = invocation.getArgument(0);
+      out.write((size + "\n").getBytes(StandardCharsets.UTF_8));
+      return operation;
     });
     boolean result = directoryUpload.apply();
     assertThat(result).isTrue();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -90,7 +90,7 @@ class PodUploadTest {
   void upload_withDirectoryAndLongFileNames_shouldUploadDirectory() throws Exception {
     final Path toUpload = new File(PodUpload.class.getResource("/upload_long").getFile())
         .toPath();
-    uploadDirectoryAndVerify(() -> PodUpload.upload(operation, toUpload), 4096);
+    uploadDirectoryAndVerify(() -> PodUpload.upload(operation, toUpload), 5120);
   }
 
   @Test


### PR DESCRIPTION
## Description

Fix #5238

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
