### PR TITLE
fix #5293: removing all typed parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #5281: Ensure the KubernetesCrudDispatcher's backing map is accessed w/lock
+* Fix #5293: Ensured the mock server uses only generic or JsonNode parsing
 
 #### Improvements
 * Fix #5166: Remove opinionated messages from Config's `errorMessages` and deprecate it

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractor.java
@@ -319,7 +319,7 @@ public class KubernetesAttributesExtractor implements AttributeExtractor {
     if (Utils.isNullOrEmpty(s)) {
       return null;
     }
-    HasMetadata result = Serialization.unmarshal(s);
+    HasMetadata result = Serialization.unmarshal(s, GenericKubernetesResource.class);
     if (result == null) {
       throw new IllegalArgumentException("Required value: kind is required");
     }

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/WatchEventsListener.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/WatchEventsListener.java
@@ -16,7 +16,7 @@
 package io.fabric8.kubernetes.client.server.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -98,7 +98,7 @@ class WatchEventsListener extends WebSocketListener {
 
   public void sendWebSocketResponse(String object, Watcher.Action action) {
     WebSocketMessage message = toWebSocketMessage(context,
-        new WatchEvent(Serialization.unmarshal(object, KubernetesResource.class), action.name()));
+        new WatchEvent(Serialization.unmarshal(object, GenericKubernetesResource.class), action.name()));
     executor.schedule(() -> webSocketRef.get().send(message.getBody()), message.getDelay(), TimeUnit.SECONDS);
   }
 


### PR DESCRIPTION
## Description

Fix #5293 

Deserialization may fail if resources are relying upon deserialization customization.  This is just a narrow change.  A broader one would be to remove the static use of Serialization and instead use a KubernetesDeserialization that performs no scanning / registration of classes - it will then naturally use GenericKubernetesResource for everything.

cc @metacosm 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
