### PR TITLE
feat(crd-generator): Deprecation warning for CRD versions

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/CustomResourceInfo.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/CustomResourceInfo.java
@@ -42,6 +42,8 @@ public class CustomResourceInfo {
   private final String[] shortNames;
   private final boolean storage;
   private final boolean served;
+  private final boolean deprecated;
+  private final String deprecationWarning;
   private final Scope scope;
   private final TypeDef definition;
   private final String crClassName;
@@ -54,7 +56,7 @@ public class CustomResourceInfo {
   private final String[] labels;
 
   public CustomResourceInfo(String group, String version, String kind, String singular,
-      String plural, String[] shortNames, boolean storage, boolean served,
+      String plural, String[] shortNames, boolean storage, boolean served, boolean deprecated, String deprecationWarning,
       Scope scope, TypeDef definition, String crClassName,
       String specClassName, String statusClassName, String[] annotations, String[] labels) {
     this.group = group;
@@ -65,6 +67,8 @@ public class CustomResourceInfo {
     this.shortNames = shortNames;
     this.storage = storage;
     this.served = served;
+    this.deprecated = deprecated;
+    this.deprecationWarning = deprecationWarning;
     this.scope = scope;
     this.definition = definition;
     this.crClassName = crClassName;
@@ -82,6 +86,14 @@ public class CustomResourceInfo {
 
   public boolean served() {
     return served;
+  }
+
+  public boolean deprecated() {
+    return deprecated;
+  }
+
+  public String deprecationWarning() {
+    return deprecationWarning;
   }
 
   public String key() {
@@ -165,8 +177,9 @@ public class CustomResourceInfo {
       }
 
       return new CustomResourceInfo(instance.getGroup(), instance.getVersion(), instance.getKind(),
-          instance.getSingular(), instance.getPlural(), shortNames, instance.isStorage(), instance.isServed(), scope,
-          definition,
+          instance.getSingular(), instance.getPlural(), shortNames, instance.isStorage(), instance.isServed(),
+          instance.isDeprecated(), instance.getDeprecationWarning(),
+          scope, definition,
           customResource.getCanonicalName(), specAndStatus.getSpecClassName(),
           specAndStatus.getStatusClassName(), toStringArray(instance.getMetadata().getAnnotations()),
           toStringArray(instance.getMetadata().getLabels()));

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/CustomResourceHandler.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/CustomResourceHandler.java
@@ -29,6 +29,7 @@ import io.fabric8.crd.generator.v1.decorator.AddStatusReplicasPathDecorator;
 import io.fabric8.crd.generator.v1.decorator.AddStatusSubresourceDecorator;
 import io.fabric8.crd.generator.v1.decorator.AddSubresourcesDecorator;
 import io.fabric8.crd.generator.v1.decorator.EnsureSingleStorageVersionDecorator;
+import io.fabric8.crd.generator.v1.decorator.SetDeprecatedVersionDecorator;
 import io.fabric8.crd.generator.v1.decorator.SetServedVersionDecorator;
 import io.fabric8.crd.generator.v1.decorator.SetStorageVersionDecorator;
 import io.fabric8.crd.generator.v1.decorator.SortPrinterColumnsDecorator;
@@ -89,6 +90,7 @@ public class CustomResourceHandler extends AbstractCustomResourceHandler {
 
     resources.decorate(new SetServedVersionDecorator(name, version, config.served()));
     resources.decorate(new SetStorageVersionDecorator(name, version, config.storage()));
+    resources.decorate(new SetDeprecatedVersionDecorator(name, version, config.deprecated(), config.deprecationWarning()));
     resources.decorate(new EnsureSingleStorageVersionDecorator(name));
     resources.decorate(new SortPrinterColumnsDecorator(name, version));
   }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/decorator/SetDeprecatedVersionDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/decorator/SetDeprecatedVersionDecorator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.v1.decorator;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersionFluent;
+
+public class SetDeprecatedVersionDecorator
+    extends CustomResourceDefinitionVersionDecorator<CustomResourceDefinitionVersionFluent<?>> {
+
+  private final boolean deprecated;
+  private final String deprecationWarning;
+
+  public SetDeprecatedVersionDecorator(String name, String version, boolean deprecated, String deprecationWarning) {
+    super(name, version);
+    this.deprecated = deprecated;
+    this.deprecationWarning = deprecationWarning;
+  }
+
+  @Override
+  public void andThenVisit(CustomResourceDefinitionVersionFluent<?> version) {
+    if (deprecated) {
+      version.withDeprecated(true);
+      version.withDeprecationWarning(deprecationWarning);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getName() + " [name:" + getName() + ", version:" + getVersion()
+        + ", deprecated:" + deprecated + ", deprecationWarning:" + deprecationWarning + "]";
+  }
+}

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/CustomResourceHandler.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/CustomResourceHandler.java
@@ -30,6 +30,7 @@ import io.fabric8.crd.generator.v1beta1.decorator.AddStatusSubresourceDecorator;
 import io.fabric8.crd.generator.v1beta1.decorator.AddSubresourcesDecorator;
 import io.fabric8.crd.generator.v1beta1.decorator.EnsureSingleStorageVersionDecorator;
 import io.fabric8.crd.generator.v1beta1.decorator.PromoteSingleVersionAttributesDecorator;
+import io.fabric8.crd.generator.v1beta1.decorator.SetDeprecatedVersionDecorator;
 import io.fabric8.crd.generator.v1beta1.decorator.SetServedVersionDecorator;
 import io.fabric8.crd.generator.v1beta1.decorator.SetStorageVersionDecorator;
 import io.fabric8.crd.generator.v1beta1.decorator.SortPrinterColumnsDecorator;
@@ -90,6 +91,7 @@ public class CustomResourceHandler extends AbstractCustomResourceHandler {
 
     resources.decorate(new SetServedVersionDecorator(name, version, config.served()));
     resources.decorate(new SetStorageVersionDecorator(name, version, config.storage()));
+    resources.decorate(new SetDeprecatedVersionDecorator(name, version, config.deprecated(), config.deprecationWarning()));
     resources.decorate(new EnsureSingleStorageVersionDecorator(name));
     resources.decorate(new PromoteSingleVersionAttributesDecorator(name));
     resources.decorate(new SortPrinterColumnsDecorator(name, version));

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/SetDeprecatedVersionDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/SetDeprecatedVersionDecorator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.v1beta1.decorator;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersionFluent;
+
+public class SetDeprecatedVersionDecorator
+    extends CustomResourceDefinitionVersionDecorator<CustomResourceDefinitionVersionFluent<?>> {
+
+  private final boolean deprecated;
+  private final String deprecationWarning;
+
+  public SetDeprecatedVersionDecorator(String name, String version, boolean deprecated, String deprecationWarning) {
+    super(name, version);
+    this.deprecated = deprecated;
+    this.deprecationWarning = deprecationWarning;
+  }
+
+  @Override
+  public void andThenVisit(CustomResourceDefinitionVersionFluent<?> version) {
+    if (deprecated) {
+      version.withDeprecated(true);
+      version.withDeprecationWarning(deprecationWarning);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getName() + " [name:" + getName() + ", version:" + getVersion()
+        + ", deprecated:" + deprecated + ", deprecationWarning:" + deprecationWarning + "]";
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1/DeprecationExample.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1/DeprecationExample.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.deprecated.v1;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.fabric8.io")
+@Version(value = "v1", storage = false, deprecated = true)
+public class DeprecationExample extends CustomResource<DeprecationExampleSpec, Void> {
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1/DeprecationExampleSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1/DeprecationExampleSpec.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.deprecated.v1;
+
+public class DeprecationExampleSpec {
+  private String v1;
+
+  public String getV1() {
+    return v1;
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1beta1/DeprecationExample.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1beta1/DeprecationExample.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.deprecated.v1beta1;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.fabric8.io")
+@Version(value = "v1beta1", storage = false, deprecated = true, deprecationWarning = "sample.fabric8.io/v1beta1 DeprecationExample is deprecated; Migrate to sample.fabric8.io/v2")
+public class DeprecationExample extends CustomResource<DeprecationExampleSpec, Void> {
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1beta1/DeprecationExampleSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v1beta1/DeprecationExampleSpec.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.deprecated.v1beta1;
+
+public class DeprecationExampleSpec {
+  private String v1beta1;
+
+  public String getV1() {
+    return v1beta1;
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v2/DeprecationExample.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v2/DeprecationExample.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.deprecated.v2;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.fabric8.io")
+@Version("v2")
+public class DeprecationExample extends CustomResource<DeprecationExampleSpec, Void> {
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v2/DeprecationExampleSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/deprecated/v2/DeprecationExampleSpec.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.example.deprecated.v2;
+
+public class DeprecationExampleSpec {
+  private String v2;
+
+  public String getV2() {
+    return v2;
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -135,7 +135,7 @@ public abstract class CustomResource<S, T> implements HasMetadata {
 
   public static String getDeprecationWarning(Class<? extends CustomResource> clazz) {
     final Version annotation = clazz.getAnnotation(Version.class);
-    return annotation != null && annotation.deprecated() && Utils.isNotNullOrEmpty(annotation.deprecationWarning())
+    return annotation != null && Utils.isNotNullOrEmpty(annotation.deprecationWarning())
         ? annotation.deprecationWarning()
         : null;
   }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/CustomResource.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.kubernetes.model.Scope;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.ShortNames;
@@ -93,6 +94,8 @@ public abstract class CustomResource<S, T> implements HasMetadata {
   private final String plural;
   private final boolean served;
   private final boolean storage;
+  private final boolean deprecated;
+  private final String deprecationWarning;
 
   public CustomResource() {
     final String version = HasMetadata.super.getApiVersion();
@@ -109,6 +112,8 @@ public abstract class CustomResource<S, T> implements HasMetadata {
     this.crdName = getCRDName(clazz);
     this.served = getServed(clazz);
     this.storage = getStorage(clazz);
+    this.deprecated = getDeprecated(clazz);
+    this.deprecationWarning = getDeprecationWarning(clazz);
     this.spec = initSpec();
     this.status = initStatus();
   }
@@ -123,9 +128,21 @@ public abstract class CustomResource<S, T> implements HasMetadata {
     return annotation == null || annotation.storage();
   }
 
+  public static boolean getDeprecated(Class<? extends CustomResource> clazz) {
+    final Version annotation = clazz.getAnnotation(Version.class);
+    return annotation == null || annotation.deprecated();
+  }
+
+  public static String getDeprecationWarning(Class<? extends CustomResource> clazz) {
+    final Version annotation = clazz.getAnnotation(Version.class);
+    return annotation != null && annotation.deprecated() && Utils.isNotNullOrEmpty(annotation.deprecationWarning())
+        ? annotation.deprecationWarning()
+        : null;
+  }
+
   /**
    * Override to provide your own Spec instance
-   * 
+   *
    * @return a new Spec instance or {@code null} if the responsibility of instantiating the Spec is left to users of this
    *         CustomResource
    */
@@ -135,7 +152,7 @@ public abstract class CustomResource<S, T> implements HasMetadata {
 
   /**
    * Override to provide your own Status instance
-   * 
+   *
    * @return a new Status instance or {@code null} if the responsibility of instantiating the Status is left to users of this
    *         CustomResource
    */
@@ -151,6 +168,8 @@ public abstract class CustomResource<S, T> implements HasMetadata {
         ", metadata=" + metadata +
         ", spec=" + spec +
         ", status=" + status +
+        ", deprecated=" + deprecated +
+        ", deprecationWarning=" + deprecationWarning +
         '}';
   }
 
@@ -272,6 +291,16 @@ public abstract class CustomResource<S, T> implements HasMetadata {
     return storage;
   }
 
+  @JsonIgnore
+  public boolean isDeprecated() {
+    return deprecated;
+  }
+
+  @JsonIgnore
+  public String getDeprecationWarning() {
+    return deprecationWarning;
+  }
+
   public S getSpec() {
     return spec;
   }
@@ -300,6 +329,10 @@ public abstract class CustomResource<S, T> implements HasMetadata {
     if (served != that.served)
       return false;
     if (storage != that.storage)
+      return false;
+    if (deprecated != that.deprecated)
+      return false;
+    if (!Objects.equals(deprecationWarning, that.deprecationWarning))
       return false;
     if (!metadata.equals(that.metadata))
       return false;
@@ -333,6 +366,8 @@ public abstract class CustomResource<S, T> implements HasMetadata {
     result = 31 * result + plural.hashCode();
     result = 31 * result + (served ? 1 : 0);
     result = 31 * result + (storage ? 1 : 0);
+    result = 31 * result + (deprecated ? 1 : 0);
+    result = 31 * result + (deprecationWarning != null ? deprecationWarning.hashCode() : 0);
     return result;
   }
 }

--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/annotation/Version.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/annotation/Version.java
@@ -23,8 +23,8 @@ import static java.lang.annotation.ElementType.TYPE;
 
 /**
  * Allows to specify which version of the API the annotated class is defined under. Together with {@link Group}, this allows to
- * determine the `apiVersion` field associated with the annotated resource.
- * See https://kubernetes.io/docs/reference/using-api/#api-versioning for more details.
+ * determine the {@code apiVersion} field associated with the annotated resource.
+ * See <a href="https://kubernetes.io/docs/reference/using-api/#api-versioning">API versioning</a> for more details.
  */
 @Target({ TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -38,7 +38,7 @@ public @interface Version {
   String value();
 
   /**
-   * Whether or not this version corresponds to the persisted version for the associated CRD. Note that only one version can set
+   * Whether this version corresponds to the persisted version for the associated CRD. Note that only one version can set
    * {@code storage} to {@code true} for a given CRD.
    *
    * @return {@code true} if this version corresponds to the persisted version for the associated CRD, {@code false} otherwise
@@ -51,4 +51,24 @@ public @interface Version {
    * @return {@code true} if this version is served by the REST API, {@code false} otherwise
    */
   boolean served() default true;
+
+  /**
+   * Whether this version is deprecated. When API requests to a resource which is deprecated are made,
+   * a warning message is returned in the API response as a header.
+   * The warning message for this version can be customized by defining
+   * a {@link Version#deprecationWarning} if desired.
+   *
+   * @return {@code true} if this version is deprecated.
+   */
+  boolean deprecated() default false;
+
+  /**
+   * The warning message to indicate the deprecation. Note that this message is only used
+   * if {@link Version#deprecated} is {@code true}.
+   * The warning message should indicate the deprecated API group, version, and kind,
+   * and should indicate what API group, version, and kind should be used instead, if applicable.
+   *
+   * @return the deprecation warning
+   */
+  String deprecationWarning() default "";
 }


### PR DESCRIPTION
## Description

Add support for deprecation warnings in CRDGenerator.

## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
