### PR TITLE
Fix a bug where a test client is not closed in `KubernetesMockServerExtension`

### DIFF
--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -114,9 +114,7 @@ public class KubernetesMockServerExtension
       dispatcher = new MockDispatcher(responses);
     }
     final KubernetesMockServer mock = new KubernetesMockServer(new Context(Serialization.jsonMapper()),
-        new MockWebServer(), responses,
-        dispatcher,
-        a.https());
+        new MockWebServer(), responses, dispatcher, a.https());
     mock.init();
     if (isStatic) {
       staticMock = mock;

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionCloseTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionCloseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtensionCloseTest.PreDestroyResource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(PreDestroyResource.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnableKubernetesMockClient
+class KubernetesMockServerExtensionCloseTest {
+  static KubernetesMockServer staticMockServer;
+  static KubernetesClient staticClient;
+
+  KubernetesMockServer mockServer;
+  KubernetesClient client;
+
+  @Test
+  void shouldNotNull() {
+    Assertions.assertNotNull(mockServer);
+    Assertions.assertNotNull(client);
+    Assertions.assertNotNull(staticMockServer);
+    Assertions.assertNotNull(staticClient);
+  }
+
+  static class PreDestroyResource implements TestInstancePreDestroyCallback {
+
+    @Override
+    public void preDestroyTestInstance(ExtensionContext context) throws Exception {
+      final KubernetesMockServerExtensionCloseTest test = context.getTestInstances().get()
+          .findInstance(KubernetesMockServerExtensionCloseTest.class).get();
+      final KubernetesClientImpl staticClient0 = (KubernetesClientImpl) staticClient;
+      final KubernetesClientImpl client0 = (KubernetesClientImpl) test.client;
+      // Should close both static and non-static clients.
+      assertThat(staticClient0.getClosed()).isCompleted();
+      assertThat(client0.getClosed()).isCompleted();
+    }
+  }
+}

--- a/junit/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
+++ b/junit/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtension.java
@@ -39,8 +39,8 @@ public class OpenShiftMockServerExtension extends KubernetesMockServerExtension 
 
   private OpenShiftMockServer staticOpenShiftMockServer;
   private NamespacedOpenShiftClient staticOpenShiftClient;
-  private OpenShiftMockServer openShiftMockServer;
-  private NamespacedOpenShiftClient openShiftClient;
+  private OpenShiftMockServer instantOpenShiftMockServer;
+  private NamespacedOpenShiftClient instantOpenShiftClient;
 
   @Override
   protected void destroyStatic() {
@@ -50,11 +50,11 @@ public class OpenShiftMockServerExtension extends KubernetesMockServerExtension 
 
   @Override
   protected void destroy() {
-    if (openShiftMockServer != null) {
-      openShiftMockServer.destroy();
+    if (instantOpenShiftMockServer != null) {
+      instantOpenShiftMockServer.destroy();
     }
-    if (openShiftClient != null) {
-      openShiftClient.close();
+    if (instantOpenShiftClient != null) {
+      instantOpenShiftClient.close();
     }
   }
 
@@ -83,8 +83,8 @@ public class OpenShiftMockServerExtension extends KubernetesMockServerExtension 
       staticOpenShiftMockServer = openShiftMockServer;
       staticOpenShiftClient = openShiftClient;
     } else {
-      this.openShiftMockServer = openShiftMockServer;
-      this.openShiftClient = openShiftClient;
+      instantOpenShiftMockServer = openShiftMockServer;
+      instantOpenShiftClient = openShiftClient;
     }
   }
 
@@ -97,8 +97,8 @@ public class OpenShiftMockServerExtension extends KubernetesMockServerExtension 
       openShiftClient = staticOpenShiftClient;
       openShiftMockServer = staticOpenShiftMockServer;
     } else {
-      openShiftClient = this.openShiftClient;
-      openShiftMockServer = this.openShiftMockServer;
+      openShiftClient = instantOpenShiftClient;
+      openShiftMockServer = instantOpenShiftMockServer;
     }
     setFieldIfEqualsToProvidedType(context, isStatic, field, getClientType(), (i, f) -> f.set(i, openShiftClient));
     setFieldIfEqualsToProvidedType(context, isStatic, field, getKubernetesMockServerType(),


### PR DESCRIPTION
## Description

In `KubernetesMockServerExtension`, a `KubernetesClient` created by `beforeAll()` and a `KubernetesClient` created by `beforeEach()` share the same member field.

Say we have a test code that has a non-staic client field. A `KubernetesClient` created by `beforeAll()` gets overridden by a client created by `beforeEach()`. As a result, we lose the former client's reference, resulting in a leak.

```java
@EnableKubernetesMockClient
class KubernetesMockServerTest {
    private KubernetesClient client;

    ...
}
```

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
