### PR TITLE
adding support for new list options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 #### Bugs
 
 #### Improvements
+* Fix #5368: added support for additional ListOptions fields
 
 #### Dependency Upgrade
 
 #### New Features
 
 #### _**Note**_: Breaking changes
+* Fix #5368: ListOptions parameter ordering is now alphabetical.  If you are using non-crud mocking for lists with options, you may need to update your parameter order.
 
 ### 6.8.0 (2023-07-24)
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -301,7 +301,7 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
    */
   protected void startWatch() {
     listOptions.setResourceVersion(resourceVersion.get());
-    URL url = BaseOperation.appendListOptionParams(requestUrl, listOptions);
+    URL url = this.baseOperation.appendListOptionParams(requestUrl, listOptions);
 
     String origin = requestUrl.getProtocol() + "://" + requestUrl.getHost();
     if (requestUrl.getPort() != -1) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -78,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -1015,41 +1016,17 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return informer;
   }
 
-  public static URL appendListOptionParams(URL base, ListOptions listOptions) {
+  public URL appendListOptionParams(URL base, ListOptions listOptions) {
     if (listOptions == null) {
       return base;
     }
     URLBuilder urlBuilder = new URLBuilder(base);
-    if (listOptions.getLimit() != null) {
-      urlBuilder.addQueryParameter("limit", listOptions.getLimit().toString());
-    }
-    if (listOptions.getContinue() != null) {
-      urlBuilder.addQueryParameter("continue", listOptions.getContinue());
-    }
 
-    if (listOptions.getFieldSelector() != null) {
-      urlBuilder.addQueryParameter("fieldSelector", listOptions.getFieldSelector());
-    }
+    Map<String, ?> values = getKubernetesSerialization().convertValue(listOptions, TreeMap.class);
+    values.remove("apiVersion");
+    values.remove("kind");
+    values.forEach((k, v) -> urlBuilder.addQueryParameter(k, v.toString()));
 
-    if (listOptions.getLabelSelector() != null) {
-      urlBuilder.addQueryParameter("labelSelector", listOptions.getLabelSelector());
-    }
-
-    if (listOptions.getResourceVersion() != null) {
-      urlBuilder.addQueryParameter("resourceVersion", listOptions.getResourceVersion());
-    }
-
-    if (listOptions.getTimeoutSeconds() != null) {
-      urlBuilder.addQueryParameter("timeoutSeconds", listOptions.getTimeoutSeconds().toString());
-    }
-
-    if (listOptions.getAllowWatchBookmarks() != null) {
-      urlBuilder.addQueryParameter("allowWatchBookmarks", listOptions.getAllowWatchBookmarks().toString());
-    }
-
-    if (listOptions.getWatch() != null) {
-      urlBuilder.addQueryParameter(WATCH, listOptions.getWatch().toString());
-    }
     return urlBuilder.build();
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
 import io.fabric8.kubernetes.client.utils.CommonThreadPool;
+import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -285,6 +286,8 @@ class AbstractWatchManagerTest {
   static BaseOperation mockOperation() {
     BaseOperation operation = mock(BaseOperation.class, Mockito.RETURNS_DEEP_STUBS);
     Mockito.when(operation.getOperationContext().getExecutor()).thenReturn(Runnable::run);
+    Mockito.when(operation.getKubernetesSerialization()).thenReturn(new KubernetesSerialization());
+    Mockito.when(operation.appendListOptionParams(Mockito.any(), Mockito.any())).thenCallRealMethod();
     return operation;
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
@@ -34,6 +34,7 @@ import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import io.fabric8.kubernetes.client.http.TestHttpResponse;
 import io.fabric8.kubernetes.client.impl.BaseClient;
 import io.fabric8.kubernetes.client.utils.CommonThreadPool;
+import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -132,7 +133,13 @@ class BaseOperationTest {
   void testListOptions() throws MalformedURLException {
     // Given
     URL url = new URL("https://172.17.0.2:8443/api/v1/namespaces/default/pods");
-    final BaseOperation<Pod, PodList, Resource<Pod>> operation = new BaseOperation<>(new OperationContext());
+    final BaseOperation<Pod, PodList, Resource<Pod>> operation = new BaseOperation<Pod, PodList, Resource<Pod>>(
+        new OperationContext()) {
+      @Override
+      public KubernetesSerialization getKubernetesSerialization() {
+        return new KubernetesSerialization();
+      }
+    };
 
     // When and Then
     assertEquals(URLUtils.join(url.toString(), "?limit=5"),
@@ -141,20 +148,20 @@ class BaseOperationTest {
             .build()).toString());
     assertEquals(
         URLUtils.join(url.toString(),
-            "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ"),
+            "?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&limit=5"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
             .build()).toString());
     assertEquals(URLUtils.join(url.toString(),
-        "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&fieldSelector=status.phase%3DRunning"),
+        "?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&fieldSelector=status.phase%3DRunning&limit=5"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
             .withFieldSelector("status.phase=Running")
             .build()).toString());
     assertEquals(URLUtils.join(url.toString(),
-        "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&fieldSelector=status.phase%3DRunning&resourceVersion=210448"),
+        "?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&fieldSelector=status.phase%3DRunning&limit=5&resourceVersion=210448"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
@@ -162,7 +169,7 @@ class BaseOperationTest {
             .withResourceVersion("210448")
             .build()).toString());
     assertEquals(URLUtils.join(url.toString(),
-        "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448"),
+        "?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&limit=5&resourceVersion=210448"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
@@ -170,7 +177,7 @@ class BaseOperationTest {
             .withResourceVersion("210448")
             .build()).toString());
     assertEquals(URLUtils.join(url.toString(),
-        "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448&timeoutSeconds=10"),
+        "?continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&limit=5&resourceVersion=210448&timeoutSeconds=10"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
@@ -179,7 +186,7 @@ class BaseOperationTest {
             .withTimeoutSeconds(10L)
             .build()).toString());
     assertEquals(URLUtils.join(url.toString(),
-        "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448&timeoutSeconds=10&allowWatchBookmarks=true"),
+        "?allowWatchBookmarks=true&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&limit=5&resourceVersion=210448&timeoutSeconds=10"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
@@ -189,7 +196,7 @@ class BaseOperationTest {
             .withAllowWatchBookmarks(true)
             .build()).toString());
     assertEquals(URLUtils.join(url.toString(),
-        "?limit=5&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&resourceVersion=210448&timeoutSeconds=10&allowWatchBookmarks=true&watch=true"),
+        "?allowWatchBookmarks=true&continue=eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ&labelSelector=%21node-role.kubernetes.io%2Fmaster&limit=5&resourceVersion=210448&timeoutSeconds=10&watch=true"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withContinue("eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MjE0NDUzLCJzdGFydCI6ImV0Y2QtbWluaWt1YmVcdTAwMDAifQ")
@@ -208,6 +215,17 @@ class BaseOperationTest {
     assertEquals(URLUtils.join(url.toString(), "?watch=true"), operation.fetchListUrl(url, new ListOptionsBuilder()
         .withWatch(true)
         .build()).toString());
+    // taken from the example showing how to use send initial events
+    assertEquals(
+        URLUtils.join(url.toString(),
+            "?allowWatchBookmarks=true&resourceVersion=&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true"),
+        operation.fetchListUrl(url, new ListOptionsBuilder()
+            .withWatch(true)
+            .withSendInitialEvents()
+            .withAllowWatchBookmarks()
+            .withResourceVersion("")
+            .withResourceVersionMatch("NotOlderThan")
+            .build()).toString());
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -430,8 +430,8 @@ class CustomResourceTest {
   void testWatchSingleResource() throws IOException, InterruptedException {
     // Given
     server.expect()
-        .withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos" + "?fieldSelector="
-            + Utils.toUrlEncoded("metadata.name=example-hello") + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos" + "?allowWatchBookmarks=true&fieldSelector="
+            + Utils.toUrlEncoded("metadata.name=example-hello") + "&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_PERIOD)
@@ -464,8 +464,8 @@ class CustomResourceTest {
   void testWatchWithLabels() throws IOException, InterruptedException {
     // Given
     server.expect()
-        .withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?labelSelector=" + Utils.toUrlEncoded("foo=bar")
-            + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?allowWatchBookmarks=true&labelSelector="
+            + Utils.toUrlEncoded("foo=bar") + "&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_PERIOD)
@@ -498,8 +498,9 @@ class CustomResourceTest {
     // Given
     String watchResourceVersion = "1001";
     server.expect()
-        .withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?resourceVersion=" + watchResourceVersion
-            + "&allowWatchBookmarks=true&watch=true")
+        .withPath("/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?allowWatchBookmarks=true&resourceVersion="
+            + watchResourceVersion
+            + "&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_PERIOD)
@@ -533,7 +534,7 @@ class CustomResourceTest {
   void testWatchWithListOptions() throws IOException, InterruptedException {
     // Given
     server.expect().withPath(
-        "/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?resourceVersion=1003&timeoutSeconds=30&allowWatchBookmarks=true&watch=true")
+        "/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?allowWatchBookmarks=true&resourceVersion=1003&timeoutSeconds=30&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_PERIOD)
@@ -570,7 +571,7 @@ class CustomResourceTest {
   void testWatchWithNamespaceAndListOptions() throws IOException, InterruptedException {
     // Given
     server.expect().withPath(
-        "/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?resourceVersion=1003&timeoutSeconds=30&allowWatchBookmarks=true&watch=true")
+        "/apis/test.fabric8.io/v1alpha1/namespaces/ns1/hellos?allowWatchBookmarks=true&resourceVersion=1003&timeoutSeconds=30&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_PERIOD)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -128,8 +128,8 @@ class DefaultSharedIndexInformerTest {
         .once();
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?resourceVersion=" + startResourceVersion
-                + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
+                + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -187,9 +187,9 @@ class DefaultSharedIndexInformerTest {
         .andReturn(200, getList(startResourceVersion, Pod.class))
         .once();
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=" + Utils.toUrlEncoded("metadata.name=pod1")
-            + "&resourceVersion="
-            + startResourceVersion + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath(
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=" + Utils.toUrlEncoded("metadata.name=pod1")
+                + "&resourceVersion=" + startResourceVersion + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -253,8 +253,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
-            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -316,8 +316,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
-            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -347,8 +347,8 @@ class DefaultSharedIndexInformerTest {
                 .build())
         .times(2);
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + mid2ResourceVersion
-            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + mid2ResourceVersion
+            + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -404,8 +404,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
-            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -471,8 +471,8 @@ class DefaultSharedIndexInformerTest {
         .once();
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?resourceVersion=" + startResourceVersion
-                + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
+                + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -978,8 +978,8 @@ class DefaultSharedIndexInformerTest {
         .endMetadata()
         .build();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
-            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -1008,8 +1008,8 @@ class DefaultSharedIndexInformerTest {
 
     // should pick this up after the termination
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + midResourceVersion
-            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + midResourceVersion
+            + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -1080,8 +1080,8 @@ class DefaultSharedIndexInformerTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/pods?resourceVersion=" + startResourceVersion
-            + "&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
+            + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(WATCH_EVENT_EMIT_TIME)
@@ -1256,12 +1256,13 @@ class DefaultSharedIndexInformerTest {
     url += ("/" + HasMetadata.getPlural(resourceClass));
     URLUtils.URLBuilder builder = new URLUtils.URLBuilder(url);
 
-    if (labelSelector != null) {
-      builder.addQueryParameter("labelSelector", labelSelector);
-    }
     if (fieldSelector != null) {
       builder.addQueryParameter("fieldSelector", fieldSelector);
     }
+    if (labelSelector != null) {
+      builder.addQueryParameter("labelSelector", labelSelector);
+    }
+
     String watchUrl = builder.toString();
     builder.addQueryParameter("resourceVersion", "0");
     String listUrl = builder.toString();
@@ -1271,9 +1272,9 @@ class DefaultSharedIndexInformerTest {
         .once();
 
     URLBuilder watchBuilder = new URLUtils.URLBuilder(watchUrl);
-    watchUrl = watchBuilder.addQueryParameter("resourceVersion", startResourceVersion)
+    watchUrl = watchBuilder.addQueryParameter("allowWatchBookmarks", "true")
+        .addQueryParameter("resourceVersion", startResourceVersion)
         .addQueryParameter("timeoutSeconds", "600")
-        .addQueryParameter("allowWatchBookmarks", "true")
         .addQueryParameter("watch", "true")
         .toString();
     server.expect()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/InformTest.java
@@ -74,7 +74,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&labelSelector=my-label&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -128,7 +128,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/apis/demos.fabric8.io/v1/namespaces/test/dummies?labelSelector=my-label&resourceVersion=2&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/apis/demos.fabric8.io/v1/namespaces/test/dummies?allowWatchBookmarks=true&labelSelector=my-label&resourceVersion=2&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -196,7 +196,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -261,7 +261,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?labelSelector=my-label&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&labelSelector=my-label&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -332,14 +332,14 @@ class InformTest {
         .once();
 
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?limit=1&continue=x")
+        .withPath("/api/v1/namespaces/test/pods?continue=x&limit=1")
         .andReturn(HttpURLConnection.HTTP_OK,
             new PodListBuilder().withNewMetadata().withResourceVersion("2").endMetadata().withItems(pod2).build())
         .once();
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?resourceVersion=2&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=2&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()
@@ -390,7 +390,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()
@@ -457,7 +457,7 @@ class InformTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
@@ -57,7 +57,7 @@ class NodeMetricsTest {
     // Given
     server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?resourceVersion=0").andReturn(HTTP_OK,
         new NodeMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
-    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/nodes?allowWatchBookmarks=true&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
@@ -74,7 +74,7 @@ class PodMetricsTest {
     // Given
     server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?resourceVersion=0").andReturn(HTTP_OK,
         new PodMetricsListBuilder().withMetadata(new ListMeta()).build()).once();
-    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+    server.expect().withPath("/apis/metrics.k8s.io/v1beta1/pods?allowWatchBookmarks=true&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .done()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -628,7 +628,7 @@ class PodTest {
             .build())
         .once();
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(50)
@@ -708,7 +708,7 @@ class PodTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(50)

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -206,7 +206,7 @@ public class ResourceListTest {
     ResourceTest.list(server, noReady2, null);
 
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(ready1, "MODIFIED"))
@@ -214,7 +214,7 @@ public class ResourceListTest {
         .once();
 
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
@@ -256,7 +256,7 @@ public class ResourceListTest {
 
     // This pod has a non-retryable error.
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
@@ -265,7 +265,7 @@ public class ResourceListTest {
 
     // This pod succeeds.
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(ready2, "MODIFIED"))
@@ -307,7 +307,7 @@ public class ResourceListTest {
 
     // Both pods have a non-retryable error.
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))
@@ -315,7 +315,7 @@ public class ResourceListTest {
         .once();
 
     server.expect().get().withPath(
-        "/api/v1/namespaces/ns1/pods?fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+        "/api/v1/namespaces/ns1/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod2&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500).andEmit(new WatchEvent(gone, "ERROR"))

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -266,7 +266,7 @@ class ResourceTest {
 
     server.expect()
         .get()
-        .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(1000)
@@ -308,7 +308,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -322,7 +322,7 @@ class ResourceTest {
 
   /**
    * List the pod for the initial request from an informer
-   * 
+   *
    * @param pod
    */
   private void list(Pod pod) {
@@ -361,7 +361,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(100)
@@ -421,7 +421,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(1000)
@@ -469,7 +469,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -480,7 +480,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -514,7 +514,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -525,7 +525,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -578,7 +578,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(500)
@@ -611,7 +611,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(1000)
@@ -641,7 +641,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(1000)
@@ -692,7 +692,7 @@ class ResourceTest {
     server.expect()
         .get()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod&resourceVersion=1&timeoutSeconds=600&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .immediately()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -80,7 +80,7 @@ class WatchTest {
     // Given
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -122,7 +122,7 @@ class WatchTest {
     final CountDownLatch closeLatch = new CountDownLatch(1);
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
         .andReturn(410, outdatedEvent())
         .once();
     final Watcher<Pod> watcher = new Watcher<Pod>() {
@@ -158,7 +158,7 @@ class WatchTest {
   void testWithTimeoutSecondsShouldAddQueryParam() throws InterruptedException {
     // Given
     server.expect()
-        .withPath("/api/v1/namespaces/test/pods?timeoutSeconds=30&allowWatchBookmarks=true&watch=true")
+        .withPath("/api/v1/namespaces/test/pods?allowWatchBookmarks=true&timeoutSeconds=30&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -193,7 +193,7 @@ class WatchTest {
   void testHttpErrorReconnect() throws InterruptedException {
     // Given
     client.getConfiguration().setWatchReconnectInterval(10);
-    final String path = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true";
+    final String path = "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true";
     // accept watch and disconnect
     server.expect().withPath(path).andUpgradeToWebSocket().open().done().once();
     // refuse reconnect attempts 6 times
@@ -232,7 +232,7 @@ class WatchTest {
 
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)
@@ -282,7 +282,7 @@ class WatchTest {
         .endMetadata()
         .build();
 
-    final String path = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true";
+    final String path = "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true";
 
     server.expect()
         .withPath(path)
@@ -295,7 +295,7 @@ class WatchTest {
         .done()
         .once();
 
-    final String reconnectPath = "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=10&allowWatchBookmarks=true&watch=true";
+    final String reconnectPath = "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=10&watch=true";
 
     server.expect()
         .withPath(reconnectPath)
@@ -337,7 +337,7 @@ class WatchTest {
     // Given
     server.expect()
         .withPath(
-            "/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod1&resourceVersion=1&allowWatchBookmarks=true&watch=true")
+            "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
         .andUpgradeToWebSocket()
         .open()
         .waitFor(EVENT_WAIT_PERIOD_MS)


### PR DESCRIPTION
## Description
Since we directly expose ListOptions, it's good to keep it up-to-date - to future-proof it logic was switched to serialization.  This accounts for several missing properties including includeInitialEvents and resourceVersionMatch.  

Closes #5368

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
