### PR TITLE
[java-generator] Add native support for date-time fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 #### _**Note**_: Breaking changes
 * Fix #2718: KubernetesResourceUtil.isResourceReady was deprecated.  Use
+* Fix #5279: (java-generator) Add native support for `date-time` fields, they are now mapped to native `java.time.ZonedDateTime`
 
 ### 6.7.2 (2023-06-15)
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -39,6 +39,7 @@ public abstract class AbstractJSONSchema2Pojo {
   static final String FLOAT_CRD_TYPE = "float";
   static final String DOUBLE_CRD_TYPE = "double";
   static final String STRING_CRD_TYPE = "string";
+  static final String DATETIME_CRD_TYPE = "date-time";
   static final String OBJECT_CRD_TYPE = "object";
   static final String ARRAY_CRD_TYPE = "array";
 
@@ -47,6 +48,9 @@ public abstract class AbstractJSONSchema2Pojo {
         new Name("javax.annotation.processing.Generated"),
         new StringLiteralExpr("io.fabric8.java.generator.CRGeneratorRunner"));
   }
+
+  // RFC 3339 - from: https://swagger.io/docs/specification/data-models/data-types/
+  public static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX";
 
   protected final String description;
   protected final Config config;
@@ -197,7 +201,17 @@ public abstract class AbstractJSONSchema2Pojo {
               return fromJsonSchema.apply(JPrimitiveNameAndType.DOUBLE);
           }
         case STRING_CRD_TYPE:
-          return fromJsonSchema.apply(JPrimitiveNameAndType.STRING);
+          String stringFormat = prop.getFormat();
+          if (stringFormat == null)
+            stringFormat = STRING_CRD_TYPE;
+
+          switch (stringFormat) {
+            case DATETIME_CRD_TYPE:
+              return fromJsonSchema.apply(JPrimitiveNameAndType.DATETIME);
+            case STRING_CRD_TYPE:
+            default:
+              return fromJsonSchema.apply(JPrimitiveNameAndType.STRING);
+          }
         case OBJECT_CRD_TYPE:
           if (prop.getAdditionalProperties() != null && prop.getAdditionalProperties().getSchema() != null) {
             return fromJsonSchema.apply(new JMapNameAndType(key));

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -39,6 +39,8 @@ import io.fabric8.kubernetes.client.utils.Utils;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static io.fabric8.java.generator.nodes.JPrimitiveNameAndType.DATETIME_NAME;
+
 public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnnotations {
 
   public static final String DEPRECATED_FIELD_MARKER = "deprecated";
@@ -215,6 +217,12 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
                 new Name("com.fasterxml.jackson.annotation.JsonProperty"),
                 new StringLiteralExpr(originalFieldName)));
 
+        if (prop.getClassType().equals(DATETIME_NAME)) {
+          objField.addAnnotation(new SingleMemberAnnotationExpr(
+              new Name("com.fasterxml.jackson.annotation.JsonFormat"),
+              new NameExpr("timezone = \"UTC\", pattern = \"" + DATETIME_FORMAT + "\"")));
+        }
+
         if (isRequired) {
           objField.addAnnotation("io.fabric8.generator.annotation.Required");
         }
@@ -347,6 +355,9 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
         return new DoubleLiteralExpr(value + "f");
       } else if (prop.getClassType().equals("Boolean") && prop.getDefaultValue().isBoolean()) {
         return new BooleanLiteralExpr(prop.getDefaultValue().booleanValue());
+      } else if (prop.getClassType().equals(DATETIME_NAME) && prop.getDefaultValue().isTextual()) {
+        return new NameExpr(DATETIME_NAME + ".parse(" + prop.getDefaultValue()
+            + ", java.time.format.DateTimeFormatter.ofPattern(\"" + DATETIME_FORMAT + "\"))");
       } else {
         return new NameExpr(value);
       }

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitiveNameAndType.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JPrimitiveNameAndType.java
@@ -16,6 +16,7 @@
 package io.fabric8.java.generator.nodes;
 
 public class JPrimitiveNameAndType extends JavaNameAndType {
+  static final String DATETIME_NAME = "java.time.ZonedDateTime";
   static final JPrimitiveNameAndType INT_OR_STRING = new JPrimitiveNameAndType("io.fabric8.kubernetes.api.model.IntOrString");
   static final JPrimitiveNameAndType BOOL = new JPrimitiveNameAndType("Boolean");
   static final JPrimitiveNameAndType INTEGER = new JPrimitiveNameAndType("Integer");
@@ -23,6 +24,7 @@ public class JPrimitiveNameAndType extends JavaNameAndType {
   static final JPrimitiveNameAndType FLOAT = new JPrimitiveNameAndType("Float");
   static final JPrimitiveNameAndType DOUBLE = new JPrimitiveNameAndType("Double");
   static final JPrimitiveNameAndType STRING = new JPrimitiveNameAndType("String");
+  static final JPrimitiveNameAndType DATETIME = new JPrimitiveNameAndType(DATETIME_NAME);
   static final JPrimitiveNameAndType ANY_TYPE = new JPrimitiveNameAndType("io.fabric8.kubernetes.api.model.AnyType");
 
   public JPrimitiveNameAndType(String name) {

--- a/java-generator/core/src/test/resources/crontab-crd.yml
+++ b/java-generator/core/src/test/resources/crontab-crd.yml
@@ -39,6 +39,9 @@ spec:
                   type: string
                 replicas:
                   type: integer
+                issuedAt:
+                  format: date-time
+                  type: string
             status:
               type: object
               properties:

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabCrd.approved.txt
@@ -11,7 +11,7 @@ public class CronTab extends io.fabric8.kubernetes.client.CustomResource<org.tes
 CrontabJavaCr[1] = package org.test.v1;
 
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-@com.fasterxml.jackson.annotation.JsonPropertyOrder({"cronSpec","image","replicas"})
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"cronSpec","image","issuedAt","replicas"})
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 public class CronTabSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
@@ -38,6 +38,19 @@ public class CronTabSpec implements io.fabric8.kubernetes.api.model.KubernetesRe
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("issuedAt")
+    @com.fasterxml.jackson.annotation.JsonFormat(timezone = "UTC", pattern = "yyyy-MM-dd'T'HH:mm:ssX")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private java.time.ZonedDateTime issuedAt;
+
+    public java.time.ZonedDateTime getIssuedAt() {
+        return issuedAt;
+    }
+
+    public void setIssuedAt(java.time.ZonedDateTime issuedAt) {
+        this.issuedAt = issuedAt;
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("replicas")

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabExtraAnnotationsCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testCrontabExtraAnnotationsCrd.approved.txt
@@ -28,7 +28,7 @@ public class CronTab extends io.fabric8.kubernetes.client.CustomResource<org.tes
 CrontabJavaExtraAnnotationsCr[1] = package org.test.v1;
 
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-@com.fasterxml.jackson.annotation.JsonPropertyOrder({"cronSpec","image","replicas"})
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"cronSpec","image","issuedAt","replicas"})
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()
@@ -72,6 +72,19 @@ public class CronTabSpec implements io.fabric8.kubernetes.api.model.KubernetesRe
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("issuedAt")
+    @com.fasterxml.jackson.annotation.JsonFormat(timezone = "UTC", pattern = "yyyy-MM-dd'T'HH:mm:ssX")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private java.time.ZonedDateTime issuedAt;
+
+    public java.time.ZonedDateTime getIssuedAt() {
+        return issuedAt;
+    }
+
+    public void setIssuedAt(java.time.ZonedDateTime issuedAt) {
+        this.issuedAt = issuedAt;
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("replicas")

--- a/java-generator/it/src/it/default-values-instantiation/src/test/java/io/fabric8/it/certmanager/TestDefaultValues.java
+++ b/java-generator/it/src/it/default-values-instantiation/src/test/java/io/fabric8/it/certmanager/TestDefaultValues.java
@@ -21,12 +21,16 @@ import io.cert_manager.v1.certificaterequestspec.Ten;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.junit.jupiter.api.Test;
 
+import java.time.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static io.cert_manager.v1.CertificateRequestSpec.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestDefaultValues {
+
+  DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
 
   @Test
   void testDefaultValues() throws Exception {
@@ -46,6 +50,7 @@ class TestDefaultValues {
     List<String> nine = cr.getSpec().getNine();
     Ten ten = cr.getSpec().getTen();
     Eleven eleven = cr.getSpec().getEleven();
+    ZonedDateTime twelve = cr.getSpec().getTwelve();
 
     // Assert
     assertEquals("one", one);
@@ -62,5 +67,6 @@ class TestDefaultValues {
     assertEquals("tenone", ten.getTenOne());
     assertEquals("tentwo", ten.getTenTwo());
     assertEquals(Eleven.BAZ, eleven);
+    assertEquals(ZonedDateTime.parse("2017-07-21T17:32:28Z", formatter), twelve);
   }
 }

--- a/java-generator/it/src/it/default-values-instantiation/src/test/resources/example.yaml
+++ b/java-generator/it/src/it/default-values-instantiation/src/test/resources/example.yaml
@@ -97,5 +97,9 @@ spec:
                     - "bar"
                     - "baz"
                   default: "baz"
+                twelve:
+                  type: string
+                  format: date-time
+                  default: "2017-07-21T17:32:28Z"
       served: true
       storage: true

--- a/java-generator/it/src/it/enum-ser-deser/src/test/java/io/fabric8/it/certmanager/TestEnumSerialization.java
+++ b/java-generator/it/src/it/enum-ser-deser/src/test/java/io/fabric8/it/certmanager/TestEnumSerialization.java
@@ -25,11 +25,15 @@ import io.fabric8.java.generator.testing.KubernetesResourceDiff;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.Files;
+import java.time.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestEnumSerialization {
+
+  DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
 
   @Test
   void testDeserialization() {
@@ -47,6 +51,8 @@ class TestEnumSerialization {
     assertEquals(CertificateRequestSpec.Usages.DIGITAL_SIGNATURE, usagesList.get(2));
     assertEquals(CertificateRequestSpec.Usages.SERVER_AUTH, usagesList.get(3));
     assertEquals(CertificateRequestSpec.Usages.S_MIME, usagesList.get(4));
+
+    assertEquals(ZonedDateTime.parse("2017-07-21T17:32:28Z", formatter), sample.getSpec().getDatetime());
   }
 
   @Test

--- a/java-generator/it/src/it/enum-ser-deser/src/test/resources/cert-manager.crds.1.7.1.yaml
+++ b/java-generator/it/src/it/enum-ser-deser/src/test/resources/cert-manager.crds.1.7.1.yaml
@@ -92,6 +92,9 @@ spec:
                 - issuerRef
                 - request
               properties:
+                datetime:
+                  format: date-time
+                  type: string
                 duration:
                   description: The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.
                   type: string

--- a/java-generator/it/src/it/enum-ser-deser/src/test/resources/sample1.yaml
+++ b/java-generator/it/src/it/enum-ser-deser/src/test/resources/sample1.yaml
@@ -19,6 +19,7 @@ kind: CertificateRequest
 metadata:
   name: my-ca-cr
 spec:
+  datetime: "2017-07-21T17:32:28Z"
   request: dGVzdAo=
   isCA: false
   usages:
@@ -31,4 +32,4 @@ spec:
   issuerRef:
     name: ca-issuer
     kind: Issuer
-    group: cert-manager.io
+    group: cert-manager.io           

--- a/java-generator/it/src/it/plugin/.gitignore
+++ b/java-generator/it/src/it/plugin/.gitignore
@@ -1,0 +1,2 @@
+.gradle
+build


### PR DESCRIPTION
## Description

This PR adds native support for `date-time` format of fields of type `string`.
Please note that this is a breaking change, we should at least bump the minor version to introduce it.

`date-time` native parsing is very useful, especially in the standard `Conditions` in the `Status` stanza (e.g. https://maelvls.dev/kubernetes-conditions/ `lastTransitionTime`).

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
