### PR TITLE
fix: OkHttpClientImpl supports setting request method for empty payload requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #5382: [java-generator] Allow to deserialize more valid RFC3339 date-time and make the format customizable
 * Fix #5380: [java-generator] Avoid to emit Java Keywords as package names
+* Fix #5423: OkHttpClientImpl supports setting request method for empty payload requests
 
 #### Improvements
 * Fix #5368: added support for additional ListOptions fields

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -43,6 +43,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.Internal;
+import okhttp3.internal.http.HttpMethod;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -400,13 +401,16 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
           }
 
           @Override
-          public long contentLength() throws IOException {
+          public long contentLength() {
             return bodyContent.getLength();
           }
         });
       } else {
         throw new AssertionError("Unsupported body content");
       }
+    } else if (Utils.isNotNullOrEmpty(request.method())) {
+      requestBuilder.method(request.method(),
+          HttpMethod.requiresRequestBody(request.method()) ? RequestBody.create(null, new byte[0]) : null);
     }
 
     request.headers().entrySet().stream()

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/ExpectationsTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/ExpectationsTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Kubernetes Mock Server Expectations")
+class ExpectationsTest {
+  private KubernetesMockServer server;
+  private KubernetesClient client;
+
+  @BeforeEach
+  void setUp() {
+    server = new KubernetesMockServer();
+    server.start();
+    client = server.createClient();
+  }
+
+  @Nested
+  @DisplayName("POST")
+  class Post {
+
+    @Test
+    void postOk() {
+      // Given
+      server.expect()
+          .post()
+          .withPath("/api/post/ok")
+          .andReturn(200, "ok")
+          .once();
+      // When
+      final String result = client.raw("/api/post/ok", "POST", null);
+      // Then
+      assertThat(result).isEqualTo("ok");
+    }
+  }
+}

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesAttributesExtractorTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient(crud = true)
-public class KubernetesAttributesExtractorTest {
+class KubernetesAttributesExtractorTest {
 
   KubernetesClient client;
 


### PR DESCRIPTION
## Description

Fix #5423

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
