### PR TITLE
Drain `HttpResponse` in tests

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -225,10 +225,12 @@ public abstract class AbstractInterceptorTest {
         });
     // When
     try (HttpClient client = builder.build()) {
-      client.consumeBytes(
+      final HttpResponse<AsyncBody> asyncR = client.consumeBytes(
           client.newHttpRequestBuilder().uri(server.url("/not-found")).build(),
           (s, ab) -> ab.consume())
           .get(10, TimeUnit.SECONDS);
+      asyncR.body().consume();
+      asyncR.body().done().get(10L, TimeUnit.SECONDS);
     }
     // Then
     assertThat(interceptedResponses)
@@ -279,10 +281,12 @@ public abstract class AbstractInterceptorTest {
         });
     // When
     try (HttpClient client = builder.build()) {
-      client.consumeBytes(
+      final HttpResponse<AsyncBody> asyncR = client.consumeBytes(
           client.newHttpRequestBuilder().uri(server.url("/success")).build(),
           (s, ab) -> ab.consume())
           .get(10, TimeUnit.SECONDS);
+      asyncR.body().consume();
+      asyncR.body().done().get(10L, TimeUnit.SECONDS);
     }
     // Then
     assertThat(responseFuture)
@@ -306,10 +310,12 @@ public abstract class AbstractInterceptorTest {
         });
     // When
     try (HttpClient client = builder.build()) {
-      client.consumeBytes(
+      final HttpResponse<AsyncBody> asyncR = client.consumeBytes(
           client.newHttpRequestBuilder().uri(server.url("/client-error")).build(),
           (s, ab) -> ab.consume())
           .get(10, TimeUnit.SECONDS);
+      asyncR.body().consume();
+      asyncR.body().done().get(10L, TimeUnit.SECONDS);
     }
     // Then
     assertThat(responseFuture)

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
@@ -116,9 +116,13 @@ public abstract class AbstractSimultaneousConnectionsTest {
       }
       CompletableFuture.allOf(asyncResponses.toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
       assertThat(asyncResponses)
-          .hasSize(MAX_HTTP_1_CONNECTIONS)
-          .extracting(CompletableFuture::join)
-          .extracting(HttpResponse::code).containsOnly(204);
+        .hasSize(MAX_HTTP_1_CONNECTIONS)
+        .extracting(CompletableFuture::join)
+        .extracting(response -> {
+          response.body().consume();
+          return response.code();
+        })
+        .containsOnly(204);
     }
   }
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
@@ -116,13 +116,13 @@ public abstract class AbstractSimultaneousConnectionsTest {
       }
       CompletableFuture.allOf(asyncResponses.toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
       assertThat(asyncResponses)
-        .hasSize(MAX_HTTP_1_CONNECTIONS)
-        .extracting(CompletableFuture::join)
-        .extracting(response -> {
-          response.body().consume();
-          return response.code();
-        })
-        .containsOnly(204);
+          .hasSize(MAX_HTTP_1_CONNECTIONS)
+          .extracting(CompletableFuture::join)
+          .extracting(response -> {
+            response.body().consume();
+            return response.code();
+          })
+          .containsOnly(204);
     }
   }
 


### PR DESCRIPTION
## Description

In Armeria CI, we saw Netty leak reports from kubernetes-client CI tests. After investigating, I found out that some of the tests did not consume `HttpResponse`. As a result, `ByteBuf`s were not subscribed to and remained in the Publisher's internal buffer.

I fixed to call `AsyncBody.consume()` in tests where it was not called before.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
