### PR TITLE
fix: ExecCredential doesn't fail with unsupported command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ### 6.10-SNAPSHOT
 
 #### Bugs
-
 * Fix #5580: [java-generator] Correctly handle defaults for IntOrString types
 * Fix #5584: Fix CRD generation when EnumMap is used
 * Fix #5626: Prevent memory accumulation from informer usage
 * Fix #5527: Unable to transfer file to pod if `/tmp` is read-only
 * Fix #5656: Enable EC private key usage for mTLS auth
+* Fix #5694: ExecCredential doesn't fail with unsupported command output
 
 #### Improvements
 * Fix #5429: moved crd generator annotations to generator-annotations instead of crd-generator-api. Using generator-annotations introduces no transitive dependencies.
@@ -16,6 +16,7 @@
 
 #### Dependency Upgrade
 * Updated okio to version 1.17.6 to avoid CVE-2023-3635
+
 #### New Features
 * Fix #5608 Support authentication with certificate in exec-credentials
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -823,11 +823,15 @@ public class Config {
     if (p.waitFor() != 0) {
       LOGGER.warn(output);
     }
-    ExecCredential ec = Serialization.unmarshal(output, ExecCredential.class);
-    if (!apiVersion.equals(ec.apiVersion)) {
-      LOGGER.warn("Wrong apiVersion {} vs. {}", ec.apiVersion, apiVersion);
-    } else {
-      return ec;
+    try {
+      ExecCredential ec = Serialization.unmarshal(output, ExecCredential.class);
+      if (!apiVersion.equals(ec.apiVersion)) {
+        LOGGER.warn("Wrong apiVersion {} vs. {}", ec.apiVersion, apiVersion);
+      } else {
+        return ec;
+      }
+    } catch (Exception ex) {
+      LOGGER.warn("Error unmarshalling ExecCredential", ex);
     }
     return null;
   }


### PR DESCRIPTION
## Description


Relates to https://github.com/quarkusio/quarkus/issues/37939

fix: ExecCredential doesn't fail with unsupported command output


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
