### PR TITLE
Reduce CacheImpl lock contention

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/cache/BasicItemStore.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/informers/cache/BasicItemStore.java
@@ -19,13 +19,14 @@ package io.fabric8.kubernetes.client.informers.cache;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class BasicItemStore<V extends HasMetadata> implements ItemStore<V> {
 
-  private Function<V, String> keyFunction;
-  private ConcurrentHashMap<String, V> store = new ConcurrentHashMap<>();
+  private final Function<V, String> keyFunction;
+  private final ConcurrentMap<String, V> store = new ConcurrentHashMap<>();
 
   public BasicItemStore(Function<V, String> keyFunction) {
     this.keyFunction = keyFunction;

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/BasicItemStoreTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/BasicItemStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/BasicItemStoreTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/informers/cache/BasicItemStoreTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.informers.cache;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BasicItemStoreTest {
+
+  @Test
+  void testEmptyStore() {
+    Pod pod = new PodBuilder().withNewMetadata().withName("test-pod").withResourceVersion("1").endMetadata().build();
+
+    ItemStore<Pod> itemStore = new BasicItemStore<>(BasicItemStoreTest::podToKey);
+
+    assertThat(itemStore.size()).isZero();
+    assertThat(itemStore.keySet()).isEmpty();
+    assertThat(itemStore.values()).isEmpty();
+    assertThat(itemStore.getKey(pod)).isEqualTo("pods/test-pod/1");
+    assertThat(itemStore.get("pods/test-pod/1")).isNull();
+    assertThat(itemStore.remove("pods/test-pod/1")).isNull();
+    assertThat(itemStore.size()).isZero();
+  }
+
+  @Test
+  void testPopulateStore() {
+    Pod pod1 = new PodBuilder().withNewMetadata().withName("test-pod").withResourceVersion("1").endMetadata().build();
+    Pod pod2 = new PodBuilder().withNewMetadata().withName("test-pod").withResourceVersion("2").endMetadata().build();
+
+    ItemStore<Pod> itemStore = new BasicItemStore<>(BasicItemStoreTest::podToKey);
+    itemStore.put("pods/test-pod/1", pod1);
+
+    assertThat(itemStore.size()).isOne();
+    assertThat(itemStore.keySet()).hasSize(1).containsExactly("pods/test-pod/1");
+    assertThat(itemStore.values()).hasSize(1).containsExactly(pod1);
+    assertThat(itemStore.get("pods/test-pod/1")).isNotNull().isEqualTo(pod1);
+    assertThat(itemStore.put(itemStore.getKey(pod2), pod2)).isNull();
+    assertThat(itemStore.size()).isEqualTo(2);
+    assertThat(itemStore.remove("pods/test-pod/1")).isEqualTo(pod1);
+    assertThat(itemStore.get("pods/test-pod/1")).isNull();
+    assertThat(itemStore.size()).isOne();
+    assertThat(itemStore.remove("pods/test-pod/2")).isEqualTo(pod2);
+    assertThat(itemStore.get("pods/test-pod/2")).isNull();
+    assertThat(itemStore.size()).isZero();
+  }
+
+  @Test
+  void parallelStore() throws InterruptedException {
+    ItemStore<Pod> itemStore = new BasicItemStore<>(BasicItemStoreTest::podToKey);
+
+    int tasks = 1000;
+    CountDownLatch latch = new CountDownLatch(tasks);
+    IntStream.range(0, tasks).<Runnable> mapToObj(i -> () -> {
+      Pod pod = new PodBuilder().withNewMetadata().withName("test-pod").withResourceVersion(Integer.toString(i)).endMetadata()
+          .build();
+      String key = itemStore.getKey(pod);
+      assertThat(itemStore.put(key, pod)).isNull();
+      assertThat(key).isEqualTo("pods/test-pod/" + i);
+      latch.countDown();
+    }).forEach(ForkJoinPool.commonPool()::execute);
+
+    assertThat(latch.await(15, TimeUnit.SECONDS)).isTrue();
+    assertThat(itemStore.size()).isEqualTo(tasks);
+    assertThat(itemStore.keySet()).hasSize(tasks).containsExactlyInAnyOrderElementsOf(
+        IntStream.range(0, tasks).mapToObj(i -> "pods/test-pod/" + i).collect(Collectors.toList()));
+    assertThat(itemStore.values()).hasSize(tasks);
+    assertThat(itemStore.get("pods/test-pod/123")).isNotNull().extracting(pod -> pod.getMetadata().getResourceVersion())
+        .isEqualTo("123");
+  }
+
+  private static String podToKey(Pod pod) {
+    return pod.getFullResourceName() + "/" + pod.getMetadata().getName() + "/" + pod.getMetadata().getResourceVersion();
+  }
+}


### PR DESCRIPTION
## Description

When `io.fabric8.kubernetes.client.informers.cache.Lister#list` is used with a namespace under heavy concurrent load, the `CacheImpl#byIndex` becomes a performance bottleneck due to `synchronized` method contention.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
