### PR TITLE
fix: HttpLoggingInterceptor uses response body ByteBuffer copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix #5236: using scale v1beta1 compatible logic for DeploymentConfig
 * Fix #5235: Vert.x doesn't need to track derived HttpClients - prevents leakage
 * Fix #5238: Preserve folder structure again in PodUpload.upload()
+* Fix #5250: HttpLoggingInterceptor uses response body ByteBuffer copy
 
 #### Improvements
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpLoggingInterceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpLoggingInterceptor.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.fabric8.kubernetes.client.http.BufferUtil.copy;
+
 public class HttpLoggingInterceptor implements Interceptor {
 
   private final HttpLogger httpLogger;
@@ -93,7 +95,7 @@ public class HttpLoggingInterceptor implements Interceptor {
         value.stream().forEach(bb -> {
           if (responseBodySize.addAndGet(bb.remaining()) < MAX_BODY_SIZE && !bodyTruncated.get()
               && BufferUtil.isPlainText(bb)) {
-            responseBody.add(bb);
+            responseBody.add(copy(bb));
           } else {
             bodyTruncated.set(true);
           }


### PR DESCRIPTION
## Description

Some HttpClient implementations (OkHttpClientImpl) are sending downstream the originally received ByteBuffer(s).
This fix forces the interceptor to store a copy of the ByteBuffer so when the body is logged the buffer is not actually consumed

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
