### PR TITLE
adds a config property to control the use of http watches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Improvements
 * Fix #5368: added support for additional ListOptions fields
 * Fix #5377: added a createOr and unlock function to provide a straight-forward replacement for createOrReplace.
+* Fix #4624: added Config.onlyHttpWatches to control whether watches should only use regular HTTP requests, and not attempt WebSocket connections.
 * Fix #5388: [crd-generator] Generate deterministic CRDs
 * Fix #5257: Add ErrorStreamMessage and StatusStreamMessage to ease mocking of pods/exec requests
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -220,6 +220,8 @@ public class Config {
   private String userAgent = "fabric8-kubernetes-client/" + Version.clientVersion();
   private TlsVersion[] tlsVersions = new TlsVersion[] { TlsVersion.TLS_1_3, TlsVersion.TLS_1_2 };
 
+  private boolean onlyHttpWatches;
+
   /**
    * @deprecated Use Kubernetes Status directly for extracting error messages.
    */
@@ -337,7 +339,7 @@ public class Config {
         errorMessages, userAgent, tlsVersions, websocketPingInterval, proxyUsername, proxyPassword,
         trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups,
         impersonateExtras, null, null, DEFAULT_REQUEST_RETRY_BACKOFFLIMIT, DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL,
-        DEFAULT_UPLOAD_REQUEST_TIMEOUT);
+        DEFAULT_UPLOAD_REQUEST_TIMEOUT, false);
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
@@ -352,7 +354,7 @@ public class Config {
       String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase,
       String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras,
       OAuthTokenProvider oauthTokenProvider, Map<String, String> customHeaders, int requestRetryBackoffLimit,
-      int requestRetryBackoffInterval, int uploadRequestTimeout) {
+      int requestRetryBackoffInterval, int uploadRequestTimeout, boolean onlyHttpWatches) {
     this.apiVersion = apiVersion;
     this.namespace = namespace;
     this.trustCerts = trustCerts;
@@ -401,6 +403,7 @@ public class Config {
     this.maxConcurrentRequests = maxConcurrentRequests;
     this.maxConcurrentRequestsPerHost = maxConcurrentRequestsPerHost;
     this.autoOAuthToken = autoOAuthToken;
+    this.onlyHttpWatches = onlyHttpWatches;
   }
 
   public static void configFromSysPropsOrEnvVars(Config config) {
@@ -1507,6 +1510,14 @@ public class Config {
 
   public void setAutoOAuthToken(String autoOAuthToken) {
     this.autoOAuthToken = autoOAuthToken;
+  }
+
+  public boolean isOnlyHttpWatches() {
+    return onlyHttpWatches;
+  }
+
+  public void setOnlyHttpWatches(boolean onlyHttpWatches) {
+    this.onlyHttpWatches = onlyHttpWatches;
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -63,6 +63,8 @@ import io.fabric8.kubernetes.client.utils.URLUtils.URLBuilder;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.client.utils.internal.CreateOrReplaceHelper;
 import io.fabric8.kubernetes.client.utils.internal.WatcherToggle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -98,6 +100,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     MixedOperation<T, L, R>,
     ExtensibleResource<T>,
     ListerWatcher<T, L> {
+
+  static final Logger LOGGER = LoggerFactory.getLogger(BaseOperation.class);
 
   private static final String WATCH = "watch";
   private static final String READ_ONLY_UPDATE_EXCEPTION_MESSAGE = "Cannot update read-only resources";
@@ -639,9 +643,12 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public CompletableFuture<AbstractWatchManager<T>> submitWatch(ListOptions options, final Watcher<T> watcher) {
-    WatcherToggle<T> watcherToggle = new WatcherToggle<>(watcher, true);
     ListOptions optionsToUse = defaultListOptions(options, true);
     WatchConnectionManager<T, L> watch;
+    if (this.getConfig().isOnlyHttpWatches()) {
+      return CompletableFuture.completedFuture(httpWatch(watcher, optionsToUse));
+    }
+    WatcherToggle<T> watcherToggle = new WatcherToggle<>(watcher, true);
     try {
       watch = new WatchConnectionManager<>(
           httpClient,
@@ -660,29 +667,32 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
           if (t instanceof CompletionException) {
             t = t.getCause();
           }
+          boolean httpWatch = false;
           if (t instanceof KubernetesClientException) {
             KubernetesClientException ke = (KubernetesClientException) t;
+            // 503 will initially trigger re-tries, if it's "expected", we may need to short-circuit that
             List<Integer> furtherProcessedCodes = Arrays.asList(200, 503);
             if (furtherProcessedCodes.contains(ke.getCode())) {
-              //release the watch after disabling the watcher (to avoid premature call to onClose)
-              watcherToggle.disable();
-
               // If the HTTP return code is 200 or 503, we retry the watch again using a persistent hanging
               // HTTP GET. This is meant to handle cases like kubectl local proxy which does not support
               // websockets. Issue: https://github.com/kubernetes/kubernetes/issues/25126
-              try {
-                return new WatchHTTPManager<>(
-                    httpClient,
-                    this,
-                    optionsToUse,
-                    watcher,
-                    getRequestConfig().getWatchReconnectInterval(),
-                    getRequestConfig().getWatchReconnectLimit());
-              } catch (MalformedURLException e) {
-                throw KubernetesClientException.launderThrowable(forOperationType(WATCH), e);
-              }
+              LOGGER.debug(
+                  "Websocket hanshake failed with code {}, but an httpwatch may be possible.  Use Config.onlyHttpWatches to disable websocket watches.",
+                  ke.getCode());
+              httpWatch = true;
             }
+          } else {
+            LOGGER.debug(
+                "Failed to establish a websocket watch, will try regular http instead.  Use Config.onlyHttpWatches to disable websocket watches.",
+                t);
+            httpWatch = true;
           }
+          if (httpWatch) {
+            //release the watch after disabling the watcher (to avoid premature call to onClose)
+            watcherToggle.disable();
+            return httpWatch(watcher, optionsToUse);
+          }
+
           throw KubernetesClientException.launderThrowable(t);
         } finally {
           watch.close();
@@ -691,6 +701,20 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       return watch;
     });
 
+  }
+
+  private AbstractWatchManager<T> httpWatch(final Watcher<T> watcher, ListOptions optionsToUse) {
+    try {
+      return new WatchHTTPManager<>(
+          httpClient,
+          this,
+          optionsToUse,
+          watcher,
+          getRequestConfig().getWatchReconnectInterval(),
+          getRequestConfig().getWatchReconnectLimit());
+    } catch (MalformedURLException e) {
+      throw KubernetesClientException.launderThrowable(forOperationType(WATCH), e);
+    }
   }
 
   @Override

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -86,7 +86,7 @@ public class OpenShiftConfig extends Config {
       String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername,
       String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,
       Map<String, String> customHeaders, int requestRetryBackoffLimit, int requestRetryBackoffInterval,
-      int uploadRequestTimeout, long buildTimeout,
+      int uploadRequestTimeout, boolean onlyHttpWatches, long buildTimeout,
       boolean disableApiGroupCheck) {
     super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData,
         clientCertFile,
@@ -100,7 +100,7 @@ public class OpenShiftConfig extends Config {
         impersonateExtras, oauthTokenProvider, customHeaders,
         requestRetryBackoffLimit,
         requestRetryBackoffInterval,
-        uploadRequestTimeout);
+        uploadRequestTimeout, onlyHttpWatches);
     this.setOapiVersion(oapiVersion);
     this.setBuildTimeout(buildTimeout);
     this.setDisableApiGroupCheck(disableApiGroupCheck);
@@ -141,6 +141,7 @@ public class OpenShiftConfig extends Config {
         kubernetesConfig.getOauthTokenProvider(), kubernetesConfig.getCustomHeaders(),
         kubernetesConfig.getRequestRetryBackoffLimit(), kubernetesConfig.getRequestRetryBackoffInterval(),
         kubernetesConfig.getUploadRequestTimeout(),
+        kubernetesConfig.isOnlyHttpWatches(),
         buildTimeout,
         false);
   }


### PR DESCRIPTION
## Description
Adds Config.onlyHttpWatches to control if WebSocket watches should be attempted.

There are a couple of considerations here:
1. Because detecting specifically a timeoutexception may be problematic across our client implementations, the code now for any non-handshake exception will try a http watch.
2. The standard retry logic will cause a 503 or timeout response to generally be retried - this will look instead like a long pause when attempting the websocket connection, which may then succeed as a regular http request.  This is captured at a debug level, but it could be something that we want more visible.

Closes #4624

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
