### PR TITLE
fix: adding a v1beta1 deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 #### _**Note**_: Breaking changes
 * Fix #5960: The KubernetesSerializer will now by default serialize time related types to strings - rather than object, integer, number, or arrays of integer / number. If you are using these types in a custom object and were not including JsonFormat annotations to adjust the serialization they were likely being serialized in a non-standard way that would not be usable other Kubernetes clients, nor match the generated custom resource definition if one was being produced. Please open an issue if you need the previous behavior for whatever reason - there is a workaround by creating a customized KubernetesSerializer.
 * `storagemigration.k8s.io/v1alpha1` `StorageVersionMigration` introduced in Kubernetes 1.30.0 is added to [kubernetes-model-storageclass](https://github.com/fabric8io/kubernetes-client/tree/main/kubernetes-model-generator/kubernetes-model-storageclass) module. A dedicated module hasn't been created for this new ApiGroup.
+* Fix #5947: CRD generation using the v1beta1 version is deprecated. Please use only v1 instead.
 
 ### 6.12.1  (2024-04-18)
 

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
@@ -104,6 +104,7 @@ public class CRDGenerator {
                   s -> new CustomResourceHandler(resources, parallel));
               break;
             case io.fabric8.crd.generator.v1beta1.CustomResourceHandler.VERSION:
+              LOGGER.warn("CRD generator for v1beta1 is deprecated, consider using v1 instead.");
               handlers.computeIfAbsent(io.fabric8.crd.generator.v1beta1.CustomResourceHandler.VERSION,
                   s -> new io.fabric8.crd.generator.v1beta1.CustomResourceHandler(resources, parallel));
               break;

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/CustomResourceHandler.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/CustomResourceHandler.java
@@ -39,7 +39,16 @@ import io.sundr.model.TypeDef;
 
 import java.util.Optional;
 
+/**
+ * @deprecated Use {@link io.fabric8.crd.generator.v1.CustomResourceHandler} instead.
+ */
+@Deprecated
 public class CustomResourceHandler extends AbstractCustomResourceHandler {
+
+  /**
+   * @deprecated Use {@link io.fabric8.crd.generator.v1.CustomResourceHandler#VERSION} instead.
+   */
+  @Deprecated
   public static final String VERSION = "v1beta1";
 
   public CustomResourceHandler(Resources resources, boolean parallel) {

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -32,6 +32,10 @@ import java.util.stream.Collectors;
 
 import static io.fabric8.crd.generator.CRDGenerator.YAML_MAPPER;
 
+/**
+ * @deprecated Use {@link io.fabric8.crd.generator.v1.JsonSchema} instead.
+ */
+@Deprecated
 public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPropsBuilder> {
 
   private static final JsonSchema instance = new JsonSchema();


### PR DESCRIPTION
## Description

closes: #5947

Another deprecation notice about the annotation processing crd generator can be added after the plugins are ready.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
