### PR TITLE
fix: prevents memory accumulation from informers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix #5580: [java-generator] Correctly handle defaults for IntOrString types
 * Fix #5584: Fix CRD generation when EnumMap is used
+* Fix #5626: Prevent memory accumulation from informer usage
 
 #### Improvements
 * Fix #5429: moved crd generator annotations to generator-annotations instead of crd-generator-api. Using generator-annotations introduces no transitive dependencies.

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientBuilderImpl.java
@@ -25,6 +25,7 @@ import java.net.ProxySelector;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpClient.Version;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.SSLParameters;
 
@@ -48,7 +49,7 @@ class JdkHttpClientBuilderImpl
   @Override
   public HttpClient build() {
     if (client != null) {
-      return new JdkHttpClientImpl(this, client.getHttpClient());
+      return new JdkHttpClientImpl(this, client.getHttpClient(), client.getClosed());
     }
     java.net.http.HttpClient.Builder builder = clientFactory.createNewHttpClientBuilder();
     if (connectTimeout != null && !java.time.Duration.ZERO.equals(connectTimeout)) {
@@ -78,7 +79,7 @@ class JdkHttpClientBuilderImpl
           Arrays.asList(tlsVersions).stream().map(TlsVersion::javaName).toArray(String[]::new)));
     }
     clientFactory.additionalConfig(builder);
-    return new JdkHttpClientImpl(this, builder.build());
+    return new JdkHttpClientImpl(this, builder.build(), new AtomicBoolean());
   }
 
   @Override

--- a/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
+++ b/httpclient-jdk/src/main/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientImpl.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static io.fabric8.kubernetes.client.http.StandardHttpHeaders.CONTENT_TYPE;
@@ -223,13 +224,13 @@ public class JdkHttpClientImpl extends StandardHttpClient<JdkHttpClientImpl, Jdk
 
   private java.net.http.HttpClient httpClient;
 
-  public JdkHttpClientImpl(JdkHttpClientBuilderImpl builder, HttpClient httpClient) {
-    super(builder);
+  public JdkHttpClientImpl(JdkHttpClientBuilderImpl builder, HttpClient httpClient, AtomicBoolean closed) {
+    super(builder, closed);
     this.httpClient = httpClient;
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     if (this.httpClient == null) {
       return;
     }

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClient.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.fabric8.kubernetes.client.http.BufferUtil.copy;
 import static io.fabric8.kubernetes.client.http.StandardMediaTypes.APPLICATION_OCTET_STREAM;
@@ -61,13 +62,18 @@ public class JettyHttpClient extends StandardHttpClient<JettyHttpClient, JettyHt
 
   public JettyHttpClient(StandardHttpClientBuilder<JettyHttpClient, JettyHttpClientFactory, JettyHttpClientBuilder> builder,
       HttpClient jetty, WebSocketClient jettyWs) {
-    super(builder);
+    this(builder, jetty, jettyWs, new AtomicBoolean());
+  }
+
+  public JettyHttpClient(StandardHttpClientBuilder<JettyHttpClient, JettyHttpClientFactory, JettyHttpClientBuilder> builder,
+      HttpClient jetty, WebSocketClient jettyWs, AtomicBoolean closed) {
+    super(builder, closed);
     this.jetty = jetty;
     this.jettyWs = jettyWs;
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     try {
       jetty.stop();
       jettyWs.stop();

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -55,7 +55,7 @@ public class JettyHttpClientBuilder
   @Override
   public JettyHttpClient build() {
     if (client != null) {
-      return new JettyHttpClient(this, client.getJetty(), client.getJettyWs());
+      return new JettyHttpClient(this, client.getJetty(), client.getJettyWs(), client.getClosed());
     }
     final var sslContextFactory = new SslContextFactory.Client();
     if (sslContext != null) {

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientBuilderImpl.java
@@ -28,6 +28,7 @@ import okhttp3.Protocol;
 import java.net.Proxy;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.X509TrustManager;
 
@@ -119,7 +120,7 @@ class OkHttpClientBuilderImpl
 
     OkHttpClient client = builder.build();
 
-    return new OkHttpClientImpl(client, this);
+    return new OkHttpClientImpl(client, this, new AtomicBoolean());
   }
 
   @Override

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientImpl.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHttpClientFactory, OkHttpClientBuilderImpl> {
@@ -241,13 +242,13 @@ public class OkHttpClientImpl extends StandardHttpClient<OkHttpClientImpl, OkHtt
 
   private final okhttp3.OkHttpClient httpClient;
 
-  public OkHttpClientImpl(OkHttpClient client, OkHttpClientBuilderImpl builder) {
-    super(builder);
+  public OkHttpClientImpl(OkHttpClient client, OkHttpClientBuilderImpl builder, AtomicBoolean closed) {
+    super(builder, closed);
     this.httpClient = client;
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     ConnectionPool connectionPool = httpClient.connectionPool();
 
     Dispatcher dispatcher = httpClient.dispatcher();

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClient.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.fabric8.kubernetes.client.vertx.VertxHttpRequest.toHeadersMap;
 
@@ -43,8 +44,8 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
   private final Vertx vertx;
   private final HttpClient client;
 
-  VertxHttpClient(VertxHttpClientBuilder<F> vertxHttpClientBuilder, HttpClient client) {
-    super(vertxHttpClientBuilder);
+  VertxHttpClient(VertxHttpClientBuilder<F> vertxHttpClientBuilder, HttpClient client, AtomicBoolean closed) {
+    super(vertxHttpClientBuilder, closed);
     this.vertx = vertxHttpClientBuilder.vertx;
     this.client = client;
   }
@@ -119,7 +120,7 @@ public class VertxHttpClient<F extends io.fabric8.kubernetes.client.http.HttpCli
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     client.close();
   }
 

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilder.java
@@ -33,6 +33,7 @@ import io.vertx.ext.web.client.WebClientOptions;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 public class VertxHttpClientBuilder<F extends HttpClient.Factory>
@@ -52,7 +53,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
   @Override
   public VertxHttpClient<F> build() {
     if (this.client != null) {
-      return new VertxHttpClient<>(this, this.client.getClient());
+      return new VertxHttpClient<>(this, this.client.getClient(), this.client.getClosed());
     }
 
     WebClientOptions options = new WebClientOptions();
@@ -115,7 +116,7 @@ public class VertxHttpClientBuilder<F extends HttpClient.Factory>
         }
       });
     }
-    return new VertxHttpClient<>(this, vertx.createHttpClient(options));
+    return new VertxHttpClient<>(this, vertx.createHttpClient(options), new AtomicBoolean());
   }
 
   @Override

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClient.java
@@ -167,4 +167,6 @@ public interface HttpClient extends AutoCloseable {
 
   HttpRequest.Builder newHttpRequestBuilder();
 
+  boolean isClosed();
+
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -265,4 +265,18 @@ class StandardHttpClientTest {
             10000));
   }
 
+  @Test
+  void testIsClosed() {
+    client.close();
+    assertTrue(client.isClosed());
+  }
+
+  @Test
+  void testDerivedIsClosed() {
+    TestStandardHttpClient childClient = client.newBuilder().connectTimeout(0, TimeUnit.SECONDS).build();
+    childClient.close();
+    assertTrue(childClient.isClosed());
+    assertTrue(client.isClosed());
+  }
+
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestStandardHttpClient.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestStandardHttpClient.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestStandardHttpClient
     extends StandardHttpClient<TestStandardHttpClient, TestStandardHttpClientFactory, TestStandardHttpClientBuilder> {
@@ -39,15 +40,15 @@ public class TestStandardHttpClient
   @Getter
   private final List<RecordedConsumeBytesDirect> recordedConsumeBytesDirects;
 
-  protected TestStandardHttpClient(TestStandardHttpClientBuilder builder) {
-    super(builder);
+  protected TestStandardHttpClient(TestStandardHttpClientBuilder builder, AtomicBoolean closed) {
+    super(builder, closed);
     expectations = new HashMap<>();
     recordedBuildWebSocketDirects = new ArrayList<>();
     recordedConsumeBytesDirects = new ArrayList<>();
   }
 
   @Override
-  public void close() {
+  public void doClose() {
     recordedConsumeBytesDirects.clear();
     recordedBuildWebSocketDirects.clear();
     expectations.values().forEach(e -> {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestStandardHttpClientBuilder.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/TestStandardHttpClientBuilder.java
@@ -15,7 +15,9 @@
  */
 package io.fabric8.kubernetes.client.http;
 
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestStandardHttpClientBuilder
     extends StandardHttpClientBuilder<TestStandardHttpClient, TestStandardHttpClientFactory, TestStandardHttpClientBuilder> {
@@ -30,7 +32,8 @@ public class TestStandardHttpClientBuilder
 
   @Override
   public TestStandardHttpClient build() {
-    final TestStandardHttpClient instance = new TestStandardHttpClient(this);
+    final TestStandardHttpClient instance = new TestStandardHttpClient(this,
+        Optional.ofNullable(instances.peek()).map(TestStandardHttpClient::getClosed).orElse(new AtomicBoolean()));
     instances.add(instance);
     return instance;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManager.java
@@ -240,6 +240,11 @@ public abstract class AbstractWatchManager<T extends HasMetadata> implements Wat
 
   synchronized void reconnect() {
     try {
+      if (client.isClosed()) {
+        logger.debug("The client has closed, closing the watch");
+        this.close();
+        return;
+      }
       startWatch();
       if (isForceClosed()) {
         closeRequest();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/DefaultSharedIndexInformer.java
@@ -166,6 +166,10 @@ public class DefaultSharedIndexInformer<T extends HasMetadata, L extends Kuberne
     return reflector.start();
   }
 
+  public CompletableFuture<Void> started() {
+    return reflector.getStartFuture();
+  }
+
   @Override
   public SharedIndexInformer<T> run() {
     Utils.waitUntilReadyOrFail(start(), -1, TimeUnit.MILLISECONDS);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -1216,7 +1216,28 @@ class DefaultSharedIndexInformerTest {
         .inNamespace("ns1")
         .runnableInformer(60 * WATCH_EVENT_EMIT_TIME);
 
+    animalSharedIndexInformer.start();
+
     client.close();
+
+    await().atMost(60, TimeUnit.SECONDS).until(() -> animalSharedIndexInformer.stopped().toCompletableFuture().isDone());
+  }
+
+  @Test
+  void testClientStopClosesInformerBeforeStarting() throws InterruptedException {
+    // Given
+    setupMockServerExpectations(Animal.class, "ns1", this::getList,
+        r -> new WatchEvent(getAnimal("red-panda", "Carnivora", r), "ADDED"), null, null);
+
+    // When
+    SharedIndexInformer<GenericKubernetesResource> animalSharedIndexInformer = client
+        .genericKubernetesResources(animalContext)
+        .inNamespace("ns1")
+        .runnableInformer(60 * WATCH_EVENT_EMIT_TIME);
+
+    client.close();
+
+    animalSharedIndexInformer.start();
 
     assertTrue(animalSharedIndexInformer.stopped().toCompletableFuture().isDone());
   }


### PR DESCRIPTION
## Description

I completely missed the need for cleanup with the proactive closing of informers with #5327.  Unfortunately this affects both implicit and explicit usage of informers.  An alternative approach is to track if the client has been closed - I had initially avoided that because it's more work, as you can see from this pr.  This approach though doesn't have much risk other than some code complexity.

The only other possibility would be to track a set of informers on the BaseClient and close them using the completablefuture, but that will also require actively removing entires from the set once they've already been closed.

Fixes #5626
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
