### PR TITLE
fix #5236: using scale v1beta1 compatible logic for dc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #5218: No export for `io.fabric8.tekton.triggers.internal.knative.pkg.apis.duck.v1beta1` in tekton v1beta1 triggers model
 * Fix #5224: Ensuring jetty sets the User-Agent header
 * Fix #4225: Enum fields written in generated crd yaml
+* Fix #5236: using scale v1beta1 compatible logic for DeploymentConfig
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -713,7 +713,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return handlePatch(context, current, updated, getType());
   }
 
-  protected <S> S handleScale(S scaleParam, Class<S> scaleType) {
+  public <S> S handleScale(S scaleParam, Class<S> scaleType) {
     try {
       return handleScale(getCompleteResourceUrl().toString(), scaleParam, scaleType);
     } catch (InterruptedException ie) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/batch/v1/JobOperationsImpl.java
@@ -71,7 +71,7 @@ public class JobOperationsImpl extends HasMetadataOperation<Job, JobList, Scalab
     Job res = accept(b -> b.getSpec().setParallelism(count));
     if (context.getTimeout() > 0) {
       waitUntilJobIsScaled();
-      res = getItemOrRequireFromServer();
+      res = get();
     }
     return res;
   }

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
@@ -19,7 +19,6 @@ package io.fabric8.openshift;
 import io.fabric8.junit.jupiter.api.LoadKubernetesManifests;
 import io.fabric8.junit.jupiter.api.RequireK8sSupport;
 import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
@@ -61,9 +60,14 @@ class DeploymentConfigIT {
   @Test
   void update() {
     DeploymentConfig deploymentConfig1 = client.deploymentConfigs().withName("dc-update")
-        .edit(d -> new DeploymentConfigBuilder(d)
-            .editMetadata().withResourceVersion(null).endMetadata()
-            .editSpec().withReplicas(3).endSpec().build());
+        .accept(dc -> dc.getMetadata().getAnnotations().put("new", "annotation"));
+    assertThat(deploymentConfig1).isNotNull();
+    assertEquals("annotation", deploymentConfig1.getMetadata().getAnnotations().get("new"));
+  }
+
+  @Test
+  void scale() {
+    DeploymentConfig deploymentConfig1 = client.deploymentConfigs().withName("dc-update").scale(3);
     assertThat(deploymentConfig1).isNotNull();
     assertEquals(3, deploymentConfig1.getSpec().getReplicas().intValue());
   }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.openshift.client.dsl.internal.apps;
 
+import io.fabric8.kubernetes.api.model.autoscaling.v1.Scale;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.BytesLimitTerminateTimeTailPrettyLoggable;
@@ -29,6 +30,7 @@ import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.LogWatchCallback;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
+import io.fabric8.kubernetes.client.dsl.internal.extensions.v1beta1.LegacyRollableScalableResourceOperation;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -68,6 +70,11 @@ public class DeploymentConfigOperationsImpl
   @Override
   public DeploymentConfigOperationsImpl newInstance(OperationContext context) {
     return new DeploymentConfigOperationsImpl(rollingOperationContext, context);
+  }
+
+  @Override
+  public Scale scale(Scale scaleParam) {
+    return LegacyRollableScalableResourceOperation.scale(scaleParam, this);
   }
 
   @Override


### PR DESCRIPTION
## Description

Fix #5236

We can also consider turning the LegacyRollableScalableResourceOperation into just a utility, or just using that as the base scale logic if we suspect this will come up again.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
