### PR TITLE
fix flaky test

### DIFF
--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/crud/Attribute.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 import static io.fabric8.mockwebserver.crud.AttributeType.WITH;
 
-public class Attribute {
+public class Attribute implements Comparable<Attribute> {
 
   private final Key key;
   private final List<Value> values;
@@ -87,5 +87,10 @@ public class Attribute {
 
   public AttributeType getType() {
     return type;
+  }
+
+  @Override
+  public int compareTo(Attribute o) {
+    return key.compareTo(o.key);
   }
 }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/crud/Key.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/crud/Key.java
@@ -17,7 +17,7 @@ package io.fabric8.mockwebserver.crud;
 
 import java.util.Objects;
 
-public class Key {
+public class Key implements Comparable<Key> {
 
   private final String name;
 
@@ -38,6 +38,11 @@ public class Key {
   @Override
   public int hashCode() {
     return Objects.hash(name);
+  }
+
+  @Override
+  public int compareTo(Key o) {
+    return name.compareTo(o.name);
   }
 
   @Override

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
@@ -106,12 +106,13 @@ class AttributeSetTest extends Specification {
     when:
     AttributeSet attributeSet = new AttributeSet(a2)
     AttributeSet selectorWithOne = new AttributeSet(a2)
-    AttributeSet selectorWithTwo = new AttributeSet(a2, a3);
+    AttributeSet selectorWithTwo = new AttributeSet(a2, a3)
+    def orderedAttributes = new LinkedHashSet([a2, a3]);
     then:
 
     // Assert that the order is suitable for testing. The failing attribute should
     // be in the *second* position to ensure we're examining all the values of the selector
-    assert new ArrayList<>(selectorWithTwo.attributes.values()).indexOf(a3) == 1;
+    assert new ArrayList<>(orderedAttributes).indexOf(a3) == 1;
 
     assert attributeSet.matches(selectorWithOne)
     assert !attributeSet.matches(selectorWithTwo)

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy
@@ -17,6 +17,8 @@ package io.fabric8.mockwebserver.crud
 
 import spock.lang.Specification
 
+import java.util.stream.Collectors
+
 class AttributeSetTest extends Specification {
 
     def "when two feature set are empty the should be equals"() {
@@ -98,24 +100,31 @@ class AttributeSetTest extends Specification {
         assert attributeSet.matches(selector)
     }
 
+  def "when multiple attributes are specified it should not match an attribute set with a single attribute"() {
+    given: "multiple attributes"
+      def a2 = new Attribute("key2", "value2")
+      def a3 = new Attribute("key3", "", AttributeType.EXISTS)
+    and: "an AttributeSet with only one attribute"
+      def attributeSet = new AttributeSet(a2)
+    and: "an AttributeSet with two attributes as selector"
+      def selectorWithTwo = new AttributeSet(a2, a3)
+    when: "matching"
+      def matches = attributeSet.matches(selectorWithTwo)
+    then: "it should not match"
+      assert !matches
+  }
+
   def "when multiple attributes are specified it should examine all"() {
-    given:
-    // Naming is important here as it controls the hashed order
-    Attribute a2 = new Attribute("key2", "value2")
-    Attribute a3 = new Attribute("key3", "", AttributeType.EXISTS)
-    when:
-    AttributeSet attributeSet = new AttributeSet(a2)
-    AttributeSet selectorWithOne = new AttributeSet(a2)
-    AttributeSet selectorWithTwo = new AttributeSet(a2, a3)
-    def orderedAttributes = new LinkedHashSet([a2, a3]);
-    then:
-
-    // Assert that the order is suitable for testing. The failing attribute should
-    // be in the *second* position to ensure we're examining all the values of the selector
-    assert new ArrayList<>(orderedAttributes).indexOf(a3) == 1;
-
-    assert attributeSet.matches(selectorWithOne)
-    assert !attributeSet.matches(selectorWithTwo)
+    given: "multiple attributes"
+      def a2 = new Attribute("key2", "value2")
+      def a3 = new Attribute("key3", "", AttributeType.EXISTS)
+    and: "an AttributeSet with all attributes"
+      def attributeSet = new AttributeSet(a2, a3)
+    when: "listing its values"
+      def attributes = attributeSet.attributes.values().stream().sorted().collect(Collectors.toList())
+    then: "it should contain all attributes"
+      assert attributes.indexOf(a3) == 1
+      assert attributes.size() == 2
   }
 
   def "when IN attribute in selector"() {


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
Fixed the flaky test `when multiple attributes are specified it should examine all` inside the `AttributeSetTest` class
Detected flaky test `when setting an expectation as an object it should be serialized to json` inside the `DefaultMockServerTest` class.
Detected flaky tests `put /1, with missing item, should create item` `put /1, with existent item, should replace item` `get /1, with existent item, should return item` `get /, with one item, should return item` `get /, with multiple items, should return array` inside the `DefaultMockServerCrudTest` class.


### Root Cause
All tests mentioned above have been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

#### AttributeSetTest
`when multiple attributes are specified it should examine all` inside the `AttributeSetTest` class utilize `Attribute` and `AttributeSet` to perform test operation. However, groovy's `AttributeSet` does not guarantee the elements' order. Therefore, the `indexOf()` method will give different results based on the index of `a3` at line 114.
https://github.com/fabric8io/kubernetes-client/blob/56a6c2c4f336cc6f64c19029a55c2d3d0289344f/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/crud/AttributeSetTest.groovy#L109-L114

#### DefaultMockServerTest 
`when setting an expectation as an object it should be serialized to json` inside the `DefaultMockServerTest` class invokes the method `clinent.newCall()` which will return a response type result. Then convert this result to a string and compare it with the expected string. However, I guess the `Response` type will not guarantee elements order inside it. Therefore, converting `Response` to a string will generate a string that has a different order from the expected string.
https://github.com/fabric8io/kubernetes-client/blob/56a6c2c4f336cc6f64c19029a55c2d3d0289344f/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy#L243-L247

#### DefaultMockServerCrudTest
Tests in this class have the same problem as the test in the `DefaultMockServerTest ` class. Invoking to `client.newCall()` returns a `Response` type result that cannot guarantee a specific order for elements inside. Therefore, converting to a string will not generate the expected string. 
https://github.com/fabric8io/kubernetes-client/blob/56a6c2c4f336cc6f64c19029a55c2d3d0289344f/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerCrudTest.groovy#L84-L89

To reproduce run:
```
mvn -pl junit/mockwebserver/ edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<test_name>
```

### Fix
#### AttributeSetTest
I fixed this test by creating a new `LinkedHashSet` to store `Attribute`. `LinkedHashSet` will guarantee the order of `Attribute` inside it.

#### DefaultMockServerTest & DefaultMockServerCrudTest
For tests in these two classes, a simple way to fix them is to create another `Response` object and assign expected data to the object. However, I cannot find any information about how to create a `Response` object and assign a value to it. Therefore, I can only discuss one possible solution here. 

#### Key changed/added classes in this PR
- `io.fabric8.mockwebserver.crud.AttributeSetTest`


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
