### PR TITLE
fix: replaced usages of `UUID.randomUUID()` with UUID created via AtomicLong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix #5635: refined LeaderElector lifecycle and logging
 * Fix #5787: (crd-generator) add support for deprecated versions for generated CRDs
 * Fix #5788: (crd-generator) add support for Kubernetes validation rules 
+* Fix #5735: Replace usages of `UUID.randomUUID()` with UUID created via AtomicLong
 
 #### Dependency Upgrade
 

--- a/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/TaskRunCreate.java
+++ b/extensions/tekton/examples/src/main/java/io/fabric8/tekton/api/examples/TaskRunCreate.java
@@ -24,7 +24,7 @@ import io.fabric8.tekton.pipeline.v1.TaskRun;
 import io.fabric8.tekton.pipeline.v1.TaskRunBuilder;
 import io.fabric8.tekton.pipeline.v1.TaskRunList;
 
-import java.util.UUID;
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 
 public class TaskRunCreate {
   public static void main(String[] args) {
@@ -32,7 +32,7 @@ public class TaskRunCreate {
       String namespace = "default";
 
       Task task = new TaskBuilder()
-          .withNewMetadata().withName("hello-world-" + UUID.randomUUID()).endMetadata()
+          .withNewMetadata().withName("hello-world-" + generateId()).endMetadata()
           .withNewSpec()
           .withSteps(
               new StepBuilder()

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/NamespaceExtension.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/NamespaceExtension.java
@@ -31,8 +31,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 
 public class NamespaceExtension implements HasKubernetesClient, BeforeAllCallback, BeforeEachCallback, AfterAllCallback {
 
@@ -81,7 +82,7 @@ public class NamespaceExtension implements HasKubernetesClient, BeforeAllCallbac
     final Namespace namespace = client
         .resource(new NamespaceBuilder()
             .withNewMetadata()
-            .withName(UUID.randomUUID().toString())
+            .withName(generateId().toString())
             .addToLabels("app", "fabric8-kubernetes-client-test")
             .endMetadata()
             .build())

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PostHandler.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/crud/PostHandler.java
@@ -31,6 +31,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 
 public class PostHandler implements KubernetesCrudDispatcherHandler {
@@ -67,7 +68,7 @@ public class PostHandler implements KubernetesCrudDispatcherHandler {
   }
 
   private void initMetadata(HasMetadata resource, String path) throws KubernetesCrudDispatcherException {
-    final UUID uuid = UUID.randomUUID();
+    final UUID uuid = generateId();
     if (Utils.isNullOrEmpty(resource.getMetadata().getName())) {
       resource.getMetadata().setName(resource.getMetadata().getGenerateName() + "-" + uuid);
     }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpRequest.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpRequest.java
@@ -28,6 +28,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
+
 /**
  * Standard representation of a request. HttpClient implementations need to handle the special fields,
  * such as expectContinue, or content-type
@@ -113,7 +115,7 @@ public class StandardHttpRequest extends StandardHttpHeaders implements HttpRequ
   StandardHttpRequest(Map<String, List<String>> headers, URI uri, String method, String bodyString,
       BodyContent body, boolean expectContinue, String contentType, Duration timeout, boolean forStreaming) {
     super(headers);
-    this.id = UUID.randomUUID();
+    this.id = generateId();
     this.uri = uri;
     this.method = method;
     this.bodyString = bodyString;

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Utils.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -69,6 +70,7 @@ public class Utils {
   public static final String PATH_WINDOWS = "Path";
   public static final String PATH_UNIX = "PATH";
   private static final Random random = new Random();
+  private static final AtomicLong leastSigBits = new AtomicLong();
 
   private static final CachedSingleThreadScheduler SHARED_SCHEDULER = new CachedSingleThreadScheduler();
 
@@ -225,6 +227,17 @@ public class Utils {
       }
     }
     return null;
+  }
+
+  /**
+   * Utility method to generate UUIDs.
+   * This is taken from Spring Framework's <a href=
+   * "https://github.com/spring-projects/spring-framework/blob/a4db0e7448287028d228d46fe7b4df202150958a/spring-core/src/main/java/org/springframework/util/SimpleIdGenerator.java#L35">SimpleIdGenerator</a>
+   * 
+   * @return generated UUID
+   */
+  public static UUID generateId() {
+    return new UUID(0, leastSigBits.incrementAndGet());
   }
 
   public static String randomString(int length) {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/UtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/UtilsTest.java
@@ -83,6 +83,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -405,5 +406,13 @@ class UtilsTest {
       completableFuture.complete(null);
     }, 0, () -> 1L, TimeUnit.MILLISECONDS);
     completableFuture.get(1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void generateId() {
+    assertThat(Utils.generateId())
+        .isNotNull()
+        .satisfies(uuid -> assertThat(uuid.getLeastSignificantBits()).isPositive())
+        .satisfies(uuid -> assertThat(uuid.getMostSignificantBits()).isZero());
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/uploadable/PodUpload.java
@@ -34,11 +34,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl.shellQuote;
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 
 public class PodUpload {
 
@@ -131,7 +131,7 @@ public class PodUpload {
       UploadProcessor<TarArchiveOutputStream> processor)
       throws IOException {
 
-    String fileName = String.format("%sfabric8-%s.tar", directory, UUID.randomUUID());
+    String fileName = String.format("%sfabric8-%s.tar", directory, generateId());
 
     boolean uploaded = upload(operation, fileName, os -> {
       try (final TarArchiveOutputStream tar = new TarArchiveOutputStream(os)) {

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/BindingExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/BindingExample.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 
-import java.util.UUID;
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 
 /**
  * This is an example of pod binding node.
@@ -32,7 +32,7 @@ public class BindingExample {
 
   @SuppressWarnings("java:S106")
   public static void main(String[] args) {
-    final String podName = "binding-example-" + UUID.randomUUID();
+    final String podName = "binding-example-" + generateId();
     try (final KubernetesClient client = new KubernetesClientBuilder().build()) {
       final String namespace;
       if (client.getConfiguration().getNamespace() != null) {

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LeaderElectionExamples.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/LeaderElectionExamples.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.Lock;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -39,6 +38,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
+
 @SuppressWarnings("java:S106")
 public class LeaderElectionExamples {
 
@@ -47,7 +48,7 @@ public class LeaderElectionExamples {
 
   public static final class SingleThreadExample {
     public static void main(String[] args) throws InterruptedException {
-      final String lockIdentity = UUID.randomUUID().toString();
+      final String lockIdentity = generateId().toString();
       try (KubernetesClient kc = new KubernetesClientBuilder().build()) {
         LeaderElector leader = kc.leaderElector()
             .withConfig(

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/SecretExamples.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/SecretExamples.java
@@ -26,7 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
+
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 
 /**
  * This is an example of secret.
@@ -41,7 +42,7 @@ public class SecretExamples {
       logger.info("Using master with URL: {}", args[0]);
     }
     try (KubernetesClient client = new KubernetesClientBuilder().withConfig(configBuilder.build()).build()) {
-      final String secretName = UUID.randomUUID().toString();
+      final String secretName = generateId().toString();
       final String namespace = "default";
       logger.info("List of existent Secret:");
       client.secrets().inNamespace(namespace).list().getItems()

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/StorageClassExamples.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/StorageClassExamples.java
@@ -24,7 +24,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.UUID;
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 
 public class StorageClassExamples {
 
@@ -37,7 +37,7 @@ public class StorageClassExamples {
       logger.info("Using master with URL: {}", args[0]);
     }
     try (KubernetesClient client = new KubernetesClientBuilder().withConfig(configBuilder.build()).build()) {
-      final String storageClassName = UUID.randomUUID().toString();
+      final String storageClassName = generateId().toString();
       logger.info("List of existent storage classes:");
       client.storage().v1().storageClasses().list().getItems()
           .forEach(sc -> logger.info(" - {}", sc.getMetadata().getName()));

--- a/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/WatchExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/kubernetes/examples/WatchExample.java
@@ -28,7 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
-import java.util.UUID;
+
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 
 public class WatchExample {
 
@@ -40,7 +41,7 @@ public class WatchExample {
         KubernetesClient client = new KubernetesClientBuilder().build();
         Watch ignored = newConfigMapWatch(client)) {
       final String namespace = Optional.ofNullable(client.getNamespace()).orElse("default");
-      final String name = "watch-config-map-test-" + UUID.randomUUID();
+      final String name = "watch-config-map-test-" + generateId();
       final ConfigMap cm = client.configMaps().inNamespace(namespace).resource(new ConfigMapBuilder()
           .withNewMetadata().withName(name).endMetadata()
           .build())

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/CustomResourceDefinitionIT.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.UUID;
 
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RequireK8sVersionAtLeast(majorVersion = 1, minorVersion = 16)
@@ -44,7 +44,7 @@ class CustomResourceDefinitionIT {
 
   @BeforeEach
   public void setUp() {
-    singular = "a" + UUID.randomUUID().toString().replace("-", "");
+    singular = "a" + generateId().toString().replace("-", "");
     plural = singular + "s";
     group = "examples.fabric8.io";
     name = plural + "." + group;

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/LeaderIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/LeaderIT.java
@@ -26,12 +26,12 @@ import io.fabric8.kubernetes.client.extended.leaderelection.resourcelock.LeaseLo
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,7 +42,7 @@ class LeaderIT {
 
   @Test
   void testLeadershipCycle() throws InterruptedException, ExecutionException, TimeoutException {
-    final String lockIdentity = UUID.randomUUID().toString();
+    final String lockIdentity = generateId().toString();
     CompletableFuture<Void> leading = new CompletableFuture<>();
     CompletableFuture<Void> stopped = new CompletableFuture<>();
     CompletableFuture<String> changed = new CompletableFuture<>();

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/BuildIT.java
@@ -40,9 +40,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static io.fabric8.kubernetes.client.utils.Utils.generateId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KubernetesTest(createEphemeralNamespace = false)
@@ -59,7 +59,7 @@ class BuildIT {
 
   @BeforeEach
   void setUp() {
-    final String id = UUID.randomUUID().toString().replace("-", "");
+    final String id = generateId().toString().replace("-", "");
     imageStreamName = id + "-is";
     imageStreamTag = imageStreamName + ":latest";
     buildConfigName = id + "-bc";


### PR DESCRIPTION
## Description

Fix #5735

+ Port Spring's `SimpleIdGenerator.generateId` utility method to `Utils.generateId`
+ Use `Utils.generateId` in place of `UUID.randomUUID` across codebase, the only place where it's still being used is [WebSocketSession](https://github.com/fabric8io/kubernetes-client/blob/main/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java) which doesn't have kubernetes-client-api as dependency.


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [X] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
