### PR TITLE
fix (kubernetes-client-api) : Check KubeConfig file contents if null/empty before deserialization (#5221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.8-SNAPSHOT
 
 #### Bugs
+* Fix #5221: Empty kube config file causes NPE
 * Fix #5281: Ensure the KubernetesCrudDispatcher's backing map is accessed w/lock
 
 #### Improvements

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -823,5 +824,18 @@ class ConfigTest {
     assertThat(updatedConfig)
         .isSameAs(config)
         .hasFieldOrPropertyWithValue("oauthToken", "token-from-user");
+  }
+
+  @Test
+  void givenEmptyKubeConfig_whenConfigCreated_thenShouldNotProduceNPE() throws URISyntaxException {
+    // Given
+    System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE,
+        new File(Objects.requireNonNull(getClass().getResource("/test-empty-kubeconfig")).toURI()).getAbsolutePath());
+
+    // When
+    Config config = new ConfigBuilder().build();
+
+    // Then
+    assertThat(config).isNotNull();
   }
 }


### PR DESCRIPTION
## Description
Fix #5221

+ Rather than directly deserializing `.kube/config` file content in `io.fabric8.kubernetes.api.model.Config`, do it only when `.kube/config` file content is non-blank.
+ Address cognitive complexity sonar warning in loadFromKubeconfig method

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
