### PR TITLE
fix (kubernetes-server-mock) : Add opinionated current context to KubernetesMockServer's initConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #6038: Support for Gradle configuration cache
 * Fix #6059: Swallow rejected execution from internal usage of the informer executor
+* Fix #6068: KubernetesMockServer provides incomplete Configuration while creating test Config for KubernetesClient
 
 #### Improvements
 * Fix #6008: removing the optional dependency on bouncy castle

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -207,12 +207,12 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
   }
 
   protected Config initConfig() {
-    NamedContext mockServerContext = new NamedContextBuilder()
-        .withName("fabric8-mockserver-context")
+    final NamedContext mockServerContext = new NamedContextBuilder()
+        .withName("fabric8-mock-server-context")
         .withNewContext()
         .withNamespace("test")
         .withCluster(String.format("localhost:%d", getPort()))
-        .withUser("fabric8-mockserver-testuser")
+        .withUser("fabric8-mock-server-user")
         .endContext()
         .build();
     return new ConfigBuilder(Config.empty())
@@ -223,7 +223,7 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
         .withHttp2Disable(true)
         .addToContexts(mockServerContext)
         .withCurrentContext(mockServerContext)
-        .withUsername("fabric8-mockserver-testuser")
+        .withUsername("fabric8-mock-server-user")
         .withOauthToken("secret")
         .build();
   }

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -19,6 +19,8 @@ import io.fabric8.kubernetes.api.model.APIResource;
 import io.fabric8.kubernetes.api.model.APIResourceBuilder;
 import io.fabric8.kubernetes.api.model.APIResourceList;
 import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
+import io.fabric8.kubernetes.api.model.NamedContext;
+import io.fabric8.kubernetes.api.model.NamedContextBuilder;
 import io.fabric8.kubernetes.api.model.RootPathsBuilder;
 import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.Config;
@@ -205,12 +207,24 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
   }
 
   protected Config initConfig() {
+    NamedContext mockServerContext = new NamedContextBuilder()
+        .withName("fabric8-mockserver-context")
+        .withNewContext()
+        .withNamespace("test")
+        .withCluster(String.format("localhost:%d", getPort()))
+        .withUser("fabric8-mockserver-testuser")
+        .endContext()
+        .build();
     return new ConfigBuilder(Config.empty())
         .withMasterUrl(url("/"))
         .withTrustCerts(true)
         .withTlsVersions(TlsVersion.TLS_1_2)
         .withNamespace("test")
         .withHttp2Disable(true)
+        .addToContexts(mockServerContext)
+        .withCurrentContext(mockServerContext)
+        .withUsername("fabric8-mockserver-testuser")
+        .withOauthToken("secret")
         .build();
   }
 

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTest.java
@@ -29,22 +29,22 @@ class KubernetesMockServerExtensionTest {
   KubernetesClient client;
 
   @Test
-  void testExample() {
+  void mockServerConfiguration() {
     assertThat(client)
         .isNotNull()
         .extracting(Client::getConfiguration)
         .hasFieldOrPropertyWithValue("oauthToken", "secret")
-        .hasFieldOrPropertyWithValue("username", "fabric8-mockserver-testuser")
-        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mockserver-context")
+        .hasFieldOrPropertyWithValue("username", "fabric8-mock-server-user")
+        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mock-server-context")
         .hasFieldOrPropertyWithValue("currentContext.context.namespace", "test")
-        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mockserver-testuser")
+        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mock-server-user")
         .satisfies(c -> assertThat(c.getCurrentContext().getContext().getCluster()).startsWith("localhost:"))
         .satisfies(c -> assertThat(c.getContexts()).hasSize(1));
   }
 
   @Test
   @DisplayName("KubernetesMockServerExtension uses KubernetesMixedDispatcher and provides expectation for GET /version")
-  void testGetKubernetesVersion() {
+  void getKubernetesVersion() {
     // When
     final VersionInfo result = client.getKubernetesVersion();
     // Then

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTest.java
@@ -15,9 +15,9 @@
  */
 package io.fabric8.kubernetes.client.server.mock;
 
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.VersionInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -30,10 +30,16 @@ class KubernetesMockServerExtensionTest {
 
   @Test
   void testExample() {
-    Assertions.assertNotNull(client);
-    Assertions.assertNull(client.getConfiguration().getOauthToken());
-    Assertions.assertNull(client.getConfiguration().getCurrentContext());
-    Assertions.assertTrue(client.getConfiguration().getContexts().isEmpty());
+    assertThat(client)
+        .isNotNull()
+        .extracting(Client::getConfiguration)
+        .hasFieldOrPropertyWithValue("oauthToken", "secret")
+        .hasFieldOrPropertyWithValue("username", "fabric8-mockserver-testuser")
+        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mockserver-context")
+        .hasFieldOrPropertyWithValue("currentContext.context.namespace", "test")
+        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mockserver-testuser")
+        .satisfies(c -> assertThat(c.getCurrentContext().getContext().getCluster()).startsWith("localhost:"))
+        .satisfies(c -> assertThat(c.getContexts()).hasSize(1));
   }
 
   @Test

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/MockServerKubeconfigTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/MockServerKubeconfigTest.java
@@ -15,13 +15,16 @@
  */
 package io.fabric8.kubernetes.client.server.mock;
 
+import io.fabric8.kubernetes.api.model.NamedContext;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 class MockServerKubeconfigTest {
 
@@ -39,10 +42,16 @@ class MockServerKubeconfigTest {
     KubernetesClient client = server.createClient();
 
     // Then
-    Assertions.assertNotNull(client);
-    Assertions.assertNull(client.getConfiguration().getOauthToken());
-    Assertions.assertNull(client.getConfiguration().getCurrentContext());
-    Assertions.assertTrue(client.getConfiguration().getContexts().isEmpty());
+    assertThat(client).isNotNull();
+    assertThat(client.getConfiguration())
+        .isNotNull()
+        .satisfies(c -> assertThat(c.getCurrentContext().getName()).isNotEqualTo("default/api-crc-testing:6443/kubeadmin"))
+        .satisfies(c -> assertThat(c.getOauthToken()).isNotEqualTo("sha256~iYtvbJNJEE0_QSxYE0Wl1MJJxpSvDUsNyYfzkCIoDkw"))
+        .satisfies(c -> assertThat(c.getContexts())
+            .hasSize(1)
+            .singleElement(InstanceOfAssertFactories.type(NamedContext.class))
+            .extracting(NamedContext::getName)
+            .isNotEqualTo("default/api-crc-testing:6443/kubeadmin"));
   }
 
   @AfterEach

--- a/junit/openshift-server-mock/pom.xml
+++ b/junit/openshift-server-mock/pom.xml
@@ -40,6 +40,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>provided</scope>

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableOpenShiftMockClient(crud = true)
 class OpenShiftMockServerExtensionStaticTests {
@@ -28,9 +27,15 @@ class OpenShiftMockServerExtensionStaticTests {
 
   @Test
   void testStaticOpenShiftClientGetsInitialized() {
-    assertNotNull(openShiftClient);
-    assertNull(openShiftClient.getConfiguration().getOauthToken());
-    assertNull(openShiftClient.getConfiguration().getCurrentContext());
-    assertTrue(openShiftClient.getConfiguration().getContexts().isEmpty());
+    assertThat(openShiftClient)
+        .isNotNull()
+        .extracting(Client::getConfiguration)
+        .hasFieldOrPropertyWithValue("oauthToken", "secret")
+        .hasFieldOrPropertyWithValue("username", "fabric8-mockserver-testuser")
+        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mockserver-context")
+        .hasFieldOrPropertyWithValue("currentContext.context.namespace", "test")
+        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mockserver-testuser")
+        .satisfies(c -> assertThat(c.getCurrentContext().getContext().getCluster()).startsWith("localhost:"))
+        .satisfies(c -> assertThat(c.getContexts()).hasSize(1));
   }
 }

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
@@ -31,10 +31,10 @@ class OpenShiftMockServerExtensionStaticTests {
         .isNotNull()
         .extracting(Client::getConfiguration)
         .hasFieldOrPropertyWithValue("oauthToken", "secret")
-        .hasFieldOrPropertyWithValue("username", "fabric8-mockserver-testuser")
-        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mockserver-context")
+        .hasFieldOrPropertyWithValue("username", "fabric8-mock-server-user")
+        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mock-server-context")
         .hasFieldOrPropertyWithValue("currentContext.context.namespace", "test")
-        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mockserver-testuser")
+        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mock-server-user")
         .satisfies(c -> assertThat(c.getCurrentContext().getContext().getCluster()).startsWith("localhost:"))
         .satisfies(c -> assertThat(c.getContexts()).hasSize(1));
   }

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
@@ -31,10 +31,10 @@ class OpenShiftMockServerExtensionTests {
         .isNotNull()
         .extracting(Client::getConfiguration)
         .hasFieldOrPropertyWithValue("oauthToken", "secret")
-        .hasFieldOrPropertyWithValue("username", "fabric8-mockserver-testuser")
-        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mockserver-context")
+        .hasFieldOrPropertyWithValue("username", "fabric8-mock-server-user")
+        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mock-server-context")
         .hasFieldOrPropertyWithValue("currentContext.context.namespace", "test")
-        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mockserver-testuser")
+        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mock-server-user")
         .satisfies(c -> assertThat(c.getCurrentContext().getContext().getCluster()).startsWith("localhost:"))
         .satisfies(c -> assertThat(c.getContexts()).hasSize(1));
   }

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
@@ -15,12 +15,11 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.Client;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableOpenShiftMockClient(crud = true)
 class OpenShiftMockServerExtensionTests {
@@ -28,9 +27,15 @@ class OpenShiftMockServerExtensionTests {
 
   @Test
   void testOpenShiftClientGetsInitialized() {
-    assertNotNull(client);
-    assertNull(client.getConfiguration().getOauthToken());
-    assertNull(client.getConfiguration().getCurrentContext());
-    assertTrue(client.getConfiguration().getContexts().isEmpty());
+    assertThat(client)
+        .isNotNull()
+        .extracting(Client::getConfiguration)
+        .hasFieldOrPropertyWithValue("oauthToken", "secret")
+        .hasFieldOrPropertyWithValue("username", "fabric8-mockserver-testuser")
+        .hasFieldOrPropertyWithValue("currentContext.name", "fabric8-mockserver-context")
+        .hasFieldOrPropertyWithValue("currentContext.context.namespace", "test")
+        .hasFieldOrPropertyWithValue("currentContext.context.user", "fabric8-mockserver-testuser")
+        .satisfies(c -> assertThat(c.getCurrentContext().getContext().getCluster()).startsWith("localhost:"))
+        .satisfies(c -> assertThat(c.getContexts()).hasSize(1));
   }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -52,6 +52,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -332,7 +333,7 @@ public class Config {
         userAgent, tlsVersions, websocketPingInterval, proxyUsername, proxyPassword,
         trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups,
         impersonateExtras, null, null, DEFAULT_REQUEST_RETRY_BACKOFFLIMIT, DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL,
-        DEFAULT_UPLOAD_REQUEST_TIMEOUT, false);
+        DEFAULT_UPLOAD_REQUEST_TIMEOUT, false, null, Collections.emptyList());
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
@@ -347,7 +348,8 @@ public class Config {
       String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase,
       String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras,
       OAuthTokenProvider oauthTokenProvider, Map<String, String> customHeaders, int requestRetryBackoffLimit,
-      int requestRetryBackoffInterval, int uploadRequestTimeout, boolean onlyHttpWatches) {
+      int requestRetryBackoffInterval, int uploadRequestTimeout, boolean onlyHttpWatches, NamedContext currentContext,
+      List<NamedContext> contexts) {
     this.apiVersion = apiVersion;
     this.namespace = namespace;
     this.trustCerts = trustCerts;
@@ -396,6 +398,8 @@ public class Config {
     this.maxConcurrentRequestsPerHost = maxConcurrentRequestsPerHost;
     this.autoOAuthToken = autoOAuthToken;
     this.onlyHttpWatches = onlyHttpWatches;
+    this.contexts = contexts;
+    this.currentContext = currentContext;
   }
 
   public static void configFromSysPropsOrEnvVars(Config config) {

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -18,6 +18,7 @@ package io.fabric8.openshift.client;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.fabric8.kubernetes.api.model.NamedContext;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.OAuthTokenProvider;
 import io.fabric8.kubernetes.client.http.TlsVersion;
@@ -87,7 +88,7 @@ public class OpenShiftConfig extends Config {
       String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,
       Map<String, String> customHeaders, int requestRetryBackoffLimit, int requestRetryBackoffInterval,
       int uploadRequestTimeout, boolean onlyHttpWatches, long buildTimeout,
-      boolean disableApiGroupCheck) {
+      boolean disableApiGroupCheck, NamedContext currentContext, List<NamedContext> contexts) {
     super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData,
         clientCertFile,
         clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password,
@@ -99,7 +100,7 @@ public class OpenShiftConfig extends Config {
         impersonateExtras, oauthTokenProvider, customHeaders,
         requestRetryBackoffLimit,
         requestRetryBackoffInterval,
-        uploadRequestTimeout, onlyHttpWatches);
+        uploadRequestTimeout, onlyHttpWatches, currentContext, contexts);
     this.setOapiVersion(oapiVersion);
     this.setBuildTimeout(buildTimeout);
     this.setDisableApiGroupCheck(disableApiGroupCheck);
@@ -141,7 +142,9 @@ public class OpenShiftConfig extends Config {
         kubernetesConfig.getUploadRequestTimeout(),
         kubernetesConfig.isOnlyHttpWatches(),
         buildTimeout,
-        false);
+        false,
+        kubernetesConfig.getCurrentContext(),
+        kubernetesConfig.getContexts());
   }
 
   public static OpenShiftConfig wrap(Config config) {


### PR DESCRIPTION
## Description

Related to https://github.com/eclipse-jkube/jkube/pull/3142

Fix #6068 

+ Add currentContext and contexts arguments to Config constructor in order to pass them to child class OpenShiftConfig
+ Add values for username, oauthToken, and currentContext to Config created by the Kubernetes Mock Server for 
  KubernetesClient used in tests


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
