### PR TITLE
[java-generator] Avoid to emit Java Keywords as package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #5382: [java-generator] Allow to deserialize more valid RFC3339 date-time and make the format customizable
+* Fix #5380: [java-generator] Avoid to emit Java Keywords as package names
 
 #### Improvements
 * Fix #5368: added support for additional ListOptions fields

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/AbstractJSONSchema2Pojo.java
@@ -80,6 +80,11 @@ public abstract class AbstractJSONSchema2Pojo {
     if (pkg.equals(str)) { // avoid package/class name clash
       pkg = "_" + pkg;
     }
+    // https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
+    // if the package name contains a reserved Java keyword ... the suggested convention is to add an underscore
+    if (JAVA_KEYWORDS.contains(pkg)) {
+      pkg = pkg + "_";
+    }
     return pkg;
   }
 

--- a/java-generator/it/src/it/escape-characters/src/test/java/io/fabric8/it/dummy/TestEscapeCharacters.java
+++ b/java-generator/it/src/it/escape-characters/src/test/java/io/fabric8/it/dummy/TestEscapeCharacters.java
@@ -18,6 +18,8 @@ package io.fabric8.it.dummy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.example.v1.Dummy;
 import com.example.v1.DummySpec;
+import com.example.v1.dummyspec.Package;
+import com.example.v1.dummyspec.package_.Foo;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,7 @@ class TestEscapeCharacters {
     assertEquals("3", spec.getThree_quote());
     assertEquals("4", spec.getFour_doublequote());
     assertEquals("5", spec.getFive_slash());
+    assertEquals("6", spec.get_package().getFoo().getBar());
   }
 
   @Test
@@ -63,6 +66,11 @@ class TestEscapeCharacters {
     spec.setThree_quote("3");
     spec.setFour_doublequote("4");
     spec.setFive_slash("5");
+    Foo foo = new Foo();
+    foo.setBar("6");
+    Package pack = new Package();
+    pack.setFoo(foo);
+    spec.set_package(pack);
     sample.setSpec(spec);
     ObjectMeta om = new ObjectMeta();
     om.setName("sample");

--- a/java-generator/it/src/it/escape-characters/src/test/resources/dummy-crd.yml
+++ b/java-generator/it/src/it/escape-characters/src/test/resources/dummy-crd.yml
@@ -43,6 +43,14 @@ spec:
                   type: string
                 five/slash:
                   type: string
+                package:
+                  type: object
+                  properties:
+                    foo:
+                      type: object
+                      properties:
+                        bar:
+                          type: string
   scope: Namespaced
   names:
     plural: dummies

--- a/java-generator/it/src/it/escape-characters/src/test/resources/sample.yaml
+++ b/java-generator/it/src/it/escape-characters/src/test/resources/sample.yaml
@@ -25,3 +25,6 @@ spec:
   three'quote: "3"
   four"doublequote: "4"
   five/slash: "5"
+  package:
+    foo:
+      bar: "6"


### PR DESCRIPTION
## Description
Fix #5380 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
