### PR TITLE
fix: adding PodResource.patchReadinessGateStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Improvements
 * Fix #5429: moved crd generator annotations to generator-annotations instead of crd-generator-api. Using generator-annotations introduces no transitive dependencies.
 * Fix #5535: Add lombok and sundrio dependencies to the generated bom
+* Fix #5496: Added PodResource.patchReadinessGateStatus and a general subresource method to use any of the patch/edit/update methods with any subresource
 
 #### Dependency Upgrade
 * Updated okio to version 1.17.6 to avoid CVE-2023-3635

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EditReplacePatchable.java
@@ -23,8 +23,7 @@ import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
-public interface EditReplacePatchable<T>
-    extends Replaceable<T> {
+public interface EditReplacePatchable<T> extends Updatable<T> {
 
   /**
    * Issues a JSON patch against the item based upon the changes made to the object returned by the function.
@@ -131,26 +130,6 @@ public interface EditReplacePatchable<T>
    * @return updated object
    */
   T patch(PatchContext patchContext, String patch);
-
-  /**
-   * Edit the status subresource
-   *
-   * @param function to produce a modified status
-   * @return updated object
-   */
-  T editStatus(UnaryOperator<T> function);
-
-  /**
-   * Does a PATCH request to the /status subresource ignoring changes to anything except the status stanza.
-   * <p>
-   * This method has the same patching behavior as {@link #patch(PatchContext)}, with
-   * {@link PatchType#JSON_MERGE} but against the status subresource.
-   * <p>
-   * Set the resourceVersion to null to prevent optimistic locking.
-   *
-   * @return updated object
-   */
-  T patchStatus();
 
   /**
    * Update field(s) of a resource using a JSON patch which will be computed using the latest

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EphemeralContainersResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/EphemeralContainersResource.java
@@ -24,7 +24,7 @@ import io.fabric8.kubernetes.api.model.Pod;
  *
  * @see <a href="https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/">About Ephemeral Containers</a>
  * @see <a href=
- *      "hhttps://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#-strong-ephemeralcontainers-operations-pod-v1-core-strong-">Ephemeral
+ *      "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#-strong-ephemeralcontainers-operations-pod-v1-core-strong-">Ephemeral
  *      Containers Operations</a>
  */
 public interface EphemeralContainersResource extends EditReplacePatchable<Pod> {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemWritableOperation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemWritableOperation.java
@@ -68,7 +68,7 @@ public interface ItemWritableOperation<T> extends DeletableWithOptions, ItemRepl
   T updateStatus(T item);
 
   /**
-   * See {@link EditReplacePatchable#patchStatus()}
+   * See {@link NonDeletingOperation#patchStatus()}
    *
    * @param item kubernetes object
    * @return updated object

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
@@ -15,7 +15,11 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 public interface NonDeletingOperation<T> extends
     CreateOrReplaceable<T>,
@@ -44,4 +48,30 @@ public interface NonDeletingOperation<T> extends
    * @return NonDeletingOperation that may act on the unlocked item
    */
   NonDeletingOperation<T> unlock();
+
+  /**
+   * Edit the status subresource
+   *
+   * @param function to produce a modified status
+   * @return updated object
+   */
+  T editStatus(UnaryOperator<T> function);
+
+  /**
+   * Does a PATCH request to the /status subresource ignoring changes to anything except the status stanza.
+   * <p>
+   * This method has the same patching behavior as {@link #patch(PatchContext)}, with
+   * {@link PatchType#JSON_MERGE} but against the status subresource.
+   * <p>
+   * Set the resourceVersion to null to prevent optimistic locking.
+   *
+   * @return updated object
+   */
+  T patchStatus();
+
+  /**
+   * Provides edit, patch, and replace methods for the given subresource
+   */
+  EditReplacePatchable<T> subresource(String subresource);
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/PodResource.java
@@ -18,6 +18,8 @@ package io.fabric8.kubernetes.client.dsl;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.policy.v1.Eviction;
 
+import java.util.Map;
+
 public interface PodResource extends Resource<Pod>,
     Loggable,
     Containerable<String, ContainerResource>,
@@ -48,5 +50,13 @@ public interface PodResource extends Resource<Pod>,
    * @return ephemeral containers resource operations
    */
   EphemeralContainersResource ephemeralContainers();
+
+  /**
+   * Set the Pod status readiness gate fields to match the given map.
+   *
+   * @param readiness
+   * @return a new pod instance with the updated readiness gates
+   */
+  Pod patchReadinessGateStatus(Map<String, Boolean> readiness);
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Replaceable.java
@@ -15,30 +15,7 @@
  */
 package io.fabric8.kubernetes.client.dsl;
 
-public interface Replaceable<T> {
-
-  /**
-   * Replace the server's state with the given item.
-   *
-   * <p>
-   * If {@link Resource#lockResourceVersion(String)} has been used to lock the resourceVersion,
-   * this operation is effectively a single update attempt against that version.
-   * <p>
-   * If {@link Resource#lockResourceVersion(String)} has not been called, this operation
-   * will be retried a number of times in the event of a conflict. If a resourceVersion has been set
-   * on the item, the first update attempt will be made against that version. Subsequent attempts will fetch
-   * the latest resourceVersion from the server.
-   *
-   * @return returns deserialized version of api server response
-   *
-   * @deprecated use {@link #update()} instead
-   *
-   * @see <a href=
-   *      "https://github.com/fabric8io/kubernetes-client/blob/main/doc/FAQ.md#alternatives-to-createOrReplace-and-replace"
-   *      >Migration FAQ</a>
-   */
-  @Deprecated
-  T replace();
+public interface Replaceable<T> extends Updatable<T> {
 
   /**
    * Similar to {@link Replaceable#replace()}, but only affects the status subresource
@@ -60,16 +37,5 @@ public interface Replaceable<T> {
    * @return returns deserialized version of api server response
    */
   T updateStatus();
-
-  /**
-   * Update the server's state with the given item (PUT).
-   * <p>
-   * If the resourceVersion is on the resource, the update will be performed with optimistic locking, and may
-   * result in a conflict (409 error). If no resourceVersion is on the resource, the latest resourceVersion will
-   * be obtained from the server prior to the update call - which may still be a conflict in a rare circumstance.
-   *
-   * @return returns deserialized version of api server response
-   */
-  T update();
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Updatable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Updatable.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.dsl;
+
+public interface Updatable<T> {
+
+  /**
+   * Replace the server's state with the given item.
+   *
+   * <p>
+   * If {@link Resource#lockResourceVersion(String)} has been used to lock the resourceVersion,
+   * this operation is effectively a single update attempt against that version.
+   * <p>
+   * If {@link Resource#lockResourceVersion(String)} has not been called, this operation
+   * will be retried a number of times in the event of a conflict. If a resourceVersion has been set
+   * on the item, the first update attempt will be made against that version. Subsequent attempts will fetch
+   * the latest resourceVersion from the server.
+   *
+   * @return returns deserialized version of api server response
+   *
+   * @deprecated use {@link #update()} instead
+   *
+   * @see <a href=
+   *      "https://github.com/fabric8io/kubernetes-client/blob/main/doc/FAQ.md#alternatives-to-createOrReplace-and-replace"
+   *      >Migration FAQ</a>
+   */
+  @Deprecated
+  T replace();
+
+  /**
+   * Update the server's state with the given item (PUT).
+   * <p>
+   * If the resourceVersion is on the resource, the update will be performed with optimistic locking, and may
+   * result in a conflict (409 error). If no resourceVersion is on the resource, the latest resourceVersion will
+   * be obtained from the server prior to the update call - which may still be a conflict in a rare circumstance.
+   *
+   * @return returns deserialized version of api server response
+   */
+  T update();
+
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResource.java
@@ -94,6 +94,9 @@ public interface ExtensibleResource<T> extends Resource<T>, TimeoutableScalable<
   ExtensibleResource<T> unlock();
 
   @Override
+  ExtensibleResource<T> subresource(String subresource);
+
+  @Override
   default ExtensibleResource<T> withTimeoutInMillis(long timeoutInMillis) {
     return withTimeout(timeoutInMillis, TimeUnit.MILLISECONDS);
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ExtensibleResourceAdapter.java
@@ -132,4 +132,9 @@ public abstract class ExtensibleResourceAdapter<T> extends ResourceAdapter<T> im
     return newInstance().init(resource.unlock(), client);
   }
 
+  @Override
+  public ExtensibleResource<T> subresource(String subresource) {
+    return newInstance().init(resource.subresource(subresource), client);
+  }
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.ResourceNotFoundException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Deletable;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.Gettable;
 import io.fabric8.kubernetes.client.dsl.Informable;
 import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
@@ -378,6 +379,11 @@ public class ResourceAdapter<T> implements Resource<T> {
   @Override
   public NonDeletingOperation<T> unlock() {
     return resource.unlock();
+  }
+
+  @Override
+  public EditReplacePatchable<T> subresource(String subresource) {
+    return resource.subresource(subresource);
   }
 
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -1202,4 +1202,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     throw new KubernetesClientException(READ_ONLY_UPDATE_EXCEPTION_MESSAGE);
   }
 
+  @Override
+  public ExtensibleResource<T> subresource(String subresource) {
+    return newInstance(context.withSubresource(subresource));
+  }
+
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodEphemeralContainersIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodEphemeralContainersIT.java
@@ -58,6 +58,25 @@ class PodEphemeralContainersIT {
   }
 
   @Test
+  void editSubresource() {
+    Pod pod = client.pods().withName("pod-standard")
+        .subresource("ephemeralcontainers")
+        .edit(p -> new PodBuilder(p)
+            .editMetadata().withResourceVersion(null).endMetadata()
+            .editSpec()
+            .addNewEphemeralContainer()
+            .withName("debugger-sub")
+            .withImage("alpine")
+            .withCommand("sh")
+            .endEphemeralContainer()
+            .endSpec()
+            .build());
+
+    List<EphemeralContainer> containers = pod.getSpec().getEphemeralContainers();
+    assertTrue(containers.stream().anyMatch(c -> c.getName().equals("debugger-sub")));
+  }
+
+  @Test
   void replace() {
     Pod item = client.pods().withName("pod-standard").get();
     Pod replacement = new PodBuilder(item)

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PodIT.java
@@ -61,7 +61,10 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -135,6 +138,15 @@ class PodIT {
     Pod pod1 = client.pods().withName("pod-standard").edit(p -> new PodBuilder(p)
         .editMetadata().withResourceVersion(null).addToLabels("foo", "bar").endMetadata().build());
     assertEquals("bar", pod1.getMetadata().getLabels().get("foo"));
+  }
+
+  @Test
+  void readinessGate() {
+    Map<String, Boolean> readiness = new HashMap<>();
+    readiness.put("test", true);
+    Pod pod1 = client.pods().withName("pod-standard").patchReadinessGateStatus(readiness);
+    assertEquals("True", pod1.getStatus().getConditions().stream().filter(pc -> pc.getType().equals("test")).findFirst()
+        .orElseThrow(() -> new NoSuchElementException()).getStatus());
   }
 
   @Test


### PR DESCRIPTION
also adding a general subresource method - to make this a little cleaner the existing status specific methods are moved off of what is obtained when you call subresource or ephemeralContainers

closes #5496

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
