### PR TITLE
fix: JsonUnwrappedDeserializer works when serialized data is not provided

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/JsonUnwrappedDeserializer.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/JsonUnwrappedDeserializer.java
@@ -162,10 +162,11 @@ public class JsonUnwrappedDeserializer<T> extends JsonDeserializer<T> implements
 
       boolean replaced = false;
       for (UnwrappedInfo unwrapped : unwrappedInfos) {
-        final ObjectNode unwrappedNode = unwrappedNodes.computeIfAbsent(unwrapped,
-            k -> deserializationContext.getNodeFactory().objectNode());
         final String transformed = unwrapped.nameTransformer.reverse(key);
+        final ObjectNode unwrappedNode = unwrappedNodes.getOrDefault(unwrapped,
+            deserializationContext.getNodeFactory().objectNode());
         if (transformed != null && !ownPropertyNames.contains(key) && unwrapped.beanPropertyNames.contains(transformed)) {
+          unwrappedNodes.putIfAbsent(unwrapped, unwrappedNode);
           unwrappedNode.replace(transformed, value);
           replaced = true;
         }


### PR DESCRIPTION
## Description

fix: JsonUnwrappedDeserializer works when serialized data is not provided

Relates to #5182

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
