### PR TITLE
improve: public access of object mapper in KubernetesSerialization

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
@@ -380,7 +380,7 @@ public class KubernetesSerialization {
     return unmatchedFieldTypeModule;
   }
 
-  ObjectMapper getMapper() {
+  public ObjectMapper getMapper() {
     return mapper;
   }
 


### PR DESCRIPTION
This is needed for cases when the object mapper needs to be reused to explicitly (de)serialize objects.

Particularly needed for in Java Operator SDK, where this way the `ObjectMapper` can be read from the client and used further withing the framework, for (de)serialize or transfer resources for further usage.

