### PR TITLE
refactor(mockwebserver): DefaultMockServerCrudTest uses Vert.x to perform verifications

### DIFF
--- a/junit/mockwebserver/pom.xml
+++ b/junit/mockwebserver/pom.xml
@@ -44,6 +44,17 @@
       <artifactId>zjsonpatch</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-uri-template</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -818,6 +818,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
         <version>${picocli.version}</version>


### PR DESCRIPTION
## Description

Part of #5632

Updates DefaultMockWebServerCrudTest to use Vert.x instead of OkHttp to perform the verifications.

This will allow to completely remove OkHttp in a future refactor of the `mockwebserver` module (#5613). Having the tests in  Vert.x will allow us to ensure that the functionality still works without modifying the tests.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
