### PR TITLE
test (kubernetes-client-api) : Add test in AbstractHttpLoggingInterceptor to not consume response bytes (#5251)

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpLoggingInterceptorTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -179,6 +180,18 @@ public abstract class AbstractHttpLoggingInterceptorTest {
     inOrder.verify(logger).trace(eq("< {} {}"), anyInt(), anyString());
     inOrder.verify(logger).trace("This is the response body");
     inOrder.verify(logger).trace("-HTTP END-");
+  }
+
+  @Test
+  @DisplayName("Interceptor doesn't consume response bytes")
+  public void responseBodyIsNotConsumed() throws Exception {
+    server.expect().withPath("/response-body")
+        .andReturn(200, "This is the response body")
+        .always();
+    HttpResponse<String> httpResponse = httpClient.sendAsync(httpClient.newHttpRequestBuilder()
+        .uri(server.url("/response-body"))
+        .build(), String.class).get(10, TimeUnit.SECONDS);
+    assertThat(httpResponse.bodyString()).isEqualTo("This is the response body");
   }
 
   @Test


### PR DESCRIPTION
## Description

Fix #5251

Add a unit test in AbstractHttpLoggingInterceptor to verify response bytes are not consumed after they've been processed by HttpLoggingInterceptor.

I've verified that test fails when I revert https://github.com/fabric8io/kubernetes-client/pull/5250 in `httpclient-okhttp` and `httpclient-vertx` modules


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
