### PR TITLE
fix #5260: removing redundant flakey test

### DIFF
--- a/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
+++ b/httpclient-tests/src/test/java/io/fabric8/kubernetes/client/http/OkHttpClientTest.java
@@ -33,7 +33,6 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -42,9 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests a {@link HttpClient} at or below the {@link KubernetesClient} level.
@@ -138,38 +135,6 @@ class OkHttpClientTest {
         .thenCompose(ws -> opened);
 
     assertThat(future.get(10, TimeUnit.SECONDS)).isTrue();
-  }
-
-  @Test
-  void testRequest() throws Exception {
-    server.expect().withPath("/foo")
-        .andUpgradeToWebSocket()
-        .open()
-        .waitFor(0)
-        .andEmit("hello")
-        .waitFor(0)
-        .andEmit("world")
-        .done().always();
-
-    CountDownLatch latch = new CountDownLatch(2);
-
-    CompletableFuture<WebSocket> startedFuture = client.getHttpClient().newWebSocketBuilder()
-        .uri(URI.create(client.getConfiguration().getMasterUrl() + "foo"))
-        .buildAsync(new Listener() {
-
-          @Override
-          public void onMessage(WebSocket webSocket, String text) {
-            latch.countDown();
-          }
-
-        });
-
-    assertFalse(latch.await(10, TimeUnit.SECONDS));
-    assertEquals(1, latch.getCount());
-
-    startedFuture.get(10, TimeUnit.SECONDS).request();
-
-    assertTrue(latch.await(10, TimeUnit.SECONDS));
   }
 
   @Test


### PR DESCRIPTION
## Description

Fix #5260 

Removes a test with occasional failures likely due to reusing a test endpoint.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
