### PR TITLE
fix(crd-generator): Fail if multiple versions are marked as stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.12-SNAPSHOT
 
 #### Bugs
+* Fix #5845: (crd-generator) Fail generating if multiple versions are marked as stored
 
 #### Improvements
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/Resources.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/Resources.java
@@ -94,7 +94,7 @@ public class Resources {
     // We also might need it more than once. So, we'll do it as many times as we have to, till there are not more transformations.
     // But hey, let's have an upper limit just to prevent infinite loops.
     for (int i = 0; i < SORT_ROUND_LIMIT && bubbleSort(array); i++) {
-      LOGGER.debug("Sorting again:" + (i + 1));
+      LOGGER.debug("Sorting again: {}", i + 1);
     }
 
     List<Decorator<?>> result = Collections.unmodifiableList(Arrays.asList(array));

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/EnsureSingleStorageVersionDecorator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/decorator/EnsureSingleStorageVersionDecorator.java
@@ -19,46 +19,38 @@ import io.fabric8.crd.generator.decorator.Decorator;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionSpecFluent;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersion;
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersionBuilder;
 
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class EnsureSingleStorageVersionDecorator extends
     CustomResourceDefinitionDecorator<CustomResourceDefinitionSpecFluent<?>> {
-
-  private final AtomicReference<String> storageVersion = new AtomicReference<>();
-
   public EnsureSingleStorageVersionDecorator(String name) {
     super(name);
   }
 
   @Override
   public void andThenVisit(CustomResourceDefinitionSpecFluent<?> spec, ObjectMeta resourceMeta) {
-    Predicate<CustomResourceDefinitionVersionBuilder> hasStorageVersion = v -> v.getStorage() != null && v.getStorage();
+    List<CustomResourceDefinitionVersion> versions = spec.buildVersions();
 
-    if (spec.hasVersions() && !spec.hasMatchingVersion(hasStorageVersion)) {
-      spec.editFirstVersion().withStorage(true).endVersion();
-    }
+    List<String> storageVersions = versions.stream()
+        .filter(v -> Optional.ofNullable(v.getStorage()).orElse(true))
+        .map(CustomResourceDefinitionVersion::getName)
+        .collect(Collectors.toList());
 
-    for (CustomResourceDefinitionVersion version : spec.buildVersions()) {
-      if (version.getStorage() != null && version.getStorage()) {
-        String existing = storageVersion.get();
-        if (existing != null && !existing.equals(version.getName())) {
-          throw new IllegalStateException(String.format(
-              "'%s' custom resource has versions %s and %s marked as storage. Only one version can be marked as storage per custom resource.",
-              resourceMeta.getName(), version.getName(), existing));
-        } else {
-          storageVersion.set(version.getName());
-        }
-      }
+    if (storageVersions.size() > 1) {
+      throw new IllegalStateException(String.format(
+          "'%s' custom resource has versions %s marked as storage. Only one version can be marked as storage per custom resource.",
+          resourceMeta.getName(), storageVersions));
     }
   }
 
   @Override
   public Class<? extends Decorator>[] after() {
-    return new Class[] { AddCustomResourceDefinitionResourceDecorator.class,
-        AddCustomResourceDefinitionVersionDecorator.class, SetStorageVersionDecorator.class };
+    return new Class[] {
+        CustomResourceDefinitionVersionDecorator.class
+    };
   }
 
   @Override

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/multiple/v1/Multiple.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/multiple/v1/Multiple.java
@@ -20,6 +20,6 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 
 @Group("sample.fabric8.io")
-@Version("v1")
+@Version(value = "v1", storage = false)
 public class Multiple extends CustomResource<MultipleSpec, Void> {
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorAssertions.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorAssertions.java
@@ -41,11 +41,10 @@ public class CRDGeneratorAssertions {
    *
    * @param crClasses custom resource classes under test
    * @param crdGenerator a CRDGenerator instance
-   * @throws IOException, if creating temp files/directory went wrong
    */
   @SafeVarargs
   public static void assertCRDOutputEquals(CRDGenerator crdGenerator,
-      Class<? extends CustomResource<?, ?>>... crClasses) throws IOException {
+      Class<? extends CustomResource<?, ?>>... crClasses) {
 
     assertCRDOutputEquals(crdGenerator, null, crClasses);
   }
@@ -57,12 +56,11 @@ public class CRDGeneratorAssertions {
    * @param crdGenerator a CRDGenerator instance
    * @param classPathExpectedCRDsNullable the class path to the directory which contains the expected CRDs. Defaults to "/" if
    *        null.
-   * @throws IOException, if creating temp files/directory went wrong
    */
   @SafeVarargs
   public static void assertCRDOutputEquals(CRDGenerator crdGenerator,
       String classPathExpectedCRDsNullable,
-      Class<? extends CustomResource<?, ?>>... crClasses) throws IOException {
+      Class<? extends CustomResource<?, ?>>... crClasses) {
     assertNotNull(crClasses);
     assertTrue(crClasses.length > 0);
     assertEquals(1, Arrays.stream(crClasses)
@@ -70,8 +68,14 @@ public class CRDGeneratorAssertions {
         "all crClasses must be of the same kind");
 
     final String crdName = CustomResource.getCRDName(crClasses[0]);
+    final File outputDir;
+    try {
+      outputDir = Files.createTempDirectory("crd-").toFile();
+    } catch (IOException e) {
+      fail("Could not create temp directory", e);
+      throw new RuntimeException(e);
+    }
 
-    final File outputDir = Files.createTempDirectory("crd-").toFile();
     final String classPathExpectedCRDs = Optional.ofNullable(classPathExpectedCRDsNullable)
         .map(s -> s.endsWith("/") ? s : s + "/")
         .orElse("/");

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorAssertions.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorAssertions.java
@@ -1,16 +1,107 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.crd.generator;
+
+import io.fabric8.kubernetes.client.CustomResource;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class CRDGeneratorAssertions {
 
-  private CRDGeneratorAssertions(){
+  private CRDGeneratorAssertions() {
+  }
+
+  /**
+   * Generates CRD files for v1 and v1beta1 and compares them with files in classpath.
+   *
+   * @param crClasses custom resource classes under test
+   * @param crdGenerator a CRDGenerator instance
+   * @throws IOException, if creating temp files/directory went wrong
+   */
+  @SafeVarargs
+  public static void assertCRDOutputEquals(CRDGenerator crdGenerator,
+      Class<? extends CustomResource<?, ?>>... crClasses) throws IOException {
+
+    assertCRDOutputEquals(crdGenerator, null, crClasses);
+  }
+
+  /**
+   * Generates CRD files for v1 and v1beta1 and compares them with files in classpath.
+   *
+   * @param crClasses custom resource classes under test
+   * @param crdGenerator a CRDGenerator instance
+   * @param classPathExpectedCRDsNullable the class path to the directory which contains the expected CRDs. Defaults to "/" if
+   *        null.
+   * @throws IOException, if creating temp files/directory went wrong
+   */
+  @SafeVarargs
+  public static void assertCRDOutputEquals(CRDGenerator crdGenerator,
+      String classPathExpectedCRDsNullable,
+      Class<? extends CustomResource<?, ?>>... crClasses) throws IOException {
+    assertNotNull(crClasses);
+    assertTrue(crClasses.length > 0);
+    assertEquals(1, Arrays.stream(crClasses)
+        .map(CustomResource::getCRDName).distinct().count(),
+        "all crClasses must be of the same kind");
+
+    final String crdName = CustomResource.getCRDName(crClasses[0]);
+
+    final File outputDir = Files.createTempDirectory("crd-").toFile();
+    final String classPathExpectedCRDs = Optional.ofNullable(classPathExpectedCRDsNullable)
+        .map(s -> s.endsWith("/") ? s : s + "/")
+        .orElse("/");
+
+    // generate actual CRDs
+    final CRDGenerationInfo crdInfo = crdGenerator
+        .inOutputDir(outputDir)
+        .customResourceClasses(crClasses)
+        .forCRDVersions("v1", "v1beta1")
+        .detailedGenerate();
+    final File actualCRDFile = new File(crdInfo.getCRDInfos(crdName).get("v1").getFilePath());
+    final File actualCRDFileV1Beta1 = new File(crdInfo.getCRDInfos(crdName).get("v1beta1").getFilePath());
+
+    // expected CRDs
+    final URL expectedCRDResource = CRDGeneratorTest.class.getResource(classPathExpectedCRDs + actualCRDFile.getName());
+    final URL expectedCRDResourceV1Beta1 = CRDGeneratorTest.class
+        .getResource(classPathExpectedCRDs + actualCRDFileV1Beta1.getName());
+    assertNotNull(expectedCRDResource);
+    assertNotNull(expectedCRDResourceV1Beta1);
+    final File expectedCrdFile = new File(expectedCRDResource.getFile());
+    final File expectedCrdFileV1Beta1 = new File(expectedCRDResourceV1Beta1.getFile());
+
+    // compare
+    assertFileEquals(expectedCrdFile, actualCRDFile);
+    assertFileEquals(expectedCrdFileV1Beta1, actualCRDFileV1Beta1);
+
+    // only delete the generated files if the test is successful
+    assertTrue(actualCRDFile.delete());
+    assertTrue(actualCRDFileV1Beta1.delete());
+    assertTrue(outputDir.delete());
   }
 
   /**
@@ -22,7 +113,7 @@ public class CRDGeneratorAssertions {
    */
   public static void assertFileEquals(final File expectedFile, final File actualFile) {
     try (final BufferedReader expectedReader = new BufferedReader(new FileReader(expectedFile));
-         final BufferedReader actualReader = new BufferedReader(new FileReader(actualFile))) {
+        final BufferedReader actualReader = new BufferedReader(new FileReader(actualFile))) {
       // skip license headers
       String expectedLine = skipCommentsAndEmptyLines(expectedReader);
       String actualLine = skipCommentsAndEmptyLines(actualReader);

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorAssertions.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorAssertions.java
@@ -1,0 +1,49 @@
+package io.fabric8.crd.generator;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class CRDGeneratorAssertions {
+
+  private CRDGeneratorAssertions(){
+  }
+
+  /**
+   * Compares two YAML files and fails if they are not equal.
+   * Comments and empty lines are ignored.
+   *
+   * @param expectedFile the file which contains the expected content
+   * @param actualFile the file which contains the content to test
+   */
+  public static void assertFileEquals(final File expectedFile, final File actualFile) {
+    try (final BufferedReader expectedReader = new BufferedReader(new FileReader(expectedFile));
+         final BufferedReader actualReader = new BufferedReader(new FileReader(actualFile))) {
+      // skip license headers
+      String expectedLine = skipCommentsAndEmptyLines(expectedReader);
+      String actualLine = skipCommentsAndEmptyLines(actualReader);
+      // compare both files
+      final String message = String.format("Expected %s and actual %s files are not equal", expectedFile, actualFile);
+      while (expectedLine != null || actualLine != null) {
+        assertEquals(expectedLine, actualLine, message);
+        expectedLine = expectedReader.readLine();
+        actualLine = actualReader.readLine();
+      }
+    } catch (final IOException e) {
+      fail(String.format("Cannot compare files %s and %s: %s", expectedFile, actualFile, e.getMessage()));
+    }
+  }
+
+  private static String skipCommentsAndEmptyLines(final BufferedReader reader) throws IOException {
+    String line = reader.readLine();
+    while (line.startsWith("#") || line.isEmpty()) {
+      line = reader.readLine();
+    }
+    return line;
+  }
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorExamplesTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorExamplesTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import static io.fabric8.crd.generator.CRDGeneratorAssertions.assertCRDOutputEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CRDGeneratorExamplesTest {
+class CRDGeneratorExamplesTest {
 
   protected boolean parallelCRDGeneration;
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorExamplesTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorExamplesTest.java
@@ -44,7 +44,8 @@ class CRDGeneratorExamplesTest {
 
   @Test
   void multipleStorage_thenFail() {
-    assertThrows(IllegalStateException.class, () -> assertCRDOutputEquals(newCRDGenerator(),
+    CRDGenerator crdGenerator = newCRDGenerator();
+    assertThrows(IllegalStateException.class, () -> assertCRDOutputEquals(crdGenerator,
         io.fabric8.crd.example.multiple.v2.Multiple.class, Multiple.class));
   }
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorExamplesTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorExamplesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator;
+
+import io.fabric8.crd.example.k8svalidation.K8sValidation;
+import io.fabric8.crd.example.multiple.v2.MultipleSpec;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.fabric8.crd.generator.CRDGeneratorAssertions.assertCRDOutputEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CRDGeneratorExamplesTest {
+
+  protected boolean parallelCRDGeneration;
+
+  @Test
+  void multiple() throws IOException {
+    assertCRDOutputEquals(newCRDGenerator(),
+        io.fabric8.crd.example.multiple.v1.Multiple.class, io.fabric8.crd.example.multiple.v2.Multiple.class);
+  }
+
+  @Group("sample.fabric8.io")
+  @Version(value = "v3")
+  public static class Multiple extends CustomResource<MultipleSpec, Void> {
+  }
+
+  @Test
+  void multipleStorage_thenFail() {
+    assertThrows(IllegalStateException.class, () -> assertCRDOutputEquals(newCRDGenerator(),
+        io.fabric8.crd.example.multiple.v2.Multiple.class, Multiple.class));
+  }
+
+  @Test
+  void k8sValidation() throws IOException {
+    assertCRDOutputEquals(newCRDGenerator(), K8sValidation.class);
+  }
+
+  private CRDGenerator newCRDGenerator() {
+    return new CRDGenerator()
+        .withParallelGenerationEnabled(parallelCRDGeneration);
+  }
+
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -73,6 +73,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static io.fabric8.crd.generator.CRDGeneratorAssertions.assertFileEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -576,32 +577,6 @@ class CRDGeneratorTest {
     assertTrue(crdFile.delete());
     assertTrue(crdFileV1Beta1.delete());
     assertTrue(outputDir.delete());
-  }
-
-  private void assertFileEquals(final File expectedFile, final File actualFile) {
-    try (final BufferedReader expectedReader = new BufferedReader(new FileReader(expectedFile));
-        final BufferedReader actualReader = new BufferedReader(new FileReader(actualFile))) {
-      // skip license headers
-      String expectedLine = skipCommentsAndEmptyLines(expectedReader);
-      String actualLine = skipCommentsAndEmptyLines(actualReader);
-      // compare both files
-      final String message = String.format("Expected %s and actual %s files are not equal", expectedFile, actualFile);
-      while (expectedLine != null || actualLine != null) {
-        assertEquals(expectedLine, actualLine, message);
-        expectedLine = expectedReader.readLine();
-        actualLine = actualReader.readLine();
-      }
-    } catch (final IOException e) {
-      fail(String.format("Cannot compare files %s and %s: %s", expectedFile, actualFile, e.getMessage()));
-    }
-  }
-
-  private String skipCommentsAndEmptyLines(final BufferedReader reader) throws IOException {
-    String line = reader.readLine();
-    while (line.startsWith("#") || line.isEmpty()) {
-      line = reader.readLine();
-    }
-    return line;
   }
 
   private CustomResourceDefinitionVersion checkCRD(Class<? extends CustomResource<?, ?>> customResource, String kind,

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -58,12 +58,9 @@ import org.opentest4j.AssertionFailedError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -79,7 +76,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class CRDGeneratorTest {
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/ParallelCRDGeneratorExamplesTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/ParallelCRDGeneratorExamplesTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator;
+
+public class ParallelCRDGeneratorExamplesTest extends CRDGeneratorExamplesTest {
+  public ParallelCRDGeneratorExamplesTest() {
+    parallelCRDGeneration = true;
+  }
+}

--- a/crd-generator/api/src/test/resources/multiples.sample.fabric8.io-v1.yml
+++ b/crd-generator/api/src/test/resources/multiples.sample.fabric8.io-v1.yml
@@ -54,4 +54,4 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false

--- a/crd-generator/api/src/test/resources/multiples.sample.fabric8.io-v1beta1.yml
+++ b/crd-generator/api/src/test/resources/multiples.sample.fabric8.io-v1beta1.yml
@@ -54,4 +54,4 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/MultipleVersionsCRDTest.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/MultipleVersionsCRDTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.multiple;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersion;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MultipleVersionsCRDTest {
+
+  @Test
+  void testCrd() {
+    CustomResourceDefinition d = Serialization.unmarshal(getClass().getClassLoader()
+        .getResourceAsStream("META-INF/fabric8/multiples.sample.fabric8.io-v1.yml"),
+        CustomResourceDefinition.class);
+    assertNotNull(d);
+    assertEquals(2, d.getSpec().getVersions().size());
+
+    Optional<CustomResourceDefinitionVersion> maybeV1Version = d.getSpec().getVersions().stream()
+        .filter(version -> "v1".equals(version.getName())).findFirst();
+
+    assertTrue(maybeV1Version.isPresent());
+    CustomResourceDefinitionVersion v1Version = maybeV1Version.get();
+    assertFalse(v1Version.getStorage());
+
+    Optional<CustomResourceDefinitionVersion> maybeV2Version = d.getSpec().getVersions().stream()
+        .filter(version -> "v2".equals(version.getName())).findFirst();
+
+    assertTrue(maybeV2Version.isPresent());
+    CustomResourceDefinitionVersion v2Version = maybeV2Version.get();
+    assertTrue(v2Version.getStorage());
+  }
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v1/Multiple.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v1/Multiple.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.multiple.v1;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.fabric8.io")
+@Version(value = "v1", storage = false)
+public class Multiple extends CustomResource<MultipleSpec, Void> {
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v1/MultipleSpec.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v1/MultipleSpec.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.multiple.v1;
+
+public class MultipleSpec {
+  private String v1;
+
+  public String getV1() {
+    return v1;
+  }
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v2/Multiple.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v2/Multiple.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.multiple.v2;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.fabric8.io")
+@Version("v2")
+public class Multiple extends CustomResource<MultipleSpec, Void> {
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v2/MultipleSpec.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/multiple/v2/MultipleSpec.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.multiple.v2;
+
+public class MultipleSpec {
+  private String v2;
+
+  public String getV2() {
+    return v2;
+  }
+}


### PR DESCRIPTION
## Description

Fixes a bug where the CRDGenerator allows generating CRDs with multiple versions marked as stored. 

Additional changes:
- Extract some assertions to a seperate class (reusing is planned in the next PRs)
- Allow debugging decorator sequence by changing the log level to trace
  (refer to [simplelogger.properties](https://github.com/fabric8io/kubernetes-client/blob/main/crd-generator/api/src/test/resources/simplelogger.properties#L22) during test runs)

Fixes #5845 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
