### PR TITLE
Deprecate PrinterColumn annotation to move it to the crd-generator module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 #### New Features
 * Fix #5133: Support for using TokenRequest for existing ServiceAccount
 
+#### Deprecations
+* Deprecating `io.fabric8.kubernetes.model.annotation.PrinterColumn` in favor of: `io.fabric8.crd.generator.annotation.PrinterColumn`
+
 #### _**Note**_: Breaking changes
 * Fix #2718: KubernetesResourceUtil.isResourceReady was deprecated.  Use `client.resource(item).isReady()` or `Readiness.getInstance().isReady(item)` instead.
 * Fix #5171: Removed Camel-K extension, use [`org.apache.camel.k:camel-k-crds`](https://central.sonatype.com/artifact/org.apache.camel.k/camel-k-crds) instead.

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PrinterColumn.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PrinterColumn.java
@@ -13,32 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.model.annotation;
+package io.fabric8.crd.generator.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * @deprecated: use io.fabric8.crd.generator.annotation.PrinterColumn instead
- */
 @Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
-@Deprecated
 public @interface PrinterColumn {
 
   /**
    * The name of the column.
    * An empty column name implies the use of the property name
-   * 
+   *
    * @return the column name, or empty string if the annotated property name should be used.
    */
   String name() default "";
 
   /**
    * The printer column format.
-   * 
+   *
    * @return the format or empty string if no format is specified.
    */
   String format() default "";

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AdditionalPrinterColumnDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AdditionalPrinterColumnDetector.java
@@ -15,7 +15,7 @@
  */
 package io.fabric8.crd.generator.visitor;
 
-import io.fabric8.kubernetes.model.annotation.PrinterColumn;
+import io.fabric8.crd.generator.annotation.PrinterColumn;
 
 import java.util.ArrayList;
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequestSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequestSpec.java
@@ -16,7 +16,7 @@
 package io.fabric8.crd.example.joke;
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import io.fabric8.kubernetes.model.annotation.PrinterColumn;
+import io.fabric8.crd.generator.annotation.PrinterColumn;
 
 public class JokeRequestSpec {
 
@@ -42,7 +42,7 @@ public class JokeRequestSpec {
   @PrinterColumn(name = "jokeCategory", priority = 1)
   @JsonPropertyDescription("category-description")
   private Category category = Category.Any;
-  @PrinterColumn(name = "excludedTopics")
+  @io.fabric8.kubernetes.model.annotation.PrinterColumn(name = "excludedTopics")
   private ExcludedTopic[] excluded = new ExcludedTopic[] { ExcludedTopic.nsfw, ExcludedTopic.racist,
       ExcludedTopic.sexist };
   private boolean safe;

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -271,9 +271,9 @@ The field will be marked as `required` in the generated CRD, such as:
             type: object
 ```
 
-### io.fabric8.kubernetes.model.annotation.PrinterColumn
+### io.fabric8.crd.generator.annotation.PrinterColumn
 
-If a field or one of its accessors is annotated with `io.fabric8.kubernetes.model.annotation.PrinterColumn`
+If a field or one of its accessors is annotated with `io.fabric8.crd.generator.annotation.PrinterColumn`
 
 ```java
 public class ExampleSpec { 
@@ -465,7 +465,7 @@ The CRD generator will add the additional `labels`:
 | `io.fabric8.crd.generator.annotation.SchemaSwap`             | Similar to SchemaFrom, but can be applied at any point in the class hierarchy            |
 | `io.fabric8.crd.generator.annotation.Annotations`            | Additional `annotations` in `metadata`                                                |
 | `io.fabric8.crd.generator.annotation.Labels`                 | Additional `labels` in `metadata`                                                     |
-| `io.fabric8.kubernetes.model.annotation.PrinterColumn`       | Customize columns shown by the `kubectl get` command                                  |
+| `io.fabric8.crd.generator.annotation.PrinterColumn`       | Customize columns shown by the `kubectl get` command                                  |
 
 A field of type `com.fasterxml.jackson.databind.JsonNode` is encoded as an empty object with `x-kubernetes-preserve-unknown-fields: true` defined.
 


### PR DESCRIPTION
## Description
Follow up from #5339 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
