### PR TITLE
[chore] Remove dangling link to platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,6 @@ All the resource objects used here will be according to OpenShift 3.9.0  and Kub
   Platforms:
   - [Apache Openwhisk](https://github.com/apache/incubator-openwhisk)
   - [Eclipse che](https://www.eclipse.org/che/)
-  - [EnMasse](https://enmasse.io)
   - [Openshift.io (Launcher service)](https://github.com/fabric8-launcher)
   - [Spotify Styx](https://github.com/spotify/styx)
   - [Strimzi](https://github.com/strimzi/)


### PR DESCRIPTION
## Description
The link doesn't work anymore.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
