### PR TITLE
Ignore .DS_Store file with Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ extensions/*/generator/generate
 
 # Formatter and Impsort cache directory
 .cache
+
+# MacOS
+.DS_Store


### PR DESCRIPTION
## Description
.DS_Store, short for Desktop Services Store, is a hidden file created by MacOS to store custom attributes of a folder, such as the positions of icons or the choice of a background image. Whenever you open a folder using Finder, MacOS generates this file to remember your view settings for that particular folder.

When developers work on MacOs, they may find those .DS_Store file are track by git.

It's best practice for us to ignore this file with git.

Close #5805
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
