### PR TITLE
fix (kubernetes-client) : Change Pod upload tarball location to target upload directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #5580: [java-generator] Correctly handle defaults for IntOrString types
 * Fix #5584: Fix CRD generation when EnumMap is used
 * Fix #5626: Prevent memory accumulation from informer usage
+* Fix #5527: Unable to transfer file to pod if `/tmp` is read-only
 
 #### Improvements
 * Fix #5429: moved crd generator annotations to generator-annotations instead of crd-generator-api. Using generator-annotations introduces no transitive dependencies.

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/UploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/UploadTest.java
@@ -135,7 +135,7 @@ class UploadTest {
         .extracting(StandardWebSocketBuilder::asHttpRequest)
         .extracting(StandardHttpRequest::uri)
         .extracting(URI::getQuery).asString()
-        .contains("command=rm /tmp/fabric8-");
+        .contains("command=rm /target/fabric8-");
   }
 
   @Nested
@@ -213,7 +213,7 @@ class UploadTest {
             .extracting(StandardWebSocketBuilder::asHttpRequest)
             .extracting(StandardHttpRequest::uri)
             .extracting(URI::getQuery).asString()
-            .contains("command=mkdir -p '/tmp' && cat - > '/tmp/fabric8-");
+            .contains("command=mkdir -p '/target/' && cat - > '/target/fabric8-");
       }
 
       @Test
@@ -229,7 +229,7 @@ class UploadTest {
             .extracting(StandardWebSocketBuilder::asHttpRequest)
             .extracting(StandardHttpRequest::uri)
             .extracting(URI::getQuery).asString()
-            .contains("command=wc -c < '/tmp/fabric8-");
+            .contains("command=wc -c < '/target/fabric8-");
       }
 
       @Test
@@ -246,7 +246,7 @@ class UploadTest {
             .extracting(StandardHttpRequest::uri)
             .extracting(URI::getQuery).asString()
             .matches(
-                ".+command=mkdir -p '/target-dir'; tar -C '/target-dir' -xmf /tmp/fabric8-.+\\.tar; e=\\$\\?; rm /tmp/fabric8-.+");
+                ".+command=mkdir -p '/target-dir/'; tar -C '/target-dir/' -xmf /target-dir/fabric8-.+\\.tar; e=\\$\\?; rm /target-dir/fabric8-.+");
       }
 
       @Nested
@@ -272,7 +272,7 @@ class UploadTest {
           final byte[] tarBytes = new byte[sendCaptor.getValue().remaining() - 1];
           System.arraycopy(sendCaptor.getValue().array(), 1, tarBytes, 0, tarBytes.length);
           final TarArchiveInputStream tar = new TarArchiveInputStream(new ByteArrayInputStream(tarBytes));
-          assertThat(tar.getNextTarEntry())
+          assertThat(tar.getNextEntry())
               .hasFieldOrPropertyWithValue("name", "file-name.txt")
               .hasFieldOrPropertyWithValue("size", toUpload.toFile().length());
         }
@@ -292,7 +292,7 @@ class UploadTest {
           final byte[] tarBytes = new byte[sendCaptor.getValue().remaining() - 1];
           System.arraycopy(sendCaptor.getValue().array(), 1, tarBytes, 0, tarBytes.length);
           final TarArchiveInputStream tar = new TarArchiveInputStream(new ByteArrayInputStream(tarBytes));
-          assertThat(tar.getNextTarEntry())
+          assertThat(tar.getNextEntry())
               .hasFieldOrPropertyWithValue("name", longFileName);
         }
 
@@ -310,7 +310,7 @@ class UploadTest {
           final byte[] tarBytes = new byte[sendCaptor.getValue().remaining() - 1];
           System.arraycopy(sendCaptor.getValue().array(), 1, tarBytes, 0, tarBytes.length);
           final TarArchiveInputStream tar = new TarArchiveInputStream(new ByteArrayInputStream(tarBytes));
-          assertThat(tar.getNextTarEntry())
+          assertThat(tar.getNextEntry())
               .hasFieldOrPropertyWithValue("name", "file-name.txt")
               .hasFieldOrPropertyWithValue("lastModifiedTime", FileTime.fromMillis(9999999999999L));
         }
@@ -351,7 +351,7 @@ class UploadTest {
             .extracting(StandardWebSocketBuilder::asHttpRequest)
             .extracting(StandardHttpRequest::uri)
             .extracting(URI::getQuery).asString()
-            .contains("command=mkdir -p '/tmp' && cat - > '/tmp/fabric8-");
+            .contains("command=mkdir -p '/target/location/' && cat - > '/target/location/fabric8-");
       }
 
       @Test
@@ -367,7 +367,7 @@ class UploadTest {
             .extracting(StandardWebSocketBuilder::asHttpRequest)
             .extracting(StandardHttpRequest::uri)
             .extracting(URI::getQuery).asString()
-            .contains("command=wc -c < '/tmp/fabric8-");
+            .contains("command=wc -c < '/target/location/fabric8-");
       }
 
       @Test
@@ -384,7 +384,7 @@ class UploadTest {
             .extracting(StandardHttpRequest::uri)
             .extracting(URI::getQuery).asString()
             .matches(
-                ".+command=mkdir -p '/target-dir/location'; tar -C '/target-dir/location' -xmf /tmp/fabric8-.+\\.tar; e=\\$\\?; rm /tmp/fabric8-.+");
+                ".+command=mkdir -p '/target-dir/location/'; tar -C '/target-dir/location/' -xmf /target-dir/location/fabric8-.+\\.tar; e=\\$\\?; rm /target-dir/location/fabric8-.+");
       }
 
     }
@@ -423,7 +423,7 @@ class UploadTest {
             .extracting(StandardWebSocketBuilder::asHttpRequest)
             .extracting(StandardHttpRequest::uri)
             .extracting(URI::getQuery).asString()
-            .contains("command=mkdir -p '/target' && cat - > '/target/location");
+            .contains("command=mkdir -p '/target/' && cat - > '/target/location");
       }
 
       @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUploadTest.java
@@ -57,7 +57,7 @@ class PodUploadTest {
       // When
       String result = PodUpload.createExecCommandForUpload("/tmp/foo/cp.log");
       // Then
-      assertThat(result).isEqualTo("mkdir -p '/tmp/foo' && cat - > '/tmp/foo/cp.log'");
+      assertThat(result).isEqualTo("mkdir -p '/tmp/foo/' && cat - > '/tmp/foo/cp.log'");
     }
 
     //
@@ -66,7 +66,7 @@ class PodUploadTest {
       // When
       String result = PodUpload.createExecCommandForUpload("/tmp/fo'o/cp.log");
       // Then
-      assertThat(result).isEqualTo("mkdir -p '/tmp/fo\'\\'\'o' && cat - > '/tmp/fo\'\\'\'o/cp.log'");
+      assertThat(result).isEqualTo("mkdir -p '/tmp/fo\'\\'\'o/' && cat - > '/tmp/fo\'\\'\'o/cp.log'");
     }
 
     @Test
@@ -74,7 +74,7 @@ class PodUploadTest {
       // When
       String result = PodUpload.createExecCommandForUpload("/tmp/f'o'o/c'p.log");
       // Then
-      assertThat(result).isEqualTo("mkdir -p '/tmp/f\'\\'\'o\'\\'\'o' && cat - > '/tmp/f\'\\'\'o\'\\'\'o/c\'\\'\'p.log'");
+      assertThat(result).isEqualTo("mkdir -p '/tmp/f\'\\'\'o\'\\'\'o/' && cat - > '/tmp/f\'\\'\'o\'\\'\'o/c\'\\'\'p.log'");
     }
   }
 


### PR DESCRIPTION
## Description

Fix #5527 

Using `/tmp` as upload directory can be problematic for scenarios where `/tmp` is read only. We can directly upload the intermediate upload tarball to the directory where we are uploading the content.

- In case of uploading a file to a Pod, temporary tarball would be uploaded in the parent directory of that file.

- In case of uploading a directory to a Pod, temporary tarball would be uploaded in the same directory that's specified for upload path.

Other minor changes:
- Replace deprecated `getNextTarEntry()` with `getNextEntry()` in UploadTest
- Refactor `getDirectoryFromFile` method to reuse logic for extracting directory from file path. For consistency we always add a trailing `/` at the end of file path.


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
