### PR TITLE
Fix #5847: missing Log4j Core plugin descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #5845: (crd-generator) Fail generating if multiple versions are marked as stored
+* Fix #5847: Missing `Log4j2Plugins.dat` descriptor in Kubernetes Lookup
 * Fix #5853: [java-generator] Gracefully handle colliding enum definitions
 * Fix #5860: Corrections to java-generator gradle plugin extension
 * Fix #5817: NPE on EKS OIDC cluster when token needs to be refreshed

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -32,6 +32,13 @@
   <properties>
     <osgi.export>io.fabric8.kubernetes.log4j.*</osgi.export>
     <osgi.import>*</osgi.import>
+
+    <!-- Resources to copy into the JAR -->
+    <osgi.include.resources.default>
+      {maven-resources},
+      /META-INF/org/apache/logging/=${project.build.outputDirectory}/META-INF/org/apache/logging/,
+      /META-INF/jandex.idx=${project.build.outputDirectory}/META-INF/jandex.idx
+    </osgi.include.resources.default>
   </properties>
 
   <dependencies>
@@ -78,4 +85,23 @@
     </dependency>
   </dependencies>
 
+  <build>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven.surefire.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
 </project>

--- a/log4j/src/test/java/io/fabric8/kubernetes/log4j/lookup/it/KubernetesLookupIT.java
+++ b/log4j/src/test/java/io/fabric8/kubernetes/log4j/lookup/it/KubernetesLookupIT.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KubernetesLookupIT {
+class KubernetesLookupIT {
 
   @Test
   void should_find_lookup() {

--- a/log4j/src/test/java/io/fabric8/kubernetes/log4j/lookup/it/KubernetesLookupIT.java
+++ b/log4j/src/test/java/io/fabric8/kubernetes/log4j/lookup/it/KubernetesLookupIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.log4j.lookup.it;
+
+import io.fabric8.kubernetes.log4j.lookup.KubernetesLookup;
+import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
+import org.apache.logging.log4j.core.config.plugins.util.PluginType;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KubernetesLookupIT {
+
+  @Test
+  void should_find_lookup() {
+    PluginManager manager = new PluginManager(StrLookup.CATEGORY);
+    manager.collectPlugins();
+    PluginType<?> pluginType = manager.getPluginType("k8s");
+    assertThat(pluginType)
+        .as("check 'k8s' lookup")
+        .isNotNull()
+        .extracting(PluginType::getPluginClass)
+        .isEqualTo(KubernetesLookup.class);
+  }
+}


### PR DESCRIPTION
## Description

Fix #5847
Due to a misconfiguration of the Maven Bundle Plugin, the Log4j Core plugin descriptor:

```
META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat
```

file is missing in the generated JAR.

This PR fixes the Maven configuration and adds a simple integration test to prevent ensure that `PluginManager` is able to detect the Kubernetes Lookup.

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

