### PR TITLE
fix #5229: allowing for other exits from the readiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #5218: No export for `io.fabric8.tekton.triggers.internal.knative.pkg.apis.duck.v1beta1` in tekton v1beta1 triggers model
 * Fix #5224: Ensuring jetty sets the User-Agent header
 * Fix #4225: Enum fields written in generated crd yaml
+* Fix #5229: Correcting the timeout units and behavior of withReadyWaitTimeout
 * Fix #5236: using scale v1beta1 compatible logic for DeploymentConfig
 * Fix #5235: Vert.x doesn't need to track derived HttpClients - prevents leakage
 * Fix #5238: Preserve folder structure again in PodUpload.upload()

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ContainerResource.java
@@ -55,7 +55,7 @@ public interface ContainerResource
   CopyOrReadable dir(String path);
 
   /**
-   * How long to wait for the pod to be ready before performing an operation, such as
+   * How long to wait for the pod to be ready or terminal before performing an operation, such as
    * getting the logs, exec, attach, copy, etc.
    *
    * @param timeout in milliseconds

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CopyOrReadable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CopyOrReadable.java
@@ -41,7 +41,7 @@ public interface CopyOrReadable {
   boolean copy(Path destination);
 
   /**
-   * How long to wait for a ready pod before performing the copy or read operation.
+   * How long to wait for a ready or terminal pod before performing the copy or read operation.
    *
    * @param timeout in milliseconds
    */

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Execable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Execable.java
@@ -36,7 +36,7 @@ public interface Execable {
   ExecWatch attach();
 
   /**
-   * How long shall we wait until a Pod is ready before attaching or execing
+   * How long shall we wait until a Pod is ready or terminal before attaching or execing
    *
    * @param timeout in milliseconds
    * @return {@link Loggable} for fetching logs

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Loggable.java
@@ -86,7 +86,7 @@ public interface Loggable {
 
   /**
    * While waiting for Pod logs, how long shall we wait until a Pod
-   * becomes ready and starts producing logs
+   * becomes ready or terminal and starts producing logs
    *
    * @param timeout in milliseconds
    * @return {@link Loggable} for fetching logs

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -92,7 +92,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     implements PodResource, EphemeralContainersResource, CopyOrReadable {
 
   public static final int HTTP_TOO_MANY_REQUESTS = 429;
-  private static final Integer DEFAULT_POD_READY_WAIT_TIMEOUT = 5;
+  public static final int DEFAULT_POD_READY_WAIT_TIMEOUT_MS = 5000;
   private static final String[] EMPTY_COMMAND = { "/bin/sh", "-i" };
   public static final String DEFAULT_CONTAINER_ANNOTATION_NAME = "kubectl.kubernetes.io/default-container";
 
@@ -122,8 +122,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     try {
       URL url = new URL(URLUtils.join(getResourceUrl().toString(), podOperationContext.getLogParameters()));
 
-      PodOperationUtil.waitUntilReadyOrSucceded(this,
-          getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT);
+      PodOperationUtil.waitUntilReadyOrTerminal(this,
+          getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT_MS);
 
       return handleRawGet(url, type);
     } catch (IOException ioException) {
@@ -176,8 +176,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   public LogWatch watchLog(OutputStream out) {
     checkForPiped(out);
     try {
-      PodOperationUtil.waitUntilReadyOrSucceded(this,
-          getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT);
+      PodOperationUtil.waitUntilReadyOrTerminal(this,
+          getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT_MS);
       // Issue Pod Logs HTTP request
       URL url = new URL(URLUtils.join(getResourceUrl().toString(), getContext().getLogParameters() + "&follow=true"));
       final LogWatchCallback callback = new LogWatchCallback(out, context);
@@ -303,8 +303,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   private URL getURL(String operation, String[] commands) throws MalformedURLException {
-    Pod fromServer = PodOperationUtil.waitUntilReadyOrSucceded(this,
-        getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT);
+    Pod fromServer = PodOperationUtil.waitUntilReadyOrTerminal(this,
+        getContext().getReadyWaitTimeout() != null ? getContext().getReadyWaitTimeout() : DEFAULT_POD_READY_WAIT_TIMEOUT_MS);
 
     String url = URLUtils.join(getResourceUrl().toString(), operation);
     URLBuilder httpUrlBuilder = new URLBuilder(url);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
@@ -42,7 +42,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -91,9 +93,17 @@ class PodOperationUtilTest {
   @Test
   void testWaitUntilReadyBeforeFetchingLogs() {
     // When
-    PodOperationUtil.waitUntilReadyOrSucceded(podOperations, 5);
+    PodOperationUtil.waitUntilReadyOrTerminal(podOperations, 5);
     // Then
-    verify(podOperations, times(1)).waitUntilCondition(any(), eq(5L), eq(TimeUnit.SECONDS));
+    verify(podOperations, times(1)).waitUntilCondition(any(), eq(5L), eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  void testIsReadyOrTerminal() {
+    assertTrue(PodOperationUtil.isReadyOrTerminal(null));
+    assertFalse(PodOperationUtil.isReadyOrTerminal(new Pod()));
+    assertTrue(PodOperationUtil.isReadyOrTerminal(new PodBuilder().withNewStatus().withPhase("Failed").endStatus().build()));
+    assertFalse(PodOperationUtil.isReadyOrTerminal(new PodBuilder().withNewStatus().withPhase("Pending").endStatus().build()));
   }
 
   @Test

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/DeploymentConfigIT.java
@@ -60,7 +60,10 @@ class DeploymentConfigIT {
   @Test
   void update() {
     DeploymentConfig deploymentConfig1 = client.deploymentConfigs().withName("dc-update")
-        .accept(dc -> dc.getMetadata().getAnnotations().put("new", "annotation"));
+        .accept(dc -> {
+          dc.getMetadata().setResourceVersion(null);
+          dc.getMetadata().getAnnotations().put("new", "annotation");
+        });
     assertThat(deploymentConfig1).isNotNull();
     assertEquals("annotation", deploymentConfig1.getMetadata().getAnnotations().get("new"));
   }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/apps/DeploymentConfigOperationsImpl.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.LogWatchCallback;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
+import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.extensions.v1beta1.LegacyRollableScalableResourceOperation;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
@@ -53,7 +54,6 @@ public class DeploymentConfigOperationsImpl
     extends HasMetadataOperation<DeploymentConfig, DeploymentConfigList, DeployableScalableResource<DeploymentConfig>>
     implements DeployableScalableResource<DeploymentConfig> {
 
-  private static final Integer DEFAULT_POD_LOG_WAIT_TIMEOUT = 5;
   public static final String OPENSHIFT_IO_DEPLOYMENT_CONFIG_NAME = "openshift.io/deployment-config.name";
   private final PodOperationContext rollingOperationContext;
 
@@ -185,12 +185,13 @@ public class DeploymentConfigOperationsImpl
         rollingOperationContext,
         deploymentConfig.getMetadata().getUid(), getDeploymentConfigPodLabels(deploymentConfig));
 
-    waitForBuildPodToBecomeReady(podOps, podLogWaitTimeout != null ? podLogWaitTimeout : DEFAULT_POD_LOG_WAIT_TIMEOUT);
+    waitForBuildPodToBecomeReady(podOps,
+        podLogWaitTimeout != null ? podLogWaitTimeout : PodOperationsImpl.DEFAULT_POD_READY_WAIT_TIMEOUT_MS);
   }
 
   private static void waitForBuildPodToBecomeReady(List<PodResource> podOps, Integer podLogWaitTimeout) {
     for (PodResource podOp : podOps) {
-      PodOperationUtil.waitUntilReadyOrSucceded(podOp, podLogWaitTimeout);
+      PodOperationUtil.waitUntilReadyOrTerminal(podOp, podLogWaitTimeout);
     }
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/build/BuildOperationsImpl.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.LogWatchCallback;
 import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext;
+import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.internal.PodOperationUtil;
 import io.fabric8.openshift.api.model.Build;
@@ -52,7 +53,6 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
 
   public static final String OPENSHIFT_IO_BUILD_NAME = "openshift.io/build.name";
   private Integer version;
-  private static final Integer DEFAULT_POD_LOG_WAIT_TIMEOUT = 5;
   private final PodOperationContext operationContext;
 
   public BuildOperationsImpl(Client client) {
@@ -197,12 +197,13 @@ public class BuildOperationsImpl extends HasMetadataOperation<Build, BuildList, 
         getBuildPodLabels(build));
 
     waitForBuildPodToBecomeReady(podOps,
-        operationContext.getReadyWaitTimeout() != null ? operationContext.getReadyWaitTimeout() : DEFAULT_POD_LOG_WAIT_TIMEOUT);
+        operationContext.getReadyWaitTimeout() != null ? operationContext.getReadyWaitTimeout()
+            : PodOperationsImpl.DEFAULT_POD_READY_WAIT_TIMEOUT_MS);
   }
 
   private static void waitForBuildPodToBecomeReady(List<PodResource> podOps, Integer podLogWaitTimeout) {
     for (PodResource podOp : podOps) {
-      PodOperationUtil.waitUntilReadyOrSucceded(podOp, podLogWaitTimeout);
+      PodOperationUtil.waitUntilReadyOrTerminal(podOp, podLogWaitTimeout);
     }
   }
 


### PR DESCRIPTION
## Description

Fix #5229 

Addressing the timeout units and other exit conditions from the wait brought up on #5229

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
