### PR TITLE
feat (kubernetes-client-api) : Support for using TokenRequest for existing ServiceAccount (#5133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Fix #5133: Support for using TokenRequest for existing ServiceAccount
 
 #### _**Note**_: Breaking changes
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClient.java
@@ -83,6 +83,7 @@ import io.fabric8.kubernetes.client.dsl.RbacAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.SchedulingAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.kubernetes.client.dsl.StorageAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.V1APIGroupDSL;
@@ -445,7 +446,7 @@ public interface KubernetesClient extends Client {
    *
    * @return MixedOperation object for ServiceAccount related operations.
    */
-  MixedOperation<ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> serviceAccounts();
+  MixedOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> serviceAccounts();
 
   /**
    * API entrypoint for APIService related operations. APIService (apiregistration.k8s.io/v1)

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/NamespacedKubernetesClientAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/NamespacedKubernetesClientAdapter.java
@@ -84,6 +84,7 @@ import io.fabric8.kubernetes.client.dsl.RbacAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.SchedulingAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.kubernetes.client.dsl.StorageAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.V1APIGroupDSL;
@@ -351,7 +352,7 @@ public class NamespacedKubernetesClientAdapter<N extends NamespacedKubernetesCli
   }
 
   @Override
-  public MixedOperation<ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> serviceAccounts() {
+  public MixedOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> serviceAccounts() {
     return getClient().serviceAccounts();
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ServiceAccountResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ServiceAccountResource.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+
+public interface ServiceAccountResource extends Resource<ServiceAccount>, TokenRequestable {
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TokenRequestable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/TokenRequestable.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
+
+public interface TokenRequestable {
+  /**
+   * Request a token to authenticate to the kubernetes api server as the given service account.
+   * Creates an opinionated TokenRequest object with default expiration seconds time of 3600.
+   *
+   * @return TokenRequest object containing token in status
+   */
+  default TokenRequest tokenRequest() {
+    return tokenRequest(new TokenRequestBuilder()
+        .withNewSpec()
+        .withExpirationSeconds(3600L)
+        .endSpec()
+        .build());
+  }
+
+  /**
+   * Request a token to authenticate to the kubernetes api server as the given service account.
+   *
+   * @param tokenRequest TokenRequest
+   * @return TokenRequest object containing token in status
+   */
+  TokenRequest tokenRequest(TokenRequest tokenRequest);
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceAccountOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceAccountOperationsImpl.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal.core.v1;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountList;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
+import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation;
+import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.OperationContext;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.utils.URLUtils;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class ServiceAccountOperationsImpl
+    extends HasMetadataOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> implements ServiceAccountResource {
+  public ServiceAccountOperationsImpl(Client client) {
+    this(HasMetadataOperationsImpl.defaultContext(client));
+  }
+
+  private ServiceAccountOperationsImpl(OperationContext context) {
+    super(context.withPlural("serviceaccounts"), ServiceAccount.class, ServiceAccountList.class);
+  }
+
+  @Override
+  public ServiceAccountOperationsImpl newInstance(OperationContext context) {
+    return new ServiceAccountOperationsImpl(context);
+  }
+
+  @Override
+  public TokenRequest tokenRequest(TokenRequest tokenRequest) {
+    return handleTokenRequest(tokenRequest);
+  }
+
+  private TokenRequest handleTokenRequest(TokenRequest tokenRequest) {
+    try {
+      URL requestUrl = new URL(URLUtils.join(getResourceUrl().toString(), "token"));
+
+      HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
+          .post(JSON, getKubernetesSerialization().asJson(tokenRequest)).url(requestUrl);
+      return handleResponse(requestBuilder, TokenRequest.class);
+    } catch (IOException exception) {
+      throw KubernetesClientException.launderThrowable(forOperationType("token request"), exception);
+    }
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/KubernetesClientImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/KubernetesClientImpl.java
@@ -121,6 +121,7 @@ import io.fabric8.kubernetes.client.dsl.RbacAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.SchedulingAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.kubernetes.client.dsl.StorageAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.V1APIGroupDSL;
@@ -152,6 +153,7 @@ import io.fabric8.kubernetes.client.dsl.internal.batch.v1.JobOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.certificates.v1.CertificateSigningRequestOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.ReplicationControllerOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.core.v1.ServiceAccountOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.ServiceOperationsImpl;
 import io.fabric8.kubernetes.client.extended.leaderelection.LeaderElectorBuilder;
 import io.fabric8.kubernetes.client.extended.run.RunConfigBuilder;
@@ -251,6 +253,7 @@ public class KubernetesClientImpl extends BaseClient implements NamespacedKubern
     this.getAdapters().registerClient(V1beta1CertificatesAPIGroupDSL.class, new V1beta1CertificatesAPIGroupClient());
 
     this.getHandlers().register(Pod.class, PodOperationsImpl::new);
+    this.getHandlers().register(ServiceAccount.class, ServiceAccountOperationsImpl::new);
     this.getHandlers().register(Job.class, JobOperationsImpl::new);
     this.getHandlers().register(Service.class, ServiceOperationsImpl::new);
     this.getHandlers().register(Deployment.class, DeploymentOperationsImpl::new);
@@ -475,8 +478,8 @@ public class KubernetesClientImpl extends BaseClient implements NamespacedKubern
    * {@inheritDoc}
    */
   @Override
-  public MixedOperation<ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> serviceAccounts() {
-    return resources(ServiceAccount.class, ServiceAccountList.class);
+  public MixedOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> serviceAccounts() {
+    return new ServiceAccountOperationsImpl(this);
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceAccountOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceAccountOperationsImplTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl.internal.core.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
+import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.TestHttpResponse;
+import io.fabric8.kubernetes.client.impl.BaseClient;
+import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceAccountOperationsImplTest {
+  private ServiceAccountOperationsImpl serviceAccountOperations;
+  private HttpClient mockedHttpClient;
+
+  @BeforeEach
+  void setUp() {
+    Client mockedClient = mock(Client.class);
+    BaseClient mockedBaseClient = mock(BaseClient.class);
+    mockedHttpClient = mock(HttpClient.class);
+    when(mockedClient.getConfiguration()).thenReturn(new ConfigBuilder()
+        .withMasterUrl("http://test.kubernetes.server")
+        .build());
+    when(mockedClient.getHttpClient()).thenReturn(mockedHttpClient);
+    when(mockedClient.adapt(BaseClient.class)).thenReturn(mockedBaseClient);
+    when(mockedBaseClient.getKubernetesSerialization()).thenReturn(new KubernetesSerialization(new ObjectMapper(), false));
+    serviceAccountOperations = new ServiceAccountOperationsImpl(mockedClient);
+  }
+
+  @Test
+  void tokenRequest_whenApiServerCallSuccessful_thenReturnTokenInTokenRequestStatus() throws URISyntaxException {
+    // Given
+    String responseFromServer = "{\"kind\":\"TokenRequest\",\"apiVersion\":\"authentication.k8s.io/v1\"," +
+        "\"status\":{\"token\":\"my.secret.token\",\"expirationTimestamp\":\"2023-06-14T18:42:15Z\"}}";
+    HttpRequest.Builder mockHttpRequestBuilder = createMockHttpRequestBuilder();
+    HttpRequest mockHttpRequest = createMockHttpRequest(mockHttpRequestBuilder);
+    when(mockedHttpClient.sendAsync(mockHttpRequest, byte[].class))
+        .thenReturn(CompletableFuture.completedFuture(new TestHttpResponse<byte[]>().withCode(HTTP_CREATED)
+            .withBody(responseFromServer.getBytes(StandardCharsets.UTF_8))));
+    TokenRequest tokenRequest = new TokenRequestBuilder()
+        .withNewSpec()
+        .withAudiences("http://example.svc")
+        .endSpec()
+        .build();
+
+    // When
+    TokenRequest updatedTokenRequest = serviceAccountOperations.inNamespace("test").withName("my-serviceaccount")
+        .tokenRequest(tokenRequest);
+
+    // Then
+    verify(mockHttpRequestBuilder, times(1)).post(eq("application/json"), anyString());
+    ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
+    verify(mockHttpRequestBuilder, times(1)).url(urlArgumentCaptor.capture());
+    assertThat(urlArgumentCaptor.getValue()).hasPath("/api/v1/namespaces/test/serviceaccounts/my-serviceaccount/token");
+    assertThat(updatedTokenRequest)
+        .hasFieldOrPropertyWithValue("status.token", "my.secret.token")
+        .hasFieldOrPropertyWithValue("status.expirationTimestamp", "2023-06-14T18:42:15Z");
+  }
+
+  @Test
+  void tokenRequest_whenApiServerRequestFailure_thenThrowException() throws URISyntaxException {
+    String responseFromServer = "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"status\":\"Failure\",\"message\":\"serviceaccount my-serviceaccount not found\",\"reason\":\"NotFound\",\"details\":{\"name\":\"my-service-account\",\"kind\":\"serviceaccounts\"},\"code\":404}";
+    HttpRequest.Builder mockHttpRequestBuilder = createMockHttpRequestBuilder();
+    HttpRequest mockHttpRequest = createMockHttpRequest(mockHttpRequestBuilder);
+    when(mockedHttpClient.sendAsync(mockHttpRequest, byte[].class))
+        .thenReturn(CompletableFuture.completedFuture(new TestHttpResponse<byte[]>().withCode(HTTP_NOT_FOUND)
+            .withBody(responseFromServer.getBytes(StandardCharsets.UTF_8))));
+    ServiceAccountResource serviceAccountResource = serviceAccountOperations.inNamespace("test").withName("my-serviceaccount");
+
+    // When
+    assertThatExceptionOfType(KubernetesClientException.class)
+        .isThrownBy(serviceAccountResource::tokenRequest)
+        .withMessageContaining("serviceaccount my-serviceaccount not found")
+        .hasFieldOrPropertyWithValue("code", HTTP_NOT_FOUND)
+        .hasFieldOrPropertyWithValue("status.code", HTTP_NOT_FOUND)
+        .hasFieldOrPropertyWithValue("status.message", "serviceaccount my-serviceaccount not found")
+        .hasFieldOrPropertyWithValue("status.reason", "NotFound");
+  }
+
+  private HttpRequest createMockHttpRequest(HttpRequest.Builder mockHttpRequestBuilder) throws URISyntaxException {
+    HttpRequest mockHttpRequest = mock(HttpRequest.class);
+    when(mockHttpRequestBuilder.build()).thenReturn(mockHttpRequest);
+    when(mockHttpRequest.uri())
+        .thenReturn(new URI("http://test.kubernetes.server/api/v1/namespaces/test/serviceaccounts/my-serviceaccount/token"));
+    when(mockHttpRequest.method()).thenReturn("POST");
+    return mockHttpRequest;
+  }
+
+  private HttpRequest.Builder createMockHttpRequestBuilder() {
+    HttpRequest.Builder mockHttpRequestBuilder = mock(HttpRequest.Builder.class);
+    when(mockedHttpClient.newHttpRequestBuilder()).thenReturn(mockHttpRequestBuilder);
+    when(mockHttpRequestBuilder.post(anyString(), anyString())).thenReturn(mockHttpRequestBuilder);
+    when(mockHttpRequestBuilder.url(any(URL.class))).thenReturn(mockHttpRequestBuilder);
+    when(mockHttpRequestBuilder.timeout(anyLong(), any(TimeUnit.class))).thenReturn(mockHttpRequestBuilder);
+    return mockHttpRequestBuilder;
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceAccountOperationsImplTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/ServiceAccountOperationsImplTest.java
@@ -15,125 +15,95 @@
  */
 package io.fabric8.kubernetes.client.dsl.internal.core.v1;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
 import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
-import io.fabric8.kubernetes.client.http.HttpClient;
-import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.AsyncBody;
+import io.fabric8.kubernetes.client.http.TestAsyncBody;
 import io.fabric8.kubernetes.client.http.TestHttpResponse;
-import io.fabric8.kubernetes.client.impl.BaseClient;
-import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
+import io.fabric8.kubernetes.client.http.TestStandardHttpClient;
+import io.fabric8.kubernetes.client.http.TestStandardHttpClientFactory;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
-import static java.net.HttpURLConnection.HTTP_CREATED;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class ServiceAccountOperationsImplTest {
-  private ServiceAccountOperationsImpl serviceAccountOperations;
-  private HttpClient mockedHttpClient;
+
+  private TestStandardHttpClientFactory factory;
+  private KubernetesClient client;
 
   @BeforeEach
   void setUp() {
-    Client mockedClient = mock(Client.class);
-    BaseClient mockedBaseClient = mock(BaseClient.class);
-    mockedHttpClient = mock(HttpClient.class);
-    when(mockedClient.getConfiguration()).thenReturn(new ConfigBuilder()
-        .withMasterUrl("http://test.kubernetes.server")
-        .build());
-    when(mockedClient.getHttpClient()).thenReturn(mockedHttpClient);
-    when(mockedClient.adapt(BaseClient.class)).thenReturn(mockedBaseClient);
-    when(mockedBaseClient.getKubernetesSerialization()).thenReturn(new KubernetesSerialization(new ObjectMapper(), false));
-    serviceAccountOperations = new ServiceAccountOperationsImpl(mockedClient);
+    factory = new TestStandardHttpClientFactory();
+    client = new KubernetesClientBuilder().withConfig(Config.empty()).withHttpClientFactory(factory).build();
   }
 
   @Test
   void tokenRequest_whenApiServerCallSuccessful_thenReturnTokenInTokenRequestStatus() throws URISyntaxException {
     // Given
-    String responseFromServer = "{\"kind\":\"TokenRequest\",\"apiVersion\":\"authentication.k8s.io/v1\"," +
+    final String responseFromServer = "{\"kind\":\"TokenRequest\",\"apiVersion\":\"authentication.k8s.io/v1\"," +
         "\"status\":{\"token\":\"my.secret.token\",\"expirationTimestamp\":\"2023-06-14T18:42:15Z\"}}";
-    HttpRequest.Builder mockHttpRequestBuilder = createMockHttpRequestBuilder();
-    HttpRequest mockHttpRequest = createMockHttpRequest(mockHttpRequestBuilder);
-    when(mockedHttpClient.sendAsync(mockHttpRequest, byte[].class))
-        .thenReturn(CompletableFuture.completedFuture(new TestHttpResponse<byte[]>().withCode(HTTP_CREATED)
-            .withBody(responseFromServer.getBytes(StandardCharsets.UTF_8))));
+    factory.getInstances().iterator().next()
+        .expect("/api/v1/namespaces/test/serviceaccounts/my-serviceaccount/token", (r, c) -> {
+          final AsyncBody body = new TestAsyncBody();
+          c.consume(Collections.singletonList(ByteBuffer.wrap((responseFromServer).getBytes(StandardCharsets.UTF_8))), body);
+          return CompletableFuture.completedFuture(new TestHttpResponse<AsyncBody>().withCode(200).withBody(body));
+        });
     TokenRequest tokenRequest = new TokenRequestBuilder()
         .withNewSpec()
         .withAudiences("http://example.svc")
         .endSpec()
         .build();
-
     // When
-    TokenRequest updatedTokenRequest = serviceAccountOperations.inNamespace("test").withName("my-serviceaccount")
+    TokenRequest updatedTokenRequest = client.serviceAccounts().inNamespace("test").withName("my-serviceaccount")
         .tokenRequest(tokenRequest);
-
     // Then
-    verify(mockHttpRequestBuilder, times(1)).post(eq("application/json"), anyString());
-    ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
-    verify(mockHttpRequestBuilder, times(1)).url(urlArgumentCaptor.capture());
-    assertThat(urlArgumentCaptor.getValue()).hasPath("/api/v1/namespaces/test/serviceaccounts/my-serviceaccount/token");
+    Assertions.assertThat(factory.getInstances())
+        .singleElement()
+        .extracting(TestStandardHttpClient::getRecordedConsumeBytesDirects)
+        .asList()
+        .hasSize(1)
+        .singleElement()
+        .extracting("request")
+        .extracting("uri").asString()
+        .endsWith("/api/v1/namespaces/test/serviceaccounts/my-serviceaccount/token");
     assertThat(updatedTokenRequest)
         .hasFieldOrPropertyWithValue("status.token", "my.secret.token")
         .hasFieldOrPropertyWithValue("status.expirationTimestamp", "2023-06-14T18:42:15Z");
   }
 
   @Test
-  void tokenRequest_whenApiServerRequestFailure_thenThrowException() throws URISyntaxException {
-    String responseFromServer = "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"status\":\"Failure\",\"message\":\"serviceaccount my-serviceaccount not found\",\"reason\":\"NotFound\",\"details\":{\"name\":\"my-service-account\",\"kind\":\"serviceaccounts\"},\"code\":404}";
-    HttpRequest.Builder mockHttpRequestBuilder = createMockHttpRequestBuilder();
-    HttpRequest mockHttpRequest = createMockHttpRequest(mockHttpRequestBuilder);
-    when(mockedHttpClient.sendAsync(mockHttpRequest, byte[].class))
-        .thenReturn(CompletableFuture.completedFuture(new TestHttpResponse<byte[]>().withCode(HTTP_NOT_FOUND)
-            .withBody(responseFromServer.getBytes(StandardCharsets.UTF_8))));
-    ServiceAccountResource serviceAccountResource = serviceAccountOperations.inNamespace("test").withName("my-serviceaccount");
-
-    // When
+  void tokenRequest_whenApiServerRequestFailure_thenThrowException() {
+    // Given
+    final String responseFromServer = "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"status\":\"Failure\",\"message\":\"serviceaccount my-serviceaccount not found\",\"reason\":\"NotFound\",\"details\":{\"name\":\"my-service-account\",\"kind\":\"serviceaccounts\"},\"code\":404}";
+    factory.getInstances().iterator().next()
+        .expect("/api/v1/namespaces/test/serviceaccounts/my-serviceaccount/token", (r, c) -> {
+          final AsyncBody body = new TestAsyncBody();
+          c.consume(Collections.singletonList(ByteBuffer.wrap((responseFromServer).getBytes(StandardCharsets.UTF_8))), body);
+          return CompletableFuture.completedFuture(new TestHttpResponse<AsyncBody>().withCode(404).withBody(body));
+        });
+    ServiceAccountResource serviceAccountResource = client.serviceAccounts()
+        .inNamespace("test").withName("my-serviceaccount");
+    // When - Then
     assertThatExceptionOfType(KubernetesClientException.class)
         .isThrownBy(serviceAccountResource::tokenRequest)
         .withMessageContaining("serviceaccount my-serviceaccount not found")
-        .hasFieldOrPropertyWithValue("code", HTTP_NOT_FOUND)
-        .hasFieldOrPropertyWithValue("status.code", HTTP_NOT_FOUND)
+        .hasFieldOrPropertyWithValue("code", 404)
+        .hasFieldOrPropertyWithValue("status.code", 404)
         .hasFieldOrPropertyWithValue("status.message", "serviceaccount my-serviceaccount not found")
         .hasFieldOrPropertyWithValue("status.reason", "NotFound");
-  }
-
-  private HttpRequest createMockHttpRequest(HttpRequest.Builder mockHttpRequestBuilder) throws URISyntaxException {
-    HttpRequest mockHttpRequest = mock(HttpRequest.class);
-    when(mockHttpRequestBuilder.build()).thenReturn(mockHttpRequest);
-    when(mockHttpRequest.uri())
-        .thenReturn(new URI("http://test.kubernetes.server/api/v1/namespaces/test/serviceaccounts/my-serviceaccount/token"));
-    when(mockHttpRequest.method()).thenReturn("POST");
-    return mockHttpRequest;
-  }
-
-  private HttpRequest.Builder createMockHttpRequestBuilder() {
-    HttpRequest.Builder mockHttpRequestBuilder = mock(HttpRequest.Builder.class);
-    when(mockedHttpClient.newHttpRequestBuilder()).thenReturn(mockHttpRequestBuilder);
-    when(mockHttpRequestBuilder.post(anyString(), anyString())).thenReturn(mockHttpRequestBuilder);
-    when(mockHttpRequestBuilder.url(any(URL.class))).thenReturn(mockHttpRequestBuilder);
-    when(mockHttpRequestBuilder.timeout(anyLong(), any(TimeUnit.class))).thenReturn(mockHttpRequestBuilder);
-    return mockHttpRequestBuilder;
   }
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceAccountTokenRequestIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ServiceAccountTokenRequestIT.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes;
+
+import io.fabric8.junit.jupiter.api.LoadKubernetesManifests;
+import io.fabric8.junit.jupiter.api.RequireK8sVersionAtLeast;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@LoadKubernetesManifests("/serviceaccounttokenrequest-it.yml")
+@RequireK8sVersionAtLeast(majorVersion = 1, minorVersion = 20)
+class ServiceAccountTokenRequestIT {
+  KubernetesClient client;
+
+  @Test
+  void tokenRequest_whenNoArgsProvided_thenCreateToken() {
+    // Given
+    // When
+    TokenRequest tokenRequest = client.serviceAccounts().withName("sa-token-request-no-args").tokenRequest();
+
+    // Then
+    assertThat(tokenRequest).isNotNull();
+    assertThat(tokenRequest.getStatus()).isNotNull();
+    assertThat(tokenRequest.getStatus().getToken()).isNotEmpty();
+  }
+
+  @Test
+  void tokenRequest_whenArgsProvided_thenCreateToken() {
+    // Given
+    TokenRequest tokenRequest = new TokenRequestBuilder()
+        .withNewSpec()
+        .addToAudiences("https://kubernetes.default.svc")
+        .withExpirationSeconds(3600L)
+        .endSpec()
+        .build();
+
+    // When
+    tokenRequest = client.serviceAccounts().withName("sa-token-request-args").tokenRequest(tokenRequest);
+
+    // Then
+    assertThat(tokenRequest).isNotNull();
+    assertThat(tokenRequest.getStatus()).isNotNull();
+    assertThat(tokenRequest.getStatus().getToken()).isNotEmpty();
+  }
+}

--- a/kubernetes-itests/src/test/resources/serviceaccounttokenrequest-it.yml
+++ b/kubernetes-itests/src/test/resources/serviceaccounttokenrequest-it.yml
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-token-request-no-args
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-token-request-args
+automountServiceAccountToken: true

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceAccountTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceAccountTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.api.model.StatusDetails;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequest;
+import io.fabric8.kubernetes.api.model.authentication.TokenRequestBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@EnableKubernetesMockClient
+class ServiceAccountTest {
+
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  void create() {
+    // Given
+    ServiceAccount serviceAccount = createNewServiceAccount("sa-create");
+    server.expect().post()
+        .withPath("/api/v1/namespaces/test/serviceaccounts")
+        .andReturn(HTTP_CREATED, serviceAccount)
+        .once();
+
+    // When
+    serviceAccount = client.serviceAccounts().resource(serviceAccount).create();
+
+    // Then
+    assertThat(serviceAccount)
+        .hasFieldOrPropertyWithValue("metadata.name", "sa-create");
+  }
+
+  @Test
+  void delete() {
+    // Given
+    ServiceAccount serviceAccount = createNewServiceAccount("sa-delete");
+    server.expect().delete()
+        .withPath("/api/v1/namespaces/test/serviceaccounts/sa-delete")
+        .andReturn(HTTP_OK, serviceAccount)
+        .once();
+
+    // When
+    List<StatusDetails> statusDetails = client.serviceAccounts().resource(serviceAccount).delete();
+
+    // Then
+    assertThat(statusDetails).hasSize(1);
+  }
+
+  @Test
+  void tokenRequest() {
+    // Given
+    TokenRequest tokenRequest = new TokenRequestBuilder()
+        .withNewMetadata()
+        .withName("sa-token-request")
+        .endMetadata()
+        .withNewSpec()
+        .withAudiences("https://kubernetes.default.svc")
+        .withExpirationSeconds(3600L)
+        .withNewBoundObjectRef()
+        .withKind("Pod")
+        .withApiVersion("v1")
+        .withName("pod-foo-346acf")
+        .endBoundObjectRef()
+        .endSpec()
+        .build();
+    server.expect().post()
+        .withPath("/api/v1/namespaces/test/serviceaccounts/sa-token-request/token")
+        .andReturn(HTTP_CREATED, new TokenRequestBuilder(tokenRequest)
+            .withNewStatus()
+            .withToken("my.secret.token")
+            .endStatus()
+            .build())
+        .once();
+
+    // When
+    tokenRequest = client.serviceAccounts().withName("sa-token-request").tokenRequest(tokenRequest);
+
+    // Then
+    assertThat(tokenRequest)
+        .hasFieldOrPropertyWithValue("status.token", "my.secret.token");
+  }
+
+  private ServiceAccount createNewServiceAccount(String name) {
+    return new ServiceAccountBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .build();
+  }
+}


### PR DESCRIPTION
## Description

Fix #5133

+ Add new DSL method `tokenRequest()` in ServiceAccount DSL which will request apiserver for token for the given ServiceAccount.
+ Since this TokenRequest isn't any standard resource but subresource for ServiceAccount, add ServiceAccountResource in order to add new TokenRequestable interface for ServiceAccount

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
