### PR TITLE
feat: proxy configs support proxy URLs without a scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #5866: Addressed cycle in crd generation with Java 19+ and ZonedDateTime
 
 #### Improvements
+* Fix #5605: proxy configs support proxy URLs without a scheme
 * Fix #5878: (java-generator) Add implements Editable for extraAnnotations
 * Fix #5878: (java-generator) Update documentation to include dependencies
 * Fix #5867: (crd-generator) Imply schemaFrom via JsonFormat shape (SchemaFrom takes precedence)

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -86,7 +86,14 @@ public class HttpClientUtils {
       proxy = config.getHttpProxy();
     }
     if (proxy != null) {
-      URI proxyUrl = new URI(proxy);
+      final String completedProxy;
+      if (proxy.contains("://")) {
+        completedProxy = proxy;
+      } else {
+        // No protocol specified, default to cluster requirements
+        completedProxy = master.getProtocol() + "://" + proxy;
+      }
+      final URI proxyUrl = new URI(completedProxy);
       if (proxyUrl.getPort() < 0) {
         throw new IllegalArgumentException("Failure in creating proxy URL. Proxy port is required!");
       }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
@@ -65,12 +65,12 @@ import static org.mockito.Mockito.when;
 class HttpClientUtilsTest {
 
   @Test
-  void toProxyTypeTestUnknown() throws MalformedURLException {
+  void toProxyTypeTestUnknown() {
     assertThrows(MalformedURLException.class, () -> HttpClientUtils.toProxyType("unknown"));
   }
 
   @Test
-  void toProxyTypeTestNull() throws MalformedURLException {
+  void toProxyTypeTestNull() {
     assertThrows(MalformedURLException.class, () -> HttpClientUtils.toProxyType(null));
   }
 
@@ -160,7 +160,7 @@ class HttpClientUtilsTest {
     @ParameterizedTest(name = "{index}: Master hostname ''{0}'' matched by No Proxy ''{1}'' ")
     @MethodSource("masterHostnameDoesMatchNoProxyInput")
     void masterHostnameDoesMatchNoProxy(String masterHostname, String[] noProxy)
-        throws MalformedURLException, URISyntaxException {
+        throws MalformedURLException {
       assertTrue(HttpClientUtils.isHostMatchedByNoProxy(masterHostname, noProxy));
     }
 
@@ -235,6 +235,19 @@ class HttpClientUtilsTest {
       URI url = HttpClientUtils.getProxyUri(new URL("http://localhost"), config);
       // Then
       assertThat(url).isNull();
+    }
+
+    @Test
+    void whenIncompleteHttpProxyUrlProvided_shouldInferProtocol() throws MalformedURLException, URISyntaxException {
+      // Given
+      Config config = configBuilder.withHttpProxy("example.com:8080").build();
+      // When
+      URI url = HttpClientUtils.getProxyUri(new URL("http://localhost"), config);
+      // Then
+      assertThat(url)
+          .hasScheme("http")
+          .hasHost("example.com")
+          .hasPort(8080);
     }
   }
 


### PR DESCRIPTION
## Description

Fix #5605

feat: proxy configs support proxy URLs without a scheme

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
