### PR TITLE
fix: JUnit5 Kubernetes Extension works with Nested tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.11-SNAPSHOT
 
 #### Bugs
+* Fix #3032: JUnit5 Kubernetes Extension works with Nested tests
 
 #### Improvements
 * Fix #5701: Owner reference validity check regarding scope and namespace

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/KubernetesExtension.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/KubernetesExtension.java
@@ -36,7 +36,11 @@ public class KubernetesExtension implements HasKubernetesClient, BeforeAllCallba
   @Override
   public void beforeEach(ExtensionContext context) throws Exception {
     for (Field field : extractFields(context, KubernetesClient.class, f -> !Modifier.isStatic(f.getModifiers()))) {
-      setFieldValue(field, context.getRequiredTestInstance(), getClient(context).adapt((Class<Client>) field.getType()));
+      for (Object testInstance : context.getRequiredTestInstances().getAllInstances()) {
+        if (field.getDeclaringClass().isAssignableFrom(testInstance.getClass())) {
+          setFieldValue(field, testInstance, getClient(context).adapt((Class<Client>) field.getType()));
+        }
+      }
     }
   }
 }

--- a/junit/kubernetes-junit-jupiter/src/test/java/io/fabric8/junit/jupiter/api/KubernetesTestWithNestedTest.java
+++ b/junit/kubernetes-junit-jupiter/src/test/java/io/fabric8/junit/jupiter/api/KubernetesTestWithNestedTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.junit.jupiter.api;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KubernetesTest(createEphemeralNamespace = false)
+class KubernetesTestWithNestedTest {
+
+  private static KubernetesClient staticKubernetesClient;
+  private KubernetesClient kubernetesClient;
+
+  @Test
+  void staticKubernetesClient() {
+    assertThat(staticKubernetesClient).isNotNull();
+  }
+
+  @Test
+  void kubernetesClient() {
+    assertThat(kubernetesClient).isNotNull();
+  }
+
+  @Nested
+  class NestedTest {
+
+    @Test
+    void staticKubernetesClient() {
+      assertThat(staticKubernetesClient).isNotNull();
+    }
+
+    @Test
+    void kubernetesClient() {
+      assertThat(kubernetesClient).isNotNull();
+    }
+
+    @Nested
+    class NestedNestedTest {
+
+      @Test
+      void staticKubernetesClient() {
+        assertThat(staticKubernetesClient).isNotNull();
+      }
+
+      @Test
+      void kubernetesClient() {
+        assertThat(kubernetesClient).isNotNull();
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
## Description

fix: JUnit5 Kubernetes Extension works with Nested tests

Partially addresses #3032 for the kubernetes-junit-jupiter extension.

The kubernetes-server-mock extension still needs to be fixed (maybe after #5632)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
