### PR TITLE
Remove project from task extension

### DIFF
--- a/java-generator/gradle-plugin/src/main/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPlugin.java
+++ b/java-generator/gradle-plugin/src/main/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPlugin.java
@@ -23,7 +23,7 @@ public class JavaGeneratorPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     // create an extension for the plugin
-    project.getExtensions().create(JavaGeneratorPluginExtension.NAME, JavaGeneratorPluginExtension.class, project);
+    project.getExtensions().create(JavaGeneratorPluginExtension.NAME, JavaGeneratorPluginExtension.class);
     // register tasks
     project.getTasks().register(JavaGeneratorCrd2JavaTask.NAME, JavaGeneratorCrd2JavaTask.class,
         JavaGeneratorPluginExtension.class);

--- a/java-generator/gradle-plugin/src/main/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPluginExtension.java
+++ b/java-generator/gradle-plugin/src/main/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPluginExtension.java
@@ -16,8 +16,8 @@
 package io.fabric8.java.generator.gradle.plugin;
 
 import io.fabric8.java.generator.Config;
-import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 
@@ -29,12 +29,12 @@ import java.util.Map;
 public abstract class JavaGeneratorPluginExtension {
 
   public static final String NAME = "javaGen";
-  protected Project gradleProject;
+  protected final ProjectLayout layout;
 
   private Config javaGeneratorConfig = Config.builder().build();
 
-  public JavaGeneratorPluginExtension(Project gradleProject) {
-    this.gradleProject = gradleProject;
+  public JavaGeneratorPluginExtension(ProjectLayout layout) {
+    this.layout = layout;
   }
 
   public Config getConfig() {
@@ -68,7 +68,7 @@ public abstract class JavaGeneratorPluginExtension {
 
   public File getDownloadTargetOrDefault() {
     return this.getDownloadTarget().getAsFile()
-        .getOrElse(this.gradleProject.getLayout().getProjectDirectory()
+        .getOrElse(layout.getProjectDirectory()
             .dir("build")
             .dir("crds")
             .getAsFile());
@@ -82,7 +82,7 @@ public abstract class JavaGeneratorPluginExtension {
 
   public File getTargetOrDefault() {
     return this.getTarget().getAsFile()
-        .getOrElse(this.gradleProject.getLayout().getProjectDirectory()
+        .getOrElse(layout.getProjectDirectory()
             .dir("build")
             .dir("generated")
             .dir("sources").getAsFile());

--- a/java-generator/gradle-plugin/src/test/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPluginTest.java
+++ b/java-generator/gradle-plugin/src/test/java/io/fabric8/java/generator/gradle/plugin/JavaGeneratorPluginTest.java
@@ -32,7 +32,7 @@ class JavaGeneratorPluginTest {
     new JavaGeneratorPlugin().apply(project);
     // Then
     verify(project.getExtensions(), times(1))
-        .create(JavaGeneratorPluginExtension.NAME, JavaGeneratorPluginExtension.class, project);
+        .create(JavaGeneratorPluginExtension.NAME, JavaGeneratorPluginExtension.class);
     verify(project.getTasks(), times(1))
         .register(JavaGeneratorCrd2JavaTask.NAME, JavaGeneratorCrd2JavaTask.class, JavaGeneratorPluginExtension.class);
   }


### PR DESCRIPTION
In order to support Gradle's configuration cache, having the Project object in extensions/tasks is not allowed https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:disallowed_types. We can avoid that by injecting the ProjectLayout object directly which is legal.

> There are a number of types that task instances must not reference from their fields. 
> These types fall into some categories as follows:
> - Live JVM state types
> - Gradle model types
> - Dependency management types
>
> In all cases the reason these types are disallowed is that their state cannot easily be stored or recreated by the configuration cache.

Specifically
> Gradle model types (e.g. Gradle, Settings, Project, SourceSet, Configuration etc…​) are usually used to carry some task input that should be explicitly and precisely declared instead.