### PR TITLE
draft of omitting null / empty by default

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
@@ -91,8 +91,8 @@ public class KubernetesSerialization {
   protected void configureMapper(ObjectMapper mapper) {
     mapper.registerModules(new JavaTimeModule(), unmatchedFieldTypeModule);
     mapper.disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
-    // omit null fields, but keep null map values
-    mapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(Include.NON_NULL, Include.ALWAYS));
+    // omit null / empty fields, but keep null map values for patches
+    mapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(Include.NON_EMPTY, Include.ALWAYS));
     HandlerInstantiator instanciator = mapper.getDeserializationConfig().getHandlerInstantiator();
     mapper.setConfig(mapper.getDeserializationConfig().with(new HandlerInstantiator() {
 

--- a/pom.xml
+++ b/pom.xml
@@ -1037,6 +1037,7 @@
             <removeOldOutput>true</removeOldOutput>
             <outputDirectory>${generate.targetDirectory}</outputDirectory>
             <annotationStyle>none</annotationStyle>
+            <inclusionLevel>USE_DEFAULTS</inclusionLevel>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
## Description
Addresses #5255 It turns out that the "easiest" fix for omitting empty strings would also address any remaining collections that lack a NON_EMPTY jsoninclude.

This approach would be to have the jsonschema2pojo delegate the authority over the include to the KubernetesSerializer by setting USE_DEFAULTS.  Then the KubernetesSerializer will specify NON_EMPTY.

Pros:
- gives us more control in the furture over serialization from the serializer, rather than having it baked into the pojos.  This means it could also be made a top level option for the KubernetesSerializer if desired.
- also covers the collection case, but of course users with custom classes can annotate their collection fields with JsonInclude NON_NULL if they want to preserve empty collections (keeping in mind that the builders will initialize to empty).
- we can go further and remove the existing JsonIncludes we are adding to the fields

Cons:
- will require an update to every generated model class and will also mean that serializing the values outside of using the KubernetesSerializer will change (I'm not sure how explicit of a goal that is).
- any users relying on the current built-in empty collection (which is inconsistent, just up to whether the go class is marked as omitempty - with the same caveat about builders) and they won't have an option to override with their own jsoninclude.

@manusa @metacosm 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
