### PR TITLE
fix: adds filtering and switches to iterative traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 * Fix #5580: [java-generator] Correctly handle defaults for IntOrString types
+* Fix #5584: Fix CRD generation when EnumMap is used
 
 #### Improvements
 * Fix #5429: moved crd generator annotations to generator-annotations instead of crd-generator-api. Using generator-annotations introduces no transitive dependencies.

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AdditionalPrinterColumnDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AdditionalPrinterColumnDetector.java
@@ -17,8 +17,6 @@ package io.fabric8.crd.generator.visitor;
 
 import io.fabric8.crd.generator.annotation.PrinterColumn;
 
-import java.util.ArrayList;
-
 public class AdditionalPrinterColumnDetector extends AnnotatedMultiPropertyPathDetector {
 
   public AdditionalPrinterColumnDetector() {
@@ -26,6 +24,6 @@ public class AdditionalPrinterColumnDetector extends AnnotatedMultiPropertyPathD
   }
 
   public AdditionalPrinterColumnDetector(String prefix) {
-    super(prefix, PrinterColumn.class.getSimpleName(), new ArrayList<>());
+    super(prefix, PrinterColumn.class.getSimpleName());
   }
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/LabelSelectorPathDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/LabelSelectorPathDetector.java
@@ -17,8 +17,6 @@ package io.fabric8.crd.generator.visitor;
 
 import io.fabric8.kubernetes.model.annotation.LabelSelector;
 
-import java.util.ArrayList;
-
 public class LabelSelectorPathDetector extends AnnotatedPropertyPathDetector {
 
   public LabelSelectorPathDetector() {
@@ -26,6 +24,6 @@ public class LabelSelectorPathDetector extends AnnotatedPropertyPathDetector {
   }
 
   public LabelSelectorPathDetector(String prefix) {
-    super(prefix, LabelSelector.class.getSimpleName(), new ArrayList<>());
+    super(prefix, LabelSelector.class.getSimpleName());
   }
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/SpecReplicasPathDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/SpecReplicasPathDetector.java
@@ -17,8 +17,6 @@ package io.fabric8.crd.generator.visitor;
 
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
 
-import java.util.ArrayList;
-
 public class SpecReplicasPathDetector extends AnnotatedPropertyPathDetector {
 
   public SpecReplicasPathDetector() {
@@ -26,6 +24,6 @@ public class SpecReplicasPathDetector extends AnnotatedPropertyPathDetector {
   }
 
   public SpecReplicasPathDetector(String prefix) {
-    super(prefix, SpecReplicas.class.getSimpleName(), new ArrayList<>());
+    super(prefix, SpecReplicas.class.getSimpleName());
   }
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/StatusReplicasPathDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/StatusReplicasPathDetector.java
@@ -17,12 +17,10 @@ package io.fabric8.crd.generator.visitor;
 
 import io.fabric8.kubernetes.model.annotation.StatusReplicas;
 
-import java.util.ArrayList;
-
 public class StatusReplicasPathDetector extends AnnotatedPropertyPathDetector {
 
   public StatusReplicasPathDetector(String prefix) {
-    super(prefix, StatusReplicas.class.getSimpleName(), new ArrayList<>());
+    super(prefix, StatusReplicas.class.getSimpleName());
 
   }
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/map/ContainingMaps.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/map/ContainingMaps.java
@@ -19,8 +19,16 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 
+import java.util.EnumMap;
+
 @Group("map.fabric8.io")
 @Version("v1alpha1")
 public class ContainingMaps extends CustomResource<ContainingMapsSpec, Void> {
+
+  public enum Foo {
+    BAR
+  }
+
+  private EnumMap<Foo, String> enumToStringMap;
 
 }


### PR DESCRIPTION
## Description

closes #5584

It doesn't seem like we need traversal below java. classes as we're only looking for our annotations.  Also we can switch to an iterative traversal, which should be less likely to blow out.

cc @andreaTP 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
