### PR TITLE
fix: type inference fixed by bumping Sundrio to 0.101.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #5501: [crd-generator] Fix fallback value of `Default` annotation in presence of multiple accessors
+* Fix #5522: type inference fixed by bumping Sundrio to 0.101.2 (see https://github.com/sundrio/sundrio/pull/431)
 
 #### Improvements
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/TypeInferenceTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/TypeInferenceTest.java
@@ -27,15 +27,13 @@ import java.util.Optional;
 
 class TypeInferenceTest {
 
-  // Commented-out due to compilation failure
-  // TODO: Enable after #5522 is fixed
-  //  @Test
-  //  void typeInferenceWithLambda() {
-  //    final ConfigMapDependentResource cdr = new ConfigMapDependentResource();
-  //    final DeploymentDependentResource ddr = new DeploymentDependentResource();
-  //    Arrays.asList(cdr, ddr).forEach(dr -> dr.reconcile());
-  //    Assertions.assertTrue(true);
-  //  }
+  @Test
+  void typeInferenceWithLambda() {
+    final ConfigMapDependentResource cdr = new ConfigMapDependentResource();
+    final DeploymentDependentResource ddr = new DeploymentDependentResource();
+    Arrays.asList(cdr, ddr).forEach(dr -> dr.reconcile());
+    Assertions.assertTrue(true);
+  }
 
   @Test
   void typeInferenceWithMethodReference() {

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Core versions -->
-    <sundrio.version>0.101.1</sundrio.version>
+    <sundrio.version>0.101.2</sundrio.version>
     <okhttp.version>3.12.12</okhttp.version>
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>


### PR DESCRIPTION


## Description
Fixes #5522

fix: type inference fixed by bumping Sundrio to 0.101.2

see https://github.com/sundrio/sundrio/pull/431

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
