### PR TITLE
fix: unsupported java version

### DIFF
--- a/crd-generator/apt/src/main/java/io/fabric8/crd/generator/apt/CustomResourceAnnotationProcessor.java
+++ b/crd-generator/apt/src/main/java/io/fabric8/crd/generator/apt/CustomResourceAnnotationProcessor.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
@@ -54,6 +55,12 @@ public class CustomResourceAnnotationProcessor extends AbstractProcessor {
   public static final String PROCESSOR_OPTION_PARALLEL = "io.fabric8.crd.generator.parallel";
   private final CRDGenerator generator = new CRDGenerator();
 
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
+  @SuppressWarnings("unchecked")
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     if (roundEnv.processingOver()) {
       final Messager messager = processingEnv.getMessager();


### PR DESCRIPTION
There are warnings that we're using an unsupported version when using annotation processors, this should address this problem, at least for the CRD generator.

```
[WARNING] No SupportedSourceVersion annotation found on io.fabric8.crd.generator.apt.CustomResourceAnnotationProcessor, returning RELEASE_6.
[WARNING] Supported source version 'RELEASE_6' from annotation processor 'io.fabric8.crd.generator.apt.CustomResourceAnnotationProcessor' less than -source '11'
```