### PR TITLE
fix: ensures kind is set for generic resource lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.11-SNAPSHOT
 
 #### Bugs
+* Fix #5729: ensure that kind is set for generic resource lists
 * Fix #3032: JUnit5 Kubernetes Extension works with Nested tests
 
 #### Improvements

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperationsImpl.java
@@ -59,8 +59,14 @@ public class HasMetadataOperationsImpl<T extends HasMetadata, L extends Kubernet
     return rdc.isNamespaceScoped();
   }
 
+  @Override
   public OperationContext getOperationContext() {
     return this.context;
+  }
+
+  @Override
+  public String getKind() {
+    return rdc.getKind();
   }
 
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/GenericResourceIT.java
@@ -62,7 +62,9 @@ class GenericResourceIT {
 
     MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> resources = client
         .genericKubernetesResources("v1", "ConfigMap");
-    assertTrue(!resources.list().getItems().isEmpty());
+    List<GenericKubernetesResource> items = resources.list().getItems();
+    assertTrue(!items.isEmpty());
+    assertTrue(items.stream().allMatch(g -> g.getKind().equals("ConfigMap")));
   }
 
   @Test


### PR DESCRIPTION
closes #5729

There are two additional thoughts here:
1. we should not need to, but we could do this for types other than generic if we add setKind to HasMetadata.
2. the logic is currently only doing this for lists as other operations and events doen't seem to have the same problem - but we could of course move the logic into the updateApiVersion if needed.

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
