### PR TITLE
chore(docs): Describe multi-version support and ValidationRule in docs for CRD Generator

### DIFF
--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/Default.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/Default.java
@@ -20,9 +20,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/*
- * Java representation of the `default` field of JSONSchemaProps
- * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jsonschemaprops-v1-apiextensions-k8s-io
+/**
+ * Java representation of the {@code default} field of JSONSchemaProps.
+ *
+ * @see <a href=
+ *      "https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#JSONSchemaProps">
+ *      Kubernetes Docs - API Reference - CRD v1 - JSONSchemaProps
+ *      </a>
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/Max.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/Max.java
@@ -17,9 +17,13 @@ package io.fabric8.generator.annotation;
 
 import java.lang.annotation.*;
 
-/*
- * Java representation of the `maximum` field of JSONSchemaProps
- * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jsonschemaprops-v1-apiextensions-k8s-io
+/**
+ * Java representation of the {@code maximum} field of JSONSchemaProps.
+ *
+ * @see <a href=
+ *      "https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#JSONSchemaProps">
+ *      Kubernetes Docs - API Reference - CRD v1 - JSONSchemaProps
+ *      </a>
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/Min.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/Min.java
@@ -17,9 +17,13 @@ package io.fabric8.generator.annotation;
 
 import java.lang.annotation.*;
 
-/*
- * Java representation of the `minimum` field of JSONSchemaProps
- * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jsonschemaprops-v1-apiextensions-k8s-io
+/**
+ * Java representation of the {@code minimum} field of JSONSchemaProps.
+ *
+ * @see <a href=
+ *      "https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#JSONSchemaProps">
+ *      Kubernetes Docs - API Reference - CRD v1 - JSONSchemaProps
+ *      </a>
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/Nullable.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/Nullable.java
@@ -17,9 +17,13 @@ package io.fabric8.generator.annotation;
 
 import java.lang.annotation.*;
 
-/*
- * Java representation of the `nullable` field of JSONSchemaProps
- * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jsonschemaprops-v1-apiextensions-k8s-io
+/**
+ * Java representation of the {@code nullable} field of JSONSchemaProps.
+ *
+ * @see <a href=
+ *      "https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#JSONSchemaProps">
+ *      Kubernetes Docs - API Reference - CRD v1 - JSONSchemaProps
+ *      </a>
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/Pattern.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/Pattern.java
@@ -17,9 +17,13 @@ package io.fabric8.generator.annotation;
 
 import java.lang.annotation.*;
 
-/*
- * Java representation of the `pattern` field of JSONSchemaProps
- * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jsonschemaprops-v1-apiextensions-k8s-io
+/**
+ * Java representation of the {@code pattern} field of JSONSchemaProps.
+ *
+ * @see <a href=
+ *      "https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#JSONSchemaProps">
+ *      Kubernetes Docs - API Reference - CRD v1 - JSONSchemaProps
+ *      </a>
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/Required.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/Required.java
@@ -17,9 +17,13 @@ package io.fabric8.generator.annotation;
 
 import java.lang.annotation.*;
 
-/*
- * Java representation of the `required` field of JSONSchemaProps
- * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jsonschemaprops-v1-apiextensions-k8s-io
+/**
+ * Java representation of the {@code required} field of JSONSchemaProps.
+ *
+ * @see <a href=
+ *      "https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#JSONSchemaProps">
+ *      Kubernetes Docs - API Reference - CRD v1 - JSONSchemaProps
+ *      </a>
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesVersionFactory.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesVersionFactory.java
@@ -113,12 +113,11 @@ public class KubernetesVersionFactory {
     /**
      * Compares this version to another version and returns whether this version has a
      * higher, equal or lower priority than the version that it is being compared to.
-     *
-     * The kubernetes specs v1.28 at <a href=
-     * "https://v1-28.docs.kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority">Version
-     * Priority</a>
-     * state the following:
-     *
+     * <p>
+     * The Kubernetes specs at <a href=
+     * "https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority">
+     * Version Priority</a> state the following:
+     * </p>
      * <ul>
      * <li>Entries that follow Kubernetes version patterns are sorted before those that do not.</li>
      * <li>For entries that follow Kubernetes version patterns, the numeric portions of the version string is sorted largest to

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesVersionPriority.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesVersionPriority.java
@@ -28,11 +28,11 @@ import static io.fabric8.kubernetes.client.utils.KubernetesVersionFactory.Versio
 
 /**
  * A utility class that allows to deal with Kubernetes versions and their priorities.
- *
- * The kubernetes specs v1.28 at <a href=
- * "https://v1-28.docs.kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority">Version
- * Priority</a>
- * state the following:
+ * <p>
+ * The Kubernetes specs at <a href=
+ * "https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority">
+ * Version Priority</a> state the following:
+ * </p>
  * <ul>
  * <li>Entries that follow Kubernetes version patterns are sorted before those that do not.</li>
  * <li>For entries that follow Kubernetes version patterns, the numeric portions of the version string is sorted largest to


### PR DESCRIPTION
## Description

- Describe multi-version support in CRD Generator docs
- Describe ValidationRule in CRD Generator docs

Closes #5793, Depends on #5788

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

## TODO

- [x] Change descriptions of annotations to Javadoc
- [x] Change links to Kubernetes docs to always use the latest version (for CRD Generator related Javadoc)
