### PR TITLE
ci: update windows pipeline to run on Java 17

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        java: [11]
+        java: [17]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/SerializationTest.java
@@ -16,7 +16,6 @@
 package io.fabric8.kubernetes.client.utils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -79,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class SerializationTest {
 
   static class WithNull {
-    @JsonInclude(value = Include.ALWAYS)
+    @JsonInclude
     public Integer field;
   }
 
@@ -88,7 +87,7 @@ class SerializationTest {
   }
 
   @Test
-  void testNullSerialization() throws Exception {
+  void testNullSerialization() {
     assertEquals("---\nfield: null\n", Serialization.asYaml(new WithNull()));
     assertEquals("{\"field\":null}", Serialization.asJson(new WithNull()));
     assertEquals("--- {}\n", Serialization.asYaml(new WithoutNull()));
@@ -168,7 +167,8 @@ class SerializationTest {
         .hasFieldOrPropertyWithValue("spec.securityContext.runAsGroup", 1000L)
         .hasFieldOrPropertyWithValue("spec.securityContext.runAsUser", 1000L)
         .extracting(Pod::getSpec)
-        .returns(Arrays.asList(new Toleration("NoSchedule", "nodeType", "Equal", null, "build")), PodSpec::getTolerations)
+        .returns(Collections.singletonList(new Toleration("NoSchedule", "nodeType", "Equal", null, "build")),
+            PodSpec::getTolerations)
         .extracting(PodSpec::getContainers).asList()
         .hasSize(2)
         .extracting("name", "image", "resources.requests.cpu")

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -822,7 +822,8 @@ class PodTest {
           // On windows an exception is thrown when connection is reset during read
           // It can only be distinguished via message, and that message is localized
           // So let's at least handle English
-          if (!io.getMessage().startsWith("An existing connection was forcibly closed")) {
+          if (!io.getMessage().startsWith("An existing connection was forcibly closed") &&
+              !io.getMessage().startsWith("Connection reset")) {
             throw io;
           }
           read = -1;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient
-public class ResourceListTest {
+class ResourceListTest {
 
   KubernetesMockServer server;
   KubernetesClient client;


### PR DESCRIPTION
## Description

ci: update windows pipeline to run on Java 17

Requires updating #3245 (#3244 #3243)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
