### PR TITLE
[crd-generator] Fix fallback value of `Default` annotation in presence of multiple accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.10-SNAPSHOT
 
 #### Bugs
+* Fix #5501: [crd-generator] Fix fallback value of `Default` annotation in presence of multiple accessors
 
 #### Improvements
 

--- a/crd-generator/api/pom.xml
+++ b/crd-generator/api/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>validation-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -558,7 +558,7 @@ public abstract class AbstractJsonSchema<T, B> {
             LOGGER.debug("Description for property {} has already been contributed by: {}", name, descriptionContributedBy);
           }
         }
-        defaultValue = p.getDefault().orElse(null);
+        defaultValue = p.getDefault().orElse(defaultValue);
         min = p.getMin().orElse(min);
         max = p.getMax().orElse(max);
         pattern = p.getPattern().orElse(pattern);

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -24,7 +24,9 @@ import io.fabric8.generator.annotation.Min;
 import io.fabric8.generator.annotation.Nullable;
 import io.fabric8.generator.annotation.Pattern;
 import io.fabric8.generator.annotation.Required;
+import lombok.Data;
 
+@Data
 public class AnnotatedSpec {
   @JsonProperty("from-field")
   @JsonPropertyDescription("from-field-description")

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -37,6 +37,8 @@ public class AnnotatedSpec {
   private String singleDigit;
   private String nullable;
   private String defaultValue;
+  @Default("my-value2")
+  private String defaultValue2;
   @Required
   private boolean emptySetter;
   @Required

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -156,10 +156,10 @@ class JsonSchemaTest {
 
     final JSONSchemaProps defaultValue2 = spec.get("defaultValue2");
     assertEquals("my-value2", YAML_MAPPER.writeValueAsString(defaultValue2.getDefault()).trim());
-    assertNull(defaultValue.getNullable());
-    assertNull(defaultValue.getMinimum());
-    assertNull(defaultValue.getMaximum());
-    assertNull(defaultValue.getPattern());
+    assertNull(defaultValue2.getNullable());
+    assertNull(defaultValue2.getMinimum());
+    assertNull(defaultValue2.getMaximum());
+    assertNull(defaultValue2.getPattern());
 
     // check required list, should register properties with their modified name if needed
     final List<String> required = specSchema.getRequired();

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -102,7 +102,7 @@ class JsonSchemaTest {
     assertNotNull(schema);
     Map<String, JSONSchemaProps> properties = assertSchemaHasNumberOfProperties(schema, 2);
     final JSONSchemaProps specSchema = properties.get("spec");
-    Map<String, JSONSchemaProps> spec = assertSchemaHasNumberOfProperties(specSchema, 12);
+    Map<String, JSONSchemaProps> spec = assertSchemaHasNumberOfProperties(specSchema, 13);
 
     // check descriptions are present
     assertTrue(spec.containsKey("from-field"));
@@ -149,6 +149,13 @@ class JsonSchemaTest {
 
     final JSONSchemaProps defaultValue = spec.get("defaultValue");
     assertEquals("my-value", YAML_MAPPER.writeValueAsString(defaultValue.getDefault()).trim());
+    assertNull(defaultValue.getNullable());
+    assertNull(defaultValue.getMinimum());
+    assertNull(defaultValue.getMaximum());
+    assertNull(defaultValue.getPattern());
+
+    final JSONSchemaProps defaultValue2 = spec.get("defaultValue2");
+    assertEquals("my-value2", YAML_MAPPER.writeValueAsString(defaultValue2.getDefault()).trim());
     assertNull(defaultValue.getNullable());
     assertNull(defaultValue.getMinimum());
     assertNull(defaultValue.getMaximum());

--- a/crd-generator/test/pom.xml
+++ b/crd-generator/test/pom.xml
@@ -38,6 +38,12 @@
       <groupId>io.fabric8</groupId>
       <artifactId>crd-generator-apt</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>test</scope>
+    </dependency>
     
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/zookeeper/ZookeeperCustomResourceTest.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/zookeeper/ZookeeperCustomResourceTest.java
@@ -66,6 +66,7 @@ class ZookeeperCustomResourceTest {
       assertEquals(1, v.getAdditionalPrinterColumns().get(0).getPriority());
       assertEquals("UPTIME", v.getAdditionalPrinterColumns().get(1).getName());
       assertEquals(0, v.getAdditionalPrinterColumns().get(1).getPriority());
+      assertEquals("false", props.getProperties().get("ephemeral").getDefault().asText());
     });
 
     Optional<CustomResourceDefinitionVersion> v1alpha1 = d.getSpec().getVersions().stream()

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/zookeeper/v1/ZookeeperSpec.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/zookeeper/v1/ZookeeperSpec.java
@@ -16,9 +16,9 @@
 package io.fabric8.crd.generator.zookeeper.v1;
 
 import io.fabric8.generator.annotation.Default;
-import lombok.Data;
 import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
+import lombok.Data;
 
 @Data
 public class ZookeeperSpec {

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/zookeeper/v1/ZookeeperSpec.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/zookeeper/v1/ZookeeperSpec.java
@@ -15,14 +15,18 @@
  */
 package io.fabric8.crd.generator.zookeeper.v1;
 
+import io.fabric8.generator.annotation.Default;
+import lombok.Data;
 import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
 
+@Data
 public class ZookeeperSpec {
 
   @SpecReplicas
   private int size;
   @Required
   private String version;
+  @Default("false")
   private boolean ephemeral;
 }


### PR DESCRIPTION
## Description
Fix #5501 

## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
