### PR TITLE
fix: swallow rejected execution after shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #6038: Support for Gradle configuration cache
+* Fix #6059: Swallow rejected execution from internal usage of the informer executor
 
 #### Improvements
 * Fix #6008: removing the optional dependency on bouncy castle

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
@@ -113,7 +113,7 @@ public class ProcessorStore<T extends HasMetadata> {
       }
     });
     if (cacheStateComplete != null) {
-      cacheStateComplete.accept(this.processor::execute);
+      cacheStateComplete.accept(this.processor::executeIfPossible);
     }
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/SharedProcessor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/SharedProcessor.java
@@ -175,7 +175,11 @@ public class SharedProcessor<T> {
     }
   }
 
-  public void execute(Runnable runnable) {
-    this.executor.execute(runnable);
+  public void executeIfPossible(Runnable runnable) {
+    try {
+      this.executor.execute(runnable);
+    } catch (RejectedExecutionException e) {
+      // already shutdown
+    }
   }
 }


### PR DESCRIPTION
## Description

The handling to make the informer behavior deterministic allows for the cache call to happen after shutdown. The simplest thing to do is to just swallow the rejected execution exception.

closes: #6059


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
