### PR TITLE
[java-generator] Add the possibility to always emit `additionalProperties` on generated POJOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #5423: OkHttpClientImpl supports setting request method for empty payload requests
 
 #### Improvements
+* Fix #5432: [java-generator] Add the possibility to always emit `additionalProperties` on generated POJOs
 * Fix #5368: added support for additional ListOptions fields
 * Fix #5377: added a createOr and unlock function to provide a straight-forward replacement for createOrReplace.
 * Fix #5388: [crd-generator] Generate deterministic CRDs

--- a/doc/java-generation-from-CRD.md
+++ b/doc/java-generation-from-CRD.md
@@ -88,6 +88,9 @@ Usage: java-gen [-hV] [-add-extra-annotations] [-enum-uppercase]
       -add-extra-annotations, --add-extra-annotations
                           Add extra lombok and sundrio annotation to the
                             generated classes
+      -always-preserve-unknown, --always-preserve-unknown
+                          Always preserve unknown fields in the generated
+                            classes
       -deserialization-datetime-format, 
         --deserialization-datetime-format=<deserializationDateTimeFormat>
                           DateTime format used for Deserialization of fields of
@@ -117,6 +120,11 @@ Usage: java-gen [-hV] [-add-extra-annotations] [-enum-uppercase]
 And the corresponding configurations of the Maven plugin are (output of `mvn help:describe -DgroupId=io.fabric8 -DartifactId=java-generator-maven-plugin -Dversion=<version> -Ddetail`):
 
 ```
+    alwaysPreserveUnknown
+      User property: fabric8.java-generator.always-preserve-unknown
+      Always preserve unknown fields in the generated classes by emitting an
+      additionalProperties field
+
     datetimeDeserializationFormat
       User property: fabric8.java-generator.datetime-deserialization-format
       DateTime format used for Deserialization of fields of type `date-time`

--- a/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
+++ b/java-generator/cli/src/main/java/io/fabric8/java/generator/cli/GenerateJavaSources.java
@@ -63,6 +63,10 @@ public class GenerateJavaSources implements Runnable {
       "--skip-generated-annotations" }, description = "Skip emitting the @javax.annotation.processing.Generated annotation on the generated sources", required = false, hidden = true)
   Boolean skipGeneratedAnnotations = null;
 
+  @Option(names = { "-always-preserve-unknown",
+      "--always-preserve-unknown" }, description = "Always preserve unknown fields in the generated classes by emitting an additionalProperties field", required = false, hidden = false)
+  Boolean alwaysPreserveUnkown = null;
+
   @Option(names = { "-package-overrides",
       "--package-overrides" }, description = "Apply the overrides to the package names", required = false)
   Map<String, String> packageOverrides = null;
@@ -86,6 +90,7 @@ public class GenerateJavaSources implements Runnable {
         uppercaseEnum,
         addExtraAnnotations,
         !noGeneratedAnnotations,
+        alwaysPreserveUnkown,
         packageOverrides,
         filesSuffixes,
         serializationDateTimeFormat,

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/Config.java
@@ -29,6 +29,7 @@ public class Config {
   public static final boolean DEFAULT_UPPERCASE_ENUM = true;
   public static final boolean DEFAULT_ADD_EXTRA_ANNOTATIONS = false;
   public static final boolean DEFAULT_ADD_GENERATED_ANNOTATIONS = true;
+  public static final boolean DEFAULT_ALWAYS_PRESERVE_UNKNOWN = false;
   public static final Map<String, String> DEFAULT_PACKAGE_OVERRIDES = new HashMap<>();
   public static final List<String> DEFAULT_FILES_SUFFIXES = Arrays.asList(".yaml", ".yml", ".json");
   // RFC 3339 - from: https://swagger.io/docs/specification/data-models/data-types/
@@ -38,6 +39,7 @@ public class Config {
   private Boolean uppercaseEnums = DEFAULT_UPPERCASE_ENUM;
   private Boolean objectExtraAnnotations = DEFAULT_ADD_EXTRA_ANNOTATIONS;
   private Boolean generatedAnnotations = DEFAULT_ADD_GENERATED_ANNOTATIONS;
+  private Boolean alwaysPreserveUnknown = DEFAULT_ALWAYS_PRESERVE_UNKNOWN;
   private Map<String, String> packageOverrides = DEFAULT_PACKAGE_OVERRIDES;
   private List<String> filesSuffixes = DEFAULT_FILES_SUFFIXES;
   private String serDatetimeFormat = DEFAULT_SER_DATETIME_FORMAT;
@@ -116,6 +118,41 @@ public class Config {
     }
   }
 
+  public Config(
+      Boolean uppercaseEnums,
+      Boolean objectExtraAnnotations,
+      Boolean generatedAnnotations,
+      Boolean alwaysPreserveUnknown,
+      Map<String, String> packageOverrides,
+      List<String> filesSuffixes,
+      String serDatetimeFormat,
+      String deserDatetimeFormat) {
+    if (uppercaseEnums != null) {
+      this.uppercaseEnums = uppercaseEnums;
+    }
+    if (objectExtraAnnotations != null) {
+      this.objectExtraAnnotations = objectExtraAnnotations;
+    }
+    if (generatedAnnotations != null) {
+      this.generatedAnnotations = generatedAnnotations;
+    }
+    if (alwaysPreserveUnknown != null) {
+      this.alwaysPreserveUnknown = alwaysPreserveUnknown;
+    }
+    if (packageOverrides != null) {
+      this.packageOverrides = packageOverrides;
+    }
+    if (filesSuffixes != null) {
+      this.filesSuffixes = filesSuffixes;
+    }
+    if (serDatetimeFormat != null) {
+      this.serDatetimeFormat = serDatetimeFormat;
+    }
+    if (deserDatetimeFormat != null) {
+      this.deserDatetimeFormat = deserDatetimeFormat;
+    }
+  }
+
   public boolean isUppercaseEnums() {
     return (uppercaseEnums == null) ? DEFAULT_UPPERCASE_ENUM : uppercaseEnums;
   }
@@ -130,6 +167,12 @@ public class Config {
     return (generatedAnnotations == null)
         ? DEFAULT_ADD_GENERATED_ANNOTATIONS
         : generatedAnnotations;
+  }
+
+  public boolean isAlwaysPreserveUnknown() {
+    return (alwaysPreserveUnknown == null)
+        ? DEFAULT_ALWAYS_PRESERVE_UNKNOWN
+        : alwaysPreserveUnknown;
   }
 
   public Map<String, String> getPackageOverrides() {

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -307,7 +307,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
       }
     }
 
-    if (this.preserveUnknownFields) {
+    if (this.preserveUnknownFields || config.isAlwaysPreserveUnknown()) {
       ClassOrInterfaceType mapType = new ClassOrInterfaceType()
           .setName(Keywords.JAVA_UTIL_MAP)
           .setTypeArguments(

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/ConfigTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/ConfigTest.java
@@ -23,11 +23,12 @@ class ConfigTest {
 
   @Test
   void defaultValuesWithAllArgsConstructor() {
-    final Config result = new Config(null, null, null, null, null, null, null);
+    final Config result = new Config(null, null, null, null, null, null, null, null);
     assertThat(result)
         .returns(Config.DEFAULT_UPPERCASE_ENUM, Config::isUppercaseEnums)
         .returns(Config.DEFAULT_ADD_EXTRA_ANNOTATIONS, Config::isObjectExtraAnnotations)
         .returns(Config.DEFAULT_ADD_GENERATED_ANNOTATIONS, Config::isGeneratedAnnotations)
+        .returns(Config.DEFAULT_ALWAYS_PRESERVE_UNKNOWN, Config::isAlwaysPreserveUnknown)
         .returns(Config.DEFAULT_PACKAGE_OVERRIDES, Config::getPackageOverrides)
         .returns(Config.DEFAULT_FILES_SUFFIXES, Config::getFilesSuffixes)
         .returns(Config.DEFAULT_SER_DATETIME_FORMAT, Config::getSerDatetimeFormat)
@@ -41,6 +42,7 @@ class ConfigTest {
         .returns(Config.DEFAULT_UPPERCASE_ENUM, Config::isUppercaseEnums)
         .returns(Config.DEFAULT_ADD_EXTRA_ANNOTATIONS, Config::isObjectExtraAnnotations)
         .returns(Config.DEFAULT_ADD_GENERATED_ANNOTATIONS, Config::isGeneratedAnnotations)
+        .returns(Config.DEFAULT_ALWAYS_PRESERVE_UNKNOWN, Config::isAlwaysPreserveUnknown)
         .returns(Config.DEFAULT_PACKAGE_OVERRIDES, Config::getPackageOverrides)
         .returns(Config.DEFAULT_FILES_SUFFIXES, Config::getFilesSuffixes)
         .returns(Config.DEFAULT_SER_DATETIME_FORMAT, Config::getSerDatetimeFormat)
@@ -54,6 +56,7 @@ class ConfigTest {
         .returns(Config.DEFAULT_UPPERCASE_ENUM, Config::isUppercaseEnums)
         .returns(Config.DEFAULT_ADD_EXTRA_ANNOTATIONS, Config::isObjectExtraAnnotations)
         .returns(Config.DEFAULT_ADD_GENERATED_ANNOTATIONS, Config::isGeneratedAnnotations)
+        .returns(Config.DEFAULT_ALWAYS_PRESERVE_UNKNOWN, Config::isAlwaysPreserveUnknown)
         .returns(Config.DEFAULT_PACKAGE_OVERRIDES, Config::getPackageOverrides)
         .returns(Config.DEFAULT_FILES_SUFFIXES, Config::getFilesSuffixes)
         .returns(Config.DEFAULT_SER_DATETIME_FORMAT, Config::getSerDatetimeFormat)

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/GeneratorTest.java
@@ -614,6 +614,33 @@ class GeneratorTest {
   }
 
   @Test
+  void testConfigToGeneratePreservedUnknownFields() {
+    // Arrange
+    Config config = new Config(null, null, null, true, new HashMap<>(), new ArrayList<>(), null, null);
+    JObject obj = new JObject(
+        null,
+        "t",
+        null,
+        null,
+        false,
+        config,
+        null,
+        Boolean.FALSE,
+        null);
+
+    // Act
+    GeneratorResult res = obj.generateJava();
+
+    // Assert
+    assertEquals(1, res.getTopLevelClasses().size());
+    assertEquals("T", res.getTopLevelClasses().get(0).getName());
+
+    Optional<ClassOrInterfaceDeclaration> clzT = res.getTopLevelClasses().get(0).getClassByName("T");
+    assertTrue(clzT.isPresent());
+    assertTrue(clzT.get().getFieldByName("additionalProperties").isPresent());
+  }
+
+  @Test
   void testObjectWithSpecialFieldNames() {
     // Arrange
     Map<String, JSONSchemaProps> props = new HashMap<>();

--- a/java-generator/gradle-plugin/src/main/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPluginExtension.java
+++ b/java-generator/gradle-plugin/src/main/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPluginExtension.java
@@ -100,6 +100,7 @@ public abstract class JavaGeneratorPluginExtension {
     javaGeneratorConfig = new Config(isEnumUppercase,
         javaGeneratorConfig.isObjectExtraAnnotations(),
         javaGeneratorConfig.isGeneratedAnnotations(),
+        javaGeneratorConfig.isAlwaysPreserveUnknown(),
         javaGeneratorConfig.getPackageOverrides(),
         javaGeneratorConfig.getFilesSuffixes(),
         javaGeneratorConfig.getSerDatetimeFormat(),
@@ -118,6 +119,7 @@ public abstract class JavaGeneratorPluginExtension {
     javaGeneratorConfig = new Config(javaGeneratorConfig.isUppercaseEnums(),
         isExtraAnnotations,
         javaGeneratorConfig.isGeneratedAnnotations(),
+        javaGeneratorConfig.isAlwaysPreserveUnknown(),
         javaGeneratorConfig.getPackageOverrides(),
         javaGeneratorConfig.getFilesSuffixes(),
         javaGeneratorConfig.getSerDatetimeFormat(),
@@ -136,6 +138,26 @@ public abstract class JavaGeneratorPluginExtension {
     javaGeneratorConfig = new Config(javaGeneratorConfig.isUppercaseEnums(),
         javaGeneratorConfig.isObjectExtraAnnotations(),
         isGeneratedAnnotations,
+        javaGeneratorConfig.isAlwaysPreserveUnknown(),
+        javaGeneratorConfig.getPackageOverrides(),
+        javaGeneratorConfig.getFilesSuffixes(),
+        javaGeneratorConfig.getSerDatetimeFormat(),
+        javaGeneratorConfig.getDeserDatetimeFormat());
+  }
+
+  /**
+   * Always preserve unknown fields in the generated classes by emitting an additionalProperties field
+   *
+   */
+  public Boolean getAlwaysPreserveUnknown() {
+    return javaGeneratorConfig.isAlwaysPreserveUnknown();
+  }
+
+  public void setAlwaysPreserveUnknown(final Boolean isAlwaysPreserveUnknown) {
+    javaGeneratorConfig = new Config(javaGeneratorConfig.isUppercaseEnums(),
+        javaGeneratorConfig.isObjectExtraAnnotations(),
+        javaGeneratorConfig.isGeneratedAnnotations(),
+        isAlwaysPreserveUnknown,
         javaGeneratorConfig.getPackageOverrides(),
         javaGeneratorConfig.getFilesSuffixes(),
         javaGeneratorConfig.getSerDatetimeFormat(),
@@ -154,6 +176,7 @@ public abstract class JavaGeneratorPluginExtension {
     javaGeneratorConfig = new Config(javaGeneratorConfig.isUppercaseEnums(),
         javaGeneratorConfig.isObjectExtraAnnotations(),
         javaGeneratorConfig.isGeneratedAnnotations(),
+        javaGeneratorConfig.isAlwaysPreserveUnknown(),
         packageOverrides,
         javaGeneratorConfig.getFilesSuffixes(),
         javaGeneratorConfig.getSerDatetimeFormat(),
@@ -172,6 +195,7 @@ public abstract class JavaGeneratorPluginExtension {
     javaGeneratorConfig = new Config(javaGeneratorConfig.isUppercaseEnums(),
         javaGeneratorConfig.isObjectExtraAnnotations(),
         javaGeneratorConfig.isGeneratedAnnotations(),
+        javaGeneratorConfig.isAlwaysPreserveUnknown(),
         javaGeneratorConfig.getPackageOverrides(),
         filesSuffixes,
         javaGeneratorConfig.getSerDatetimeFormat(),
@@ -190,6 +214,7 @@ public abstract class JavaGeneratorPluginExtension {
     javaGeneratorConfig = new Config(javaGeneratorConfig.isUppercaseEnums(),
         javaGeneratorConfig.isObjectExtraAnnotations(),
         javaGeneratorConfig.isGeneratedAnnotations(),
+        javaGeneratorConfig.isAlwaysPreserveUnknown(),
         javaGeneratorConfig.getPackageOverrides(),
         javaGeneratorConfig.getFilesSuffixes(),
         serDatetimeFmt,
@@ -208,6 +233,7 @@ public abstract class JavaGeneratorPluginExtension {
     javaGeneratorConfig = new Config(javaGeneratorConfig.isUppercaseEnums(),
         javaGeneratorConfig.isObjectExtraAnnotations(),
         javaGeneratorConfig.isGeneratedAnnotations(),
+        javaGeneratorConfig.isAlwaysPreserveUnknown(),
         javaGeneratorConfig.getPackageOverrides(),
         javaGeneratorConfig.getFilesSuffixes(),
         javaGeneratorConfig.getSerDatetimeFormat(),

--- a/java-generator/it/src/it/crd-names/pom.xml
+++ b/java-generator/it/src/it/crd-names/pom.xml
@@ -79,7 +79,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>@maven.surefire.plugin.version@</version>
         <configuration>
           <useFile>false</useFile>
           <trimStackTrace>false</trimStackTrace>

--- a/java-generator/it/src/it/datetime-fmt/pom.xml
+++ b/java-generator/it/src/it/datetime-fmt/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>@maven.surefire.plugin.version@</version>
         <configuration>
           <useFile>false</useFile>
           <trimStackTrace>false</trimStackTrace>

--- a/java-generator/it/src/it/escape-characters/pom.xml
+++ b/java-generator/it/src/it/escape-characters/pom.xml
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>@maven.surefire.plugin.version@</version>
         <configuration>
           <useFile>false</useFile>
           <trimStackTrace>false</trimStackTrace>

--- a/java-generator/it/src/it/preserve-unknown-objects-through-config/invoker.properties
+++ b/java-generator/it/src/it/preserve-unknown-objects-through-config/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=test

--- a/java-generator/it/src/it/preserve-unknown-objects-through-config/pom.xml
+++ b/java-generator/it/src/it/preserve-unknown-objects-through-config/pom.xml
@@ -20,7 +20,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>default-values-instantiation</artifactId>
+  <artifactId>preserve-unknown-objects</artifactId>
   <groupId>io.fabric8.it</groupId>
   <version>0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -31,24 +31,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>io.sundr</groupId>
-      <artifactId>sundr-adapter-reflect</artifactId>
-      <version>@sundrio.version@</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.sundr</groupId>
-      <artifactId>builder-annotations</artifactId>
-      <version>@sundrio.version@</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>@lombok.version@</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>java-generator-integration-tests</artifactId>
@@ -87,8 +69,9 @@
           </execution>
         </executions>
         <configuration>
-          <source>src/test/resources/example.yaml</source>
+          <source>src/test/resources/dapr-components-crd.yaml</source>
           <generatedAnnotations>false</generatedAnnotations>
+          <alwaysPreserveUnknown>true</alwaysPreserveUnknown>
         </configuration>
       </plugin>
       <plugin>

--- a/java-generator/it/src/it/preserve-unknown-objects-through-config/src/test/java/io/fabric8/it/certmanager/TestPreserveUnkonwnUsabilityFromConfig.java
+++ b/java-generator/it/src/it/preserve-unknown-objects-through-config/src/test/java/io/fabric8/it/certmanager/TestPreserveUnkonwnUsabilityFromConfig.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.it.certmanager;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.dapr.v1alpha1.Component;
+import io.dapr.v1alpha1.ComponentSpec;
+import io.dapr.v1alpha1.componentspec.Metadata;
+import io.fabric8.kubernetes.api.model.AnyType;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.jupiter.api.Test;
+import io.fabric8.java.generator.testing.KubernetesResourceDiff;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestPreserveUnknownUsabilityFromConfig {
+
+  @Test
+  void testDeserialization() {
+    // Arrange
+    Component sample =
+      Serialization.unmarshal(getClass().getResourceAsStream("/sample.yaml"), Component.class);
+
+    // Act
+    List<Metadata> metadataList = sample.getSpec().getMetadata();
+
+    // Assert
+    assertEquals(5, metadataList.size());
+  }
+
+  private Component createSampleComponent() throws Exception {
+    Component component = new Component();
+    ComponentSpec spec = new ComponentSpec();
+    spec.setType("pubsub.mqtt");
+    spec.setVersion("v1");
+
+    Metadata meta1 = new Metadata();
+    meta1.setAdditionalProperty("consumerID", new AnyType("{uuid}"));
+
+    Metadata meta2 = new Metadata();
+    meta2.setAdditionalProperty("url", new AnyType("tcp://admin:public@localhost:1883"));
+
+    Metadata meta3 = new Metadata();
+    meta3.setAdditionalProperty("qos", new AnyType(1));
+
+    Metadata meta4 = new Metadata();
+    meta4.setAdditionalProperty("anArray", new AnyType(new int[]{1, 2, 3}));
+
+    Metadata meta5 = new Metadata();
+    Map<String, Object> obj = new HashMap();
+    obj.put("ONE", 1);
+    obj.put("TWO", 2);
+    meta5.setAdditionalProperty("anObject", new AnyType(obj));
+
+    List<Metadata> lst = new ArrayList();
+    lst.add(meta1);
+    lst.add(meta2);
+    lst.add(meta3);
+    lst.add(meta4);
+    lst.add(meta5);
+    spec.setMetadata(lst);
+
+    component.setSpec(spec);
+    ObjectMeta om = new ObjectMeta();
+    om.setName("messagebus");
+    component.setMetadata(om);
+
+    return component;
+  }
+
+  @Test
+  void testAgainstSample() throws Exception {
+    // Arrange
+    Path resPath = Paths.get(getClass().getResource("/sample.yaml").toURI());
+    String yamlContent = new String(Files.readAllBytes(resPath), "UTF8");
+    Component sample = createSampleComponent();
+    KubernetesResourceDiff diff = new KubernetesResourceDiff(yamlContent, Serialization.asYaml(sample));
+
+    // Act
+    List<JsonNode> aggregatedDiffs = diff.getListOfDiffs();
+
+    // Assert
+    assertEquals(0, aggregatedDiffs.size());
+  }
+}

--- a/java-generator/it/src/it/preserve-unknown-objects-through-config/src/test/resources/dapr-components-crd.yaml
+++ b/java-generator/it/src/it/preserve-unknown-objects-through-config/src/test/resources/dapr-components-crd.yaml
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: components.dapr.io
+spec:
+  group: dapr.io
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Component describes an Dapr component type
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          auth:
+            description: Auth represents authentication details for the component
+            properties:
+              secretStore:
+                type: string
+            required:
+            - secretStore
+            type: object
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          scopes:
+            items:
+              type: string
+            type: array
+          spec:
+            description: ComponentSpec is the spec for a component
+            properties:
+              initTimeout:
+                type: string
+              ignoreErrors:
+                type: boolean
+              metadata:
+                items:
+                  description: MetadataItem is a name/value pair for a metadata
+                  properties:
+                    name:
+                      type: string
+                    secretKeyRef:
+                      description: SecretKeyRef is a reference to a secret holding
+                        the value for the metadata item. Name is the secret name,
+                        and key is the field in the secret.
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    # intentionally left out
+                    # value:
+                      # x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - name
+                  type: object
+                type: array
+              type:
+                type: string
+              version:
+                type: string
+            required:
+            - metadata
+            - type
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+  names:
+    kind: Component
+    plural: components
+    singular: component
+    categories:
+    - all
+    - dapr
+  scope: Namespaced

--- a/java-generator/it/src/it/preserve-unknown-objects-through-config/src/test/resources/sample.yaml
+++ b/java-generator/it/src/it/preserve-unknown-objects-through-config/src/test/resources/sample.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebus
+spec:
+  type: pubsub.mqtt
+  version: v1
+  metadata:
+    - consumerID: "{uuid}"
+    - url: "tcp://admin:public@localhost:1883"
+    - qos: 1
+    - anArray:
+        - 1
+        - 2
+        - 3
+    - anObject:
+        ONE: 1
+        TWO: 2

--- a/java-generator/it/src/it/preserve-unknown-objects/pom.xml
+++ b/java-generator/it/src/it/preserve-unknown-objects/pom.xml
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>@maven.surefire.plugin.version@</version>
         <configuration>
           <useFile>false</useFile>
           <trimStackTrace>false</trimStackTrace>

--- a/java-generator/it/src/it/preserve-unknown-serdeser/pom.xml
+++ b/java-generator/it/src/it/preserve-unknown-serdeser/pom.xml
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>@maven.surefire.plugin.version@</version>
         <configuration>
           <useFile>false</useFile>
           <trimStackTrace>false</trimStackTrace>

--- a/java-generator/it/src/it/ser-deser/pom.xml
+++ b/java-generator/it/src/it/ser-deser/pom.xml
@@ -94,7 +94,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>@maven.surefire.plugin.version@</version>
         <configuration>
           <useFile>false</useFile>
           <trimStackTrace>false</trimStackTrace>

--- a/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
+++ b/java-generator/maven-plugin/src/main/java/io/fabric8/java/generator/maven/plugin/JavaGeneratorMojo.java
@@ -88,6 +88,13 @@ public class JavaGeneratorMojo extends AbstractMojo {
   Boolean generatedAnnotations = null;
 
   /**
+   * Always preserve unknown fields in the generated classes by emitting an additionalProperties field
+   *
+   */
+  @Parameter(property = "fabric8.java-generator.always-preserve-unknown", required = false)
+  Boolean alwaysPreserveUnknown = null;
+
+  /**
    * Package names to be substituted
    *
    */
@@ -121,6 +128,7 @@ public class JavaGeneratorMojo extends AbstractMojo {
         .uppercaseEnums(enumUppercase)
         .objectExtraAnnotations(extraAnnotations)
         .generatedAnnotations(generatedAnnotations)
+        .alwaysPreserveUnknown(alwaysPreserveUnknown)
         .packageOverrides(packageOverrides)
         .filesSuffixes(filesSuffixes)
         .serDatetimeFormat(datetimeSerializationFormat)


### PR DESCRIPTION
## Description
Fix #5432 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
