### PR TITLE
fix: vert.x doesn't need to track derived HttpClients - prevents leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #5224: Ensuring jetty sets the User-Agent header
 * Fix #4225: Enum fields written in generated crd yaml
 * Fix #5236: using scale v1beta1 compatible logic for DeploymentConfig
+* Fix #5235: Vert.x doesn't need to track derived HttpClients - prevents leakage
 
 #### Improvements
 

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
@@ -29,7 +29,6 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.UpgradeRejectedException;
 import io.vertx.core.http.WebSocketConnectOptions;
-import io.vertx.ext.web.client.WebClientOptions;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -44,10 +43,14 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
   private final Vertx vertx;
   private final HttpClient client;
 
-  VertxHttpClient(VertxHttpClientBuilder<F> vertxHttpClientBuilder, WebClientOptions options) {
+  VertxHttpClient(VertxHttpClientBuilder<F> vertxHttpClientBuilder, HttpClient client) {
     super(vertxHttpClientBuilder);
     this.vertx = vertxHttpClientBuilder.vertx;
-    this.client = vertx.createHttpClient(options);
+    this.client = client;
+  }
+
+  HttpClient getClient() {
+    return client;
   }
 
   @Override

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
@@ -32,7 +32,6 @@ import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.ext.web.client.WebClientOptions;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -42,14 +41,11 @@ import static io.fabric8.kubernetes.client.vertx.VertxHttpRequest.toHeadersMap;
 
 public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpClient.Factory>
     extends StandardHttpClient<VertxHttpClient<F>, F, VertxHttpClientBuilder<F>> {
-
-  private final List<VertxHttpClient<F>> derivedClients;
   private final Vertx vertx;
   private final HttpClient client;
 
   VertxHttpClient(VertxHttpClientBuilder<F> vertxHttpClientBuilder, WebClientOptions options) {
     super(vertxHttpClientBuilder);
-    derivedClients = Collections.synchronizedList(new ArrayList<>());
     this.vertx = vertxHttpClientBuilder.vertx;
     this.client = vertx.createHttpClient(options);
   }
@@ -119,17 +115,9 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
     return new VertxHttpRequest(vertx, options, request).consumeBytes(this.client, consumer);
   }
 
-  void addDerivedClient(VertxHttpClient<F> client) {
-    derivedClients.add(client);
-  }
-
   @Override
   public void close() {
     client.close();
-    synchronized (derivedClients) {
-      derivedClients.forEach(VertxHttpClient::close);
-      derivedClients.clear();
-    }
   }
 
 }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -51,6 +51,10 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
 
   @Override
   public VertxHttpClient<F> build() {
+    if (this.client != null) {
+      return new VertxHttpClient<>(this, this.client.getClient());
+    }
+
     WebClientOptions options = new WebClientOptions();
 
     options.setMaxPoolSize(MAX_CONNECTIONS);
@@ -111,7 +115,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
         }
       });
     }
-    return new VertxHttpClient<>(this, options);
+    return new VertxHttpClient<>(this, vertx.createHttpClient(options));
   }
 
   @Override

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -39,7 +39,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
     extends StandardHttpClientBuilder<VertxHttpClient<F>, F, VertxHttpClientBuilder<F>> {
 
   private static final int MAX_CONNECTIONS = 8192;
-  // the default for etcd seems to be 3 MB, but we'll default to unlimited to have the same behavior across clients
+  // the default for etcd seems to be 3 MB, but we'll default to unlimited, so we have the same behavior across clients
   private static final int MAX_WS_MESSAGE_SIZE = Integer.MAX_VALUE;
 
   final Vertx vertx;
@@ -111,13 +111,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
         }
       });
     }
-
-    // track derived clients to clean up properly
-    VertxHttpClient<F> result = new VertxHttpClient<>(this, options);
-    if (this.client != null) {
-      this.client.addDerivedClient(result);
-    }
-    return result;
+    return new VertxHttpClient<>(this, options);
   }
 
   @Override


### PR DESCRIPTION
## Description

Fix #5235

Vert.x doesn't need to track derived HttpClients - prevents leakage

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
