### PR TITLE
fix (kubernetes-client-api) : OpenIDConnectionUtils uses caCertFile and caCertData as a fallback option when `idp-certificate-authority-data` is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #5853: [java-generator] Gracefully handle colliding enum definitions
+* Fix #5817: NPE on EKS OIDC cluster when token needs to be refreshed
 
 #### Improvements
 


### PR DESCRIPTION
## Description

Fix #5817

Currently, we fall back to caCertData specified in Config when `idp-certificate-authority-data` is not specified. We should also consider reading cert data from caCertFile. From discussion in https://github.com/redhat-developer/intellij-kubernetes/issues/726 , user had cert data specified in `caCertFile`

The fix was tested by @adietish in build of IntelliJ Plugin and it seems to fix the issue for the user https://github.com/fabric8io/kubernetes-client/issues/5817#issuecomment-2032346453

I have tested the token refresh flow on EKS cluster (thanks to @adietish) , it seems to be working.


<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
