### PR TITLE
test: fix MockWebServer crud test concurrency issue

### DIFF
--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerCrudTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerCrudTest.groovy
@@ -90,12 +90,12 @@ class DefaultMockServerCrudTest extends Specification {
     and: "An instance of AsyncConditions"
       def async = new AsyncConditions(1)
     and: "Items in the server"
-      def itemsInServer = Future.all(
-        client.post(server.port, server.getHostName(), "/")
-          .sendJson(new User(1L, "user", true)),
-        client.post(server.port, server.getHostName(), "/")
-          .sendJson(new User(2L, "user-2", true))
-      )
+      def itemsInServer = client.post(server.port, server.getHostName(), "/")
+        .sendJson(new User(1L, "user", true))
+        .compose { _ ->
+          client.post(server.port, server.getHostName(), "/")
+            .sendJson(new User(2L, "user-2", true))
+        }
 
     when: "The request is sent and completed"
       itemsInServer.onComplete {isr ->


### PR DESCRIPTION
## Description
test: fix MockWebServer crud test concurrency issue

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
