### PR TITLE
test:refactor: Chaos tests require single Maven execution

### DIFF
--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -67,13 +67,8 @@ jobs:
         run: |
           curl -sSL https://mirrors.chaos-mesh.org/v${CHAOS_MESH_VERSION}/install.sh | bash
           kubectl wait --for=condition=Ready pods --all-namespaces --all --timeout=600s
-      - name: Build the Support apps containers
-        run: |
-          # eval $(minikube -p minikube docker-env) -> check if needed in CI
-          ./mvnw ${MAVEN_ARGS} -U -Pitests -P"httpclient-${{ matrix.http-client }}" -Pchecker clean package k8s:build -pl $CHAOS_TESTS_MODULE -DskipTests
-          ./mvnw ${MAVEN_ARGS} -U -Pitests -P"httpclient-${{ matrix.http-client }}" -Pcontrol clean package k8s:build -pl $CHAOS_TESTS_MODULE -DskipTests
       - name: Run Chaos Tests
         env:
           CHAOS_TEST: ${{ matrix.chaos-test }}
         run: |
-          ./mvnw ${MAVEN_ARGS} -Pitests verify -pl chaos-tests
+          ./mvnw ${MAVEN_ARGS} -Pitests -P"httpclient-${{ matrix.http-client }}" verify -pl chaos-tests

--- a/chaos-tests/README.md
+++ b/chaos-tests/README.md
@@ -22,18 +22,11 @@ Wait for the pods to be all ready:
 kubectl wait --for=condition=Ready pods -n chaos-mesh --all --timeout=600s
 ```
 
-Build the control and checker Docker images in the minikube docker-env:
+Build the control and checker Docker images in the minikube docker-env and run the test:
 
 ```bash
 eval $(minikube -p minikube docker-env)
-mvn -Pitests -Phttpclient-jdk -Pchecker clean package k8s:build -pl chaos-tests -DskipTests
-mvn -Pitests -Phttpclient-jdk -Pcontrol clean package k8s:build -pl chaos-tests -DskipTests
-```
-
-and finally run the test:
-
-```bash
-mvn -Pitests verify -pl chaos-tests
+mvn -pl chaos-tests -Pitests -Phttpclient-jdk verify
 ```
 
 ### Glossary

--- a/chaos-tests/pom.xml
+++ b/chaos-tests/pom.xml
@@ -27,12 +27,6 @@
   <artifactId>chaos-tests</artifactId>
   <name>Fabric8 :: Chaos Tests</name>
 
-  <properties>
-    <app-name/>
-    <main-class/>
-    <jkube.generator.name>chaos-test-${app-name}:latest</jkube.generator.name>
-  </properties>
-
   <repositories>
     <repository>
       <id>sonatype-snapshots</id>
@@ -89,11 +83,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.jkube</groupId>
-        <artifactId>kubernetes-maven-plugin</artifactId>
-        <version>${jkube.version}</version>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
@@ -106,11 +95,51 @@
         </executions>
         <configuration>
           <transformers>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>${main-class}</mainClass>
-            </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
           </transformers>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <version>${jkube.version}</version>
+        <executions>
+          <execution>
+            <id>checker</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <generator>
+                <config>
+                  <java-exec>
+                    <name>chaos-test-checker:latest</name>
+                    <mainClass>io.fabric8.it.CheckerCommand</mainClass>
+                  </java-exec>
+                </config>
+              </generator>
+            </configuration>
+          </execution>
+          <execution>
+            <id>control</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <generator>
+                <config>
+                  <java-exec>
+                    <name>chaos-test-control:latest</name>
+                    <mainClass>io.fabric8.it.ControlCommand</mainClass>
+                  </java-exec>
+                </config>
+              </generator>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,22 +181,6 @@
             <artifactId>kubernetes-httpclient-jetty</artifactId>
           </dependency>
         </dependencies>
-      </profile>
-
-      <!-- Support Apps container configuration -->
-      <profile>
-        <id>checker</id>
-        <properties>
-          <app-name>checker</app-name>
-          <main-class>io.fabric8.it.CheckerCommand</main-class>
-        </properties>
-      </profile>
-      <profile>
-        <id>control</id>
-        <properties>
-          <app-name>control</app-name>
-          <main-class>io.fabric8.it.ControlCommand</main-class>
-        </properties>
       </profile>
     </profiles>
 

--- a/chaos-tests/src/main/java/io/fabric8/it/CheckerCommand.java
+++ b/chaos-tests/src/main/java/io/fabric8/it/CheckerCommand.java
@@ -56,7 +56,7 @@ public class CheckerCommand implements Runnable {
 
   @Override
   public void run() {
-    System.out.println("Running Checker App");
+    System.out.printf("Running Checker App%n - num: %s%n - namespace: %s%n", num, namespace);
     KubernetesClient client = new KubernetesClientBuilder().build();
 
     CountDownLatch latch = new CountDownLatch(1);

--- a/chaos-tests/src/main/java/io/fabric8/it/ControlCommand.java
+++ b/chaos-tests/src/main/java/io/fabric8/it/ControlCommand.java
@@ -56,7 +56,7 @@ public class ControlCommand implements Runnable {
 
   @Override
   public void run() {
-    System.out.println("Running Control App");
+    System.out.printf("Running Control App%n - num: %s%n - namespace: %s%n", num, namespace);
     KubernetesClient client = new KubernetesClientBuilder().build();
 
     Map<String, String> labels = new HashMap<>();

--- a/chaos-tests/src/test/java/ChaosIT.java
+++ b/chaos-tests/src/test/java/ChaosIT.java
@@ -16,11 +16,11 @@
  */
 import io.fabric8.junit.jupiter.api.KubernetesTest;
 import io.fabric8.junit.jupiter.api.LoadKubernetesManifests;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.Version;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -126,8 +126,11 @@ class ChaosIT {
             .withName(name)
             .withImagePullPolicy("Never")
             .withImage(image)
-            .addToCommand("java", "-jar", "/deployments/chaos-tests-" + Version.clientVersion() + ".jar",
-                "--namespace", namespace, "--num", Integer.toString(TOTAL_COUNT))
+            .addToEnv(
+                new EnvVarBuilder()
+                    .withName("JAVA_ARGS")
+                    .withValue("--num " + TOTAL_COUNT + " --namespace " + namespace)
+                    .build())
             .endContainer()
             .withRestartPolicy("Never")
             .withServiceAccount("chaos-test-" + name + "-sa")


### PR DESCRIPTION
## Description

Simplified Chaos Tests configuration to allow for a single Maven execution.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
