### PR TITLE
test(crd-generator-v2): ensure Collection properties work like List in CRD generation

### DIFF
--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/complex/k8s/ServiceSpec.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/complex/k8s/ServiceSpec.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +89,7 @@ public class ServiceSpec implements KubernetesResource {
   private String loadBalancerIP;
   @JsonProperty("loadBalancerSourceRanges")
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
-  private List<String> loadBalancerSourceRanges = new ArrayList<>();
+  private Collection<String> loadBalancerSourceRanges = new ArrayList<>();
   @JsonProperty("publishNotReadyAddresses")
   private Boolean publishNotReadyAddresses;
   @JsonProperty("selector")
@@ -225,12 +226,12 @@ public class ServiceSpec implements KubernetesResource {
   }
 
   @JsonProperty("loadBalancerSourceRanges")
-  public List<String> getLoadBalancerSourceRanges() {
+  public Collection<String> getLoadBalancerSourceRanges() {
     return loadBalancerSourceRanges;
   }
 
   @JsonProperty("loadBalancerSourceRanges")
-  public void setLoadBalancerSourceRanges(List<String> loadBalancerSourceRanges) {
+  public void setLoadBalancerSourceRanges(Collection<String> loadBalancerSourceRanges) {
     this.loadBalancerSourceRanges = loadBalancerSourceRanges;
   }
 


### PR DESCRIPTION
## Description
Making sure https://github.com/fabric8io/kubernetes-client/issues/5417 could not be reproduced with crd-generator-v2
In the tests
- Updated `ServiceSpec` to use `Collection` instead of `List` for `loadBalancerSourceRanges`.
- Modified getter and setter methods for `loadBalancerSourceRanges` to use `Collection`.
- Confirmed that CRD generation produces a field of type array when using `Collection`, ensuring compatibility and correct schema output.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
