### PR TITLE
operations to generalize createOrReplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Improvements
 * Fix #5368: added support for additional ListOptions fields
+* Fix #5377: added a createOr and unlock function to provide a straight-forward replacement for createOrReplace.
 * Fix #5388: [crd-generator] Generate deterministic CRDs
 
 #### Dependency Upgrade

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -23,7 +23,8 @@ public interface CreateOrReplaceable<T> extends Replaceable<T> {
    *
    * @return created item returned in kubernetes api response
    *
-   * @deprecated please use {@link ServerSideApplicable#serverSideApply()} or attempt a create then edit/patch operation.
+   * @deprecated please use {@link ServerSideApplicable#serverSideApply()}
+   *             or the {@link NonDeletingOperation#createOr(java.util.function.Function)}.
    * @see <a href=
    *      "https://github.com/fabric8io/kubernetes-client/blob/main/doc/FAQ.md#alternatives-to-createOrReplace-and-replace"
    *      >Migration FAQ</a>
@@ -37,4 +38,5 @@ public interface CreateOrReplaceable<T> extends Replaceable<T> {
    * @return the item from the api server
    */
   T create();
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
@@ -15,10 +15,33 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import java.util.function.Function;
+
 public interface NonDeletingOperation<T> extends
     CreateOrReplaceable<T>,
     EditReplacePatchable<T>,
     Replaceable<T>, ItemReplacable<T>,
     ItemWritableOperation<T>,
     ServerSideApplicable<T> {
+
+  /**
+   * Alternative to {@link CreateOrReplaceable#createOrReplace()}.
+   * <p>
+   * Will attempt a create, and if that fails will perform the conflictAction.
+   * <p>
+   * Most commonly the conflictAction will be NonDeletingOperation::update or NonDeletingOperation::patch,
+   * but you are free to provide whatever Function suits your needs.
+   *
+   * @param conflictAction to be performed it the create fails with a conflict
+   * @return
+   */
+  T createOr(Function<NonDeletingOperation<T>, T> conflictAction);
+
+  /**
+   * Removes the resource version from the current item. If the operation context was
+   * created by name, and without an item, this will fetch the item from the api server first.
+   *
+   * @return NonDeletingOperation that may act on the unlocked item
+   */
+  NonDeletingOperation<T> unlock();
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResource.java
@@ -91,6 +91,9 @@ public interface ExtensibleResource<T> extends Resource<T>, TimeoutableScalable<
   ExtensibleResource<T> withTimeout(long timeout, TimeUnit unit);
 
   @Override
+  ExtensibleResource<T> unlock();
+
+  @Override
   default ExtensibleResource<T> withTimeoutInMillis(long timeoutInMillis) {
     return withTimeout(timeoutInMillis, TimeUnit.MILLISECONDS);
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
@@ -127,4 +127,9 @@ public abstract class ExtensibleResourceAdapter<T> extends ResourceAdapter<T> im
     return withTimeout(timeoutInMillis, TimeUnit.MILLISECONDS);
   }
 
+  @Override
+  public ExtensibleResource<T> unlock() {
+    return newInstance().init(resource.unlock(), client);
+  }
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -370,4 +370,14 @@ public class ResourceAdapter<T> implements Resource<T> {
     return resource.scale(scale);
   }
 
+  @Override
+  public T createOr(Function<NonDeletingOperation<T>, T> conflictAction) {
+    return resource.createOr(conflictAction);
+  }
+
+  @Override
+  public NonDeletingOperation<T> unlock() {
+    return resource.unlock();
+  }
+
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.mock;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@EnableKubernetesMockClient
+class CreateOrTest {
+
+  KubernetesMockServer server;
+  KubernetesClient client;
+
+  @Test
+  @DisplayName("Should replace an existing resource in Kubernetes Cluster")
+  void testResourceReplace() {
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, new PodBuilder()
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
+
+    server.expect().get().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
+        .withNewMetadata().withResourceVersion("12345").and().build()).times(2);
+
+    server.expect().put().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
+
+    Pod pod = client.resource(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build())
+        .createOr(NonDeletingOperation::update);
+    assertNotNull(pod);
+    assertEquals("12345", pod.getMetadata().getResourceVersion());
+  }
+
+  @Test
+  @DisplayName("Should create a new resource in Kubernetes Cluster")
+  void testResourceCreate() {
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CREATED, new PodBuilder()
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
+
+    HasMetadata result = client
+        .resource(new PodBuilder().withNewMetadata().withName("pod123").and().withNewSpec().and().build())
+        .createOr(NonDeletingOperation::update);
+    assertNotNull(result);
+    assertEquals("12345", result.getMetadata().getResourceVersion());
+  }
+
+  @Test
+  @DisplayName("Should throw Exception on failed create")
+  void testResourceCreateFailure() {
+    // Given
+    server.expect().post().withPath("/api/v1/namespaces/test/pods")
+        .andReturn(HttpURLConnection.HTTP_BAD_REQUEST, new PodBuilder()
+            .withNewMetadata().withResourceVersion("12345").endMetadata().build())
+        .once();
+    NamespaceableResource<Pod> podOperation = client
+        .resource(new PodBuilder().withNewMetadata().withName("pod123").endMetadata().build());
+
+    // When
+    assertThrows(KubernetesClientException.class, () -> podOperation.createOr(NonDeletingOperation::update));
+  }
+
+  @Test
+  void testUnlock() {
+    // Given
+    server.expect().post().withPath("/api/v1/namespaces/test/pods").andReturn(HttpURLConnection.HTTP_CONFLICT, "").once();
+
+    server.expect().get().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
+        .withNewMetadata().withResourceVersion("12345").and().build()).once();
+
+    server.expect().put().withPath("/api/v1/namespaces/test/pods/pod123").andReturn(HttpURLConnection.HTTP_OK, new PodBuilder()
+        .withNewMetadata().withResourceVersion("12346").and().build()).once();
+
+    NamespaceableResource<Pod> podOperation = client
+        .resource(new PodBuilder().withNewMetadata().withResourceVersion("12344").withName("pod123").endMetadata().build());
+
+    Pod pod = podOperation.unlock().createOr(NonDeletingOperation::update);
+    assertNotNull(pod);
+    assertEquals("12346", pod.getMetadata().getResourceVersion());
+  }
+
+}


### PR DESCRIPTION
## Description

Covers one of the cases described in #5377 

As mentioned on https://github.com/fabric8io/kubernetes-client/issues/5337#issuecomment-1653494385 one path to createOrReplace replacement is offering alternative dsl.  It's a bit more work to do something like createIfNotFound - we'll need an additional context flag, and some new interfaces, so this shows what createOr method and unlock method would look like:

resource.createOrReplace() -> resource.unlock().createOr(NonDeletingOperation::upadate)

This means the user depending on the scenario may leave the operation as locked or use a json patch instead, for example:

resource.createOr(NonDeletingOperation::patch)

The thing that reads a little oddly is the use of the NonDeletingOperation - that is the first parent interface that knows about both patching and update.  It could just as easily be moved more to the Resource interface without too much confusion over available methods.

For users on a list context the expectation is that instead of list.createOrReplace() they'd use list.resources().forEach(alternative lamda) - rather than offering new top-level methods on the list context.

Side note - NonDeletingOperation currently does offer delete transitively, I think that is probably a mistake, but one that is currently not meaningful.  I'm not sure if it belongs in 6.x, but it would be good to clean the interfaces once again to remove the deprecated item based methods, which would further allow some consolidation.

Any thoughts @manusa @rohanKanojia

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
