### PR TITLE
fix #5223: using a separate annotation to control cycle expansion

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/InternalSchemaExpands.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/InternalSchemaExpands.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator;
+
+import io.sundr.model.ClassRef;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class InternalSchemaExpands {
+  private final Map<ClassRef, Value> terminalTypes;
+  private final Map<ClassRef, Integer> replacementDepths = new HashMap<>();
+
+  public InternalSchemaExpands() {
+    this(new HashMap<>());
+  }
+
+  private InternalSchemaExpands(Map<ClassRef, Value> terminalTypes) {
+    this.terminalTypes = terminalTypes;
+  }
+
+  public InternalSchemaExpands branchDepths() {
+    InternalSchemaExpands result = new InternalSchemaExpands(this.terminalTypes);
+    result.replacementDepths.putAll(this.replacementDepths);
+    return result;
+  }
+
+  public void registerReplacement(ClassRef definitionType, ClassRef originalType, ClassRef terminalType,
+      int depth) {
+    Value value = new Value(definitionType, originalType, terminalType, depth);
+    terminalTypes.put(originalType, value);
+  }
+
+  public ClassRef lookupAndMark(ClassRef originalType, Runnable swapApplicableAction) {
+    Value value = terminalTypes.get(originalType);
+    if (value != null) {
+      swapApplicableAction.run();
+      int depth = replacementDepths.compute(originalType, (k, v) -> {
+        if (v == null) {
+          return 1;
+        }
+        return v + 1;
+      });
+      value.used = true;
+      if (depth > value.depth) {
+        return value.terminalType;
+      }
+    }
+    return null;
+  }
+
+  public void throwIfUnmatchedReplacements() {
+    String unmatchedSchemaSwaps = terminalTypes.values().stream().filter(value -> !value.used)
+        .map(Object::toString)
+        .collect(Collectors.joining(", "));
+    if (!unmatchedSchemaSwaps.isEmpty()) {
+      throw new IllegalArgumentException("Unmatched SchemaExpands: " + unmatchedSchemaSwaps);
+    }
+  }
+
+  private static class Value {
+    private final ClassRef originalType;
+    private final ClassRef terminalType;
+    private boolean used;
+    private final ClassRef definitionType;
+    private final int depth;
+
+    public Value(ClassRef definitionType, ClassRef originalType, ClassRef terminalType, int cycleDepth) {
+      this.definitionType = definitionType;
+      this.originalType = originalType;
+      this.terminalType = terminalType;
+      this.depth = cycleDepth;
+      this.used = false;
+    }
+
+    @Override
+    public String toString() {
+      return "@SchemaSwap(originalType=" + originalType + ", depth=\"" + depth + "\", terminalType=" + terminalType
+          + ") on " + definitionType;
+    }
+  }
+}

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaExpand.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaExpand.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that allows controlling/replacing a nested schema expansion.
+ *
+ * This is an alternative to {@link SchemaFrom} for cases when the classes
+ * are coming from an external source and fields cannot be annotated directly.
+ *
+ * @see SchemaFrom
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE_USE, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(SchemaExpands.class)
+public @interface SchemaExpand {
+  /**
+   * The class be replaced.
+   * <p>
+   * It is an error if the type is not used in the same schema hierarchy where the {@link SchemaExpand} is used.
+   */
+  Class<?> originalType();
+
+  /**
+   * The replacement schema that will be used for the {@link #originalType()} instead of its specified type once
+   * the depth has been reached.
+   * <p>
+   * The default value of {@code void.class} causes the field to be skipped
+   */
+  Class<?> terminalType() default void.class;
+
+  /**
+   * For classes that include a reference cycle, how many expansions to include in the output
+   * <p>
+   * The default value of 0 replaces the {@link #originalType()} with the {@link #terminalType()} without any expansion
+   */
+  int depth() default 0;
+}

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaExpands.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/SchemaExpands.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A container for multiple {@link SchemaExpand}s
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE_USE, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SchemaExpands {
+  SchemaExpand[] value();
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CollectionCyclicSchemaSwap.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CollectionCyclicSchemaSwap.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.SchemaExpand;
+import io.fabric8.kubernetes.api.model.AnyType;
+import io.fabric8.kubernetes.client.CustomResource;
+
+import java.util.List;
+
+@SchemaExpand(originalType = CollectionCyclicSchemaSwap.Level.class, terminalType = AnyType.class, depth = 3)
+public class CollectionCyclicSchemaSwap extends CustomResource<CollectionCyclicSchemaSwap.Spec, Void> {
+
+  public static class Spec {
+    private MyObject myObject;
+    private List<Level> levels;
+  }
+
+  public static class Level {
+    private MyObject myObject;
+    private List<Level> levels;
+  }
+
+  public static class MyObject {
+    private int value;
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CyclicSchemaSwap.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/CyclicSchemaSwap.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.SchemaExpand;
+import io.fabric8.kubernetes.client.CustomResource;
+
+import java.util.List;
+
+@SchemaExpand(originalType = CyclicSchemaSwap.Level.class, depth = 1)
+public class CyclicSchemaSwap extends CustomResource<CyclicSchemaSwap.Spec, Void> {
+
+  public static class Spec {
+    private MyObject myObject;
+    private Level level;
+    private List<Level> levels; // should not interfere with the rendering depth of level
+  }
+
+  public static class Level {
+    private MyObject myObject;
+    private Level level;
+  }
+
+  public static class MyObject {
+    private int value;
+  }
+}


### PR DESCRIPTION
## Description
Here's something similar to the previous pr, but with a completely separate annotation / logic - if that helps make the feature seem more palatable.  The replacement is happening at a higher-level (class rather than property), which seems to simplify the mechanics. cc @metacosm 

Now that the config swaps have been removed keycloak usage of schemaswap looks like:
```
@SchemaSwap(originalType = GroupRepresentation.class, fieldName = "subGroups", targetType = org.keycloak.representations.overrides.NoSubGroupsGroupRepresentationList.class)
@SchemaSwap(originalType = RealmRepresentation.class, fieldName = "components", targetType = org.keycloak.representations.overrides.ComponentExportRepresentationMap.class)
@SchemaSwap(originalType = ComponentExportRepresentation.class, fieldName = "subComponents", targetType = org.keycloak.representations.overrides.NoSubcomponentsComponentExportRepresentationMap.class)
@SchemaSwap(originalType = ScopeRepresentation.class, fieldName = "policies")
@SchemaSwap(originalType = ScopeRepresentation.class, fieldName = "resources")
public class KeycloakRealmImport extends CustomResource<KeycloakRealmImportSpec, KeycloakRealmImportStatus> implements Namespaced {

}
```
Updating to use this pr looks like:
```
@SchemaExpand(originalType = ScopeRepresentation.class, terminalType = AnyType.class, depth = 3)
@SchemaExpand(originalType = GroupRepresentation.class, terminalType = AnyType.class, depth = 3)
@SchemaExpand(originalType = ComponentExportRepresentation.class, terminalType = AnyType.class, depth = 3)
public class KeycloakRealmImport extends CustomResource<KeycloakRealmImportSpec, KeycloakRealmImportStatus> implements Namespaced {

}
```
One up side is that since SchemaSwap is no longer used, there's a potential to deprecate it - as that seems undesirable to @andreaTP to maintain in its current form.

Obviously the crd size, even for a depth of 3, is greatly increased.  I don't think a depth of 10 is even possible with the default kubernetes resource size limit.

One thing that I noticed that if you use void as the replacement there are a couple of behaviors depending on where the class is used.  If it's a field or a collection, then it will be omitted.  If it's a map value however, it will instead become object - it might be better to omit the map instead.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
