### PR TITLE
fix: generated classes handle java.lang.String type consistently

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admission/v1/AdmissionResponse.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admission/v1/AdmissionResponse.java
@@ -71,18 +71,18 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> auditAnnotations = new LinkedHashMap<String, String>();
     @JsonProperty("patch")
-    private java.lang.String patch;
+    private String patch;
     @JsonProperty("patchType")
-    private java.lang.String patchType;
+    private String patchType;
     @JsonProperty("status")
     private Status status;
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("warnings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> warnings = new ArrayList<java.lang.String>();
+    private List<String> warnings = new ArrayList<String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -91,7 +91,7 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     public AdmissionResponse() {
     }
 
-    public AdmissionResponse(Boolean allowed, Map<String, String> auditAnnotations, java.lang.String patch, java.lang.String patchType, Status status, java.lang.String uid, List<java.lang.String> warnings) {
+    public AdmissionResponse(Boolean allowed, Map<String, String> auditAnnotations, String patch, String patchType, Status status, String uid, List<String> warnings) {
         super();
         this.allowed = allowed;
         this.auditAnnotations = auditAnnotations;
@@ -123,22 +123,22 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     }
 
     @JsonProperty("patch")
-    public java.lang.String getPatch() {
+    public String getPatch() {
         return patch;
     }
 
     @JsonProperty("patch")
-    public void setPatch(java.lang.String patch) {
+    public void setPatch(String patch) {
         this.patch = patch;
     }
 
     @JsonProperty("patchType")
-    public java.lang.String getPatchType() {
+    public String getPatchType() {
         return patchType;
     }
 
     @JsonProperty("patchType")
-    public void setPatchType(java.lang.String patchType) {
+    public void setPatchType(String patchType) {
         this.patchType = patchType;
     }
 
@@ -153,23 +153,23 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("warnings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getWarnings() {
+    public List<String> getWarnings() {
         return warnings;
     }
 
     @JsonProperty("warnings")
-    public void setWarnings(List<java.lang.String> warnings) {
+    public void setWarnings(List<String> warnings) {
         this.warnings = warnings;
     }
 
@@ -184,12 +184,12 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admission/v1beta1/AdmissionResponse.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/admission/v1beta1/AdmissionResponse.java
@@ -71,18 +71,18 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> auditAnnotations = new LinkedHashMap<String, String>();
     @JsonProperty("patch")
-    private java.lang.String patch;
+    private String patch;
     @JsonProperty("patchType")
-    private java.lang.String patchType;
+    private String patchType;
     @JsonProperty("status")
     private Status status;
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("warnings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> warnings = new ArrayList<java.lang.String>();
+    private List<String> warnings = new ArrayList<String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -91,7 +91,7 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     public AdmissionResponse() {
     }
 
-    public AdmissionResponse(Boolean allowed, Map<String, String> auditAnnotations, java.lang.String patch, java.lang.String patchType, Status status, java.lang.String uid, List<java.lang.String> warnings) {
+    public AdmissionResponse(Boolean allowed, Map<String, String> auditAnnotations, String patch, String patchType, Status status, String uid, List<String> warnings) {
         super();
         this.allowed = allowed;
         this.auditAnnotations = auditAnnotations;
@@ -123,22 +123,22 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     }
 
     @JsonProperty("patch")
-    public java.lang.String getPatch() {
+    public String getPatch() {
         return patch;
     }
 
     @JsonProperty("patch")
-    public void setPatch(java.lang.String patch) {
+    public void setPatch(String patch) {
         this.patch = patch;
     }
 
     @JsonProperty("patchType")
-    public java.lang.String getPatchType() {
+    public String getPatchType() {
         return patchType;
     }
 
     @JsonProperty("patchType")
-    public void setPatchType(java.lang.String patchType) {
+    public void setPatchType(String patchType) {
         this.patchType = patchType;
     }
 
@@ -153,23 +153,23 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("warnings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getWarnings() {
+    public List<String> getWarnings() {
         return warnings;
     }
 
     @JsonProperty("warnings")
-    public void setWarnings(List<java.lang.String> warnings) {
+    public void setWarnings(List<String> warnings) {
         this.warnings = warnings;
     }
 
@@ -184,12 +184,12 @@ public class AdmissionResponse implements Editable<AdmissionResponseBuilder> , K
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/authentication/UserInfo.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/authentication/UserInfo.java
@@ -66,13 +66,13 @@ public class UserInfo implements Editable<UserInfoBuilder> , KubernetesResource
     private Map<String, ArrayList<String>> extra = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> groups = new ArrayList<java.lang.String>();
+    private List<String> groups = new ArrayList<String>();
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("username")
-    private java.lang.String username;
+    private String username;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -81,7 +81,7 @@ public class UserInfo implements Editable<UserInfoBuilder> , KubernetesResource
     public UserInfo() {
     }
 
-    public UserInfo(Map<String, ArrayList<String>> extra, List<java.lang.String> groups, java.lang.String uid, java.lang.String username) {
+    public UserInfo(Map<String, ArrayList<String>> extra, List<String> groups, String uid, String username) {
         super();
         this.extra = extra;
         this.groups = groups;
@@ -101,32 +101,32 @@ public class UserInfo implements Editable<UserInfoBuilder> , KubernetesResource
 
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getGroups() {
+    public List<String> getGroups() {
         return groups;
     }
 
     @JsonProperty("groups")
-    public void setGroups(List<java.lang.String> groups) {
+    public void setGroups(List<String> groups) {
         this.groups = groups;
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("username")
-    public java.lang.String getUsername() {
+    public String getUsername() {
         return username;
     }
 
     @JsonProperty("username")
-    public void setUsername(java.lang.String username) {
+    public void setUsername(String username) {
         this.username = username;
     }
 
@@ -141,12 +141,12 @@ public class UserInfo implements Editable<UserInfoBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/authorization/v1/SubjectAccessReviewSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/authorization/v1/SubjectAccessReviewSpec.java
@@ -68,17 +68,17 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     private Map<String, ArrayList<String>> extra = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> groups = new ArrayList<java.lang.String>();
+    private List<String> groups = new ArrayList<String>();
     @JsonProperty("nonResourceAttributes")
     private NonResourceAttributes nonResourceAttributes;
     @JsonProperty("resourceAttributes")
     private ResourceAttributes resourceAttributes;
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("user")
-    private java.lang.String user;
+    private String user;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -87,7 +87,7 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     public SubjectAccessReviewSpec() {
     }
 
-    public SubjectAccessReviewSpec(Map<String, ArrayList<String>> extra, List<java.lang.String> groups, NonResourceAttributes nonResourceAttributes, ResourceAttributes resourceAttributes, java.lang.String uid, java.lang.String user) {
+    public SubjectAccessReviewSpec(Map<String, ArrayList<String>> extra, List<String> groups, NonResourceAttributes nonResourceAttributes, ResourceAttributes resourceAttributes, String uid, String user) {
         super();
         this.extra = extra;
         this.groups = groups;
@@ -109,12 +109,12 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
 
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getGroups() {
+    public List<String> getGroups() {
         return groups;
     }
 
     @JsonProperty("groups")
-    public void setGroups(List<java.lang.String> groups) {
+    public void setGroups(List<String> groups) {
         this.groups = groups;
     }
 
@@ -139,22 +139,22 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("user")
-    public java.lang.String getUser() {
+    public String getUser() {
         return user;
     }
 
     @JsonProperty("user")
-    public void setUser(java.lang.String user) {
+    public void setUser(String user) {
         this.user = user;
     }
 
@@ -169,12 +169,12 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/authorization/v1beta1/SubjectAccessReviewSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/generated/java/io/fabric8/kubernetes/api/model/authorization/v1beta1/SubjectAccessReviewSpec.java
@@ -68,17 +68,17 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     private Map<String, ArrayList<String>> extra = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("group")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> group = new ArrayList<java.lang.String>();
+    private List<String> group = new ArrayList<String>();
     @JsonProperty("nonResourceAttributes")
     private NonResourceAttributes nonResourceAttributes;
     @JsonProperty("resourceAttributes")
     private ResourceAttributes resourceAttributes;
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("user")
-    private java.lang.String user;
+    private String user;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -87,7 +87,7 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     public SubjectAccessReviewSpec() {
     }
 
-    public SubjectAccessReviewSpec(Map<String, ArrayList<String>> extra, List<java.lang.String> group, NonResourceAttributes nonResourceAttributes, ResourceAttributes resourceAttributes, java.lang.String uid, java.lang.String user) {
+    public SubjectAccessReviewSpec(Map<String, ArrayList<String>> extra, List<String> group, NonResourceAttributes nonResourceAttributes, ResourceAttributes resourceAttributes, String uid, String user) {
         super();
         this.extra = extra;
         this.group = group;
@@ -109,12 +109,12 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
 
     @JsonProperty("group")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getGroup() {
+    public List<String> getGroup() {
         return group;
     }
 
     @JsonProperty("group")
-    public void setGroup(List<java.lang.String> group) {
+    public void setGroup(List<String> group) {
         this.group = group;
     }
 
@@ -139,22 +139,22 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("user")
-    public java.lang.String getUser() {
+    public String getUser() {
         return user;
     }
 
     @JsonProperty("user")
-    public void setUser(java.lang.String user) {
+    public void setUser(String user) {
         this.user = user;
     }
 
@@ -169,12 +169,12 @@ public class SubjectAccessReviewSpec implements Editable<SubjectAccessReviewSpec
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/main/resources/schema/kube-schema.json
@@ -90,7 +90,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patch": {
           "type": "string"
@@ -221,7 +221,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patch": {
           "type": "string"
@@ -2594,7 +2594,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2774,7 +2774,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -2807,7 +2807,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -3396,7 +3396,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -3780,7 +3780,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -4140,7 +4140,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "group": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/src/main/resources/schema/validation-schema.json
@@ -90,7 +90,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patch": {
           "type": "string"
@@ -221,7 +221,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patch": {
           "type": "string"
@@ -2594,7 +2594,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2774,7 +2774,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -2807,7 +2807,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -3396,7 +3396,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -3780,7 +3780,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -4140,7 +4140,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "group": {
           "type": "array",
@@ -4556,7 +4556,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patch": {
           "type": "string"
@@ -4585,7 +4585,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "admission.k8s.io/v1beta1",
+          "default": "admission.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -4594,12 +4594,12 @@
           "required": true
         },
         "request": {
-          "$ref": "#/definitions/kubernetes_admission_v1beta1_AdmissionRequest",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admission.v1beta1.AdmissionRequest"
+          "$ref": "#/definitions/kubernetes_admission_v1_AdmissionRequest",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest"
         },
         "response": {
-          "$ref": "#/definitions/kubernetes_admission_v1beta1_AdmissionResponse",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admission.v1beta1.AdmissionResponse"
+          "$ref": "#/definitions/kubernetes_admission_v1_AdmissionResponse",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse"
         }
       },
       "additionalProperties": true
@@ -4898,7 +4898,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -5114,14 +5114,13 @@
       "properties": {
         "admissionReviewVersions": {
           "type": "array",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string"
           }
         },
         "clientConfig": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_WebhookClientConfig",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.WebhookClientConfig"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1_WebhookClientConfig",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.WebhookClientConfig"
         },
         "failurePolicy": {
           "type": "string"
@@ -5130,8 +5129,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_MatchCondition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MatchCondition"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_MatchCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.MatchCondition"
           }
         },
         "matchPolicy": {
@@ -5172,7 +5171,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "admissionregistration.k8s.io/v1beta1",
+          "default": "admissionregistration.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -5188,8 +5187,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_MutatingWebhook",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MutatingWebhook"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_MutatingWebhook",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.MutatingWebhook"
           }
         }
       },
@@ -5199,14 +5198,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "admissionregistration.k8s.io/v1",
+          "default": "admissionregistration.k8s.io/v1beta1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1_MutatingWebhookConfiguration",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.MutatingWebhookConfiguration"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_MutatingWebhookConfiguration",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MutatingWebhookConfiguration"
           }
         },
         "kind": {
@@ -5300,7 +5299,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -5333,7 +5332,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -5617,7 +5616,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "authorization.k8s.io/v1",
+          "default": "authorization.k8s.io/v1beta1",
           "required": true
         },
         "kind": {
@@ -5630,12 +5629,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_authorization_v1_SelfSubjectAccessReviewSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectAccessReviewSpec"
+          "$ref": "#/definitions/kubernetes_authorization_v1beta1_SelfSubjectAccessReviewSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.SelfSubjectAccessReviewSpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_authorization_v1_SubjectAccessReviewStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.SubjectAccessReviewStatus"
+          "$ref": "#/definitions/kubernetes_authorization_v1beta1_SubjectAccessReviewStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.SubjectAccessReviewStatus"
         }
       },
       "additionalProperties": true
@@ -5689,7 +5688,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "authorization.k8s.io/v1beta1",
+          "default": "authorization.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -5702,12 +5701,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_authorization_v1beta1_SelfSubjectRulesReviewSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.SelfSubjectRulesReviewSpec"
+          "$ref": "#/definitions/kubernetes_authorization_v1_SelfSubjectRulesReviewSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.SelfSubjectRulesReviewSpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_authorization_v1beta1_SubjectRulesReviewStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.SubjectRulesReviewStatus"
+          "$ref": "#/definitions/kubernetes_authorization_v1_SubjectRulesReviewStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.SubjectRulesReviewStatus"
         }
       },
       "additionalProperties": true
@@ -5829,7 +5828,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "authorization.k8s.io/v1",
+          "default": "authorization.k8s.io/v1beta1",
           "required": true
         },
         "kind": {
@@ -5842,12 +5841,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_authorization_v1_SubjectAccessReviewSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.SubjectAccessReviewSpec"
+          "$ref": "#/definitions/kubernetes_authorization_v1beta1_SubjectAccessReviewSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.SubjectAccessReviewSpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_authorization_v1_SubjectAccessReviewStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.SubjectAccessReviewStatus"
+          "$ref": "#/definitions/kubernetes_authorization_v1beta1_SubjectAccessReviewStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.SubjectAccessReviewStatus"
         }
       },
       "additionalProperties": true
@@ -5862,9 +5861,9 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
-        "groups": {
+        "group": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
@@ -5872,12 +5871,12 @@
           }
         },
         "nonResourceAttributes": {
-          "$ref": "#/definitions/kubernetes_authorization_v1_NonResourceAttributes",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.NonResourceAttributes"
+          "$ref": "#/definitions/kubernetes_authorization_v1beta1_NonResourceAttributes",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.NonResourceAttributes"
         },
         "resourceAttributes": {
-          "$ref": "#/definitions/kubernetes_authorization_v1_ResourceAttributes",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1.ResourceAttributes"
+          "$ref": "#/definitions/kubernetes_authorization_v1beta1_ResourceAttributes",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.authorization.v1beta1.ResourceAttributes"
         },
         "uid": {
           "type": "string"
@@ -6122,7 +6121,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -6144,7 +6143,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "admissionregistration.k8s.io/v1alpha1",
+          "default": "admissionregistration.k8s.io/v1beta1",
           "required": true
         },
         "kind": {
@@ -6157,12 +6156,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1alpha1_ValidatingAdmissionPolicySpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1alpha1.ValidatingAdmissionPolicySpec"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ValidatingAdmissionPolicySpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingAdmissionPolicySpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1alpha1_ValidatingAdmissionPolicyStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1alpha1.ValidatingAdmissionPolicyStatus"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ValidatingAdmissionPolicyStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingAdmissionPolicyStatus"
         }
       },
       "additionalProperties": true
@@ -6171,7 +6170,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "admissionregistration.k8s.io/v1",
+          "default": "admissionregistration.k8s.io/v1beta1",
           "required": true
         },
         "kind": {
@@ -6184,8 +6183,8 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1_ValidatingAdmissionPolicyBindingSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingAdmissionPolicyBindingSpec"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ValidatingAdmissionPolicyBindingSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingAdmissionPolicyBindingSpec"
         }
       },
       "additionalProperties": true
@@ -6220,12 +6219,12 @@
     "validatingadmissionpolicybindingspec": {
       "properties": {
         "matchResources": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1alpha1_MatchResources",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1alpha1.MatchResources"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_MatchResources",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MatchResources"
         },
         "paramRef": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1alpha1_ParamRef",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1alpha1.ParamRef"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ParamRef",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ParamRef"
         },
         "policyName": {
           "type": "string"
@@ -6244,15 +6243,15 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "admissionregistration.k8s.io/v1beta1",
+          "default": "admissionregistration.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ValidatingAdmissionPolicy",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingAdmissionPolicy"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_ValidatingAdmissionPolicy",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingAdmissionPolicy"
           }
         },
         "kind": {
@@ -6273,8 +6272,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_AuditAnnotation",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.AuditAnnotation"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_AuditAnnotation",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.AuditAnnotation"
           }
         },
         "failurePolicy": {
@@ -6284,32 +6283,32 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_MatchCondition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MatchCondition"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_MatchCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.MatchCondition"
           }
         },
         "matchConstraints": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_MatchResources",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MatchResources"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1_MatchResources",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.MatchResources"
         },
         "paramKind": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ParamKind",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ParamKind"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1_ParamKind",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.ParamKind"
         },
         "validations": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_Validation",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.Validation"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_Validation",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.Validation"
           }
         },
         "variables": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_Variable",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.Variable"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_Variable",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.Variable"
           }
         }
       },
@@ -6330,8 +6329,8 @@
           "existingJavaType": "Long"
         },
         "typeChecking": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1alpha1_TypeChecking",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1alpha1.TypeChecking"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_TypeChecking",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.TypeChecking"
         }
       },
       "additionalProperties": true
@@ -6340,14 +6339,13 @@
       "properties": {
         "admissionReviewVersions": {
           "type": "array",
-          "javaOmitEmpty": true,
           "items": {
             "type": "string"
           }
         },
         "clientConfig": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_WebhookClientConfig",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.WebhookClientConfig"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1_WebhookClientConfig",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.WebhookClientConfig"
         },
         "failurePolicy": {
           "type": "string"
@@ -6356,8 +6354,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_MatchCondition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.MatchCondition"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1_MatchCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.MatchCondition"
           }
         },
         "matchPolicy": {
@@ -6422,14 +6420,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "admissionregistration.k8s.io/v1",
+          "default": "admissionregistration.k8s.io/v1beta1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_admissionregistration_v1_ValidatingWebhookConfiguration",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration"
+            "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ValidatingWebhookConfiguration",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ValidatingWebhookConfiguration"
           }
         },
         "kind": {
@@ -6478,8 +6476,8 @@
           "type": "string"
         },
         "service": {
-          "$ref": "#/definitions/kubernetes_admissionregistration_v1beta1_ServiceReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1beta1.ServiceReference"
+          "$ref": "#/definitions/kubernetes_admissionregistration_v1_ServiceReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.admissionregistration.v1.ServiceReference"
         },
         "url": {
           "type": "string"

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/JSONSchemaProps.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1/JSONSchemaProps.java
@@ -101,9 +101,9 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
 {
 
     @JsonProperty("$ref")
-    private java.lang.String $ref;
+    private String $ref;
     @JsonProperty("$schema")
-    private java.lang.String $schema;
+    private String $schema;
     @JsonProperty("additionalItems")
     private JSONSchemaPropsOrBool additionalItems;
     @JsonProperty("additionalProperties")
@@ -123,7 +123,7 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, JSONSchemaPropsOrStringArray> dependencies = new LinkedHashMap<String, JSONSchemaPropsOrStringArray>();
     @JsonProperty("description")
-    private java.lang.String description;
+    private String description;
     @JsonProperty("enum")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<JsonNode> _enum = new ArrayList<JsonNode>();
@@ -136,9 +136,9 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     @JsonProperty("externalDocs")
     private ExternalDocumentation externalDocs;
     @JsonProperty("format")
-    private java.lang.String format;
+    private String format;
     @JsonProperty("id")
-    private java.lang.String id;
+    private String id;
     @JsonProperty("items")
     private JSONSchemaPropsOrArray items;
     @JsonProperty("maxItems")
@@ -167,7 +167,7 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<JSONSchemaProps> oneOf = new ArrayList<JSONSchemaProps>();
     @JsonProperty("pattern")
-    private java.lang.String pattern;
+    private String pattern;
     @JsonProperty("patternProperties")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> patternProperties = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps>();
@@ -176,11 +176,11 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     private Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> properties = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps>();
     @JsonProperty("required")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> required = new ArrayList<java.lang.String>();
+    private List<String> required = new ArrayList<String>();
     @JsonProperty("title")
-    private java.lang.String title;
+    private String title;
     @JsonProperty("type")
-    private java.lang.String type;
+    private String type;
     @JsonProperty("uniqueItems")
     private Boolean uniqueItems;
     @JsonProperty("x-kubernetes-embedded-resource")
@@ -189,11 +189,11 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     private Boolean xKubernetesIntOrString;
     @JsonProperty("x-kubernetes-list-map-keys")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> xKubernetesListMapKeys = new ArrayList<java.lang.String>();
+    private List<String> xKubernetesListMapKeys = new ArrayList<String>();
     @JsonProperty("x-kubernetes-list-type")
-    private java.lang.String xKubernetesListType;
+    private String xKubernetesListType;
     @JsonProperty("x-kubernetes-map-type")
-    private java.lang.String xKubernetesMapType;
+    private String xKubernetesMapType;
     @JsonProperty("x-kubernetes-preserve-unknown-fields")
     private Boolean xKubernetesPreserveUnknownFields;
     @JsonProperty("x-kubernetes-validations")
@@ -207,7 +207,7 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     public JSONSchemaProps() {
     }
 
-    public JSONSchemaProps(java.lang.String $ref, java.lang.String $schema, JSONSchemaPropsOrBool additionalItems, JSONSchemaPropsOrBool additionalProperties, List<JSONSchemaProps> allOf, List<JSONSchemaProps> anyOf, JsonNode _default, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> definitions, Map<String, JSONSchemaPropsOrStringArray> dependencies, java.lang.String description, List<JsonNode> _enum, JsonNode example, Boolean exclusiveMaximum, Boolean exclusiveMinimum, ExternalDocumentation externalDocs, java.lang.String format, java.lang.String id, JSONSchemaPropsOrArray items, Long maxItems, Long maxLength, Long maxProperties, Double maximum, Long minItems, Long minLength, Long minProperties, Double minimum, Double multipleOf, JSONSchemaProps not, Boolean nullable, List<JSONSchemaProps> oneOf, java.lang.String pattern, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> patternProperties, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> properties, List<java.lang.String> required, java.lang.String title, java.lang.String type, Boolean uniqueItems, Boolean xKubernetesEmbeddedResource, Boolean xKubernetesIntOrString, List<java.lang.String> xKubernetesListMapKeys, java.lang.String xKubernetesListType, java.lang.String xKubernetesMapType, Boolean xKubernetesPreserveUnknownFields, List<ValidationRule> xKubernetesValidations) {
+    public JSONSchemaProps(String $ref, String $schema, JSONSchemaPropsOrBool additionalItems, JSONSchemaPropsOrBool additionalProperties, List<JSONSchemaProps> allOf, List<JSONSchemaProps> anyOf, JsonNode _default, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> definitions, Map<String, JSONSchemaPropsOrStringArray> dependencies, String description, List<JsonNode> _enum, JsonNode example, Boolean exclusiveMaximum, Boolean exclusiveMinimum, ExternalDocumentation externalDocs, String format, String id, JSONSchemaPropsOrArray items, Long maxItems, Long maxLength, Long maxProperties, Double maximum, Long minItems, Long minLength, Long minProperties, Double minimum, Double multipleOf, JSONSchemaProps not, Boolean nullable, List<JSONSchemaProps> oneOf, String pattern, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> patternProperties, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps> properties, List<String> required, String title, String type, Boolean uniqueItems, Boolean xKubernetesEmbeddedResource, Boolean xKubernetesIntOrString, List<String> xKubernetesListMapKeys, String xKubernetesListType, String xKubernetesMapType, Boolean xKubernetesPreserveUnknownFields, List<ValidationRule> xKubernetesValidations) {
         super();
         this.$ref = $ref;
         this.$schema = $schema;
@@ -256,22 +256,22 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("$ref")
-    public java.lang.String get$ref() {
+    public String get$ref() {
         return $ref;
     }
 
     @JsonProperty("$ref")
-    public void set$ref(java.lang.String $ref) {
+    public void set$ref(String $ref) {
         this.$ref = $ref;
     }
 
     @JsonProperty("$schema")
-    public java.lang.String get$schema() {
+    public String get$schema() {
         return $schema;
     }
 
     @JsonProperty("$schema")
-    public void set$schema(java.lang.String $schema) {
+    public void set$schema(String $schema) {
         this.$schema = $schema;
     }
 
@@ -348,12 +348,12 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("description")
-    public java.lang.String getDescription() {
+    public String getDescription() {
         return description;
     }
 
     @JsonProperty("description")
-    public void setDescription(java.lang.String description) {
+    public void setDescription(String description) {
         this.description = description;
     }
 
@@ -408,22 +408,22 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("format")
-    public java.lang.String getFormat() {
+    public String getFormat() {
         return format;
     }
 
     @JsonProperty("format")
-    public void setFormat(java.lang.String format) {
+    public void setFormat(String format) {
         this.format = format;
     }
 
     @JsonProperty("id")
-    public java.lang.String getId() {
+    public String getId() {
         return id;
     }
 
     @JsonProperty("id")
-    public void setId(java.lang.String id) {
+    public void setId(String id) {
         this.id = id;
     }
 
@@ -559,12 +559,12 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("pattern")
-    public java.lang.String getPattern() {
+    public String getPattern() {
         return pattern;
     }
 
     @JsonProperty("pattern")
-    public void setPattern(java.lang.String pattern) {
+    public void setPattern(String pattern) {
         this.pattern = pattern;
     }
 
@@ -590,32 +590,32 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
 
     @JsonProperty("required")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getRequired() {
+    public List<String> getRequired() {
         return required;
     }
 
     @JsonProperty("required")
-    public void setRequired(List<java.lang.String> required) {
+    public void setRequired(List<String> required) {
         this.required = required;
     }
 
     @JsonProperty("title")
-    public java.lang.String getTitle() {
+    public String getTitle() {
         return title;
     }
 
     @JsonProperty("title")
-    public void setTitle(java.lang.String title) {
+    public void setTitle(String title) {
         this.title = title;
     }
 
     @JsonProperty("type")
-    public java.lang.String getType() {
+    public String getType() {
         return type;
     }
 
     @JsonProperty("type")
-    public void setType(java.lang.String type) {
+    public void setType(String type) {
         this.type = type;
     }
 
@@ -650,32 +650,32 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("x-kubernetes-list-map-keys")
-    public List<java.lang.String> getXKubernetesListMapKeys() {
+    public List<String> getXKubernetesListMapKeys() {
         return xKubernetesListMapKeys;
     }
 
     @JsonProperty("x-kubernetes-list-map-keys")
-    public void setXKubernetesListMapKeys(List<java.lang.String> xKubernetesListMapKeys) {
+    public void setXKubernetesListMapKeys(List<String> xKubernetesListMapKeys) {
         this.xKubernetesListMapKeys = xKubernetesListMapKeys;
     }
 
     @JsonProperty("x-kubernetes-list-type")
-    public java.lang.String getXKubernetesListType() {
+    public String getXKubernetesListType() {
         return xKubernetesListType;
     }
 
     @JsonProperty("x-kubernetes-list-type")
-    public void setXKubernetesListType(java.lang.String xKubernetesListType) {
+    public void setXKubernetesListType(String xKubernetesListType) {
         this.xKubernetesListType = xKubernetesListType;
     }
 
     @JsonProperty("x-kubernetes-map-type")
-    public java.lang.String getXKubernetesMapType() {
+    public String getXKubernetesMapType() {
         return xKubernetesMapType;
     }
 
     @JsonProperty("x-kubernetes-map-type")
-    public void setXKubernetesMapType(java.lang.String xKubernetesMapType) {
+    public void setXKubernetesMapType(String xKubernetesMapType) {
         this.xKubernetesMapType = xKubernetesMapType;
     }
 

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1beta1/JSONSchemaProps.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/generated/java/io/fabric8/kubernetes/api/model/apiextensions/v1beta1/JSONSchemaProps.java
@@ -101,9 +101,9 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
 {
 
     @JsonProperty("$ref")
-    private java.lang.String $ref;
+    private String $ref;
     @JsonProperty("$schema")
-    private java.lang.String $schema;
+    private String $schema;
     @JsonProperty("additionalItems")
     private JSONSchemaPropsOrBool additionalItems;
     @JsonProperty("additionalProperties")
@@ -123,7 +123,7 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, JSONSchemaPropsOrStringArray> dependencies = new LinkedHashMap<String, JSONSchemaPropsOrStringArray>();
     @JsonProperty("description")
-    private java.lang.String description;
+    private String description;
     @JsonProperty("enum")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<JsonNode> _enum = new ArrayList<JsonNode>();
@@ -136,9 +136,9 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     @JsonProperty("externalDocs")
     private ExternalDocumentation externalDocs;
     @JsonProperty("format")
-    private java.lang.String format;
+    private String format;
     @JsonProperty("id")
-    private java.lang.String id;
+    private String id;
     @JsonProperty("items")
     private JSONSchemaPropsOrArray items;
     @JsonProperty("maxItems")
@@ -167,7 +167,7 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<JSONSchemaProps> oneOf = new ArrayList<JSONSchemaProps>();
     @JsonProperty("pattern")
-    private java.lang.String pattern;
+    private String pattern;
     @JsonProperty("patternProperties")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> patternProperties = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps>();
@@ -176,11 +176,11 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     private Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> properties = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps>();
     @JsonProperty("required")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> required = new ArrayList<java.lang.String>();
+    private List<String> required = new ArrayList<String>();
     @JsonProperty("title")
-    private java.lang.String title;
+    private String title;
     @JsonProperty("type")
-    private java.lang.String type;
+    private String type;
     @JsonProperty("uniqueItems")
     private Boolean uniqueItems;
     @JsonProperty("x-kubernetes-embedded-resource")
@@ -189,11 +189,11 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     private Boolean xKubernetesIntOrString;
     @JsonProperty("x-kubernetes-list-map-keys")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> xKubernetesListMapKeys = new ArrayList<java.lang.String>();
+    private List<String> xKubernetesListMapKeys = new ArrayList<String>();
     @JsonProperty("x-kubernetes-list-type")
-    private java.lang.String xKubernetesListType;
+    private String xKubernetesListType;
     @JsonProperty("x-kubernetes-map-type")
-    private java.lang.String xKubernetesMapType;
+    private String xKubernetesMapType;
     @JsonProperty("x-kubernetes-preserve-unknown-fields")
     private Boolean xKubernetesPreserveUnknownFields;
     @JsonProperty("x-kubernetes-validations")
@@ -207,7 +207,7 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     public JSONSchemaProps() {
     }
 
-    public JSONSchemaProps(java.lang.String $ref, java.lang.String $schema, JSONSchemaPropsOrBool additionalItems, JSONSchemaPropsOrBool additionalProperties, List<JSONSchemaProps> allOf, List<JSONSchemaProps> anyOf, JsonNode _default, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> definitions, Map<String, JSONSchemaPropsOrStringArray> dependencies, java.lang.String description, List<JsonNode> _enum, JsonNode example, Boolean exclusiveMaximum, Boolean exclusiveMinimum, ExternalDocumentation externalDocs, java.lang.String format, java.lang.String id, JSONSchemaPropsOrArray items, Long maxItems, Long maxLength, Long maxProperties, Double maximum, Long minItems, Long minLength, Long minProperties, Double minimum, Double multipleOf, JSONSchemaProps not, Boolean nullable, List<JSONSchemaProps> oneOf, java.lang.String pattern, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> patternProperties, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> properties, List<java.lang.String> required, java.lang.String title, java.lang.String type, Boolean uniqueItems, Boolean xKubernetesEmbeddedResource, Boolean xKubernetesIntOrString, List<java.lang.String> xKubernetesListMapKeys, java.lang.String xKubernetesListType, java.lang.String xKubernetesMapType, Boolean xKubernetesPreserveUnknownFields, List<ValidationRule> xKubernetesValidations) {
+    public JSONSchemaProps(String $ref, String $schema, JSONSchemaPropsOrBool additionalItems, JSONSchemaPropsOrBool additionalProperties, List<JSONSchemaProps> allOf, List<JSONSchemaProps> anyOf, JsonNode _default, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> definitions, Map<String, JSONSchemaPropsOrStringArray> dependencies, String description, List<JsonNode> _enum, JsonNode example, Boolean exclusiveMaximum, Boolean exclusiveMinimum, ExternalDocumentation externalDocs, String format, String id, JSONSchemaPropsOrArray items, Long maxItems, Long maxLength, Long maxProperties, Double maximum, Long minItems, Long minLength, Long minProperties, Double minimum, Double multipleOf, JSONSchemaProps not, Boolean nullable, List<JSONSchemaProps> oneOf, String pattern, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> patternProperties, Map<String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps> properties, List<String> required, String title, String type, Boolean uniqueItems, Boolean xKubernetesEmbeddedResource, Boolean xKubernetesIntOrString, List<String> xKubernetesListMapKeys, String xKubernetesListType, String xKubernetesMapType, Boolean xKubernetesPreserveUnknownFields, List<ValidationRule> xKubernetesValidations) {
         super();
         this.$ref = $ref;
         this.$schema = $schema;
@@ -256,22 +256,22 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("$ref")
-    public java.lang.String get$ref() {
+    public String get$ref() {
         return $ref;
     }
 
     @JsonProperty("$ref")
-    public void set$ref(java.lang.String $ref) {
+    public void set$ref(String $ref) {
         this.$ref = $ref;
     }
 
     @JsonProperty("$schema")
-    public java.lang.String get$schema() {
+    public String get$schema() {
         return $schema;
     }
 
     @JsonProperty("$schema")
-    public void set$schema(java.lang.String $schema) {
+    public void set$schema(String $schema) {
         this.$schema = $schema;
     }
 
@@ -348,12 +348,12 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("description")
-    public java.lang.String getDescription() {
+    public String getDescription() {
         return description;
     }
 
     @JsonProperty("description")
-    public void setDescription(java.lang.String description) {
+    public void setDescription(String description) {
         this.description = description;
     }
 
@@ -408,22 +408,22 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("format")
-    public java.lang.String getFormat() {
+    public String getFormat() {
         return format;
     }
 
     @JsonProperty("format")
-    public void setFormat(java.lang.String format) {
+    public void setFormat(String format) {
         this.format = format;
     }
 
     @JsonProperty("id")
-    public java.lang.String getId() {
+    public String getId() {
         return id;
     }
 
     @JsonProperty("id")
-    public void setId(java.lang.String id) {
+    public void setId(String id) {
         this.id = id;
     }
 
@@ -559,12 +559,12 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("pattern")
-    public java.lang.String getPattern() {
+    public String getPattern() {
         return pattern;
     }
 
     @JsonProperty("pattern")
-    public void setPattern(java.lang.String pattern) {
+    public void setPattern(String pattern) {
         this.pattern = pattern;
     }
 
@@ -590,32 +590,32 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
 
     @JsonProperty("required")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getRequired() {
+    public List<String> getRequired() {
         return required;
     }
 
     @JsonProperty("required")
-    public void setRequired(List<java.lang.String> required) {
+    public void setRequired(List<String> required) {
         this.required = required;
     }
 
     @JsonProperty("title")
-    public java.lang.String getTitle() {
+    public String getTitle() {
         return title;
     }
 
     @JsonProperty("title")
-    public void setTitle(java.lang.String title) {
+    public void setTitle(String title) {
         this.title = title;
     }
 
     @JsonProperty("type")
-    public java.lang.String getType() {
+    public String getType() {
         return type;
     }
 
     @JsonProperty("type")
-    public void setType(java.lang.String type) {
+    public void setType(String type) {
         this.type = type;
     }
 
@@ -650,32 +650,32 @@ public class JSONSchemaProps implements Editable<JSONSchemaPropsBuilder> , Kuber
     }
 
     @JsonProperty("x-kubernetes-list-map-keys")
-    public List<java.lang.String> getXKubernetesListMapKeys() {
+    public List<String> getXKubernetesListMapKeys() {
         return xKubernetesListMapKeys;
     }
 
     @JsonProperty("x-kubernetes-list-map-keys")
-    public void setXKubernetesListMapKeys(List<java.lang.String> xKubernetesListMapKeys) {
+    public void setXKubernetesListMapKeys(List<String> xKubernetesListMapKeys) {
         this.xKubernetesListMapKeys = xKubernetesListMapKeys;
     }
 
     @JsonProperty("x-kubernetes-list-type")
-    public java.lang.String getXKubernetesListType() {
+    public String getXKubernetesListType() {
         return xKubernetesListType;
     }
 
     @JsonProperty("x-kubernetes-list-type")
-    public void setXKubernetesListType(java.lang.String xKubernetesListType) {
+    public void setXKubernetesListType(String xKubernetesListType) {
         this.xKubernetesListType = xKubernetesListType;
     }
 
     @JsonProperty("x-kubernetes-map-type")
-    public java.lang.String getXKubernetesMapType() {
+    public String getXKubernetesMapType() {
         return xKubernetesMapType;
     }
 
     @JsonProperty("x-kubernetes-map-type")
-    public void setXKubernetesMapType(java.lang.String xKubernetesMapType) {
+    public void setXKubernetesMapType(String xKubernetesMapType) {
         this.xKubernetesMapType = xKubernetesMapType;
     }
 

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/kube-schema.json
@@ -498,7 +498,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
         },
         "dependencies": {
           "type": "object",
@@ -506,7 +506,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaPropsOrStringArray",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray\u003e"
         },
         "description": {
           "type": "string"
@@ -600,7 +600,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
         },
         "properties": {
           "type": "object",
@@ -608,7 +608,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
         },
         "required": {
           "type": "array",
@@ -1272,7 +1272,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "dependencies": {
           "type": "object",
@@ -1280,7 +1280,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaPropsOrStringArray",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray\u003e"
         },
         "description": {
           "type": "string"
@@ -1374,7 +1374,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "properties": {
           "type": "object",
@@ -1382,7 +1382,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "required": {
           "type": "array",
@@ -1922,7 +1922,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1955,7 +1955,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/main/resources/schema/validation-schema.json
@@ -498,7 +498,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
         },
         "dependencies": {
           "type": "object",
@@ -506,7 +506,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaPropsOrStringArray",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray\u003e"
         },
         "description": {
           "type": "string"
@@ -600,7 +600,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
         },
         "properties": {
           "type": "object",
@@ -608,7 +608,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
         },
         "required": {
           "type": "array",
@@ -1272,7 +1272,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "dependencies": {
           "type": "object",
@@ -1280,7 +1280,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaPropsOrStringArray",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray\u003e"
         },
         "description": {
           "type": "string"
@@ -1374,7 +1374,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "properties": {
           "type": "object",
@@ -1382,7 +1382,7 @@
             "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
             "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "required": {
           "type": "array",
@@ -1922,7 +1922,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1955,7 +1955,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -2634,13 +2634,13 @@
     },
     "customresourcecolumndefinition": {
       "properties": {
+        "JSONPath": {
+          "type": "string"
+        },
         "description": {
           "type": "string"
         },
         "format": {
-          "type": "string"
-        },
-        "jsonPath": {
           "type": "string"
         },
         "name": {
@@ -2781,24 +2781,16 @@
     },
     "customresourcedefinitionspec": {
       "properties": {
-        "additionalPrinterColumns": {
-          "type": "array",
-          "javaOmitEmpty": true,
-          "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceColumnDefinition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceColumnDefinition"
-          }
-        },
         "conversion": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceConversion",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceConversion"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceConversion",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceConversion"
         },
         "group": {
           "type": "string"
         },
         "names": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceDefinitionNames",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionNames"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceDefinitionNames",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionNames"
         },
         "preserveUnknownFields": {
           "type": "boolean"
@@ -2806,31 +2798,11 @@
         "scope": {
           "type": "string"
         },
-        "selectableFields": {
-          "type": "array",
-          "javaOmitEmpty": true,
-          "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_SelectableField",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.SelectableField"
-          }
-        },
-        "subresources": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceSubresources",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresources"
-        },
-        "validation": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceValidation",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceValidation"
-        },
-        "version": {
-          "type": "string"
-        },
         "versions": {
           "type": "array",
-          "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceDefinitionVersion",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionVersion"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceDefinitionVersion",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionVersion"
           }
         }
       },
@@ -2864,8 +2836,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceColumnDefinition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceColumnDefinition"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceColumnDefinition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceColumnDefinition"
           }
         },
         "deprecated": {
@@ -2878,15 +2850,15 @@
           "type": "string"
         },
         "schema": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceValidation",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceValidation"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceValidation",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceValidation"
         },
         "selectableFields": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_SelectableField",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.SelectableField"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_SelectableField",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.SelectableField"
           }
         },
         "served": {
@@ -2896,8 +2868,8 @@
           "type": "boolean"
         },
         "subresources": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceSubresources",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceSubresources"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceSubresources",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresources"
         }
       },
       "additionalProperties": true
@@ -2905,12 +2877,12 @@
     "customresourcesubresources": {
       "properties": {
         "scale": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceSubresourceScale",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceSubresourceScale"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceSubresourceScale",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresourceScale"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_CustomResourceSubresourceStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceSubresourceStatus"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_CustomResourceSubresourceStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceSubresourceStatus"
         }
       },
       "additionalProperties": true
@@ -3064,48 +3036,48 @@
           "type": "string"
         },
         "additionalItems": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaPropsOrBool",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrBool"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaPropsOrBool",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrBool"
         },
         "additionalProperties": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaPropsOrBool",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrBool"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaPropsOrBool",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrBool"
         },
         "allOf": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           }
         },
         "anyOf": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           }
         },
         "default": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_JSON",
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSON",
           "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "definitions": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "dependencies": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaPropsOrStringArray",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaPropsOrStringArray",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrStringArray\u003e"
         },
         "description": {
           "type": "string"
@@ -3114,12 +3086,12 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSON",
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSON",
             "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
           }
         },
         "example": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_JSON",
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSON",
           "existingJavaType": "com.fasterxml.jackson.databind.JsonNode"
         },
         "exclusiveMaximum": {
@@ -3129,8 +3101,8 @@
           "type": "boolean"
         },
         "externalDocs": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_ExternalDocumentation",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.ExternalDocumentation"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_ExternalDocumentation",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.ExternalDocumentation"
         },
         "format": {
           "type": "string"
@@ -3139,8 +3111,8 @@
           "type": "string"
         },
         "items": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaPropsOrArray",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrArray"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaPropsOrArray",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaPropsOrArray"
         },
         "maxItems": {
           "type": "integer",
@@ -3176,8 +3148,8 @@
           "type": "number"
         },
         "not": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
         },
         "nullable": {
           "type": "boolean"
@@ -3186,8 +3158,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           }
         },
         "pattern": {
@@ -3196,18 +3168,18 @@
         "patternProperties": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "properties": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps\u003e"
         },
         "required": {
           "type": "array",
@@ -3251,8 +3223,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_ValidationRule",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.ValidationRule"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_ValidationRule",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.ValidationRule"
           }
         }
       },
@@ -3263,13 +3235,13 @@
         "JSONSchemas": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
           }
         },
         "Schema": {
-          "$ref": "#/definitions/kubernetes_apiextensions_v1_JSONSchemaProps",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps"
+          "$ref": "#/definitions/kubernetes_apiextensions_v1beta1_JSONSchemaProps",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps"
         }
       },
       "additionalProperties": true
@@ -3427,7 +3399,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -3460,7 +3432,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-apps/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/main/resources/schema/kube-schema.json
@@ -252,7 +252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -432,7 +432,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -465,7 +465,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1931,7 +1931,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -1964,7 +1964,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2261,14 +2261,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "data": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -2718,7 +2718,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "containerID": {
           "type": "string"
@@ -3410,7 +3410,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3440,7 +3440,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3863,7 +3863,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "defaultRequest": {
           "type": "object",
@@ -3871,7 +3871,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "max": {
           "type": "object",
@@ -3879,7 +3879,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "maxLimitRequestRatio": {
           "type": "object",
@@ -3887,7 +3887,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "min": {
           "type": "object",
@@ -3895,7 +3895,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "type": {
           "type": "string"
@@ -4532,7 +4532,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4540,7 +4540,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -4877,7 +4877,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -4885,7 +4885,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4893,7 +4893,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -5112,7 +5112,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -5731,7 +5731,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -5743,7 +5743,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -6369,7 +6369,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "template": {
           "$ref": "#/definitions/kubernetes_core_PodTemplateSpec",
@@ -6523,7 +6523,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -6552,7 +6552,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -6560,7 +6560,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6586,7 +6586,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -6594,7 +6594,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6777,7 +6777,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -6796,7 +6796,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -7262,7 +7262,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sessionAffinity": {
           "type": "string"
@@ -7801,7 +7801,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -7809,7 +7809,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/kubernetes-model-apps/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/main/resources/schema/validation-schema.json
@@ -252,7 +252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -432,7 +432,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -465,7 +465,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1931,7 +1931,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -1964,7 +1964,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2261,14 +2261,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "data": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -2718,7 +2718,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "containerID": {
           "type": "string"
@@ -3410,7 +3410,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3440,7 +3440,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3863,7 +3863,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "defaultRequest": {
           "type": "object",
@@ -3871,7 +3871,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "max": {
           "type": "object",
@@ -3879,7 +3879,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "maxLimitRequestRatio": {
           "type": "object",
@@ -3887,7 +3887,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "min": {
           "type": "object",
@@ -3895,7 +3895,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "type": {
           "type": "string"
@@ -4532,7 +4532,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4540,7 +4540,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -4877,7 +4877,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -4885,7 +4885,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4893,7 +4893,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -5112,7 +5112,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -5731,7 +5731,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -5743,7 +5743,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -6369,7 +6369,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "template": {
           "$ref": "#/definitions/kubernetes_core_PodTemplateSpec",
@@ -6523,7 +6523,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -6552,7 +6552,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -6560,7 +6560,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6586,7 +6586,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -6594,7 +6594,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6777,7 +6777,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -6796,7 +6796,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -7262,7 +7262,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sessionAffinity": {
           "type": "string"
@@ -7801,7 +7801,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -7809,7 +7809,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -8683,14 +8683,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "data": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -9063,7 +9063,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "containerID": {
           "type": "string"
@@ -9228,7 +9228,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -9256,7 +9256,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -10154,7 +10154,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -10179,7 +10179,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -10537,7 +10537,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -10625,7 +10625,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "defaultRequest": {
           "type": "object",
@@ -10633,7 +10633,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "max": {
           "type": "object",
@@ -10641,7 +10641,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "maxLimitRequestRatio": {
           "type": "object",
@@ -10649,7 +10649,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "min": {
           "type": "object",
@@ -10657,7 +10657,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "type": {
           "type": "string"
@@ -11270,7 +11270,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -11278,7 +11278,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -11390,7 +11390,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -11423,7 +11423,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -11703,7 +11703,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -11711,7 +11711,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -11719,7 +11719,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -11912,7 +11912,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -12439,7 +12439,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -12451,7 +12451,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -13132,7 +13132,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "template": {
           "$ref": "#/definitions/kubernetes_core_PodTemplateSpec",
@@ -13254,7 +13254,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -13278,7 +13278,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -13286,7 +13286,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -13307,7 +13307,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -13315,7 +13315,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -13495,7 +13495,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -13514,7 +13514,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -13932,7 +13932,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sessionAffinity": {
           "type": "string"
@@ -14694,7 +14694,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -14702,7 +14702,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/kube-schema.json
@@ -209,7 +209,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -389,7 +389,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -422,7 +422,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
@@ -209,7 +209,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -389,7 +389,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -422,7 +422,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -2767,8 +2767,8 @@
           "type": "string"
         },
         "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
         }
       },
       "additionalProperties": true
@@ -2872,12 +2872,12 @@
     "externalmetricsource": {
       "properties": {
         "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
         },
         "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
         }
       },
       "additionalProperties": true
@@ -2992,14 +2992,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "autoscaling/v2beta2",
+          "default": "autoscaling/v2",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscaler",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscaler"
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscaler",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler"
           }
         },
         "kind": {
@@ -3017,8 +3017,8 @@
     "horizontalpodautoscalerspec": {
       "properties": {
         "behavior": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerBehavior",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerBehavior"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscalerBehavior",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior"
         },
         "maxReplicas": {
           "type": "integer"
@@ -3027,16 +3027,16 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricSpec",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricSpec"
+            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricSpec",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricSpec"
           }
         },
         "minReplicas": {
           "type": "integer"
         },
         "scaleTargetRef": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.CrossVersionObjectReference"
         }
       },
       "additionalProperties": true
@@ -3046,15 +3046,15 @@
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_HorizontalPodAutoscalerCondition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscalerCondition"
+            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscalerCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerCondition"
           }
         },
         "currentMetrics": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_MetricStatus",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.MetricStatus"
+            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricStatus",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricStatus"
           }
         },
         "currentReplicas": {
@@ -3154,7 +3154,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -3311,24 +3311,24 @@
     "metricspec": {
       "properties": {
         "containerResource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ContainerResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ContainerResourceMetricSource"
         },
         "external": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ExternalMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ExternalMetricSource"
         },
         "object": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ObjectMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ObjectMetricSource"
         },
         "pods": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_PodsMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.PodsMetricSource"
         },
         "resource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ResourceMetricSource"
         },
         "type": {
           "type": "string"
@@ -3406,7 +3406,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -3439,7 +3439,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -3479,17 +3479,24 @@
     },
     "objectmetricsource": {
       "properties": {
-        "describedObject": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_CrossVersionObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.CrossVersionObjectReference"
+        "averageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
         },
-        "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
+        "metricName": {
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
         },
         "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.CrossVersionObjectReference"
+        },
+        "targetValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
         }
       },
       "additionalProperties": true
@@ -3570,29 +3577,29 @@
     },
     "podsmetricsource": {
       "properties": {
-        "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
-        },
-        "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
-        }
-      },
-      "additionalProperties": true
-    },
-    "podsmetricstatus": {
-      "properties": {
-        "currentAverageValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
-        },
         "metricName": {
           "type": "string"
         },
         "selector": {
           "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
           "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        },
+        "targetAverageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        }
+      },
+      "additionalProperties": true
+    },
+    "podsmetricstatus": {
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
         }
       },
       "additionalProperties": true
@@ -3624,9 +3631,12 @@
         "name": {
           "type": "string"
         },
-        "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+        "targetAverageUtilization": {
+          "type": "integer"
+        },
+        "targetAverageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/kubernetes-model-batch/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/main/resources/schema/kube-schema.json
@@ -222,7 +222,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -402,7 +402,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -435,7 +435,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1579,7 +1579,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2447,7 +2447,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3355,7 +3355,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -3367,7 +3367,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3755,7 +3755,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3763,7 +3763,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4406,7 +4406,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -4414,7 +4414,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/kubernetes-model-batch/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-batch/src/main/resources/schema/validation-schema.json
@@ -222,7 +222,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -402,7 +402,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -435,7 +435,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1579,7 +1579,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2447,7 +2447,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3355,7 +3355,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -3367,7 +3367,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3755,7 +3755,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3763,7 +3763,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4406,7 +4406,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -4414,7 +4414,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -5324,7 +5324,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -5788,7 +5788,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -6273,7 +6273,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -6557,7 +6557,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -6590,7 +6590,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -7138,7 +7138,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -7150,7 +7150,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -7499,7 +7499,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -7507,7 +7507,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -8228,7 +8228,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -8236,7 +8236,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1/CertificateSigningRequestSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1/CertificateSigningRequestSpec.java
@@ -72,20 +72,20 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
     private Map<String, ArrayList<String>> extra = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> groups = new ArrayList<java.lang.String>();
+    private List<String> groups = new ArrayList<String>();
     @JsonProperty("request")
-    private java.lang.String request;
+    private String request;
     @JsonProperty("signerName")
-    private java.lang.String signerName;
+    private String signerName;
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("usages")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> usages = new ArrayList<java.lang.String>();
+    private List<String> usages = new ArrayList<String>();
     @JsonProperty("username")
-    private java.lang.String username;
+    private String username;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -94,7 +94,7 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
     public CertificateSigningRequestSpec() {
     }
 
-    public CertificateSigningRequestSpec(Integer expirationSeconds, Map<String, ArrayList<String>> extra, List<java.lang.String> groups, java.lang.String request, java.lang.String signerName, java.lang.String uid, List<java.lang.String> usages, java.lang.String username) {
+    public CertificateSigningRequestSpec(Integer expirationSeconds, Map<String, ArrayList<String>> extra, List<String> groups, String request, String signerName, String uid, List<String> usages, String username) {
         super();
         this.expirationSeconds = expirationSeconds;
         this.extra = extra;
@@ -128,63 +128,63 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
 
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getGroups() {
+    public List<String> getGroups() {
         return groups;
     }
 
     @JsonProperty("groups")
-    public void setGroups(List<java.lang.String> groups) {
+    public void setGroups(List<String> groups) {
         this.groups = groups;
     }
 
     @JsonProperty("request")
-    public java.lang.String getRequest() {
+    public String getRequest() {
         return request;
     }
 
     @JsonProperty("request")
-    public void setRequest(java.lang.String request) {
+    public void setRequest(String request) {
         this.request = request;
     }
 
     @JsonProperty("signerName")
-    public java.lang.String getSignerName() {
+    public String getSignerName() {
         return signerName;
     }
 
     @JsonProperty("signerName")
-    public void setSignerName(java.lang.String signerName) {
+    public void setSignerName(String signerName) {
         this.signerName = signerName;
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("usages")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getUsages() {
+    public List<String> getUsages() {
         return usages;
     }
 
     @JsonProperty("usages")
-    public void setUsages(List<java.lang.String> usages) {
+    public void setUsages(List<String> usages) {
         this.usages = usages;
     }
 
     @JsonProperty("username")
-    public java.lang.String getUsername() {
+    public String getUsername() {
         return username;
     }
 
     @JsonProperty("username")
-    public void setUsername(java.lang.String username) {
+    public void setUsername(String username) {
         this.username = username;
     }
 
@@ -199,12 +199,12 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1beta1/CertificateSigningRequestSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-certificates/src/generated/java/io/fabric8/kubernetes/api/model/certificates/v1beta1/CertificateSigningRequestSpec.java
@@ -72,20 +72,20 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
     private Map<String, ArrayList<String>> extra = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> groups = new ArrayList<java.lang.String>();
+    private List<String> groups = new ArrayList<String>();
     @JsonProperty("request")
-    private java.lang.String request;
+    private String request;
     @JsonProperty("signerName")
-    private java.lang.String signerName;
+    private String signerName;
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("usages")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> usages = new ArrayList<java.lang.String>();
+    private List<String> usages = new ArrayList<String>();
     @JsonProperty("username")
-    private java.lang.String username;
+    private String username;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -94,7 +94,7 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
     public CertificateSigningRequestSpec() {
     }
 
-    public CertificateSigningRequestSpec(Integer expirationSeconds, Map<String, ArrayList<String>> extra, List<java.lang.String> groups, java.lang.String request, java.lang.String signerName, java.lang.String uid, List<java.lang.String> usages, java.lang.String username) {
+    public CertificateSigningRequestSpec(Integer expirationSeconds, Map<String, ArrayList<String>> extra, List<String> groups, String request, String signerName, String uid, List<String> usages, String username) {
         super();
         this.expirationSeconds = expirationSeconds;
         this.extra = extra;
@@ -128,63 +128,63 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
 
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getGroups() {
+    public List<String> getGroups() {
         return groups;
     }
 
     @JsonProperty("groups")
-    public void setGroups(List<java.lang.String> groups) {
+    public void setGroups(List<String> groups) {
         this.groups = groups;
     }
 
     @JsonProperty("request")
-    public java.lang.String getRequest() {
+    public String getRequest() {
         return request;
     }
 
     @JsonProperty("request")
-    public void setRequest(java.lang.String request) {
+    public void setRequest(String request) {
         this.request = request;
     }
 
     @JsonProperty("signerName")
-    public java.lang.String getSignerName() {
+    public String getSignerName() {
         return signerName;
     }
 
     @JsonProperty("signerName")
-    public void setSignerName(java.lang.String signerName) {
+    public void setSignerName(String signerName) {
         this.signerName = signerName;
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("usages")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getUsages() {
+    public List<String> getUsages() {
         return usages;
     }
 
     @JsonProperty("usages")
-    public void setUsages(List<java.lang.String> usages) {
+    public void setUsages(List<String> usages) {
         this.usages = usages;
     }
 
     @JsonProperty("username")
-    public java.lang.String getUsername() {
+    public String getUsername() {
         return username;
     }
 
     @JsonProperty("username")
-    public void setUsername(java.lang.String username) {
+    public void setUsername(String username) {
         this.username = username;
     }
 
@@ -199,12 +199,12 @@ public class CertificateSigningRequestSpec implements Editable<CertificateSignin
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-certificates/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-certificates/src/main/resources/schema/kube-schema.json
@@ -354,7 +354,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -387,7 +387,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -856,7 +856,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -1096,7 +1096,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-certificates/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-certificates/src/main/resources/schema/validation-schema.json
@@ -354,7 +354,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -387,7 +387,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -856,7 +856,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -1096,7 +1096,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -1337,7 +1337,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "certificates.k8s.io/v1beta1",
+          "default": "certificates.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -1350,12 +1350,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_certificates_v1beta1_CertificateSigningRequestSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestSpec"
+          "$ref": "#/definitions/kubernetes_certificates_v1_CertificateSigningRequestSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestSpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_certificates_v1beta1_CertificateSigningRequestStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.certificates.v1beta1.CertificateSigningRequestStatus"
+          "$ref": "#/definitions/kubernetes_certificates_v1_CertificateSigningRequestStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.certificates.v1.CertificateSigningRequestStatus"
         }
       },
       "additionalProperties": true
@@ -1424,7 +1424,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -1785,7 +1785,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1818,7 +1818,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-coordination/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-coordination/src/main/resources/schema/kube-schema.json
@@ -367,7 +367,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -400,7 +400,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-coordination/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-coordination/src/main/resources/schema/validation-schema.json
@@ -367,7 +367,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -400,7 +400,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1323,7 +1323,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1356,7 +1356,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/AuthInfo.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/AuthInfo.java
@@ -52,40 +52,40 @@ public class AuthInfo implements Editable<AuthInfoBuilder> , KubernetesResource
 {
 
     @JsonProperty("as")
-    private java.lang.String as;
+    private String as;
     @JsonProperty("as-groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> asGroups = new ArrayList<java.lang.String>();
+    private List<String> asGroups = new ArrayList<String>();
     @JsonProperty("as-uid")
-    private java.lang.String asUid;
+    private String asUid;
     @JsonProperty("as-user-extra")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, ArrayList<String>> asUserExtra = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("auth-provider")
     private AuthProviderConfig authProvider;
     @JsonProperty("client-certificate")
-    private java.lang.String clientCertificate;
+    private String clientCertificate;
     @JsonProperty("client-certificate-data")
-    private java.lang.String clientCertificateData;
+    private String clientCertificateData;
     @JsonProperty("client-key")
-    private java.lang.String clientKey;
+    private String clientKey;
     @JsonProperty("client-key-data")
-    private java.lang.String clientKeyData;
+    private String clientKeyData;
     @JsonProperty("exec")
     private ExecConfig exec;
     @JsonProperty("extensions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<NamedExtension> extensions = new ArrayList<NamedExtension>();
     @JsonProperty("password")
-    private java.lang.String password;
+    private String password;
     @JsonProperty("token")
-    private java.lang.String token;
+    private String token;
     @JsonProperty("tokenFile")
-    private java.lang.String tokenFile;
+    private String tokenFile;
     @JsonProperty("username")
-    private java.lang.String username;
+    private String username;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -94,7 +94,7 @@ public class AuthInfo implements Editable<AuthInfoBuilder> , KubernetesResource
     public AuthInfo() {
     }
 
-    public AuthInfo(java.lang.String as, List<java.lang.String> asGroups, java.lang.String asUid, Map<String, ArrayList<String>> asUserExtra, AuthProviderConfig authProvider, java.lang.String clientCertificate, java.lang.String clientCertificateData, java.lang.String clientKey, java.lang.String clientKeyData, ExecConfig exec, List<NamedExtension> extensions, java.lang.String password, java.lang.String token, java.lang.String tokenFile, java.lang.String username) {
+    public AuthInfo(String as, List<String> asGroups, String asUid, Map<String, ArrayList<String>> asUserExtra, AuthProviderConfig authProvider, String clientCertificate, String clientCertificateData, String clientKey, String clientKeyData, ExecConfig exec, List<NamedExtension> extensions, String password, String token, String tokenFile, String username) {
         super();
         this.as = as;
         this.asGroups = asGroups;
@@ -114,32 +114,32 @@ public class AuthInfo implements Editable<AuthInfoBuilder> , KubernetesResource
     }
 
     @JsonProperty("as")
-    public java.lang.String getAs() {
+    public String getAs() {
         return as;
     }
 
     @JsonProperty("as")
-    public void setAs(java.lang.String as) {
+    public void setAs(String as) {
         this.as = as;
     }
 
     @JsonProperty("as-groups")
-    public List<java.lang.String> getAsGroups() {
+    public List<String> getAsGroups() {
         return asGroups;
     }
 
     @JsonProperty("as-groups")
-    public void setAsGroups(List<java.lang.String> asGroups) {
+    public void setAsGroups(List<String> asGroups) {
         this.asGroups = asGroups;
     }
 
     @JsonProperty("as-uid")
-    public java.lang.String getAsUid() {
+    public String getAsUid() {
         return asUid;
     }
 
     @JsonProperty("as-uid")
-    public void setAsUid(java.lang.String asUid) {
+    public void setAsUid(String asUid) {
         this.asUid = asUid;
     }
 
@@ -164,42 +164,42 @@ public class AuthInfo implements Editable<AuthInfoBuilder> , KubernetesResource
     }
 
     @JsonProperty("client-certificate")
-    public java.lang.String getClientCertificate() {
+    public String getClientCertificate() {
         return clientCertificate;
     }
 
     @JsonProperty("client-certificate")
-    public void setClientCertificate(java.lang.String clientCertificate) {
+    public void setClientCertificate(String clientCertificate) {
         this.clientCertificate = clientCertificate;
     }
 
     @JsonProperty("client-certificate-data")
-    public java.lang.String getClientCertificateData() {
+    public String getClientCertificateData() {
         return clientCertificateData;
     }
 
     @JsonProperty("client-certificate-data")
-    public void setClientCertificateData(java.lang.String clientCertificateData) {
+    public void setClientCertificateData(String clientCertificateData) {
         this.clientCertificateData = clientCertificateData;
     }
 
     @JsonProperty("client-key")
-    public java.lang.String getClientKey() {
+    public String getClientKey() {
         return clientKey;
     }
 
     @JsonProperty("client-key")
-    public void setClientKey(java.lang.String clientKey) {
+    public void setClientKey(String clientKey) {
         this.clientKey = clientKey;
     }
 
     @JsonProperty("client-key-data")
-    public java.lang.String getClientKeyData() {
+    public String getClientKeyData() {
         return clientKeyData;
     }
 
     @JsonProperty("client-key-data")
-    public void setClientKeyData(java.lang.String clientKeyData) {
+    public void setClientKeyData(String clientKeyData) {
         this.clientKeyData = clientKeyData;
     }
 
@@ -225,42 +225,42 @@ public class AuthInfo implements Editable<AuthInfoBuilder> , KubernetesResource
     }
 
     @JsonProperty("password")
-    public java.lang.String getPassword() {
+    public String getPassword() {
         return password;
     }
 
     @JsonProperty("password")
-    public void setPassword(java.lang.String password) {
+    public void setPassword(String password) {
         this.password = password;
     }
 
     @JsonProperty("token")
-    public java.lang.String getToken() {
+    public String getToken() {
         return token;
     }
 
     @JsonProperty("token")
-    public void setToken(java.lang.String token) {
+    public void setToken(String token) {
         this.token = token;
     }
 
     @JsonProperty("tokenFile")
-    public java.lang.String getTokenFile() {
+    public String getTokenFile() {
         return tokenFile;
     }
 
     @JsonProperty("tokenFile")
-    public void setTokenFile(java.lang.String tokenFile) {
+    public void setTokenFile(String tokenFile) {
         this.tokenFile = tokenFile;
     }
 
     @JsonProperty("username")
-    public java.lang.String getUsername() {
+    public String getUsername() {
         return username;
     }
 
     @JsonProperty("username")
-    public void setUsername(java.lang.String username) {
+    public void setUsername(String username) {
         this.username = username;
     }
 
@@ -275,12 +275,12 @@ public class AuthInfo implements Editable<AuthInfoBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/AuthProviderConfig.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/AuthProviderConfig.java
@@ -40,9 +40,9 @@ public class AuthProviderConfig implements Editable<AuthProviderConfigBuilder> ,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> config = new LinkedHashMap<String, String>();
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -51,7 +51,7 @@ public class AuthProviderConfig implements Editable<AuthProviderConfigBuilder> ,
     public AuthProviderConfig() {
     }
 
-    public AuthProviderConfig(Map<String, String> config, java.lang.String name) {
+    public AuthProviderConfig(Map<String, String> config, String name) {
         super();
         this.config = config;
         this.name = name;
@@ -68,12 +68,12 @@ public class AuthProviderConfig implements Editable<AuthProviderConfigBuilder> ,
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -88,12 +88,12 @@ public class AuthProviderConfig implements Editable<AuthProviderConfigBuilder> ,
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/CSIPersistentVolumeSource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/CSIPersistentVolumeSource.java
@@ -49,9 +49,9 @@ public class CSIPersistentVolumeSource implements Editable<CSIPersistentVolumeSo
     @JsonProperty("controllerPublishSecretRef")
     private SecretReference controllerPublishSecretRef;
     @JsonProperty("driver")
-    private java.lang.String driver;
+    private String driver;
     @JsonProperty("fsType")
-    private java.lang.String fsType;
+    private String fsType;
     @JsonProperty("nodeExpandSecretRef")
     private SecretReference nodeExpandSecretRef;
     @JsonProperty("nodePublishSecretRef")
@@ -64,9 +64,9 @@ public class CSIPersistentVolumeSource implements Editable<CSIPersistentVolumeSo
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> volumeAttributes = new LinkedHashMap<String, String>();
     @JsonProperty("volumeHandle")
-    private java.lang.String volumeHandle;
+    private String volumeHandle;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -75,7 +75,7 @@ public class CSIPersistentVolumeSource implements Editable<CSIPersistentVolumeSo
     public CSIPersistentVolumeSource() {
     }
 
-    public CSIPersistentVolumeSource(SecretReference controllerExpandSecretRef, SecretReference controllerPublishSecretRef, java.lang.String driver, java.lang.String fsType, SecretReference nodeExpandSecretRef, SecretReference nodePublishSecretRef, SecretReference nodeStageSecretRef, Boolean readOnly, Map<String, String> volumeAttributes, java.lang.String volumeHandle) {
+    public CSIPersistentVolumeSource(SecretReference controllerExpandSecretRef, SecretReference controllerPublishSecretRef, String driver, String fsType, SecretReference nodeExpandSecretRef, SecretReference nodePublishSecretRef, SecretReference nodeStageSecretRef, Boolean readOnly, Map<String, String> volumeAttributes, String volumeHandle) {
         super();
         this.controllerExpandSecretRef = controllerExpandSecretRef;
         this.controllerPublishSecretRef = controllerPublishSecretRef;
@@ -110,22 +110,22 @@ public class CSIPersistentVolumeSource implements Editable<CSIPersistentVolumeSo
     }
 
     @JsonProperty("driver")
-    public java.lang.String getDriver() {
+    public String getDriver() {
         return driver;
     }
 
     @JsonProperty("driver")
-    public void setDriver(java.lang.String driver) {
+    public void setDriver(String driver) {
         this.driver = driver;
     }
 
     @JsonProperty("fsType")
-    public java.lang.String getFsType() {
+    public String getFsType() {
         return fsType;
     }
 
     @JsonProperty("fsType")
-    public void setFsType(java.lang.String fsType) {
+    public void setFsType(String fsType) {
         this.fsType = fsType;
     }
 
@@ -180,12 +180,12 @@ public class CSIPersistentVolumeSource implements Editable<CSIPersistentVolumeSo
     }
 
     @JsonProperty("volumeHandle")
-    public java.lang.String getVolumeHandle() {
+    public String getVolumeHandle() {
         return volumeHandle;
     }
 
     @JsonProperty("volumeHandle")
-    public void setVolumeHandle(java.lang.String volumeHandle) {
+    public void setVolumeHandle(String volumeHandle) {
         this.volumeHandle = volumeHandle;
     }
 
@@ -200,12 +200,12 @@ public class CSIPersistentVolumeSource implements Editable<CSIPersistentVolumeSo
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/CSIVolumeSource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/CSIVolumeSource.java
@@ -40,9 +40,9 @@ public class CSIVolumeSource implements Editable<CSIVolumeSourceBuilder> , Kuber
 {
 
     @JsonProperty("driver")
-    private java.lang.String driver;
+    private String driver;
     @JsonProperty("fsType")
-    private java.lang.String fsType;
+    private String fsType;
     @JsonProperty("nodePublishSecretRef")
     private LocalObjectReference nodePublishSecretRef;
     @JsonProperty("readOnly")
@@ -51,7 +51,7 @@ public class CSIVolumeSource implements Editable<CSIVolumeSourceBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> volumeAttributes = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -60,7 +60,7 @@ public class CSIVolumeSource implements Editable<CSIVolumeSourceBuilder> , Kuber
     public CSIVolumeSource() {
     }
 
-    public CSIVolumeSource(java.lang.String driver, java.lang.String fsType, LocalObjectReference nodePublishSecretRef, Boolean readOnly, Map<String, String> volumeAttributes) {
+    public CSIVolumeSource(String driver, String fsType, LocalObjectReference nodePublishSecretRef, Boolean readOnly, Map<String, String> volumeAttributes) {
         super();
         this.driver = driver;
         this.fsType = fsType;
@@ -70,22 +70,22 @@ public class CSIVolumeSource implements Editable<CSIVolumeSourceBuilder> , Kuber
     }
 
     @JsonProperty("driver")
-    public java.lang.String getDriver() {
+    public String getDriver() {
         return driver;
     }
 
     @JsonProperty("driver")
-    public void setDriver(java.lang.String driver) {
+    public void setDriver(String driver) {
         this.driver = driver;
     }
 
     @JsonProperty("fsType")
-    public java.lang.String getFsType() {
+    public String getFsType() {
         return fsType;
     }
 
     @JsonProperty("fsType")
-    public void setFsType(java.lang.String fsType) {
+    public void setFsType(String fsType) {
         this.fsType = fsType;
     }
 
@@ -130,12 +130,12 @@ public class CSIVolumeSource implements Editable<CSIVolumeSourceBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ConfigMap.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ConfigMap.java
@@ -55,7 +55,7 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "v1";
+    private String apiVersion = "v1";
     @JsonProperty("binaryData")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> binaryData = new LinkedHashMap<String, String>();
@@ -70,11 +70,11 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "ConfigMap";
+    private String kind = "ConfigMap";
     @JsonProperty("metadata")
     private ObjectMeta metadata;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -83,7 +83,7 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
     public ConfigMap() {
     }
 
-    public ConfigMap(java.lang.String apiVersion, Map<String, String> binaryData, Map<String, String> data, Boolean immutable, java.lang.String kind, ObjectMeta metadata) {
+    public ConfigMap(String apiVersion, Map<String, String> binaryData, Map<String, String> data, Boolean immutable, String kind, ObjectMeta metadata) {
         super();
         this.apiVersion = apiVersion;
         this.binaryData = binaryData;
@@ -99,7 +99,7 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -109,7 +109,7 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
@@ -149,7 +149,7 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -159,7 +159,7 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -184,12 +184,12 @@ public class ConfigMap implements Editable<ConfigMapBuilder> , HasMetadata, Name
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ContainerStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ContainerStatus.java
@@ -52,15 +52,15 @@ public class ContainerStatus implements Editable<ContainerStatusBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Quantity> allocatedResources = new LinkedHashMap<String, Quantity>();
     @JsonProperty("containerID")
-    private java.lang.String containerID;
+    private String containerID;
     @JsonProperty("image")
-    private java.lang.String image;
+    private String image;
     @JsonProperty("imageID")
-    private java.lang.String imageID;
+    private String imageID;
     @JsonProperty("lastState")
     private ContainerState lastState;
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("ready")
     private Boolean ready;
     @JsonProperty("resources")
@@ -75,7 +75,7 @@ public class ContainerStatus implements Editable<ContainerStatusBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<VolumeMountStatus> volumeMounts = new ArrayList<VolumeMountStatus>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -84,7 +84,7 @@ public class ContainerStatus implements Editable<ContainerStatusBuilder> , Kuber
     public ContainerStatus() {
     }
 
-    public ContainerStatus(Map<String, Quantity> allocatedResources, java.lang.String containerID, java.lang.String image, java.lang.String imageID, ContainerState lastState, java.lang.String name, Boolean ready, ResourceRequirements resources, Integer restartCount, Boolean started, ContainerState state, List<VolumeMountStatus> volumeMounts) {
+    public ContainerStatus(Map<String, Quantity> allocatedResources, String containerID, String image, String imageID, ContainerState lastState, String name, Boolean ready, ResourceRequirements resources, Integer restartCount, Boolean started, ContainerState state, List<VolumeMountStatus> volumeMounts) {
         super();
         this.allocatedResources = allocatedResources;
         this.containerID = containerID;
@@ -111,32 +111,32 @@ public class ContainerStatus implements Editable<ContainerStatusBuilder> , Kuber
     }
 
     @JsonProperty("containerID")
-    public java.lang.String getContainerID() {
+    public String getContainerID() {
         return containerID;
     }
 
     @JsonProperty("containerID")
-    public void setContainerID(java.lang.String containerID) {
+    public void setContainerID(String containerID) {
         this.containerID = containerID;
     }
 
     @JsonProperty("image")
-    public java.lang.String getImage() {
+    public String getImage() {
         return image;
     }
 
     @JsonProperty("image")
-    public void setImage(java.lang.String image) {
+    public void setImage(String image) {
         this.image = image;
     }
 
     @JsonProperty("imageID")
-    public java.lang.String getImageID() {
+    public String getImageID() {
         return imageID;
     }
 
     @JsonProperty("imageID")
-    public void setImageID(java.lang.String imageID) {
+    public void setImageID(String imageID) {
         this.imageID = imageID;
     }
 
@@ -151,12 +151,12 @@ public class ContainerStatus implements Editable<ContainerStatusBuilder> , Kuber
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -232,12 +232,12 @@ public class ContainerStatus implements Editable<ContainerStatusBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/FlexPersistentVolumeSource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/FlexPersistentVolumeSource.java
@@ -40,9 +40,9 @@ public class FlexPersistentVolumeSource implements Editable<FlexPersistentVolume
 {
 
     @JsonProperty("driver")
-    private java.lang.String driver;
+    private String driver;
     @JsonProperty("fsType")
-    private java.lang.String fsType;
+    private String fsType;
     @JsonProperty("options")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> options = new LinkedHashMap<String, String>();
@@ -51,7 +51,7 @@ public class FlexPersistentVolumeSource implements Editable<FlexPersistentVolume
     @JsonProperty("secretRef")
     private SecretReference secretRef;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -60,7 +60,7 @@ public class FlexPersistentVolumeSource implements Editable<FlexPersistentVolume
     public FlexPersistentVolumeSource() {
     }
 
-    public FlexPersistentVolumeSource(java.lang.String driver, java.lang.String fsType, Map<String, String> options, Boolean readOnly, SecretReference secretRef) {
+    public FlexPersistentVolumeSource(String driver, String fsType, Map<String, String> options, Boolean readOnly, SecretReference secretRef) {
         super();
         this.driver = driver;
         this.fsType = fsType;
@@ -70,22 +70,22 @@ public class FlexPersistentVolumeSource implements Editable<FlexPersistentVolume
     }
 
     @JsonProperty("driver")
-    public java.lang.String getDriver() {
+    public String getDriver() {
         return driver;
     }
 
     @JsonProperty("driver")
-    public void setDriver(java.lang.String driver) {
+    public void setDriver(String driver) {
         this.driver = driver;
     }
 
     @JsonProperty("fsType")
-    public java.lang.String getFsType() {
+    public String getFsType() {
         return fsType;
     }
 
     @JsonProperty("fsType")
-    public void setFsType(java.lang.String fsType) {
+    public void setFsType(String fsType) {
         this.fsType = fsType;
     }
 
@@ -130,12 +130,12 @@ public class FlexPersistentVolumeSource implements Editable<FlexPersistentVolume
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/FlexVolumeSource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/FlexVolumeSource.java
@@ -40,9 +40,9 @@ public class FlexVolumeSource implements Editable<FlexVolumeSourceBuilder> , Kub
 {
 
     @JsonProperty("driver")
-    private java.lang.String driver;
+    private String driver;
     @JsonProperty("fsType")
-    private java.lang.String fsType;
+    private String fsType;
     @JsonProperty("options")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> options = new LinkedHashMap<String, String>();
@@ -51,7 +51,7 @@ public class FlexVolumeSource implements Editable<FlexVolumeSourceBuilder> , Kub
     @JsonProperty("secretRef")
     private LocalObjectReference secretRef;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -60,7 +60,7 @@ public class FlexVolumeSource implements Editable<FlexVolumeSourceBuilder> , Kub
     public FlexVolumeSource() {
     }
 
-    public FlexVolumeSource(java.lang.String driver, java.lang.String fsType, Map<String, String> options, Boolean readOnly, LocalObjectReference secretRef) {
+    public FlexVolumeSource(String driver, String fsType, Map<String, String> options, Boolean readOnly, LocalObjectReference secretRef) {
         super();
         this.driver = driver;
         this.fsType = fsType;
@@ -70,22 +70,22 @@ public class FlexVolumeSource implements Editable<FlexVolumeSourceBuilder> , Kub
     }
 
     @JsonProperty("driver")
-    public java.lang.String getDriver() {
+    public String getDriver() {
         return driver;
     }
 
     @JsonProperty("driver")
-    public void setDriver(java.lang.String driver) {
+    public void setDriver(String driver) {
         this.driver = driver;
     }
 
     @JsonProperty("fsType")
-    public java.lang.String getFsType() {
+    public String getFsType() {
         return fsType;
     }
 
     @JsonProperty("fsType")
-    public void setFsType(java.lang.String fsType) {
+    public void setFsType(String fsType) {
         this.fsType = fsType;
     }
 
@@ -130,12 +130,12 @@ public class FlexVolumeSource implements Editable<FlexVolumeSourceBuilder> , Kub
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/LabelSelector.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/LabelSelector.java
@@ -45,7 +45,7 @@ public class LabelSelector implements Editable<LabelSelectorBuilder> , Kubernete
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> matchLabels = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -92,12 +92,12 @@ public class LabelSelector implements Editable<LabelSelectorBuilder> , Kubernete
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/LimitRangeItem.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/LimitRangeItem.java
@@ -56,9 +56,9 @@ public class LimitRangeItem implements Editable<LimitRangeItemBuilder> , Kuberne
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, io.fabric8.kubernetes.api.model.Quantity> min = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.Quantity>();
     @JsonProperty("type")
-    private java.lang.String type;
+    private String type;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -67,7 +67,7 @@ public class LimitRangeItem implements Editable<LimitRangeItemBuilder> , Kuberne
     public LimitRangeItem() {
     }
 
-    public LimitRangeItem(Map<String, io.fabric8.kubernetes.api.model.Quantity> _default, Map<String, io.fabric8.kubernetes.api.model.Quantity> defaultRequest, Map<String, io.fabric8.kubernetes.api.model.Quantity> max, Map<String, io.fabric8.kubernetes.api.model.Quantity> maxLimitRequestRatio, Map<String, io.fabric8.kubernetes.api.model.Quantity> min, java.lang.String type) {
+    public LimitRangeItem(Map<String, io.fabric8.kubernetes.api.model.Quantity> _default, Map<String, io.fabric8.kubernetes.api.model.Quantity> defaultRequest, Map<String, io.fabric8.kubernetes.api.model.Quantity> max, Map<String, io.fabric8.kubernetes.api.model.Quantity> maxLimitRequestRatio, Map<String, io.fabric8.kubernetes.api.model.Quantity> min, String type) {
         super();
         this._default = _default;
         this.defaultRequest = defaultRequest;
@@ -128,12 +128,12 @@ public class LimitRangeItem implements Editable<LimitRangeItemBuilder> , Kuberne
     }
 
     @JsonProperty("type")
-    public java.lang.String getType() {
+    public String getType() {
         return type;
     }
 
     @JsonProperty("type")
-    public void setType(java.lang.String type) {
+    public void setType(String type) {
         this.type = type;
     }
 
@@ -148,12 +148,12 @@ public class LimitRangeItem implements Editable<LimitRangeItemBuilder> , Kuberne
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/NodeStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/NodeStatus.java
@@ -70,7 +70,7 @@ public class NodeStatus implements Editable<NodeStatusBuilder> , KubernetesResou
     @JsonProperty("nodeInfo")
     private NodeSystemInfo nodeInfo;
     @JsonProperty("phase")
-    private java.lang.String phase;
+    private String phase;
     @JsonProperty("runtimeHandlers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<NodeRuntimeHandler> runtimeHandlers = new ArrayList<NodeRuntimeHandler>();
@@ -79,9 +79,9 @@ public class NodeStatus implements Editable<NodeStatusBuilder> , KubernetesResou
     private List<AttachedVolume> volumesAttached = new ArrayList<AttachedVolume>();
     @JsonProperty("volumesInUse")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> volumesInUse = new ArrayList<java.lang.String>();
+    private List<String> volumesInUse = new ArrayList<String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -90,7 +90,7 @@ public class NodeStatus implements Editable<NodeStatusBuilder> , KubernetesResou
     public NodeStatus() {
     }
 
-    public NodeStatus(List<NodeAddress> addresses, Map<String, io.fabric8.kubernetes.api.model.Quantity> allocatable, Map<String, io.fabric8.kubernetes.api.model.Quantity> capacity, List<NodeCondition> conditions, NodeConfigStatus config, NodeDaemonEndpoints daemonEndpoints, List<ContainerImage> images, NodeSystemInfo nodeInfo, java.lang.String phase, List<NodeRuntimeHandler> runtimeHandlers, List<AttachedVolume> volumesAttached, List<java.lang.String> volumesInUse) {
+    public NodeStatus(List<NodeAddress> addresses, Map<String, io.fabric8.kubernetes.api.model.Quantity> allocatable, Map<String, io.fabric8.kubernetes.api.model.Quantity> capacity, List<NodeCondition> conditions, NodeConfigStatus config, NodeDaemonEndpoints daemonEndpoints, List<ContainerImage> images, NodeSystemInfo nodeInfo, String phase, List<NodeRuntimeHandler> runtimeHandlers, List<AttachedVolume> volumesAttached, List<String> volumesInUse) {
         super();
         this.addresses = addresses;
         this.allocatable = allocatable;
@@ -190,12 +190,12 @@ public class NodeStatus implements Editable<NodeStatusBuilder> , KubernetesResou
     }
 
     @JsonProperty("phase")
-    public java.lang.String getPhase() {
+    public String getPhase() {
         return phase;
     }
 
     @JsonProperty("phase")
-    public void setPhase(java.lang.String phase) {
+    public void setPhase(String phase) {
         this.phase = phase;
     }
 
@@ -223,12 +223,12 @@ public class NodeStatus implements Editable<NodeStatusBuilder> , KubernetesResou
 
     @JsonProperty("volumesInUse")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getVolumesInUse() {
+    public List<String> getVolumesInUse() {
         return volumesInUse;
     }
 
     @JsonProperty("volumesInUse")
-    public void setVolumesInUse(List<java.lang.String> volumesInUse) {
+    public void setVolumesInUse(List<String> volumesInUse) {
         this.volumesInUse = volumesInUse;
     }
 
@@ -243,12 +243,12 @@ public class NodeStatus implements Editable<NodeStatusBuilder> , KubernetesResou
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ObjectMeta.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ObjectMeta.java
@@ -53,7 +53,7 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
 
     @JsonProperty("annotations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private Map<String, String> annotations = new LinkedHashMap<String, String>();
+    private Map<java.lang.String, java.lang.String> annotations = new LinkedHashMap<java.lang.String, java.lang.String>();
     @JsonProperty("creationTimestamp")
     private String creationTimestamp;
     @JsonProperty("deletionGracePeriodSeconds")
@@ -69,7 +69,7 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     private Long generation;
     @JsonProperty("labels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private Map<String, String> labels = new LinkedHashMap<String, String>();
+    private Map<java.lang.String, java.lang.String> labels = new LinkedHashMap<java.lang.String, java.lang.String>();
     @JsonProperty("managedFields")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ManagedFieldsEntry> managedFields = new ArrayList<ManagedFieldsEntry>();
@@ -96,7 +96,7 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     public ObjectMeta() {
     }
 
-    public ObjectMeta(Map<String, String> annotations, String creationTimestamp, Long deletionGracePeriodSeconds, String deletionTimestamp, List<java.lang.String> finalizers, java.lang.String generateName, Long generation, Map<String, String> labels, List<ManagedFieldsEntry> managedFields, java.lang.String name, java.lang.String namespace, List<OwnerReference> ownerReferences, java.lang.String resourceVersion, java.lang.String selfLink, java.lang.String uid) {
+    public ObjectMeta(Map<java.lang.String, java.lang.String> annotations, String creationTimestamp, Long deletionGracePeriodSeconds, String deletionTimestamp, List<java.lang.String> finalizers, java.lang.String generateName, Long generation, Map<java.lang.String, java.lang.String> labels, List<ManagedFieldsEntry> managedFields, java.lang.String name, java.lang.String namespace, List<OwnerReference> ownerReferences, java.lang.String resourceVersion, java.lang.String selfLink, java.lang.String uid) {
         super();
         this.annotations = annotations;
         this.creationTimestamp = creationTimestamp;
@@ -116,12 +116,12 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     }
 
     @JsonProperty("annotations")
-    public Map<String, String> getAnnotations() {
+    public Map<java.lang.String, java.lang.String> getAnnotations() {
         return annotations;
     }
 
     @JsonProperty("annotations")
-    public void setAnnotations(Map<String, String> annotations) {
+    public void setAnnotations(Map<java.lang.String, java.lang.String> annotations) {
         this.annotations = annotations;
     }
 
@@ -187,12 +187,12 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     }
 
     @JsonProperty("labels")
-    public Map<String, String> getLabels() {
+    public Map<java.lang.String, java.lang.String> getLabels() {
         return labels;
     }
 
     @JsonProperty("labels")
-    public void setLabels(Map<String, String> labels) {
+    public void setLabels(Map<java.lang.String, java.lang.String> labels) {
         this.labels = labels;
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolumeClaimStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolumeClaimStatus.java
@@ -46,7 +46,7 @@ public class PersistentVolumeClaimStatus implements Editable<PersistentVolumeCla
 
     @JsonProperty("accessModes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> accessModes = new ArrayList<java.lang.String>();
+    private List<String> accessModes = new ArrayList<String>();
     @JsonProperty("allocatedResourceStatuses")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> allocatedResourceStatuses = new LinkedHashMap<String, String>();
@@ -60,13 +60,13 @@ public class PersistentVolumeClaimStatus implements Editable<PersistentVolumeCla
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PersistentVolumeClaimCondition> conditions = new ArrayList<PersistentVolumeClaimCondition>();
     @JsonProperty("currentVolumeAttributesClassName")
-    private java.lang.String currentVolumeAttributesClassName;
+    private String currentVolumeAttributesClassName;
     @JsonProperty("modifyVolumeStatus")
     private ModifyVolumeStatus modifyVolumeStatus;
     @JsonProperty("phase")
-    private java.lang.String phase;
+    private String phase;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -75,7 +75,7 @@ public class PersistentVolumeClaimStatus implements Editable<PersistentVolumeCla
     public PersistentVolumeClaimStatus() {
     }
 
-    public PersistentVolumeClaimStatus(List<java.lang.String> accessModes, Map<String, String> allocatedResourceStatuses, Map<String, io.fabric8.kubernetes.api.model.Quantity> allocatedResources, Map<String, io.fabric8.kubernetes.api.model.Quantity> capacity, List<PersistentVolumeClaimCondition> conditions, java.lang.String currentVolumeAttributesClassName, ModifyVolumeStatus modifyVolumeStatus, java.lang.String phase) {
+    public PersistentVolumeClaimStatus(List<String> accessModes, Map<String, String> allocatedResourceStatuses, Map<String, io.fabric8.kubernetes.api.model.Quantity> allocatedResources, Map<String, io.fabric8.kubernetes.api.model.Quantity> capacity, List<PersistentVolumeClaimCondition> conditions, String currentVolumeAttributesClassName, ModifyVolumeStatus modifyVolumeStatus, String phase) {
         super();
         this.accessModes = accessModes;
         this.allocatedResourceStatuses = allocatedResourceStatuses;
@@ -89,12 +89,12 @@ public class PersistentVolumeClaimStatus implements Editable<PersistentVolumeCla
 
     @JsonProperty("accessModes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getAccessModes() {
+    public List<String> getAccessModes() {
         return accessModes;
     }
 
     @JsonProperty("accessModes")
-    public void setAccessModes(List<java.lang.String> accessModes) {
+    public void setAccessModes(List<String> accessModes) {
         this.accessModes = accessModes;
     }
 
@@ -140,12 +140,12 @@ public class PersistentVolumeClaimStatus implements Editable<PersistentVolumeCla
     }
 
     @JsonProperty("currentVolumeAttributesClassName")
-    public java.lang.String getCurrentVolumeAttributesClassName() {
+    public String getCurrentVolumeAttributesClassName() {
         return currentVolumeAttributesClassName;
     }
 
     @JsonProperty("currentVolumeAttributesClassName")
-    public void setCurrentVolumeAttributesClassName(java.lang.String currentVolumeAttributesClassName) {
+    public void setCurrentVolumeAttributesClassName(String currentVolumeAttributesClassName) {
         this.currentVolumeAttributesClassName = currentVolumeAttributesClassName;
     }
 
@@ -160,12 +160,12 @@ public class PersistentVolumeClaimStatus implements Editable<PersistentVolumeCla
     }
 
     @JsonProperty("phase")
-    public java.lang.String getPhase() {
+    public String getPhase() {
         return phase;
     }
 
     @JsonProperty("phase")
-    public void setPhase(java.lang.String phase) {
+    public void setPhase(String phase) {
         this.phase = phase;
     }
 
@@ -180,12 +180,12 @@ public class PersistentVolumeClaimStatus implements Editable<PersistentVolumeCla
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolumeSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PersistentVolumeSpec.java
@@ -69,7 +69,7 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
 
     @JsonProperty("accessModes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> accessModes = new ArrayList<java.lang.String>();
+    private List<String> accessModes = new ArrayList<String>();
     @JsonProperty("awsElasticBlockStore")
     private AWSElasticBlockStoreVolumeSource awsElasticBlockStore;
     @JsonProperty("azureDisk")
@@ -105,13 +105,13 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
     private LocalVolumeSource local;
     @JsonProperty("mountOptions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> mountOptions = new ArrayList<java.lang.String>();
+    private List<String> mountOptions = new ArrayList<String>();
     @JsonProperty("nfs")
     private NFSVolumeSource nfs;
     @JsonProperty("nodeAffinity")
     private VolumeNodeAffinity nodeAffinity;
     @JsonProperty("persistentVolumeReclaimPolicy")
-    private java.lang.String persistentVolumeReclaimPolicy;
+    private String persistentVolumeReclaimPolicy;
     @JsonProperty("photonPersistentDisk")
     private PhotonPersistentDiskVolumeSource photonPersistentDisk;
     @JsonProperty("portworxVolume")
@@ -123,17 +123,17 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
     @JsonProperty("scaleIO")
     private ScaleIOPersistentVolumeSource scaleIO;
     @JsonProperty("storageClassName")
-    private java.lang.String storageClassName;
+    private String storageClassName;
     @JsonProperty("storageos")
     private StorageOSPersistentVolumeSource storageos;
     @JsonProperty("volumeAttributesClassName")
-    private java.lang.String volumeAttributesClassName;
+    private String volumeAttributesClassName;
     @JsonProperty("volumeMode")
-    private java.lang.String volumeMode;
+    private String volumeMode;
     @JsonProperty("vsphereVolume")
     private VsphereVirtualDiskVolumeSource vsphereVolume;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -142,7 +142,7 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
     public PersistentVolumeSpec() {
     }
 
-    public PersistentVolumeSpec(List<java.lang.String> accessModes, AWSElasticBlockStoreVolumeSource awsElasticBlockStore, AzureDiskVolumeSource azureDisk, AzureFilePersistentVolumeSource azureFile, Map<String, Quantity> capacity, CephFSPersistentVolumeSource cephfs, CinderPersistentVolumeSource cinder, ObjectReference claimRef, CSIPersistentVolumeSource csi, FCVolumeSource fc, FlexPersistentVolumeSource flexVolume, FlockerVolumeSource flocker, GCEPersistentDiskVolumeSource gcePersistentDisk, GlusterfsPersistentVolumeSource glusterfs, HostPathVolumeSource hostPath, ISCSIPersistentVolumeSource iscsi, LocalVolumeSource local, List<java.lang.String> mountOptions, NFSVolumeSource nfs, VolumeNodeAffinity nodeAffinity, java.lang.String persistentVolumeReclaimPolicy, PhotonPersistentDiskVolumeSource photonPersistentDisk, PortworxVolumeSource portworxVolume, QuobyteVolumeSource quobyte, RBDPersistentVolumeSource rbd, ScaleIOPersistentVolumeSource scaleIO, java.lang.String storageClassName, StorageOSPersistentVolumeSource storageos, java.lang.String volumeAttributesClassName, java.lang.String volumeMode, VsphereVirtualDiskVolumeSource vsphereVolume) {
+    public PersistentVolumeSpec(List<String> accessModes, AWSElasticBlockStoreVolumeSource awsElasticBlockStore, AzureDiskVolumeSource azureDisk, AzureFilePersistentVolumeSource azureFile, Map<String, Quantity> capacity, CephFSPersistentVolumeSource cephfs, CinderPersistentVolumeSource cinder, ObjectReference claimRef, CSIPersistentVolumeSource csi, FCVolumeSource fc, FlexPersistentVolumeSource flexVolume, FlockerVolumeSource flocker, GCEPersistentDiskVolumeSource gcePersistentDisk, GlusterfsPersistentVolumeSource glusterfs, HostPathVolumeSource hostPath, ISCSIPersistentVolumeSource iscsi, LocalVolumeSource local, List<String> mountOptions, NFSVolumeSource nfs, VolumeNodeAffinity nodeAffinity, String persistentVolumeReclaimPolicy, PhotonPersistentDiskVolumeSource photonPersistentDisk, PortworxVolumeSource portworxVolume, QuobyteVolumeSource quobyte, RBDPersistentVolumeSource rbd, ScaleIOPersistentVolumeSource scaleIO, String storageClassName, StorageOSPersistentVolumeSource storageos, String volumeAttributesClassName, String volumeMode, VsphereVirtualDiskVolumeSource vsphereVolume) {
         super();
         this.accessModes = accessModes;
         this.awsElasticBlockStore = awsElasticBlockStore;
@@ -179,12 +179,12 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
 
     @JsonProperty("accessModes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getAccessModes() {
+    public List<String> getAccessModes() {
         return accessModes;
     }
 
     @JsonProperty("accessModes")
-    public void setAccessModes(List<java.lang.String> accessModes) {
+    public void setAccessModes(List<String> accessModes) {
         this.accessModes = accessModes;
     }
 
@@ -350,12 +350,12 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
 
     @JsonProperty("mountOptions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getMountOptions() {
+    public List<String> getMountOptions() {
         return mountOptions;
     }
 
     @JsonProperty("mountOptions")
-    public void setMountOptions(List<java.lang.String> mountOptions) {
+    public void setMountOptions(List<String> mountOptions) {
         this.mountOptions = mountOptions;
     }
 
@@ -380,12 +380,12 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
     }
 
     @JsonProperty("persistentVolumeReclaimPolicy")
-    public java.lang.String getPersistentVolumeReclaimPolicy() {
+    public String getPersistentVolumeReclaimPolicy() {
         return persistentVolumeReclaimPolicy;
     }
 
     @JsonProperty("persistentVolumeReclaimPolicy")
-    public void setPersistentVolumeReclaimPolicy(java.lang.String persistentVolumeReclaimPolicy) {
+    public void setPersistentVolumeReclaimPolicy(String persistentVolumeReclaimPolicy) {
         this.persistentVolumeReclaimPolicy = persistentVolumeReclaimPolicy;
     }
 
@@ -440,12 +440,12 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
     }
 
     @JsonProperty("storageClassName")
-    public java.lang.String getStorageClassName() {
+    public String getStorageClassName() {
         return storageClassName;
     }
 
     @JsonProperty("storageClassName")
-    public void setStorageClassName(java.lang.String storageClassName) {
+    public void setStorageClassName(String storageClassName) {
         this.storageClassName = storageClassName;
     }
 
@@ -460,22 +460,22 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
     }
 
     @JsonProperty("volumeAttributesClassName")
-    public java.lang.String getVolumeAttributesClassName() {
+    public String getVolumeAttributesClassName() {
         return volumeAttributesClassName;
     }
 
     @JsonProperty("volumeAttributesClassName")
-    public void setVolumeAttributesClassName(java.lang.String volumeAttributesClassName) {
+    public void setVolumeAttributesClassName(String volumeAttributesClassName) {
         this.volumeAttributesClassName = volumeAttributesClassName;
     }
 
     @JsonProperty("volumeMode")
-    public java.lang.String getVolumeMode() {
+    public String getVolumeMode() {
         return volumeMode;
     }
 
     @JsonProperty("volumeMode")
-    public void setVolumeMode(java.lang.String volumeMode) {
+    public void setVolumeMode(String volumeMode) {
         this.volumeMode = volumeMode;
     }
 
@@ -500,12 +500,12 @@ public class PersistentVolumeSpec implements Editable<PersistentVolumeSpecBuilde
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PodSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/PodSpec.java
@@ -87,7 +87,7 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     @JsonProperty("dnsConfig")
     private PodDNSConfig dnsConfig;
     @JsonProperty("dnsPolicy")
-    private java.lang.String dnsPolicy;
+    private String dnsPolicy;
     @JsonProperty("enableServiceLinks")
     private Boolean enableServiceLinks;
     @JsonProperty("ephemeralContainers")
@@ -105,7 +105,7 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     @JsonProperty("hostUsers")
     private Boolean hostUsers;
     @JsonProperty("hostname")
-    private java.lang.String hostname;
+    private String hostname;
     @JsonProperty("imagePullSecrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<LocalObjectReference> imagePullSecrets = new ArrayList<LocalObjectReference>();
@@ -113,7 +113,7 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Container> initContainers = new ArrayList<Container>();
     @JsonProperty("nodeName")
-    private java.lang.String nodeName;
+    private String nodeName;
     @JsonProperty("nodeSelector")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> nodeSelector = new LinkedHashMap<String, String>();
@@ -123,11 +123,11 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Quantity> overhead = new LinkedHashMap<String, Quantity>();
     @JsonProperty("preemptionPolicy")
-    private java.lang.String preemptionPolicy;
+    private String preemptionPolicy;
     @JsonProperty("priority")
     private Integer priority;
     @JsonProperty("priorityClassName")
-    private java.lang.String priorityClassName;
+    private String priorityClassName;
     @JsonProperty("readinessGates")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PodReadinessGate> readinessGates = new ArrayList<PodReadinessGate>();
@@ -135,26 +135,26 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PodResourceClaim> resourceClaims = new ArrayList<PodResourceClaim>();
     @JsonProperty("restartPolicy")
-    private java.lang.String restartPolicy;
+    private String restartPolicy;
     @JsonProperty("runtimeClassName")
-    private java.lang.String runtimeClassName;
+    private String runtimeClassName;
     @JsonProperty("schedulerName")
-    private java.lang.String schedulerName;
+    private String schedulerName;
     @JsonProperty("schedulingGates")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PodSchedulingGate> schedulingGates = new ArrayList<PodSchedulingGate>();
     @JsonProperty("securityContext")
     private PodSecurityContext securityContext;
     @JsonProperty("serviceAccount")
-    private java.lang.String serviceAccount;
+    private String serviceAccount;
     @JsonProperty("serviceAccountName")
-    private java.lang.String serviceAccountName;
+    private String serviceAccountName;
     @JsonProperty("setHostnameAsFQDN")
     private Boolean setHostnameAsFQDN;
     @JsonProperty("shareProcessNamespace")
     private Boolean shareProcessNamespace;
     @JsonProperty("subdomain")
-    private java.lang.String subdomain;
+    private String subdomain;
     @JsonProperty("terminationGracePeriodSeconds")
     private Long terminationGracePeriodSeconds;
     @JsonProperty("tolerations")
@@ -167,7 +167,7 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Volume> volumes = new ArrayList<Volume>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -176,7 +176,7 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     public PodSpec() {
     }
 
-    public PodSpec(Long activeDeadlineSeconds, Affinity affinity, Boolean automountServiceAccountToken, List<Container> containers, PodDNSConfig dnsConfig, java.lang.String dnsPolicy, Boolean enableServiceLinks, List<EphemeralContainer> ephemeralContainers, List<HostAlias> hostAliases, Boolean hostIPC, Boolean hostNetwork, Boolean hostPID, Boolean hostUsers, java.lang.String hostname, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, java.lang.String nodeName, Map<String, String> nodeSelector, PodOS os, Map<String, Quantity> overhead, java.lang.String preemptionPolicy, Integer priority, java.lang.String priorityClassName, List<PodReadinessGate> readinessGates, List<PodResourceClaim> resourceClaims, java.lang.String restartPolicy, java.lang.String runtimeClassName, java.lang.String schedulerName, List<PodSchedulingGate> schedulingGates, PodSecurityContext securityContext, java.lang.String serviceAccount, java.lang.String serviceAccountName, Boolean setHostnameAsFQDN, Boolean shareProcessNamespace, java.lang.String subdomain, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, List<Volume> volumes) {
+    public PodSpec(Long activeDeadlineSeconds, Affinity affinity, Boolean automountServiceAccountToken, List<Container> containers, PodDNSConfig dnsConfig, String dnsPolicy, Boolean enableServiceLinks, List<EphemeralContainer> ephemeralContainers, List<HostAlias> hostAliases, Boolean hostIPC, Boolean hostNetwork, Boolean hostPID, Boolean hostUsers, String hostname, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, String nodeName, Map<String, String> nodeSelector, PodOS os, Map<String, Quantity> overhead, String preemptionPolicy, Integer priority, String priorityClassName, List<PodReadinessGate> readinessGates, List<PodResourceClaim> resourceClaims, String restartPolicy, String runtimeClassName, String schedulerName, List<PodSchedulingGate> schedulingGates, PodSecurityContext securityContext, String serviceAccount, String serviceAccountName, Boolean setHostnameAsFQDN, Boolean shareProcessNamespace, String subdomain, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, List<Volume> volumes) {
         super();
         this.activeDeadlineSeconds = activeDeadlineSeconds;
         this.affinity = affinity;
@@ -270,12 +270,12 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("dnsPolicy")
-    public java.lang.String getDnsPolicy() {
+    public String getDnsPolicy() {
         return dnsPolicy;
     }
 
     @JsonProperty("dnsPolicy")
-    public void setDnsPolicy(java.lang.String dnsPolicy) {
+    public void setDnsPolicy(String dnsPolicy) {
         this.dnsPolicy = dnsPolicy;
     }
 
@@ -352,12 +352,12 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("hostname")
-    public java.lang.String getHostname() {
+    public String getHostname() {
         return hostname;
     }
 
     @JsonProperty("hostname")
-    public void setHostname(java.lang.String hostname) {
+    public void setHostname(String hostname) {
         this.hostname = hostname;
     }
 
@@ -384,12 +384,12 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("nodeName")
-    public java.lang.String getNodeName() {
+    public String getNodeName() {
         return nodeName;
     }
 
     @JsonProperty("nodeName")
-    public void setNodeName(java.lang.String nodeName) {
+    public void setNodeName(String nodeName) {
         this.nodeName = nodeName;
     }
 
@@ -424,12 +424,12 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("preemptionPolicy")
-    public java.lang.String getPreemptionPolicy() {
+    public String getPreemptionPolicy() {
         return preemptionPolicy;
     }
 
     @JsonProperty("preemptionPolicy")
-    public void setPreemptionPolicy(java.lang.String preemptionPolicy) {
+    public void setPreemptionPolicy(String preemptionPolicy) {
         this.preemptionPolicy = preemptionPolicy;
     }
 
@@ -444,12 +444,12 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("priorityClassName")
-    public java.lang.String getPriorityClassName() {
+    public String getPriorityClassName() {
         return priorityClassName;
     }
 
     @JsonProperty("priorityClassName")
-    public void setPriorityClassName(java.lang.String priorityClassName) {
+    public void setPriorityClassName(String priorityClassName) {
         this.priorityClassName = priorityClassName;
     }
 
@@ -476,32 +476,32 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("restartPolicy")
-    public java.lang.String getRestartPolicy() {
+    public String getRestartPolicy() {
         return restartPolicy;
     }
 
     @JsonProperty("restartPolicy")
-    public void setRestartPolicy(java.lang.String restartPolicy) {
+    public void setRestartPolicy(String restartPolicy) {
         this.restartPolicy = restartPolicy;
     }
 
     @JsonProperty("runtimeClassName")
-    public java.lang.String getRuntimeClassName() {
+    public String getRuntimeClassName() {
         return runtimeClassName;
     }
 
     @JsonProperty("runtimeClassName")
-    public void setRuntimeClassName(java.lang.String runtimeClassName) {
+    public void setRuntimeClassName(String runtimeClassName) {
         this.runtimeClassName = runtimeClassName;
     }
 
     @JsonProperty("schedulerName")
-    public java.lang.String getSchedulerName() {
+    public String getSchedulerName() {
         return schedulerName;
     }
 
     @JsonProperty("schedulerName")
-    public void setSchedulerName(java.lang.String schedulerName) {
+    public void setSchedulerName(String schedulerName) {
         this.schedulerName = schedulerName;
     }
 
@@ -527,22 +527,22 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("serviceAccount")
-    public java.lang.String getServiceAccount() {
+    public String getServiceAccount() {
         return serviceAccount;
     }
 
     @JsonProperty("serviceAccount")
-    public void setServiceAccount(java.lang.String serviceAccount) {
+    public void setServiceAccount(String serviceAccount) {
         this.serviceAccount = serviceAccount;
     }
 
     @JsonProperty("serviceAccountName")
-    public java.lang.String getServiceAccountName() {
+    public String getServiceAccountName() {
         return serviceAccountName;
     }
 
     @JsonProperty("serviceAccountName")
-    public void setServiceAccountName(java.lang.String serviceAccountName) {
+    public void setServiceAccountName(String serviceAccountName) {
         this.serviceAccountName = serviceAccountName;
     }
 
@@ -567,12 +567,12 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonProperty("subdomain")
-    public java.lang.String getSubdomain() {
+    public String getSubdomain() {
         return subdomain;
     }
 
     @JsonProperty("subdomain")
-    public void setSubdomain(java.lang.String subdomain) {
+    public void setSubdomain(String subdomain) {
         this.subdomain = subdomain;
     }
 
@@ -630,12 +630,12 @@ public class PodSpec implements Editable<PodSpecBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ReplicationControllerSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ReplicationControllerSpec.java
@@ -48,7 +48,7 @@ public class ReplicationControllerSpec implements Editable<ReplicationController
     @JsonProperty("template")
     private PodTemplateSpec template;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -116,12 +116,12 @@ public class ReplicationControllerSpec implements Editable<ReplicationController
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceQuotaSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceQuotaSpec.java
@@ -46,9 +46,9 @@ public class ResourceQuotaSpec implements Editable<ResourceQuotaSpecBuilder> , K
     private ScopeSelector scopeSelector;
     @JsonProperty("scopes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> scopes = new ArrayList<java.lang.String>();
+    private List<String> scopes = new ArrayList<String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -57,7 +57,7 @@ public class ResourceQuotaSpec implements Editable<ResourceQuotaSpecBuilder> , K
     public ResourceQuotaSpec() {
     }
 
-    public ResourceQuotaSpec(Map<String, Quantity> hard, ScopeSelector scopeSelector, List<java.lang.String> scopes) {
+    public ResourceQuotaSpec(Map<String, Quantity> hard, ScopeSelector scopeSelector, List<String> scopes) {
         super();
         this.hard = hard;
         this.scopeSelector = scopeSelector;
@@ -86,12 +86,12 @@ public class ResourceQuotaSpec implements Editable<ResourceQuotaSpecBuilder> , K
 
     @JsonProperty("scopes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getScopes() {
+    public List<String> getScopes() {
         return scopes;
     }
 
     @JsonProperty("scopes")
-    public void setScopes(List<java.lang.String> scopes) {
+    public void setScopes(List<String> scopes) {
         this.scopes = scopes;
     }
 
@@ -106,12 +106,12 @@ public class ResourceQuotaSpec implements Editable<ResourceQuotaSpecBuilder> , K
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceQuotaStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceQuotaStatus.java
@@ -43,7 +43,7 @@ public class ResourceQuotaStatus implements Editable<ResourceQuotaStatusBuilder>
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, io.fabric8.kubernetes.api.model.Quantity> used = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.Quantity>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -89,12 +89,12 @@ public class ResourceQuotaStatus implements Editable<ResourceQuotaStatusBuilder>
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceRequirements.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ResourceRequirements.java
@@ -49,7 +49,7 @@ public class ResourceRequirements implements Editable<ResourceRequirementsBuilde
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, io.fabric8.kubernetes.api.model.Quantity> requests = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.Quantity>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -107,12 +107,12 @@ public class ResourceRequirements implements Editable<ResourceRequirementsBuilde
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Secret.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/Secret.java
@@ -56,7 +56,7 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "v1";
+    private String apiVersion = "v1";
     @JsonProperty("data")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> data = new LinkedHashMap<String, String>();
@@ -68,16 +68,16 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "Secret";
+    private String kind = "Secret";
     @JsonProperty("metadata")
     private ObjectMeta metadata;
     @JsonProperty("stringData")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> stringData = new LinkedHashMap<String, String>();
     @JsonProperty("type")
-    private java.lang.String type;
+    private String type;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -86,7 +86,7 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
     public Secret() {
     }
 
-    public Secret(java.lang.String apiVersion, Map<String, String> data, Boolean immutable, java.lang.String kind, ObjectMeta metadata, Map<String, String> stringData, java.lang.String type) {
+    public Secret(String apiVersion, Map<String, String> data, Boolean immutable, String kind, ObjectMeta metadata, Map<String, String> stringData, String type) {
         super();
         this.apiVersion = apiVersion;
         this.data = data;
@@ -103,7 +103,7 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -113,7 +113,7 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
@@ -143,7 +143,7 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -153,7 +153,7 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -178,12 +178,12 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
     }
 
     @JsonProperty("type")
-    public java.lang.String getType() {
+    public String getType() {
         return type;
     }
 
     @JsonProperty("type")
-    public void setType(java.lang.String type) {
+    public void setType(String type) {
         this.type = type;
     }
 
@@ -198,12 +198,12 @@ public class Secret implements Editable<SecretBuilder> , HasMetadata, Namespaced
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ServiceSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/ServiceSpec.java
@@ -59,33 +59,33 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     @JsonProperty("allocateLoadBalancerNodePorts")
     private Boolean allocateLoadBalancerNodePorts;
     @JsonProperty("clusterIP")
-    private java.lang.String clusterIP;
+    private String clusterIP;
     @JsonProperty("clusterIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> clusterIPs = new ArrayList<java.lang.String>();
+    private List<String> clusterIPs = new ArrayList<String>();
     @JsonProperty("externalIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> externalIPs = new ArrayList<java.lang.String>();
+    private List<String> externalIPs = new ArrayList<String>();
     @JsonProperty("externalName")
-    private java.lang.String externalName;
+    private String externalName;
     @JsonProperty("externalTrafficPolicy")
-    private java.lang.String externalTrafficPolicy;
+    private String externalTrafficPolicy;
     @JsonProperty("healthCheckNodePort")
     private Integer healthCheckNodePort;
     @JsonProperty("internalTrafficPolicy")
-    private java.lang.String internalTrafficPolicy;
+    private String internalTrafficPolicy;
     @JsonProperty("ipFamilies")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> ipFamilies = new ArrayList<java.lang.String>();
+    private List<String> ipFamilies = new ArrayList<String>();
     @JsonProperty("ipFamilyPolicy")
-    private java.lang.String ipFamilyPolicy;
+    private String ipFamilyPolicy;
     @JsonProperty("loadBalancerClass")
-    private java.lang.String loadBalancerClass;
+    private String loadBalancerClass;
     @JsonProperty("loadBalancerIP")
-    private java.lang.String loadBalancerIP;
+    private String loadBalancerIP;
     @JsonProperty("loadBalancerSourceRanges")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> loadBalancerSourceRanges = new ArrayList<java.lang.String>();
+    private List<String> loadBalancerSourceRanges = new ArrayList<String>();
     @JsonProperty("ports")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ServicePort> ports = new ArrayList<ServicePort>();
@@ -95,15 +95,15 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> selector = new LinkedHashMap<String, String>();
     @JsonProperty("sessionAffinity")
-    private java.lang.String sessionAffinity;
+    private String sessionAffinity;
     @JsonProperty("sessionAffinityConfig")
     private SessionAffinityConfig sessionAffinityConfig;
     @JsonProperty("trafficDistribution")
-    private java.lang.String trafficDistribution;
+    private String trafficDistribution;
     @JsonProperty("type")
-    private java.lang.String type;
+    private String type;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -112,7 +112,7 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     public ServiceSpec() {
     }
 
-    public ServiceSpec(Boolean allocateLoadBalancerNodePorts, java.lang.String clusterIP, List<java.lang.String> clusterIPs, List<java.lang.String> externalIPs, java.lang.String externalName, java.lang.String externalTrafficPolicy, Integer healthCheckNodePort, java.lang.String internalTrafficPolicy, List<java.lang.String> ipFamilies, java.lang.String ipFamilyPolicy, java.lang.String loadBalancerClass, java.lang.String loadBalancerIP, List<java.lang.String> loadBalancerSourceRanges, List<ServicePort> ports, Boolean publishNotReadyAddresses, Map<String, String> selector, java.lang.String sessionAffinity, SessionAffinityConfig sessionAffinityConfig, java.lang.String trafficDistribution, java.lang.String type) {
+    public ServiceSpec(Boolean allocateLoadBalancerNodePorts, String clusterIP, List<String> clusterIPs, List<String> externalIPs, String externalName, String externalTrafficPolicy, Integer healthCheckNodePort, String internalTrafficPolicy, List<String> ipFamilies, String ipFamilyPolicy, String loadBalancerClass, String loadBalancerIP, List<String> loadBalancerSourceRanges, List<ServicePort> ports, Boolean publishNotReadyAddresses, Map<String, String> selector, String sessionAffinity, SessionAffinityConfig sessionAffinityConfig, String trafficDistribution, String type) {
         super();
         this.allocateLoadBalancerNodePorts = allocateLoadBalancerNodePorts;
         this.clusterIP = clusterIP;
@@ -147,54 +147,54 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     }
 
     @JsonProperty("clusterIP")
-    public java.lang.String getClusterIP() {
+    public String getClusterIP() {
         return clusterIP;
     }
 
     @JsonProperty("clusterIP")
-    public void setClusterIP(java.lang.String clusterIP) {
+    public void setClusterIP(String clusterIP) {
         this.clusterIP = clusterIP;
     }
 
     @JsonProperty("clusterIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getClusterIPs() {
+    public List<String> getClusterIPs() {
         return clusterIPs;
     }
 
     @JsonProperty("clusterIPs")
-    public void setClusterIPs(List<java.lang.String> clusterIPs) {
+    public void setClusterIPs(List<String> clusterIPs) {
         this.clusterIPs = clusterIPs;
     }
 
     @JsonProperty("externalIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getExternalIPs() {
+    public List<String> getExternalIPs() {
         return externalIPs;
     }
 
     @JsonProperty("externalIPs")
-    public void setExternalIPs(List<java.lang.String> externalIPs) {
+    public void setExternalIPs(List<String> externalIPs) {
         this.externalIPs = externalIPs;
     }
 
     @JsonProperty("externalName")
-    public java.lang.String getExternalName() {
+    public String getExternalName() {
         return externalName;
     }
 
     @JsonProperty("externalName")
-    public void setExternalName(java.lang.String externalName) {
+    public void setExternalName(String externalName) {
         this.externalName = externalName;
     }
 
     @JsonProperty("externalTrafficPolicy")
-    public java.lang.String getExternalTrafficPolicy() {
+    public String getExternalTrafficPolicy() {
         return externalTrafficPolicy;
     }
 
     @JsonProperty("externalTrafficPolicy")
-    public void setExternalTrafficPolicy(java.lang.String externalTrafficPolicy) {
+    public void setExternalTrafficPolicy(String externalTrafficPolicy) {
         this.externalTrafficPolicy = externalTrafficPolicy;
     }
 
@@ -209,64 +209,64 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     }
 
     @JsonProperty("internalTrafficPolicy")
-    public java.lang.String getInternalTrafficPolicy() {
+    public String getInternalTrafficPolicy() {
         return internalTrafficPolicy;
     }
 
     @JsonProperty("internalTrafficPolicy")
-    public void setInternalTrafficPolicy(java.lang.String internalTrafficPolicy) {
+    public void setInternalTrafficPolicy(String internalTrafficPolicy) {
         this.internalTrafficPolicy = internalTrafficPolicy;
     }
 
     @JsonProperty("ipFamilies")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getIpFamilies() {
+    public List<String> getIpFamilies() {
         return ipFamilies;
     }
 
     @JsonProperty("ipFamilies")
-    public void setIpFamilies(List<java.lang.String> ipFamilies) {
+    public void setIpFamilies(List<String> ipFamilies) {
         this.ipFamilies = ipFamilies;
     }
 
     @JsonProperty("ipFamilyPolicy")
-    public java.lang.String getIpFamilyPolicy() {
+    public String getIpFamilyPolicy() {
         return ipFamilyPolicy;
     }
 
     @JsonProperty("ipFamilyPolicy")
-    public void setIpFamilyPolicy(java.lang.String ipFamilyPolicy) {
+    public void setIpFamilyPolicy(String ipFamilyPolicy) {
         this.ipFamilyPolicy = ipFamilyPolicy;
     }
 
     @JsonProperty("loadBalancerClass")
-    public java.lang.String getLoadBalancerClass() {
+    public String getLoadBalancerClass() {
         return loadBalancerClass;
     }
 
     @JsonProperty("loadBalancerClass")
-    public void setLoadBalancerClass(java.lang.String loadBalancerClass) {
+    public void setLoadBalancerClass(String loadBalancerClass) {
         this.loadBalancerClass = loadBalancerClass;
     }
 
     @JsonProperty("loadBalancerIP")
-    public java.lang.String getLoadBalancerIP() {
+    public String getLoadBalancerIP() {
         return loadBalancerIP;
     }
 
     @JsonProperty("loadBalancerIP")
-    public void setLoadBalancerIP(java.lang.String loadBalancerIP) {
+    public void setLoadBalancerIP(String loadBalancerIP) {
         this.loadBalancerIP = loadBalancerIP;
     }
 
     @JsonProperty("loadBalancerSourceRanges")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getLoadBalancerSourceRanges() {
+    public List<String> getLoadBalancerSourceRanges() {
         return loadBalancerSourceRanges;
     }
 
     @JsonProperty("loadBalancerSourceRanges")
-    public void setLoadBalancerSourceRanges(List<java.lang.String> loadBalancerSourceRanges) {
+    public void setLoadBalancerSourceRanges(List<String> loadBalancerSourceRanges) {
         this.loadBalancerSourceRanges = loadBalancerSourceRanges;
     }
 
@@ -302,12 +302,12 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     }
 
     @JsonProperty("sessionAffinity")
-    public java.lang.String getSessionAffinity() {
+    public String getSessionAffinity() {
         return sessionAffinity;
     }
 
     @JsonProperty("sessionAffinity")
-    public void setSessionAffinity(java.lang.String sessionAffinity) {
+    public void setSessionAffinity(String sessionAffinity) {
         this.sessionAffinity = sessionAffinity;
     }
 
@@ -322,22 +322,22 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     }
 
     @JsonProperty("trafficDistribution")
-    public java.lang.String getTrafficDistribution() {
+    public String getTrafficDistribution() {
         return trafficDistribution;
     }
 
     @JsonProperty("trafficDistribution")
-    public void setTrafficDistribution(java.lang.String trafficDistribution) {
+    public void setTrafficDistribution(String trafficDistribution) {
         this.trafficDistribution = trafficDistribution;
     }
 
     @JsonProperty("type")
-    public java.lang.String getType() {
+    public String getType() {
         return type;
     }
 
     @JsonProperty("type")
-    public void setType(java.lang.String type) {
+    public void setType(String type) {
         this.type = type;
     }
 
@@ -352,12 +352,12 @@ public class ServiceSpec implements Editable<ServiceSpecBuilder> , KubernetesRes
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/VolumeResourceRequirements.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/generated/java/io/fabric8/kubernetes/api/model/VolumeResourceRequirements.java
@@ -43,7 +43,7 @@ public class VolumeResourceRequirements implements Editable<VolumeResourceRequir
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, io.fabric8.kubernetes.api.model.Quantity> requests = new LinkedHashMap<String, io.fabric8.kubernetes.api.model.Quantity>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -89,12 +89,12 @@ public class VolumeResourceRequirements implements Editable<VolumeResourceRequir
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/kube-schema.json
@@ -533,7 +533,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -728,7 +728,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_Time",
@@ -761,7 +761,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1182,7 +1182,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "auth-provider": {
           "$ref": "#/definitions/kubernetes_config_AuthProviderConfig",
@@ -1239,7 +1239,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -1722,7 +1722,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -1755,7 +1755,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2052,14 +2052,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "data": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -2509,7 +2509,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "containerID": {
           "type": "string"
@@ -3340,7 +3340,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3370,7 +3370,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3793,7 +3793,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "defaultRequest": {
           "type": "object",
@@ -3801,7 +3801,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "max": {
           "type": "object",
@@ -3809,7 +3809,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "maxLimitRequestRatio": {
           "type": "object",
@@ -3817,7 +3817,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "min": {
           "type": "object",
@@ -3825,7 +3825,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "type": {
           "type": "string"
@@ -4462,7 +4462,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4470,7 +4470,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -4807,7 +4807,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -4815,7 +4815,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4823,7 +4823,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -5042,7 +5042,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -5702,7 +5702,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -5714,7 +5714,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -6340,7 +6340,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "template": {
           "$ref": "#/definitions/kubernetes_core_PodTemplateSpec",
@@ -6494,7 +6494,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -6523,7 +6523,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -6531,7 +6531,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6557,7 +6557,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -6565,7 +6565,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6748,7 +6748,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -6767,7 +6767,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -7233,7 +7233,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sessionAffinity": {
           "type": "string"
@@ -7809,7 +7809,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -7817,7 +7817,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/resources/schema/validation-schema.json
@@ -533,7 +533,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -728,7 +728,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_Time",
@@ -761,7 +761,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1182,7 +1182,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "auth-provider": {
           "$ref": "#/definitions/kubernetes_config_AuthProviderConfig",
@@ -1239,7 +1239,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -1722,7 +1722,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -1755,7 +1755,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2052,14 +2052,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "data": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -2509,7 +2509,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "containerID": {
           "type": "string"
@@ -3340,7 +3340,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3370,7 +3370,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3793,7 +3793,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "defaultRequest": {
           "type": "object",
@@ -3801,7 +3801,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "max": {
           "type": "object",
@@ -3809,7 +3809,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "maxLimitRequestRatio": {
           "type": "object",
@@ -3817,7 +3817,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "min": {
           "type": "object",
@@ -3825,7 +3825,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "type": {
           "type": "string"
@@ -4462,7 +4462,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4470,7 +4470,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -4807,7 +4807,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -4815,7 +4815,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -4823,7 +4823,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -5042,7 +5042,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -5702,7 +5702,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -5714,7 +5714,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -6340,7 +6340,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "template": {
           "$ref": "#/definitions/kubernetes_core_PodTemplateSpec",
@@ -6494,7 +6494,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -6523,7 +6523,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -6531,7 +6531,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6557,7 +6557,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -6565,7 +6565,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -6748,7 +6748,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -6767,7 +6767,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -7233,7 +7233,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sessionAffinity": {
           "type": "string"
@@ -7809,7 +7809,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -7817,7 +7817,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -8594,7 +8594,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "auth-provider": {
           "$ref": "#/definitions/kubernetes_config_AuthProviderConfig",
@@ -8646,7 +8646,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -9085,14 +9085,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "data": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -9465,7 +9465,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "containerID": {
           "type": "string"
@@ -9599,7 +9599,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -9627,7 +9627,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -10379,7 +10379,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -10404,7 +10404,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -10801,7 +10801,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -10889,7 +10889,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "defaultRequest": {
           "type": "object",
@@ -10897,7 +10897,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "max": {
           "type": "object",
@@ -10905,7 +10905,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "maxLimitRequestRatio": {
           "type": "object",
@@ -10913,7 +10913,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "min": {
           "type": "object",
@@ -10921,7 +10921,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "type": {
           "type": "string"
@@ -11589,7 +11589,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -11597,7 +11597,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -11709,7 +11709,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_apis_Time",
@@ -11742,7 +11742,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -12022,7 +12022,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -12030,7 +12030,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -12038,7 +12038,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -12231,7 +12231,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -12794,7 +12794,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -12806,7 +12806,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -13381,7 +13381,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "template": {
           "$ref": "#/definitions/kubernetes_core_PodTemplateSpec",
@@ -13503,7 +13503,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -13527,7 +13527,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -13535,7 +13535,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -13556,7 +13556,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -13564,7 +13564,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -13706,7 +13706,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "immutable": {
           "type": "boolean"
@@ -13725,7 +13725,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -14157,7 +14157,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sessionAffinity": {
           "type": "string"
@@ -14752,7 +14752,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -14760,7 +14760,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1/Endpoint.java
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1/Endpoint.java
@@ -66,7 +66,7 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
 
     @JsonProperty("addresses")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> addresses = new ArrayList<java.lang.String>();
+    private List<String> addresses = new ArrayList<String>();
     @JsonProperty("conditions")
     private EndpointConditions conditions;
     @JsonProperty("deprecatedTopology")
@@ -75,15 +75,15 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     @JsonProperty("hints")
     private EndpointHints hints;
     @JsonProperty("hostname")
-    private java.lang.String hostname;
+    private String hostname;
     @JsonProperty("nodeName")
-    private java.lang.String nodeName;
+    private String nodeName;
     @JsonProperty("targetRef")
     private io.fabric8.kubernetes.api.model.ObjectReference targetRef;
     @JsonProperty("zone")
-    private java.lang.String zone;
+    private String zone;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -92,7 +92,7 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     public Endpoint() {
     }
 
-    public Endpoint(List<java.lang.String> addresses, EndpointConditions conditions, Map<String, String> deprecatedTopology, EndpointHints hints, java.lang.String hostname, java.lang.String nodeName, io.fabric8.kubernetes.api.model.ObjectReference targetRef, java.lang.String zone) {
+    public Endpoint(List<String> addresses, EndpointConditions conditions, Map<String, String> deprecatedTopology, EndpointHints hints, String hostname, String nodeName, io.fabric8.kubernetes.api.model.ObjectReference targetRef, String zone) {
         super();
         this.addresses = addresses;
         this.conditions = conditions;
@@ -105,12 +105,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("addresses")
-    public List<java.lang.String> getAddresses() {
+    public List<String> getAddresses() {
         return addresses;
     }
 
     @JsonProperty("addresses")
-    public void setAddresses(List<java.lang.String> addresses) {
+    public void setAddresses(List<String> addresses) {
         this.addresses = addresses;
     }
 
@@ -145,22 +145,22 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("hostname")
-    public java.lang.String getHostname() {
+    public String getHostname() {
         return hostname;
     }
 
     @JsonProperty("hostname")
-    public void setHostname(java.lang.String hostname) {
+    public void setHostname(String hostname) {
         this.hostname = hostname;
     }
 
     @JsonProperty("nodeName")
-    public java.lang.String getNodeName() {
+    public String getNodeName() {
         return nodeName;
     }
 
     @JsonProperty("nodeName")
-    public void setNodeName(java.lang.String nodeName) {
+    public void setNodeName(String nodeName) {
         this.nodeName = nodeName;
     }
 
@@ -175,12 +175,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("zone")
-    public java.lang.String getZone() {
+    public String getZone() {
         return zone;
     }
 
     @JsonProperty("zone")
-    public void setZone(java.lang.String zone) {
+    public void setZone(String zone) {
         this.zone = zone;
     }
 
@@ -195,12 +195,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/Endpoint.java
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/generated/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/Endpoint.java
@@ -65,22 +65,22 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
 
     @JsonProperty("addresses")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> addresses = new ArrayList<java.lang.String>();
+    private List<String> addresses = new ArrayList<String>();
     @JsonProperty("conditions")
     private EndpointConditions conditions;
     @JsonProperty("hints")
     private EndpointHints hints;
     @JsonProperty("hostname")
-    private java.lang.String hostname;
+    private String hostname;
     @JsonProperty("nodeName")
-    private java.lang.String nodeName;
+    private String nodeName;
     @JsonProperty("targetRef")
     private io.fabric8.kubernetes.api.model.ObjectReference targetRef;
     @JsonProperty("topology")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> topology = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -89,7 +89,7 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     public Endpoint() {
     }
 
-    public Endpoint(List<java.lang.String> addresses, EndpointConditions conditions, EndpointHints hints, java.lang.String hostname, java.lang.String nodeName, io.fabric8.kubernetes.api.model.ObjectReference targetRef, Map<String, String> topology) {
+    public Endpoint(List<String> addresses, EndpointConditions conditions, EndpointHints hints, String hostname, String nodeName, io.fabric8.kubernetes.api.model.ObjectReference targetRef, Map<String, String> topology) {
         super();
         this.addresses = addresses;
         this.conditions = conditions;
@@ -101,12 +101,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("addresses")
-    public List<java.lang.String> getAddresses() {
+    public List<String> getAddresses() {
         return addresses;
     }
 
     @JsonProperty("addresses")
-    public void setAddresses(List<java.lang.String> addresses) {
+    public void setAddresses(List<String> addresses) {
         this.addresses = addresses;
     }
 
@@ -131,22 +131,22 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("hostname")
-    public java.lang.String getHostname() {
+    public String getHostname() {
         return hostname;
     }
 
     @JsonProperty("hostname")
-    public void setHostname(java.lang.String hostname) {
+    public void setHostname(String hostname) {
         this.hostname = hostname;
     }
 
     @JsonProperty("nodeName")
-    public java.lang.String getNodeName() {
+    public String getNodeName() {
         return nodeName;
     }
 
     @JsonProperty("nodeName")
-    public void setNodeName(java.lang.String nodeName) {
+    public void setNodeName(String nodeName) {
         this.nodeName = nodeName;
     }
 
@@ -181,12 +181,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/kube-schema.json
@@ -354,7 +354,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -387,7 +387,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -797,7 +797,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "hints": {
           "$ref": "#/definitions/kubernetes_discovery_v1_EndpointHints",
@@ -1003,7 +1003,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/main/resources/schema/validation-schema.json
@@ -354,7 +354,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -387,7 +387,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -797,7 +797,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "hints": {
           "$ref": "#/definitions/kubernetes_discovery_v1_EndpointHints",
@@ -1003,7 +1003,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1398,7 +1398,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "hints": {
           "$ref": "#/definitions/kubernetes_discovery_v1_EndpointHints",
@@ -1506,14 +1506,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "discovery.k8s.io/v1beta1",
+          "default": "discovery.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_discovery_v1beta1_EndpointSlice",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.discovery.v1beta1.EndpointSlice"
+            "$ref": "#/definitions/kubernetes_discovery_v1_EndpointSlice",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice"
           }
         },
         "kind": {
@@ -1726,7 +1726,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1759,7 +1759,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-events/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-events/src/main/resources/schema/kube-schema.json
@@ -367,7 +367,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -400,7 +400,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-events/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-events/src/main/resources/schema/validation-schema.json
@@ -367,7 +367,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -400,7 +400,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1286,7 +1286,7 @@
         },
         "apiVersion": {
           "type": "string",
-          "default": "events.k8s.io/v1beta1",
+          "default": "events.k8s.io/v1",
           "required": true
         },
         "deprecatedCount": {
@@ -1338,8 +1338,8 @@
           "type": "string"
         },
         "series": {
-          "$ref": "#/definitions/kubernetes_events_v1beta1_EventSeries",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.events.v1beta1.EventSeries"
+          "$ref": "#/definitions/kubernetes_events_v1_EventSeries",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.events.v1.EventSeries"
         },
         "type": {
           "type": "string"
@@ -1594,7 +1594,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1627,7 +1627,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/DeploymentRollback.java
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/generated/java/io/fabric8/kubernetes/api/model/extensions/DeploymentRollback.java
@@ -75,23 +75,23 @@ public class DeploymentRollback implements Editable<DeploymentRollbackBuilder> ,
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "extensions/v1beta1";
+    private String apiVersion = "extensions/v1beta1";
     /**
      * 
      * (Required)
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "DeploymentRollback";
+    private String kind = "DeploymentRollback";
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("rollbackTo")
     private RollbackConfig rollbackTo;
     @JsonProperty("updatedAnnotations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> updatedAnnotations = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -100,7 +100,7 @@ public class DeploymentRollback implements Editable<DeploymentRollbackBuilder> ,
     public DeploymentRollback() {
     }
 
-    public DeploymentRollback(java.lang.String apiVersion, java.lang.String kind, java.lang.String name, RollbackConfig rollbackTo, Map<String, String> updatedAnnotations) {
+    public DeploymentRollback(String apiVersion, String kind, String name, RollbackConfig rollbackTo, Map<String, String> updatedAnnotations) {
         super();
         this.apiVersion = apiVersion;
         this.kind = kind;
@@ -115,7 +115,7 @@ public class DeploymentRollback implements Editable<DeploymentRollbackBuilder> ,
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -125,7 +125,7 @@ public class DeploymentRollback implements Editable<DeploymentRollbackBuilder> ,
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
@@ -135,7 +135,7 @@ public class DeploymentRollback implements Editable<DeploymentRollbackBuilder> ,
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -145,17 +145,17 @@ public class DeploymentRollback implements Editable<DeploymentRollbackBuilder> ,
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -190,12 +190,12 @@ public class DeploymentRollback implements Editable<DeploymentRollbackBuilder> ,
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/main/resources/schema/kube-schema.json
@@ -222,7 +222,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -402,7 +402,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -435,7 +435,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -944,7 +944,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1812,7 +1812,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -2720,7 +2720,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -2732,7 +2732,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3091,7 +3091,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3099,7 +3099,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3742,7 +3742,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3750,7 +3750,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4252,7 +4252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/kubernetes-model-extensions/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-extensions/src/main/resources/schema/validation-schema.json
@@ -222,7 +222,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -402,7 +402,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -435,7 +435,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -944,7 +944,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1812,7 +1812,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -2720,7 +2720,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -2732,7 +2732,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3091,7 +3091,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3099,7 +3099,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3742,7 +3742,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3750,7 +3750,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4252,7 +4252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -5681,7 +5681,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -5978,7 +5978,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -6489,7 +6489,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -7009,7 +7009,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -7448,7 +7448,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -7481,7 +7481,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -7970,7 +7970,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -7982,7 +7982,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -8430,7 +8430,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -8438,7 +8438,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -9152,7 +9152,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -9160,7 +9160,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/kubernetes-model-flowcontrol/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-flowcontrol/src/main/resources/schema/kube-schema.json
@@ -75,7 +75,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -108,7 +108,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-flowcontrol/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-flowcontrol/src/main/resources/schema/validation-schema.json
@@ -75,7 +75,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -108,7 +108,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -2624,14 +2624,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "flowcontrol.apiserver.k8s.io/v1beta3",
+          "default": "flowcontrol.apiserver.k8s.io/v1beta1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta3_FlowSchema",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta3.FlowSchema"
+            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_FlowSchema",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.FlowSchema"
           }
         },
         "kind": {
@@ -2676,8 +2676,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta3_FlowSchemaCondition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta3.FlowSchemaCondition"
+            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_FlowSchemaCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.FlowSchemaCondition"
           }
         }
       },
@@ -2693,9 +2693,6 @@
     },
     "limitedprioritylevelconfiguration": {
       "properties": {
-        "assuredConcurrencyShares": {
-          "type": "integer"
-        },
         "borrowingLimitPercent": {
           "type": "integer"
         },
@@ -2703,8 +2700,11 @@
           "type": "integer"
         },
         "limitResponse": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_LimitResponse",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.LimitResponse"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta3_LimitResponse",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta3.LimitResponse"
+        },
+        "nominalConcurrencyShares": {
+          "type": "integer"
         }
       },
       "additionalProperties": true
@@ -2712,8 +2712,8 @@
     "limitresponse": {
       "properties": {
         "queuing": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta3_QueuingConfiguration",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta3.QueuingConfiguration"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1_QueuingConfiguration",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1.QueuingConfiguration"
         },
         "type": {
           "type": "string"
@@ -2791,7 +2791,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -2824,7 +2824,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -2891,23 +2891,23 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_NonResourcePolicyRule",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.NonResourcePolicyRule"
+            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_NonResourcePolicyRule",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.NonResourcePolicyRule"
           }
         },
         "resourceRules": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_ResourcePolicyRule",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.ResourcePolicyRule"
+            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_ResourcePolicyRule",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.ResourcePolicyRule"
           }
         },
         "subjects": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_Subject",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.Subject"
+            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_Subject",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.Subject"
           }
         }
       },
@@ -2917,7 +2917,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "flowcontrol.apiserver.k8s.io/v1beta3",
+          "default": "flowcontrol.apiserver.k8s.io/v1beta1",
           "required": true
         },
         "kind": {
@@ -2930,12 +2930,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta3_PriorityLevelConfigurationSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta3.PriorityLevelConfigurationSpec"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_PriorityLevelConfigurationSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.PriorityLevelConfigurationSpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta3_PriorityLevelConfigurationStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta3.PriorityLevelConfigurationStatus"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_PriorityLevelConfigurationStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.PriorityLevelConfigurationStatus"
         }
       },
       "additionalProperties": true
@@ -2965,14 +2965,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "flowcontrol.apiserver.k8s.io/v1beta3",
+          "default": "flowcontrol.apiserver.k8s.io/v1beta2",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta3_PriorityLevelConfiguration",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta3.PriorityLevelConfiguration"
+            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_PriorityLevelConfiguration",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.PriorityLevelConfiguration"
           }
         },
         "kind": {
@@ -2998,12 +2998,12 @@
     "prioritylevelconfigurationspec": {
       "properties": {
         "exempt": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_ExemptPriorityLevelConfiguration",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.ExemptPriorityLevelConfiguration"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_ExemptPriorityLevelConfiguration",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.ExemptPriorityLevelConfiguration"
         },
         "limited": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_LimitedPriorityLevelConfiguration",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_LimitedPriorityLevelConfiguration",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.LimitedPriorityLevelConfiguration"
         },
         "type": {
           "type": "string"
@@ -3017,8 +3017,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta1_PriorityLevelConfigurationCondition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta1.PriorityLevelConfigurationCondition"
+            "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_PriorityLevelConfigurationCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.PriorityLevelConfigurationCondition"
           }
         }
       },
@@ -3214,19 +3214,19 @@
     "subject": {
       "properties": {
         "group": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1_GroupSubject",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1.GroupSubject"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_GroupSubject",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.GroupSubject"
         },
         "kind": {
           "type": "string"
         },
         "serviceAccount": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1_ServiceAccountSubject",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1.ServiceAccountSubject"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_ServiceAccountSubject",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.ServiceAccountSubject"
         },
         "user": {
-          "$ref": "#/definitions/kubernetes_flowcontrol_v1_UserSubject",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1.UserSubject"
+          "$ref": "#/definitions/kubernetes_flowcontrol_v1beta2_UserSubject",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.flowcontrol.v1beta2.UserSubject"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/kubernetes-model-gatewayapi/src/generated/java/io/fabric8/kubernetes/api/model/gatewayapi/v1/GatewayInfrastructure.java
+++ b/kubernetes-model-generator/kubernetes-model-gatewayapi/src/generated/java/io/fabric8/kubernetes/api/model/gatewayapi/v1/GatewayInfrastructure.java
@@ -64,7 +64,7 @@ public class GatewayInfrastructure implements Editable<GatewayInfrastructureBuil
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -110,12 +110,12 @@ public class GatewayInfrastructure implements Editable<GatewayInfrastructureBuil
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-gatewayapi/src/generated/java/io/fabric8/kubernetes/api/model/gatewayapi/v1/GatewayTLSConfig.java
+++ b/kubernetes-model-generator/kubernetes-model-gatewayapi/src/generated/java/io/fabric8/kubernetes/api/model/gatewayapi/v1/GatewayTLSConfig.java
@@ -64,12 +64,12 @@ public class GatewayTLSConfig implements Editable<GatewayTLSConfigBuilder> , Kub
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<SecretObjectReference> certificateRefs = new ArrayList<SecretObjectReference>();
     @JsonProperty("mode")
-    private java.lang.String mode;
+    private String mode;
     @JsonProperty("options")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> options = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -78,7 +78,7 @@ public class GatewayTLSConfig implements Editable<GatewayTLSConfigBuilder> , Kub
     public GatewayTLSConfig() {
     }
 
-    public GatewayTLSConfig(List<SecretObjectReference> certificateRefs, java.lang.String mode, Map<String, String> options) {
+    public GatewayTLSConfig(List<SecretObjectReference> certificateRefs, String mode, Map<String, String> options) {
         super();
         this.certificateRefs = certificateRefs;
         this.mode = mode;
@@ -97,12 +97,12 @@ public class GatewayTLSConfig implements Editable<GatewayTLSConfigBuilder> , Kub
     }
 
     @JsonProperty("mode")
-    public java.lang.String getMode() {
+    public String getMode() {
         return mode;
     }
 
     @JsonProperty("mode")
-    public void setMode(java.lang.String mode) {
+    public void setMode(String mode) {
         this.mode = mode;
     }
 
@@ -127,12 +127,12 @@ public class GatewayTLSConfig implements Editable<GatewayTLSConfigBuilder> , Kub
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-gatewayapi/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-gatewayapi/src/main/resources/schema/kube-schema.json
@@ -57,7 +57,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -153,7 +153,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -186,7 +186,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -546,14 +546,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -695,7 +695,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/kubernetes-model-gatewayapi/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-gatewayapi/src/main/resources/schema/validation-schema.json
@@ -57,7 +57,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -153,7 +153,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -186,7 +186,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -546,14 +546,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -695,7 +695,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -3178,7 +3178,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "gateway.networking.k8s.io/v1alpha2",
+          "default": "gateway.networking.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -3205,14 +3205,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "gateway.networking.k8s.io/v1beta1",
+          "default": "gateway.networking.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1beta1_GatewayClass",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1beta1.GatewayClass"
+            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1_GatewayClass",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1.GatewayClass"
           }
         },
         "kind": {
@@ -3269,14 +3269,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -3285,14 +3285,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "gateway.networking.k8s.io/v1",
+          "default": "gateway.networking.k8s.io/v1beta1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1_Gateway",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1.Gateway"
+            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1beta1_Gateway",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1beta1.Gateway"
           }
         },
         "kind": {
@@ -3392,7 +3392,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -3780,7 +3780,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "gateway.networking.k8s.io/v1alpha2",
+          "default": "gateway.networking.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -3839,14 +3839,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "gateway.networking.k8s.io/v1",
+          "default": "gateway.networking.k8s.io/v1alpha2",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1_HTTPRoute",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1.HTTPRoute"
+            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1alpha2_HTTPRoute",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1alpha2.HTTPRoute"
           }
         },
         "kind": {
@@ -4000,7 +4000,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -4140,7 +4140,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -4173,7 +4173,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -4386,14 +4386,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "gateway.networking.k8s.io/v1alpha2",
+          "default": "gateway.networking.k8s.io/v1beta1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1alpha2_ReferenceGrant",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1alpha2.ReferenceGrant"
+            "$ref": "#/definitions/kubernetes_sigs_gatewayapi_v1beta1_ReferenceGrant",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.gatewayapi.v1beta1.ReferenceGrant"
           }
         },
         "kind": {

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/GeneratorOptions.java
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/GeneratorOptions.java
@@ -50,7 +50,7 @@ public class GeneratorOptions implements Editable<GeneratorOptionsBuilder> , Kub
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -118,12 +118,12 @@ public class GeneratorOptions implements Editable<GeneratorOptionsBuilder> , Kub
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/HelmChart.java
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/HelmChart.java
@@ -53,37 +53,37 @@ public class HelmChart implements Editable<HelmChartBuilder> , KubernetesResourc
 
     @JsonProperty("additionalValuesFiles")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> additionalValuesFiles = new ArrayList<java.lang.String>();
+    private List<String> additionalValuesFiles = new ArrayList<String>();
     @JsonProperty("apiVersions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> apiVersions = new ArrayList<java.lang.String>();
+    private List<String> apiVersions = new ArrayList<String>();
     @JsonProperty("includeCRDs")
     private Boolean includeCRDs;
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("nameTemplate")
-    private java.lang.String nameTemplate;
+    private String nameTemplate;
     @JsonProperty("namespace")
-    private java.lang.String namespace;
+    private String namespace;
     @JsonProperty("releaseName")
-    private java.lang.String releaseName;
+    private String releaseName;
     @JsonProperty("repo")
-    private java.lang.String repo;
+    private String repo;
     @JsonProperty("skipHooks")
     private Boolean skipHooks;
     @JsonProperty("skipTests")
     private Boolean skipTests;
     @JsonProperty("valuesFile")
-    private java.lang.String valuesFile;
+    private String valuesFile;
     @JsonProperty("valuesInline")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Object> valuesInline = new LinkedHashMap<String, Object>();
     @JsonProperty("valuesMerge")
-    private java.lang.String valuesMerge;
+    private String valuesMerge;
     @JsonProperty("version")
-    private java.lang.String version;
+    private String version;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -92,7 +92,7 @@ public class HelmChart implements Editable<HelmChartBuilder> , KubernetesResourc
     public HelmChart() {
     }
 
-    public HelmChart(List<java.lang.String> additionalValuesFiles, List<java.lang.String> apiVersions, Boolean includeCRDs, java.lang.String name, java.lang.String nameTemplate, java.lang.String namespace, java.lang.String releaseName, java.lang.String repo, Boolean skipHooks, Boolean skipTests, java.lang.String valuesFile, Map<String, Object> valuesInline, java.lang.String valuesMerge, java.lang.String version) {
+    public HelmChart(List<String> additionalValuesFiles, List<String> apiVersions, Boolean includeCRDs, String name, String nameTemplate, String namespace, String releaseName, String repo, Boolean skipHooks, Boolean skipTests, String valuesFile, Map<String, Object> valuesInline, String valuesMerge, String version) {
         super();
         this.additionalValuesFiles = additionalValuesFiles;
         this.apiVersions = apiVersions;
@@ -112,23 +112,23 @@ public class HelmChart implements Editable<HelmChartBuilder> , KubernetesResourc
 
     @JsonProperty("additionalValuesFiles")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getAdditionalValuesFiles() {
+    public List<String> getAdditionalValuesFiles() {
         return additionalValuesFiles;
     }
 
     @JsonProperty("additionalValuesFiles")
-    public void setAdditionalValuesFiles(List<java.lang.String> additionalValuesFiles) {
+    public void setAdditionalValuesFiles(List<String> additionalValuesFiles) {
         this.additionalValuesFiles = additionalValuesFiles;
     }
 
     @JsonProperty("apiVersions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getApiVersions() {
+    public List<String> getApiVersions() {
         return apiVersions;
     }
 
     @JsonProperty("apiVersions")
-    public void setApiVersions(List<java.lang.String> apiVersions) {
+    public void setApiVersions(List<String> apiVersions) {
         this.apiVersions = apiVersions;
     }
 
@@ -143,52 +143,52 @@ public class HelmChart implements Editable<HelmChartBuilder> , KubernetesResourc
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
     @JsonProperty("nameTemplate")
-    public java.lang.String getNameTemplate() {
+    public String getNameTemplate() {
         return nameTemplate;
     }
 
     @JsonProperty("nameTemplate")
-    public void setNameTemplate(java.lang.String nameTemplate) {
+    public void setNameTemplate(String nameTemplate) {
         this.nameTemplate = nameTemplate;
     }
 
     @JsonProperty("namespace")
-    public java.lang.String getNamespace() {
+    public String getNamespace() {
         return namespace;
     }
 
     @JsonProperty("namespace")
-    public void setNamespace(java.lang.String namespace) {
+    public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
 
     @JsonProperty("releaseName")
-    public java.lang.String getReleaseName() {
+    public String getReleaseName() {
         return releaseName;
     }
 
     @JsonProperty("releaseName")
-    public void setReleaseName(java.lang.String releaseName) {
+    public void setReleaseName(String releaseName) {
         this.releaseName = releaseName;
     }
 
     @JsonProperty("repo")
-    public java.lang.String getRepo() {
+    public String getRepo() {
         return repo;
     }
 
     @JsonProperty("repo")
-    public void setRepo(java.lang.String repo) {
+    public void setRepo(String repo) {
         this.repo = repo;
     }
 
@@ -213,12 +213,12 @@ public class HelmChart implements Editable<HelmChartBuilder> , KubernetesResourc
     }
 
     @JsonProperty("valuesFile")
-    public java.lang.String getValuesFile() {
+    public String getValuesFile() {
         return valuesFile;
     }
 
     @JsonProperty("valuesFile")
-    public void setValuesFile(java.lang.String valuesFile) {
+    public void setValuesFile(String valuesFile) {
         this.valuesFile = valuesFile;
     }
 
@@ -233,22 +233,22 @@ public class HelmChart implements Editable<HelmChartBuilder> , KubernetesResourc
     }
 
     @JsonProperty("valuesMerge")
-    public java.lang.String getValuesMerge() {
+    public String getValuesMerge() {
         return valuesMerge;
     }
 
     @JsonProperty("valuesMerge")
-    public void setValuesMerge(java.lang.String valuesMerge) {
+    public void setValuesMerge(String valuesMerge) {
         this.valuesMerge = valuesMerge;
     }
 
     @JsonProperty("version")
-    public java.lang.String getVersion() {
+    public String getVersion() {
         return version;
     }
 
     @JsonProperty("version")
-    public void setVersion(java.lang.String version) {
+    public void setVersion(String version) {
         this.version = version;
     }
 
@@ -263,12 +263,12 @@ public class HelmChart implements Editable<HelmChartBuilder> , KubernetesResourc
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/HelmChartArgs.java
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/HelmChartArgs.java
@@ -51,35 +51,35 @@ public class HelmChartArgs implements Editable<HelmChartArgsBuilder> , Kubernete
 {
 
     @JsonProperty("chartHome")
-    private java.lang.String chartHome;
+    private String chartHome;
     @JsonProperty("chartName")
-    private java.lang.String chartName;
+    private String chartName;
     @JsonProperty("chartRepoName")
-    private java.lang.String chartRepoName;
+    private String chartRepoName;
     @JsonProperty("chartRepoUrl")
-    private java.lang.String chartRepoUrl;
+    private String chartRepoUrl;
     @JsonProperty("chartVersion")
-    private java.lang.String chartVersion;
+    private String chartVersion;
     @JsonProperty("extraArgs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> extraArgs = new ArrayList<java.lang.String>();
+    private List<String> extraArgs = new ArrayList<String>();
     @JsonProperty("helmBin")
-    private java.lang.String helmBin;
+    private String helmBin;
     @JsonProperty("helmHome")
-    private java.lang.String helmHome;
+    private String helmHome;
     @JsonProperty("releaseName")
-    private java.lang.String releaseName;
+    private String releaseName;
     @JsonProperty("releaseNamespace")
-    private java.lang.String releaseNamespace;
+    private String releaseNamespace;
     @JsonProperty("values")
-    private java.lang.String values;
+    private String values;
     @JsonProperty("valuesLocal")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Object> valuesLocal = new LinkedHashMap<String, Object>();
     @JsonProperty("valuesMerge")
-    private java.lang.String valuesMerge;
+    private String valuesMerge;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -88,7 +88,7 @@ public class HelmChartArgs implements Editable<HelmChartArgsBuilder> , Kubernete
     public HelmChartArgs() {
     }
 
-    public HelmChartArgs(java.lang.String chartHome, java.lang.String chartName, java.lang.String chartRepoName, java.lang.String chartRepoUrl, java.lang.String chartVersion, List<java.lang.String> extraArgs, java.lang.String helmBin, java.lang.String helmHome, java.lang.String releaseName, java.lang.String releaseNamespace, java.lang.String values, Map<String, Object> valuesLocal, java.lang.String valuesMerge) {
+    public HelmChartArgs(String chartHome, String chartName, String chartRepoName, String chartRepoUrl, String chartVersion, List<String> extraArgs, String helmBin, String helmHome, String releaseName, String releaseNamespace, String values, Map<String, Object> valuesLocal, String valuesMerge) {
         super();
         this.chartHome = chartHome;
         this.chartName = chartName;
@@ -106,113 +106,113 @@ public class HelmChartArgs implements Editable<HelmChartArgsBuilder> , Kubernete
     }
 
     @JsonProperty("chartHome")
-    public java.lang.String getChartHome() {
+    public String getChartHome() {
         return chartHome;
     }
 
     @JsonProperty("chartHome")
-    public void setChartHome(java.lang.String chartHome) {
+    public void setChartHome(String chartHome) {
         this.chartHome = chartHome;
     }
 
     @JsonProperty("chartName")
-    public java.lang.String getChartName() {
+    public String getChartName() {
         return chartName;
     }
 
     @JsonProperty("chartName")
-    public void setChartName(java.lang.String chartName) {
+    public void setChartName(String chartName) {
         this.chartName = chartName;
     }
 
     @JsonProperty("chartRepoName")
-    public java.lang.String getChartRepoName() {
+    public String getChartRepoName() {
         return chartRepoName;
     }
 
     @JsonProperty("chartRepoName")
-    public void setChartRepoName(java.lang.String chartRepoName) {
+    public void setChartRepoName(String chartRepoName) {
         this.chartRepoName = chartRepoName;
     }
 
     @JsonProperty("chartRepoUrl")
-    public java.lang.String getChartRepoUrl() {
+    public String getChartRepoUrl() {
         return chartRepoUrl;
     }
 
     @JsonProperty("chartRepoUrl")
-    public void setChartRepoUrl(java.lang.String chartRepoUrl) {
+    public void setChartRepoUrl(String chartRepoUrl) {
         this.chartRepoUrl = chartRepoUrl;
     }
 
     @JsonProperty("chartVersion")
-    public java.lang.String getChartVersion() {
+    public String getChartVersion() {
         return chartVersion;
     }
 
     @JsonProperty("chartVersion")
-    public void setChartVersion(java.lang.String chartVersion) {
+    public void setChartVersion(String chartVersion) {
         this.chartVersion = chartVersion;
     }
 
     @JsonProperty("extraArgs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getExtraArgs() {
+    public List<String> getExtraArgs() {
         return extraArgs;
     }
 
     @JsonProperty("extraArgs")
-    public void setExtraArgs(List<java.lang.String> extraArgs) {
+    public void setExtraArgs(List<String> extraArgs) {
         this.extraArgs = extraArgs;
     }
 
     @JsonProperty("helmBin")
-    public java.lang.String getHelmBin() {
+    public String getHelmBin() {
         return helmBin;
     }
 
     @JsonProperty("helmBin")
-    public void setHelmBin(java.lang.String helmBin) {
+    public void setHelmBin(String helmBin) {
         this.helmBin = helmBin;
     }
 
     @JsonProperty("helmHome")
-    public java.lang.String getHelmHome() {
+    public String getHelmHome() {
         return helmHome;
     }
 
     @JsonProperty("helmHome")
-    public void setHelmHome(java.lang.String helmHome) {
+    public void setHelmHome(String helmHome) {
         this.helmHome = helmHome;
     }
 
     @JsonProperty("releaseName")
-    public java.lang.String getReleaseName() {
+    public String getReleaseName() {
         return releaseName;
     }
 
     @JsonProperty("releaseName")
-    public void setReleaseName(java.lang.String releaseName) {
+    public void setReleaseName(String releaseName) {
         this.releaseName = releaseName;
     }
 
     @JsonProperty("releaseNamespace")
-    public java.lang.String getReleaseNamespace() {
+    public String getReleaseNamespace() {
         return releaseNamespace;
     }
 
     @JsonProperty("releaseNamespace")
-    public void setReleaseNamespace(java.lang.String releaseNamespace) {
+    public void setReleaseNamespace(String releaseNamespace) {
         this.releaseNamespace = releaseNamespace;
     }
 
     @JsonProperty("values")
-    public java.lang.String getValues() {
+    public String getValues() {
         return values;
     }
 
     @JsonProperty("values")
-    public void setValues(java.lang.String values) {
+    public void setValues(String values) {
         this.values = values;
     }
 
@@ -227,12 +227,12 @@ public class HelmChartArgs implements Editable<HelmChartArgsBuilder> , Kubernete
     }
 
     @JsonProperty("valuesMerge")
-    public java.lang.String getValuesMerge() {
+    public String getValuesMerge() {
         return valuesMerge;
     }
 
     @JsonProperty("valuesMerge")
-    public void setValuesMerge(java.lang.String valuesMerge) {
+    public void setValuesMerge(String valuesMerge) {
         this.valuesMerge = valuesMerge;
     }
 
@@ -247,12 +247,12 @@ public class HelmChartArgs implements Editable<HelmChartArgsBuilder> , Kubernete
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/Kustomization.java
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/Kustomization.java
@@ -77,13 +77,13 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion;
+    private String apiVersion;
     @JsonProperty("bases")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> bases = new ArrayList<java.lang.String>();
+    private List<String> bases = new ArrayList<String>();
     @JsonProperty("buildMetadata")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> buildMetadata = new ArrayList<java.lang.String>();
+    private List<String> buildMetadata = new ArrayList<String>();
     @JsonProperty("commonAnnotations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> commonAnnotations = new LinkedHashMap<String, String>();
@@ -92,21 +92,21 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
     private Map<String, String> commonLabels = new LinkedHashMap<String, String>();
     @JsonProperty("components")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> components = new ArrayList<java.lang.String>();
+    private List<String> components = new ArrayList<String>();
     @JsonProperty("configMapGenerator")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ConfigMapArgs> configMapGenerator = new ArrayList<ConfigMapArgs>();
     @JsonProperty("configurations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> configurations = new ArrayList<java.lang.String>();
+    private List<String> configurations = new ArrayList<String>();
     @JsonProperty("crds")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> crds = new ArrayList<java.lang.String>();
+    private List<String> crds = new ArrayList<String>();
     @JsonProperty("generatorOptions")
     private GeneratorOptions generatorOptions;
     @JsonProperty("generators")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> generators = new ArrayList<java.lang.String>();
+    private List<String> generators = new ArrayList<String>();
     @JsonProperty("helmChartInflationGenerator")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<HelmChartArgs> helmChartInflationGenerator = new ArrayList<HelmChartArgs>();
@@ -127,18 +127,18 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "Kustomization";
+    private String kind = "Kustomization";
     @JsonProperty("labels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Label> labels = new ArrayList<Label>();
     @JsonProperty("metadata")
     private ObjectMeta metadata;
     @JsonProperty("namePrefix")
-    private java.lang.String namePrefix;
+    private String namePrefix;
     @JsonProperty("nameSuffix")
-    private java.lang.String nameSuffix;
+    private String nameSuffix;
     @JsonProperty("namespace")
-    private java.lang.String namespace;
+    private String namespace;
     @JsonProperty("openapi")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> openapi = new LinkedHashMap<String, String>();
@@ -150,7 +150,7 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
     private List<Patch> patchesJson6902 = new ArrayList<Patch>();
     @JsonProperty("patchesStrategicMerge")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> patchesStrategicMerge = new ArrayList<java.lang.String>();
+    private List<String> patchesStrategicMerge = new ArrayList<String>();
     @JsonProperty("replacements")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ReplacementField> replacements = new ArrayList<ReplacementField>();
@@ -159,7 +159,7 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
     private List<Replica> replicas = new ArrayList<Replica>();
     @JsonProperty("resources")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> resources = new ArrayList<java.lang.String>();
+    private List<String> resources = new ArrayList<String>();
     @JsonProperty("secretGenerator")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<SecretArgs> secretGenerator = new ArrayList<SecretArgs>();
@@ -167,15 +167,15 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
     private SortOptions sortOptions;
     @JsonProperty("transformers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> transformers = new ArrayList<java.lang.String>();
+    private List<String> transformers = new ArrayList<String>();
     @JsonProperty("validators")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> validators = new ArrayList<java.lang.String>();
+    private List<String> validators = new ArrayList<String>();
     @JsonProperty("vars")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Var> vars = new ArrayList<Var>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -184,7 +184,7 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
     public Kustomization() {
     }
 
-    public Kustomization(java.lang.String apiVersion, List<java.lang.String> bases, List<java.lang.String> buildMetadata, Map<String, String> commonAnnotations, Map<String, String> commonLabels, List<java.lang.String> components, List<ConfigMapArgs> configMapGenerator, List<java.lang.String> configurations, List<java.lang.String> crds, GeneratorOptions generatorOptions, List<java.lang.String> generators, List<HelmChartArgs> helmChartInflationGenerator, List<HelmChart> helmCharts, HelmGlobals helmGlobals, List<Image> imageTags, List<Image> images, java.lang.String kind, List<Label> labels, ObjectMeta metadata, java.lang.String namePrefix, java.lang.String nameSuffix, java.lang.String namespace, Map<String, String> openapi, List<Patch> patches, List<Patch> patchesJson6902, List<java.lang.String> patchesStrategicMerge, List<ReplacementField> replacements, List<Replica> replicas, List<java.lang.String> resources, List<SecretArgs> secretGenerator, SortOptions sortOptions, List<java.lang.String> transformers, List<java.lang.String> validators, List<Var> vars) {
+    public Kustomization(String apiVersion, List<String> bases, List<String> buildMetadata, Map<String, String> commonAnnotations, Map<String, String> commonLabels, List<String> components, List<ConfigMapArgs> configMapGenerator, List<String> configurations, List<String> crds, GeneratorOptions generatorOptions, List<String> generators, List<HelmChartArgs> helmChartInflationGenerator, List<HelmChart> helmCharts, HelmGlobals helmGlobals, List<Image> imageTags, List<Image> images, String kind, List<Label> labels, ObjectMeta metadata, String namePrefix, String nameSuffix, String namespace, Map<String, String> openapi, List<Patch> patches, List<Patch> patchesJson6902, List<String> patchesStrategicMerge, List<ReplacementField> replacements, List<Replica> replicas, List<String> resources, List<SecretArgs> secretGenerator, SortOptions sortOptions, List<String> transformers, List<String> validators, List<Var> vars) {
         super();
         this.apiVersion = apiVersion;
         this.bases = bases;
@@ -228,7 +228,7 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -238,29 +238,29 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
     @JsonProperty("bases")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getBases() {
+    public List<String> getBases() {
         return bases;
     }
 
     @JsonProperty("bases")
-    public void setBases(List<java.lang.String> bases) {
+    public void setBases(List<String> bases) {
         this.bases = bases;
     }
 
     @JsonProperty("buildMetadata")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getBuildMetadata() {
+    public List<String> getBuildMetadata() {
         return buildMetadata;
     }
 
     @JsonProperty("buildMetadata")
-    public void setBuildMetadata(List<java.lang.String> buildMetadata) {
+    public void setBuildMetadata(List<String> buildMetadata) {
         this.buildMetadata = buildMetadata;
     }
 
@@ -286,12 +286,12 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
 
     @JsonProperty("components")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getComponents() {
+    public List<String> getComponents() {
         return components;
     }
 
     @JsonProperty("components")
-    public void setComponents(List<java.lang.String> components) {
+    public void setComponents(List<String> components) {
         this.components = components;
     }
 
@@ -308,23 +308,23 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
 
     @JsonProperty("configurations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getConfigurations() {
+    public List<String> getConfigurations() {
         return configurations;
     }
 
     @JsonProperty("configurations")
-    public void setConfigurations(List<java.lang.String> configurations) {
+    public void setConfigurations(List<String> configurations) {
         this.configurations = configurations;
     }
 
     @JsonProperty("crds")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getCrds() {
+    public List<String> getCrds() {
         return crds;
     }
 
     @JsonProperty("crds")
-    public void setCrds(List<java.lang.String> crds) {
+    public void setCrds(List<String> crds) {
         this.crds = crds;
     }
 
@@ -340,12 +340,12 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
 
     @JsonProperty("generators")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getGenerators() {
+    public List<String> getGenerators() {
         return generators;
     }
 
     @JsonProperty("generators")
-    public void setGenerators(List<java.lang.String> generators) {
+    public void setGenerators(List<String> generators) {
         this.generators = generators;
     }
 
@@ -409,7 +409,7 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -419,7 +419,7 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -445,32 +445,32 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
     }
 
     @JsonProperty("namePrefix")
-    public java.lang.String getNamePrefix() {
+    public String getNamePrefix() {
         return namePrefix;
     }
 
     @JsonProperty("namePrefix")
-    public void setNamePrefix(java.lang.String namePrefix) {
+    public void setNamePrefix(String namePrefix) {
         this.namePrefix = namePrefix;
     }
 
     @JsonProperty("nameSuffix")
-    public java.lang.String getNameSuffix() {
+    public String getNameSuffix() {
         return nameSuffix;
     }
 
     @JsonProperty("nameSuffix")
-    public void setNameSuffix(java.lang.String nameSuffix) {
+    public void setNameSuffix(String nameSuffix) {
         this.nameSuffix = nameSuffix;
     }
 
     @JsonProperty("namespace")
-    public java.lang.String getNamespace() {
+    public String getNamespace() {
         return namespace;
     }
 
     @JsonProperty("namespace")
-    public void setNamespace(java.lang.String namespace) {
+    public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
 
@@ -508,12 +508,12 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
 
     @JsonProperty("patchesStrategicMerge")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getPatchesStrategicMerge() {
+    public List<String> getPatchesStrategicMerge() {
         return patchesStrategicMerge;
     }
 
     @JsonProperty("patchesStrategicMerge")
-    public void setPatchesStrategicMerge(List<java.lang.String> patchesStrategicMerge) {
+    public void setPatchesStrategicMerge(List<String> patchesStrategicMerge) {
         this.patchesStrategicMerge = patchesStrategicMerge;
     }
 
@@ -541,12 +541,12 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
 
     @JsonProperty("resources")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getResources() {
+    public List<String> getResources() {
         return resources;
     }
 
     @JsonProperty("resources")
-    public void setResources(List<java.lang.String> resources) {
+    public void setResources(List<String> resources) {
         this.resources = resources;
     }
 
@@ -573,23 +573,23 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
 
     @JsonProperty("transformers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getTransformers() {
+    public List<String> getTransformers() {
         return transformers;
     }
 
     @JsonProperty("transformers")
-    public void setTransformers(List<java.lang.String> transformers) {
+    public void setTransformers(List<String> transformers) {
         this.transformers = transformers;
     }
 
     @JsonProperty("validators")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getValidators() {
+    public List<String> getValidators() {
         return validators;
     }
 
     @JsonProperty("validators")
-    public void setValidators(List<java.lang.String> validators) {
+    public void setValidators(List<String> validators) {
         this.validators = validators;
     }
 
@@ -615,12 +615,12 @@ public class Kustomization implements Editable<KustomizationBuilder> , Kubernete
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/Label.java
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/Label.java
@@ -52,7 +52,7 @@ public class Label implements Editable<LabelBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> pairs = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -121,12 +121,12 @@ public class Label implements Editable<LabelBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/ObjectMeta.java
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/ObjectMeta.java
@@ -46,11 +46,11 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("namespace")
-    private java.lang.String namespace;
+    private String namespace;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -59,7 +59,7 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     public ObjectMeta() {
     }
 
-    public ObjectMeta(Map<String, String> annotations, Map<String, String> labels, java.lang.String name, java.lang.String namespace) {
+    public ObjectMeta(Map<String, String> annotations, Map<String, String> labels, String name, String namespace) {
         super();
         this.annotations = annotations;
         this.labels = labels;
@@ -88,22 +88,22 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
     @JsonProperty("namespace")
-    public java.lang.String getNamespace() {
+    public String getNamespace() {
         return namespace;
     }
 
     @JsonProperty("namespace")
-    public void setNamespace(java.lang.String namespace) {
+    public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
 
@@ -118,12 +118,12 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/Patch.java
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/generated/java/io/fabric8/kubernetes/api/model/kustomize/v1beta1/Patch.java
@@ -43,13 +43,13 @@ public class Patch implements Editable<PatchBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Boolean> options = new LinkedHashMap<String, Boolean>();
     @JsonProperty("patch")
-    private java.lang.String patch;
+    private String patch;
     @JsonProperty("path")
-    private java.lang.String path;
+    private String path;
     @JsonProperty("target")
     private Selector target;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -58,7 +58,7 @@ public class Patch implements Editable<PatchBuilder> , KubernetesResource
     public Patch() {
     }
 
-    public Patch(Map<String, Boolean> options, java.lang.String patch, java.lang.String path, Selector target) {
+    public Patch(Map<String, Boolean> options, String patch, String path, Selector target) {
         super();
         this.options = options;
         this.patch = patch;
@@ -77,22 +77,22 @@ public class Patch implements Editable<PatchBuilder> , KubernetesResource
     }
 
     @JsonProperty("patch")
-    public java.lang.String getPatch() {
+    public String getPatch() {
         return patch;
     }
 
     @JsonProperty("patch")
-    public void setPatch(java.lang.String patch) {
+    public void setPatch(String patch) {
         this.patch = patch;
     }
 
     @JsonProperty("path")
-    public java.lang.String getPath() {
+    public String getPath() {
         return path;
     }
 
     @JsonProperty("path")
-    public void setPath(java.lang.String path) {
+    public void setPath(String path) {
         this.path = path;
     }
 
@@ -117,12 +117,12 @@ public class Patch implements Editable<PatchBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/main/resources/schema/kube-schema.json
@@ -167,7 +167,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disableNameSuffixHash": {
           "type": "boolean"
@@ -180,7 +180,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -236,7 +236,7 @@
         "valuesInline": {
           "type": "object",
           "additionalProperties": {},
-          "existingJavaType": "java.util.Map\u003cString, java.lang.Object\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.Object\u003e"
         },
         "valuesMerge": {
           "type": "string"
@@ -294,7 +294,7 @@
         "valuesLocal": {
           "type": "object",
           "additionalProperties": {},
-          "existingJavaType": "java.util.Map\u003cString, java.lang.Object\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.Object\u003e"
         },
         "valuesMerge": {
           "type": "string"
@@ -373,14 +373,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "commonLabels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "components": {
           "type": "array",
@@ -489,7 +489,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patches": {
           "type": "array",
@@ -634,7 +634,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -673,14 +673,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -705,7 +705,7 @@
           "additionalProperties": {
             "type": "boolean"
           },
-          "existingJavaType": "java.util.Map\u003cString, Boolean\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Boolean\u003e"
         },
         "patch": {
           "type": "string"

--- a/kubernetes-model-generator/kubernetes-model-kustomize/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/src/main/resources/schema/validation-schema.json
@@ -167,7 +167,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disableNameSuffixHash": {
           "type": "boolean"
@@ -180,7 +180,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -236,7 +236,7 @@
         "valuesInline": {
           "type": "object",
           "additionalProperties": {},
-          "existingJavaType": "java.util.Map\u003cString, java.lang.Object\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.Object\u003e"
         },
         "valuesMerge": {
           "type": "string"
@@ -294,7 +294,7 @@
         "valuesLocal": {
           "type": "object",
           "additionalProperties": {},
-          "existingJavaType": "java.util.Map\u003cString, java.lang.Object\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.Object\u003e"
         },
         "valuesMerge": {
           "type": "string"
@@ -373,14 +373,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "commonLabels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "components": {
           "type": "array",
@@ -489,7 +489,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patches": {
           "type": "array",
@@ -634,7 +634,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -673,14 +673,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -705,7 +705,7 @@
           "additionalProperties": {
             "type": "boolean"
           },
-          "existingJavaType": "java.util.Map\u003cString, Boolean\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Boolean\u003e"
         },
         "patch": {
           "type": "string"
@@ -1216,7 +1216,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disableNameSuffixHash": {
           "type": "boolean"
@@ -1229,7 +1229,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -1294,7 +1294,7 @@
         "valuesInline": {
           "type": "object",
           "additionalProperties": {},
-          "existingJavaType": "java.util.Map\u003cString, java.lang.Object\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.Object\u003e"
         },
         "valuesMerge": {
           "type": "string"
@@ -1347,7 +1347,7 @@
         "valuesLocal": {
           "type": "object",
           "additionalProperties": {},
-          "existingJavaType": "java.util.Map\u003cString, java.lang.Object\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.Object\u003e"
         },
         "valuesMerge": {
           "type": "string"
@@ -1411,14 +1411,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "commonLabels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "components": {
           "type": "array",
@@ -1527,7 +1527,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "patches": {
           "type": "array",
@@ -1662,7 +1662,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -1691,14 +1691,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -1718,7 +1718,7 @@
           "additionalProperties": {
             "type": "boolean"
           },
-          "existingJavaType": "java.util.Map\u003cString, Boolean\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Boolean\u003e"
         },
         "patch": {
           "type": "string"

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/ContainerMetrics.java
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/ContainerMetrics.java
@@ -59,12 +59,12 @@ public class ContainerMetrics implements Editable<ContainerMetricsBuilder> , Kub
 {
 
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("usage")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Quantity> usage = new LinkedHashMap<String, Quantity>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -73,19 +73,19 @@ public class ContainerMetrics implements Editable<ContainerMetricsBuilder> , Kub
     public ContainerMetrics() {
     }
 
-    public ContainerMetrics(java.lang.String name, Map<String, Quantity> usage) {
+    public ContainerMetrics(String name, Map<String, Quantity> usage) {
         super();
         this.name = name;
         this.usage = usage;
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -110,12 +110,12 @@ public class ContainerMetrics implements Editable<ContainerMetricsBuilder> , Kub
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetrics.java
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/generated/java/io/fabric8/kubernetes/api/model/metrics/v1beta1/NodeMetrics.java
@@ -91,7 +91,7 @@ public class NodeMetrics implements Editable<NodeMetricsBuilder> , HasMetadata
     private String timestamp;
     @JsonProperty("usage")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private Map<String, Quantity> usage = new LinkedHashMap<String, Quantity>();
+    private Map<java.lang.String, Quantity> usage = new LinkedHashMap<java.lang.String, Quantity>();
     @JsonProperty("window")
     private Duration window;
     @JsonIgnore
@@ -104,7 +104,7 @@ public class NodeMetrics implements Editable<NodeMetricsBuilder> , HasMetadata
     public NodeMetrics() {
     }
 
-    public NodeMetrics(java.lang.String apiVersion, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, String timestamp, Map<String, Quantity> usage, Duration window) {
+    public NodeMetrics(java.lang.String apiVersion, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, String timestamp, Map<java.lang.String, Quantity> usage, Duration window) {
         super();
         this.apiVersion = apiVersion;
         this.kind = kind;
@@ -175,12 +175,12 @@ public class NodeMetrics implements Editable<NodeMetricsBuilder> , HasMetadata
     }
 
     @JsonProperty("usage")
-    public Map<String, Quantity> getUsage() {
+    public Map<java.lang.String, Quantity> getUsage() {
         return usage;
     }
 
     @JsonProperty("usage")
-    public void setUsage(Map<String, Quantity> usage) {
+    public void setUsage(Map<java.lang.String, Quantity> usage) {
         this.usage = usage;
     }
 

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/kube-schema.json
@@ -355,7 +355,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -388,7 +388,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -792,7 +792,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -828,7 +828,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "window": {
           "$ref": "#/definitions/kubernetes_apimachinery_Duration",

--- a/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-metrics/src/main/resources/schema/validation-schema.json
@@ -355,7 +355,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -388,7 +388,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -792,7 +792,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -828,7 +828,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "window": {
           "$ref": "#/definitions/kubernetes_apimachinery_Duration",
@@ -1122,7 +1122,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -1409,7 +1409,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "window": {
           "$ref": "#/definitions/kubernetes_apimachinery_Duration",
@@ -1451,7 +1451,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1484,7 +1484,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-networking/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/main/resources/schema/kube-schema.json
@@ -252,7 +252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -432,7 +432,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -465,7 +465,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-networking/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-networking/src/main/resources/schema/validation-schema.json
@@ -252,7 +252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -432,7 +432,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -465,7 +465,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -2435,8 +2435,8 @@
         "paths": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_networking_v1beta1_HTTPIngressPath",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath"
+            "$ref": "#/definitions/kubernetes_networking_v1_HTTPIngressPath",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPath"
           }
         }
       },
@@ -2478,7 +2478,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "networking.k8s.io/v1",
+          "default": "networking.k8s.io/v1beta1",
           "required": true
         },
         "kind": {
@@ -2491,12 +2491,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_networking_v1_IngressSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.IngressSpec"
+          "$ref": "#/definitions/kubernetes_networking_v1beta1_IngressSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.IngressSpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_networking_v1_IngressStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.IngressStatus"
+          "$ref": "#/definitions/kubernetes_networking_v1beta1_IngressStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.IngressStatus"
         }
       },
       "additionalProperties": true
@@ -2507,9 +2507,12 @@
           "$ref": "#/definitions/kubernetes_core_TypedLocalObjectReference",
           "existingJavaType": "io.fabric8.kubernetes.api.model.TypedLocalObjectReference"
         },
-        "service": {
-          "$ref": "#/definitions/kubernetes_networking_v1_IngressServiceBackend",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.IngressServiceBackend"
+        "serviceName": {
+          "type": "string"
+        },
+        "servicePort": {
+          "$ref": "#/definitions/kubernetes_apimachinery_pkg_util_intstr_IntOrString",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.IntOrString"
         }
       },
       "additionalProperties": true
@@ -2541,14 +2544,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "networking.k8s.io/v1beta1",
+          "default": "networking.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_networking_v1beta1_IngressClass",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.IngressClass"
+            "$ref": "#/definitions/kubernetes_networking_v1_IngressClass",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.IngressClass"
           }
         },
         "kind": {
@@ -2589,8 +2592,8 @@
           "type": "string"
         },
         "parameters": {
-          "$ref": "#/definitions/kubernetes_networking_v1beta1_IngressClassParametersReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.IngressClassParametersReference"
+          "$ref": "#/definitions/kubernetes_networking_v1_IngressClassParametersReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.IngressClassParametersReference"
         }
       },
       "additionalProperties": true
@@ -2599,14 +2602,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "networking.k8s.io/v1beta1",
+          "default": "networking.k8s.io/v1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_networking_v1beta1_Ingress",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress"
+            "$ref": "#/definitions/kubernetes_networking_v1_Ingress",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.Ingress"
           }
         },
         "kind": {
@@ -2682,8 +2685,8 @@
     "ingressrulevalue": {
       "properties": {
         "http": {
-          "$ref": "#/definitions/kubernetes_networking_v1beta1_HTTPIngressRuleValue",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressRuleValue"
+          "$ref": "#/definitions/kubernetes_networking_v1_HTTPIngressRuleValue",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressRuleValue"
         }
       },
       "additionalProperties": true
@@ -2731,8 +2734,8 @@
     "ingressstatus": {
       "properties": {
         "loadBalancer": {
-          "$ref": "#/definitions/kubernetes_networking_v1beta1_IngressLoadBalancerStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1beta1.IngressLoadBalancerStatus"
+          "$ref": "#/definitions/kubernetes_networking_v1_IngressLoadBalancerStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.networking.v1.IngressLoadBalancerStatus"
         }
       },
       "additionalProperties": true
@@ -2855,7 +2858,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -3159,7 +3162,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -3192,7 +3195,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1/Overhead.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1/Overhead.java
@@ -61,7 +61,7 @@ public class Overhead implements Editable<OverheadBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Quantity> podFixed = new LinkedHashMap<String, Quantity>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -96,12 +96,12 @@ public class Overhead implements Editable<OverheadBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1/Scheduling.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1/Scheduling.java
@@ -67,7 +67,7 @@ public class Scheduling implements Editable<SchedulingBuilder> , KubernetesResou
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -114,12 +114,12 @@ public class Scheduling implements Editable<SchedulingBuilder> , KubernetesResou
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1alpha1/Overhead.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1alpha1/Overhead.java
@@ -61,7 +61,7 @@ public class Overhead implements Editable<OverheadBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Quantity> podFixed = new LinkedHashMap<String, Quantity>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -96,12 +96,12 @@ public class Overhead implements Editable<OverheadBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1alpha1/Scheduling.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1alpha1/Scheduling.java
@@ -67,7 +67,7 @@ public class Scheduling implements Editable<SchedulingBuilder> , KubernetesResou
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -114,12 +114,12 @@ public class Scheduling implements Editable<SchedulingBuilder> , KubernetesResou
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1beta1/Overhead.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1beta1/Overhead.java
@@ -61,7 +61,7 @@ public class Overhead implements Editable<OverheadBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Quantity> podFixed = new LinkedHashMap<String, Quantity>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -96,12 +96,12 @@ public class Overhead implements Editable<OverheadBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1beta1/Scheduling.java
+++ b/kubernetes-model-generator/kubernetes-model-node/src/generated/java/io/fabric8/kubernetes/api/model/node/v1beta1/Scheduling.java
@@ -67,7 +67,7 @@ public class Scheduling implements Editable<SchedulingBuilder> , KubernetesResou
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -114,12 +114,12 @@ public class Scheduling implements Editable<SchedulingBuilder> , KubernetesResou
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-node/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-node/src/main/resources/schema/kube-schema.json
@@ -115,7 +115,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -148,7 +148,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -442,7 +442,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -526,7 +526,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -552,7 +552,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -650,7 +650,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -676,7 +676,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -760,7 +760,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-node/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-node/src/main/resources/schema/validation-schema.json
@@ -115,7 +115,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -148,7 +148,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -442,7 +442,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -526,7 +526,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -552,7 +552,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -650,7 +650,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -676,7 +676,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -760,7 +760,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -962,7 +962,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -995,7 +995,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1067,7 +1067,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -1110,7 +1110,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "node.k8s.io/v1beta1",
+          "default": "node.k8s.io/v1",
           "required": true
         },
         "handler": {
@@ -1126,12 +1126,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "overhead": {
-          "$ref": "#/definitions/kubernetes_node_v1beta1_Overhead",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.node.v1beta1.Overhead"
+          "$ref": "#/definitions/kubernetes_node_v1_Overhead",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.node.v1.Overhead"
         },
         "scheduling": {
-          "$ref": "#/definitions/kubernetes_node_v1beta1_Scheduling",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.node.v1beta1.Scheduling"
+          "$ref": "#/definitions/kubernetes_node_v1_Scheduling",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.node.v1.Scheduling"
         }
       },
       "additionalProperties": true
@@ -1185,7 +1185,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1/PodDisruptionBudgetStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1/PodDisruptionBudgetStatus.java
@@ -82,7 +82,7 @@ public class PodDisruptionBudgetStatus implements Editable<PodDisruptionBudgetSt
     @JsonProperty("observedGeneration")
     private Long observedGeneration;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -184,12 +184,12 @@ public class PodDisruptionBudgetStatus implements Editable<PodDisruptionBudgetSt
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1beta1/PodDisruptionBudgetStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/generated/java/io/fabric8/kubernetes/api/model/policy/v1beta1/PodDisruptionBudgetStatus.java
@@ -82,7 +82,7 @@ public class PodDisruptionBudgetStatus implements Editable<PodDisruptionBudgetSt
     @JsonProperty("observedGeneration")
     private Long observedGeneration;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -184,12 +184,12 @@ public class PodDisruptionBudgetStatus implements Editable<PodDisruptionBudgetSt
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-policy/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/main/resources/schema/kube-schema.json
@@ -252,7 +252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -432,7 +432,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -465,7 +465,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1019,7 +1019,7 @@
             "$ref": "#/definitions/kubernetes_apimachinery_Time",
             "existingJavaType": "String"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disruptionsAllowed": {
           "type": "integer"
@@ -1180,7 +1180,7 @@
             "$ref": "#/definitions/kubernetes_apimachinery_Time",
             "existingJavaType": "String"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disruptionsAllowed": {
           "type": "integer"

--- a/kubernetes-model-generator/kubernetes-model-policy/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-policy/src/main/resources/schema/validation-schema.json
@@ -252,7 +252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -432,7 +432,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -465,7 +465,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1019,7 +1019,7 @@
             "$ref": "#/definitions/kubernetes_apimachinery_Time",
             "existingJavaType": "String"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disruptionsAllowed": {
           "type": "integer"
@@ -1180,7 +1180,7 @@
             "$ref": "#/definitions/kubernetes_apimachinery_Time",
             "existingJavaType": "String"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disruptionsAllowed": {
           "type": "integer"
@@ -1566,7 +1566,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -1715,7 +1715,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1748,7 +1748,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1900,14 +1900,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "policy/v1",
+          "default": "policy/v1beta1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_policy_v1_PodDisruptionBudget",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget"
+            "$ref": "#/definitions/kubernetes_policy_v1beta1_PodDisruptionBudget",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.policy.v1beta1.PodDisruptionBudget"
           }
         },
         "kind": {
@@ -1964,7 +1964,7 @@
             "$ref": "#/definitions/kubernetes_apimachinery_Time",
             "existingJavaType": "String"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "disruptionsAllowed": {
           "type": "integer"

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/main/resources/schema/kube-schema.json
@@ -27,7 +27,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -123,7 +123,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -156,7 +156,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/main/resources/schema/validation-schema.json
@@ -27,7 +27,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -123,7 +123,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -156,7 +156,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -812,7 +812,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -888,7 +888,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -921,7 +921,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-resource/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-resource/src/main/resources/schema/kube-schema.json
@@ -83,7 +83,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -116,7 +116,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-resource/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-resource/src/main/resources/schema/validation-schema.json
@@ -83,7 +83,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -116,7 +116,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1733,7 +1733,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1766,7 +1766,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-scheduling/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/src/main/resources/schema/kube-schema.json
@@ -354,7 +354,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -387,7 +387,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-scheduling/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/src/main/resources/schema/validation-schema.json
@@ -354,7 +354,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -387,7 +387,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1322,7 +1322,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1355,7 +1355,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/StorageClass.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/StorageClass.java
@@ -87,30 +87,30 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "storage.k8s.io/v1";
+    private String apiVersion = "storage.k8s.io/v1";
     /**
      * 
      * (Required)
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "StorageClass";
+    private String kind = "StorageClass";
     @JsonProperty("metadata")
     private io.fabric8.kubernetes.api.model.ObjectMeta metadata;
     @JsonProperty("mountOptions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> mountOptions = new ArrayList<java.lang.String>();
+    private List<String> mountOptions = new ArrayList<String>();
     @JsonProperty("parameters")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> parameters = new LinkedHashMap<String, String>();
     @JsonProperty("provisioner")
-    private java.lang.String provisioner;
+    private String provisioner;
     @JsonProperty("reclaimPolicy")
-    private java.lang.String reclaimPolicy;
+    private String reclaimPolicy;
     @JsonProperty("volumeBindingMode")
-    private java.lang.String volumeBindingMode;
+    private String volumeBindingMode;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -119,7 +119,7 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
     public StorageClass() {
     }
 
-    public StorageClass(Boolean allowVolumeExpansion, List<TopologySelectorTerm> allowedTopologies, java.lang.String apiVersion, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, List<java.lang.String> mountOptions, Map<String, String> parameters, java.lang.String provisioner, java.lang.String reclaimPolicy, java.lang.String volumeBindingMode) {
+    public StorageClass(Boolean allowVolumeExpansion, List<TopologySelectorTerm> allowedTopologies, String apiVersion, String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, List<String> mountOptions, Map<String, String> parameters, String provisioner, String reclaimPolicy, String volumeBindingMode) {
         super();
         this.allowVolumeExpansion = allowVolumeExpansion;
         this.allowedTopologies = allowedTopologies;
@@ -160,7 +160,7 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -170,7 +170,7 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
@@ -180,7 +180,7 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -190,7 +190,7 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -206,12 +206,12 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
 
     @JsonProperty("mountOptions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getMountOptions() {
+    public List<String> getMountOptions() {
         return mountOptions;
     }
 
     @JsonProperty("mountOptions")
-    public void setMountOptions(List<java.lang.String> mountOptions) {
+    public void setMountOptions(List<String> mountOptions) {
         this.mountOptions = mountOptions;
     }
 
@@ -226,32 +226,32 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
     }
 
     @JsonProperty("provisioner")
-    public java.lang.String getProvisioner() {
+    public String getProvisioner() {
         return provisioner;
     }
 
     @JsonProperty("provisioner")
-    public void setProvisioner(java.lang.String provisioner) {
+    public void setProvisioner(String provisioner) {
         this.provisioner = provisioner;
     }
 
     @JsonProperty("reclaimPolicy")
-    public java.lang.String getReclaimPolicy() {
+    public String getReclaimPolicy() {
         return reclaimPolicy;
     }
 
     @JsonProperty("reclaimPolicy")
-    public void setReclaimPolicy(java.lang.String reclaimPolicy) {
+    public void setReclaimPolicy(String reclaimPolicy) {
         this.reclaimPolicy = reclaimPolicy;
     }
 
     @JsonProperty("volumeBindingMode")
-    public java.lang.String getVolumeBindingMode() {
+    public String getVolumeBindingMode() {
         return volumeBindingMode;
     }
 
     @JsonProperty("volumeBindingMode")
-    public void setVolumeBindingMode(java.lang.String volumeBindingMode) {
+    public void setVolumeBindingMode(String volumeBindingMode) {
         this.volumeBindingMode = volumeBindingMode;
     }
 
@@ -266,12 +266,12 @@ public class StorageClass implements Editable<StorageClassBuilder> , HasMetadata
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/VolumeAttachmentStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/VolumeAttachmentStatus.java
@@ -69,7 +69,7 @@ public class VolumeAttachmentStatus implements Editable<VolumeAttachmentStatusBu
     @JsonProperty("detachError")
     private VolumeError detachError;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -137,12 +137,12 @@ public class VolumeAttachmentStatus implements Editable<VolumeAttachmentStatusBu
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1alpha1/VolumeAttributesClass.java
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/generated/java/io/fabric8/kubernetes/api/model/storage/v1alpha1/VolumeAttributesClass.java
@@ -74,23 +74,23 @@ public class VolumeAttributesClass implements Editable<VolumeAttributesClassBuil
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "storage.k8s.io/v1alpha1";
+    private String apiVersion = "storage.k8s.io/v1alpha1";
     @JsonProperty("driverName")
-    private java.lang.String driverName;
+    private String driverName;
     /**
      * 
      * (Required)
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "VolumeAttributesClass";
+    private String kind = "VolumeAttributesClass";
     @JsonProperty("metadata")
     private io.fabric8.kubernetes.api.model.ObjectMeta metadata;
     @JsonProperty("parameters")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> parameters = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -99,7 +99,7 @@ public class VolumeAttributesClass implements Editable<VolumeAttributesClassBuil
     public VolumeAttributesClass() {
     }
 
-    public VolumeAttributesClass(java.lang.String apiVersion, java.lang.String driverName, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, Map<String, String> parameters) {
+    public VolumeAttributesClass(String apiVersion, String driverName, String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, Map<String, String> parameters) {
         super();
         this.apiVersion = apiVersion;
         this.driverName = driverName;
@@ -114,7 +114,7 @@ public class VolumeAttributesClass implements Editable<VolumeAttributesClassBuil
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -124,17 +124,17 @@ public class VolumeAttributesClass implements Editable<VolumeAttributesClassBuil
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
     @JsonProperty("driverName")
-    public java.lang.String getDriverName() {
+    public String getDriverName() {
         return driverName;
     }
 
     @JsonProperty("driverName")
-    public void setDriverName(java.lang.String driverName) {
+    public void setDriverName(String driverName) {
         this.driverName = driverName;
     }
 
@@ -144,7 +144,7 @@ public class VolumeAttributesClass implements Editable<VolumeAttributesClassBuil
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -154,7 +154,7 @@ public class VolumeAttributesClass implements Editable<VolumeAttributesClassBuil
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -189,12 +189,12 @@ public class VolumeAttributesClass implements Editable<VolumeAttributesClassBuil
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/main/resources/schema/kube-schema.json
@@ -209,7 +209,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -389,7 +389,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -422,7 +422,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -892,7 +892,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -1006,7 +1006,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -1404,7 +1404,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -2104,7 +2104,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "provisioner": {
           "type": "string"
@@ -2287,7 +2287,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "detachError": {
           "$ref": "#/definitions/kubernetes_storageclass_VolumeError",
@@ -2355,7 +2355,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/kubernetes-model-storageclass/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/src/main/resources/schema/validation-schema.json
@@ -209,7 +209,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -389,7 +389,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -422,7 +422,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -892,7 +892,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -1006,7 +1006,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -1404,7 +1404,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -2104,7 +2104,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "provisioner": {
           "type": "string"
@@ -2287,7 +2287,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "detachError": {
           "$ref": "#/definitions/kubernetes_storageclass_VolumeError",
@@ -2355,7 +2355,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -3271,8 +3271,8 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_storageclass_v1beta1_TokenRequest",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.storage.v1beta1.TokenRequest"
+            "$ref": "#/definitions/kubernetes_storageclass_TokenRequest",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.storage.TokenRequest"
           }
         },
         "volumeLifecycleModes": {
@@ -3289,7 +3289,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "storage.k8s.io/v1beta1",
+          "default": "storage.k8s.io/v1",
           "required": true
         },
         "kind": {
@@ -3302,8 +3302,8 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_storageclass_v1beta1_CSINodeSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.storage.v1beta1.CSINodeSpec"
+          "$ref": "#/definitions/kubernetes_storageclass_CSINodeSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.storage.CSINodeSpec"
         }
       },
       "additionalProperties": true
@@ -3333,14 +3333,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "storage.k8s.io/v1",
+          "default": "storage.k8s.io/v1beta1",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_storageclass_CSINode",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.storage.CSINode"
+            "$ref": "#/definitions/kubernetes_storageclass_v1beta1_CSINode",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.storage.v1beta1.CSINode"
           }
         },
         "kind": {
@@ -3360,8 +3360,8 @@
         "drivers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_storageclass_CSINodeDriver",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.storage.CSINodeDriver"
+            "$ref": "#/definitions/kubernetes_storageclass_v1beta1_CSINodeDriver",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.storage.v1beta1.CSINodeDriver"
           }
         }
       },
@@ -3403,7 +3403,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "volumeHandle": {
           "type": "string"
@@ -3551,7 +3551,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3752,7 +3752,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -3998,7 +3998,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -4031,7 +4031,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -4272,7 +4272,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "cephfs": {
           "$ref": "#/definitions/kubernetes_core_CephFSPersistentVolumeSource",
@@ -4668,7 +4668,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "provisioner": {
           "type": "string"
@@ -4990,7 +4990,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "detachError": {
           "$ref": "#/definitions/kubernetes_storageclass_VolumeError",
@@ -5023,7 +5023,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/openshift-model-clusterautoscaling/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-clusterautoscaling/src/main/resources/schema/kube-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-clusterautoscaling/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-clusterautoscaling/src/main/resources/schema/validation-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1257,7 +1257,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1290,7 +1290,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-config/src/generated/java/io/fabric8/openshift/api/model/config/v1/BuildOverrides.java
+++ b/kubernetes-model-generator/openshift-model-config/src/generated/java/io/fabric8/openshift/api/model/config/v1/BuildOverrides.java
@@ -74,7 +74,7 @@ public class BuildOverrides implements Editable<BuildOverridesBuilder> , Kuberne
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -144,12 +144,12 @@ public class BuildOverrides implements Editable<BuildOverridesBuilder> , Kuberne
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-config/src/generated/java/io/fabric8/openshift/api/model/config/v1/DNSZone.java
+++ b/kubernetes-model-generator/openshift-model-config/src/generated/java/io/fabric8/openshift/api/model/config/v1/DNSZone.java
@@ -58,12 +58,12 @@ public class DNSZone implements Editable<DNSZoneBuilder> , KubernetesResource
 {
 
     @JsonProperty("id")
-    private java.lang.String id;
+    private String id;
     @JsonProperty("tags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> tags = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -72,19 +72,19 @@ public class DNSZone implements Editable<DNSZoneBuilder> , KubernetesResource
     public DNSZone() {
     }
 
-    public DNSZone(java.lang.String id, Map<String, String> tags) {
+    public DNSZone(String id, Map<String, String> tags) {
         super();
         this.id = id;
         this.tags = tags;
     }
 
     @JsonProperty("id")
-    public java.lang.String getId() {
+    public String getId() {
         return id;
     }
 
     @JsonProperty("id")
-    public void setId(java.lang.String id) {
+    public void setId(String id) {
         this.id = id;
     }
 
@@ -109,12 +109,12 @@ public class DNSZone implements Editable<DNSZoneBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-config/src/generated/java/io/fabric8/openshift/api/model/config/v1/OpenIDIdentityProvider.java
+++ b/kubernetes-model-generator/openshift-model-config/src/generated/java/io/fabric8/openshift/api/model/config/v1/OpenIDIdentityProvider.java
@@ -69,7 +69,7 @@ public class OpenIDIdentityProvider implements Editable<OpenIDIdentityProviderBu
     @JsonProperty("claims")
     private OpenIDClaims claims;
     @JsonProperty("clientID")
-    private java.lang.String clientID;
+    private String clientID;
     @JsonProperty("clientSecret")
     private SecretNameReference clientSecret;
     @JsonProperty("extraAuthorizeParameters")
@@ -77,11 +77,11 @@ public class OpenIDIdentityProvider implements Editable<OpenIDIdentityProviderBu
     private Map<String, String> extraAuthorizeParameters = new LinkedHashMap<String, String>();
     @JsonProperty("extraScopes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> extraScopes = new ArrayList<java.lang.String>();
+    private List<String> extraScopes = new ArrayList<String>();
     @JsonProperty("issuer")
-    private java.lang.String issuer;
+    private String issuer;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -90,7 +90,7 @@ public class OpenIDIdentityProvider implements Editable<OpenIDIdentityProviderBu
     public OpenIDIdentityProvider() {
     }
 
-    public OpenIDIdentityProvider(ConfigMapNameReference ca, OpenIDClaims claims, java.lang.String clientID, SecretNameReference clientSecret, Map<String, String> extraAuthorizeParameters, List<java.lang.String> extraScopes, java.lang.String issuer) {
+    public OpenIDIdentityProvider(ConfigMapNameReference ca, OpenIDClaims claims, String clientID, SecretNameReference clientSecret, Map<String, String> extraAuthorizeParameters, List<String> extraScopes, String issuer) {
         super();
         this.ca = ca;
         this.claims = claims;
@@ -122,12 +122,12 @@ public class OpenIDIdentityProvider implements Editable<OpenIDIdentityProviderBu
     }
 
     @JsonProperty("clientID")
-    public java.lang.String getClientID() {
+    public String getClientID() {
         return clientID;
     }
 
     @JsonProperty("clientID")
-    public void setClientID(java.lang.String clientID) {
+    public void setClientID(String clientID) {
         this.clientID = clientID;
     }
 
@@ -153,22 +153,22 @@ public class OpenIDIdentityProvider implements Editable<OpenIDIdentityProviderBu
 
     @JsonProperty("extraScopes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getExtraScopes() {
+    public List<String> getExtraScopes() {
         return extraScopes;
     }
 
     @JsonProperty("extraScopes")
-    public void setExtraScopes(List<java.lang.String> extraScopes) {
+    public void setExtraScopes(List<String> extraScopes) {
         this.extraScopes = extraScopes;
     }
 
     @JsonProperty("issuer")
-    public java.lang.String getIssuer() {
+    public String getIssuer() {
         return issuer;
     }
 
     @JsonProperty("issuer")
-    public void setIssuer(java.lang.String issuer) {
+    public void setIssuer(String issuer) {
         this.issuer = issuer;
     }
 
@@ -183,12 +183,12 @@ public class OpenIDIdentityProvider implements Editable<OpenIDIdentityProviderBu
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-config/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-config/src/main/resources/schema/kube-schema.json
@@ -156,7 +156,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -284,7 +284,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -317,7 +317,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -753,7 +753,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -761,7 +761,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -1541,7 +1541,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -2412,7 +2412,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -4365,7 +4365,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "extraScopes": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-config/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-config/src/main/resources/schema/validation-schema.json
@@ -156,7 +156,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -284,7 +284,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -317,7 +317,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -753,7 +753,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -761,7 +761,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -1541,7 +1541,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -2412,7 +2412,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -4365,7 +4365,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "extraScopes": {
           "type": "array",
@@ -6512,7 +6512,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -7252,7 +7252,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -8383,7 +8383,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -8920,7 +8920,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -8953,7 +8953,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -9066,7 +9066,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "extraScopes": {
           "type": "array",
@@ -9863,7 +9863,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -9871,7 +9871,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/openshift-model-console/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-console/src/main/resources/schema/kube-schema.json
@@ -112,7 +112,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -240,7 +240,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -273,7 +273,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-console/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-console/src/main/resources/schema/validation-schema.json
@@ -112,7 +112,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -240,7 +240,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -273,7 +273,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -2241,7 +2241,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -2370,7 +2370,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -2403,7 +2403,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/aws/v1/AwsPlatform.java
+++ b/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/aws/v1/AwsPlatform.java
@@ -66,12 +66,12 @@ public class AwsPlatform implements Editable<AwsPlatformBuilder> , KubernetesRes
     @JsonProperty("privateLink")
     private PrivateLinkAccess privateLink;
     @JsonProperty("region")
-    private java.lang.String region;
+    private String region;
     @JsonProperty("userTags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> userTags = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -80,7 +80,7 @@ public class AwsPlatform implements Editable<AwsPlatformBuilder> , KubernetesRes
     public AwsPlatform() {
     }
 
-    public AwsPlatform(AssumeRole credentialsAssumeRole, io.fabric8.kubernetes.api.model.LocalObjectReference credentialsSecretRef, PrivateLinkAccess privateLink, java.lang.String region, Map<String, String> userTags) {
+    public AwsPlatform(AssumeRole credentialsAssumeRole, io.fabric8.kubernetes.api.model.LocalObjectReference credentialsSecretRef, PrivateLinkAccess privateLink, String region, Map<String, String> userTags) {
         super();
         this.credentialsAssumeRole = credentialsAssumeRole;
         this.credentialsSecretRef = credentialsSecretRef;
@@ -120,12 +120,12 @@ public class AwsPlatform implements Editable<AwsPlatformBuilder> , KubernetesRes
     }
 
     @JsonProperty("region")
-    public java.lang.String getRegion() {
+    public String getRegion() {
         return region;
     }
 
     @JsonProperty("region")
-    public void setRegion(java.lang.String region) {
+    public void setRegion(String region) {
         this.region = region;
     }
 
@@ -150,12 +150,12 @@ public class AwsPlatform implements Editable<AwsPlatformBuilder> , KubernetesRes
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/metricsconfig/v1/MetricsConfig.java
+++ b/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/metricsconfig/v1/MetricsConfig.java
@@ -66,7 +66,7 @@ public class MetricsConfig implements Editable<MetricsConfigBuilder> , Kubernete
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<MetricsWithDuration> metricsWithDuration = new ArrayList<MetricsWithDuration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -113,12 +113,12 @@ public class MetricsConfig implements Editable<MetricsConfigBuilder> , Kubernete
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/v1/ClusterPoolSpec.java
+++ b/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/v1/ClusterPoolSpec.java
@@ -78,7 +78,7 @@ public class ClusterPoolSpec implements Editable<ClusterPoolSpecBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> annotations = new LinkedHashMap<String, String>();
     @JsonProperty("baseDomain")
-    private java.lang.String baseDomain;
+    private String baseDomain;
     @JsonProperty("claimLifetime")
     private ClusterPoolClaimLifetime claimLifetime;
     @JsonProperty("hibernateAfter")
@@ -112,7 +112,7 @@ public class ClusterPoolSpec implements Editable<ClusterPoolSpecBuilder> , Kuber
     @JsonProperty("skipMachinePools")
     private Boolean skipMachinePools;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -121,7 +121,7 @@ public class ClusterPoolSpec implements Editable<ClusterPoolSpecBuilder> , Kuber
     public ClusterPoolSpec() {
     }
 
-    public ClusterPoolSpec(Map<String, String> annotations, java.lang.String baseDomain, ClusterPoolClaimLifetime claimLifetime, Duration hibernateAfter, HibernationConfig hibernationConfig, ClusterImageSetReference imageSetRef, Integer installAttemptsLimit, io.fabric8.kubernetes.api.model.LocalObjectReference installConfigSecretTemplateRef, List<InventoryEntry> inventory, Map<String, String> labels, Integer maxConcurrent, Integer maxSize, Platform platform, io.fabric8.kubernetes.api.model.LocalObjectReference pullSecretRef, Integer runningCount, Integer size, Boolean skipMachinePools) {
+    public ClusterPoolSpec(Map<String, String> annotations, String baseDomain, ClusterPoolClaimLifetime claimLifetime, Duration hibernateAfter, HibernationConfig hibernationConfig, ClusterImageSetReference imageSetRef, Integer installAttemptsLimit, io.fabric8.kubernetes.api.model.LocalObjectReference installConfigSecretTemplateRef, List<InventoryEntry> inventory, Map<String, String> labels, Integer maxConcurrent, Integer maxSize, Platform platform, io.fabric8.kubernetes.api.model.LocalObjectReference pullSecretRef, Integer runningCount, Integer size, Boolean skipMachinePools) {
         super();
         this.annotations = annotations;
         this.baseDomain = baseDomain;
@@ -153,12 +153,12 @@ public class ClusterPoolSpec implements Editable<ClusterPoolSpecBuilder> , Kuber
     }
 
     @JsonProperty("baseDomain")
-    public java.lang.String getBaseDomain() {
+    public String getBaseDomain() {
         return baseDomain;
     }
 
     @JsonProperty("baseDomain")
-    public void setBaseDomain(java.lang.String baseDomain) {
+    public void setBaseDomain(String baseDomain) {
         this.baseDomain = baseDomain;
     }
 
@@ -324,12 +324,12 @@ public class ClusterPoolSpec implements Editable<ClusterPoolSpecBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/v1/MachinePoolSpec.java
+++ b/kubernetes-model-generator/openshift-model-hive/src/generated/java/io/fabric8/openshift/api/model/hive/v1/MachinePoolSpec.java
@@ -72,7 +72,7 @@ public class MachinePoolSpec implements Editable<MachinePoolSpecBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("platform")
     private MachinePoolPlatform platform;
     @JsonProperty("replicas")
@@ -81,7 +81,7 @@ public class MachinePoolSpec implements Editable<MachinePoolSpecBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Taint> taints = new ArrayList<Taint>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -90,7 +90,7 @@ public class MachinePoolSpec implements Editable<MachinePoolSpecBuilder> , Kuber
     public MachinePoolSpec() {
     }
 
-    public MachinePoolSpec(MachinePoolAutoscaling autoscaling, io.fabric8.kubernetes.api.model.LocalObjectReference clusterDeploymentRef, Map<String, String> labels, java.lang.String name, MachinePoolPlatform platform, Long replicas, List<Taint> taints) {
+    public MachinePoolSpec(MachinePoolAutoscaling autoscaling, io.fabric8.kubernetes.api.model.LocalObjectReference clusterDeploymentRef, Map<String, String> labels, String name, MachinePoolPlatform platform, Long replicas, List<Taint> taints) {
         super();
         this.autoscaling = autoscaling;
         this.clusterDeploymentRef = clusterDeploymentRef;
@@ -132,12 +132,12 @@ public class MachinePoolSpec implements Editable<MachinePoolSpecBuilder> , Kuber
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -183,12 +183,12 @@ public class MachinePoolSpec implements Editable<MachinePoolSpecBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-hive/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-hive/src/main/resources/schema/kube-schema.json
@@ -167,7 +167,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -295,7 +295,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -328,7 +328,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -671,7 +671,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1539,7 +1539,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -2416,7 +2416,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -2428,7 +2428,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -2769,7 +2769,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -2777,7 +2777,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3443,7 +3443,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3451,7 +3451,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4115,7 +4115,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "extraScopes": {
           "type": "array",
@@ -4391,7 +4391,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -4828,7 +4828,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "metricsWithDuration": {
           "type": "array",
@@ -6395,7 +6395,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "baseDomain": {
           "type": "string"
@@ -6436,7 +6436,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "maxConcurrent": {
           "type": "integer"
@@ -7823,7 +7823,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"

--- a/kubernetes-model-generator/openshift-model-hive/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-hive/src/main/resources/schema/validation-schema.json
@@ -167,7 +167,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -295,7 +295,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -328,7 +328,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -671,7 +671,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1539,7 +1539,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -2416,7 +2416,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -2428,7 +2428,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -2769,7 +2769,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -2777,7 +2777,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3443,7 +3443,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3451,7 +3451,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4115,7 +4115,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "extraScopes": {
           "type": "array",
@@ -4391,7 +4391,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -4828,7 +4828,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "metricsWithDuration": {
           "type": "array",
@@ -6395,7 +6395,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "baseDomain": {
           "type": "string"
@@ -6436,7 +6436,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "maxConcurrent": {
           "type": "integer"
@@ -7823,7 +7823,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -10452,7 +10452,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "baseDomain": {
           "type": "string"
@@ -10493,7 +10493,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "maxConcurrent": {
           "type": "integer"
@@ -11196,7 +11196,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -11921,7 +11921,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -12647,7 +12647,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -13018,7 +13018,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -13209,7 +13209,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "metricsWithDuration": {
           "type": "array",
@@ -13354,7 +13354,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -13387,7 +13387,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -13480,7 +13480,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "extraScopes": {
           "type": "array",
@@ -13514,7 +13514,15 @@
     "osdisk": {
       "properties": {
         "diskSizeGB": {
-          "type": "integer"
+          "type": "integer",
+          "existingJavaType": "Long"
+        },
+        "diskType": {
+          "type": "string"
+        },
+        "encryptionKey": {
+          "$ref": "#/definitions/os_hive_gcp_v1_EncryptionKeyReference",
+          "existingJavaType": "io.fabric8.openshift.api.model.hive.gcp.v1.EncryptionKeyReference"
         }
       },
       "additionalProperties": true
@@ -13654,25 +13662,6 @@
       "additionalProperties": true
     },
     "platform": {
-      "properties": {
-        "certificatesSecretRef": {
-          "$ref": "#/definitions/kubernetes_core_LocalObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.LocalObjectReference"
-        },
-        "credentialsSecretRef": {
-          "$ref": "#/definitions/kubernetes_core_LocalObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.LocalObjectReference"
-        },
-        "ovirt_cluster_id": {
-          "type": "string"
-        },
-        "ovirt_network_name": {
-          "type": "string"
-        },
-        "storage_domain_id": {
-          "type": "string"
-        }
-      },
       "additionalProperties": true
     },
     "platformstatus": {
@@ -13977,7 +13966,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -13989,7 +13978,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -14424,7 +14413,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -14432,7 +14421,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -15605,7 +15594,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -15613,7 +15602,7 @@
             "$ref": "#/definitions/k8s_io_apimachinery_pkg_api_resource_Quantity",
             "existingJavaType": "Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/alibabacloud/v1/Platform.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/alibabacloud/v1/Platform.java
@@ -67,21 +67,21 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     @JsonProperty("defaultMachinePlatform")
     private MachinePool defaultMachinePlatform;
     @JsonProperty("privateZoneID")
-    private java.lang.String privateZoneID;
+    private String privateZoneID;
     @JsonProperty("region")
-    private java.lang.String region;
+    private String region;
     @JsonProperty("resourceGroupID")
-    private java.lang.String resourceGroupID;
+    private String resourceGroupID;
     @JsonProperty("tags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> tags = new LinkedHashMap<String, String>();
     @JsonProperty("vpcID")
-    private java.lang.String vpcID;
+    private String vpcID;
     @JsonProperty("vswitchIDs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> vswitchIDs = new ArrayList<java.lang.String>();
+    private List<String> vswitchIDs = new ArrayList<String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -90,7 +90,7 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     public Platform() {
     }
 
-    public Platform(MachinePool defaultMachinePlatform, java.lang.String privateZoneID, java.lang.String region, java.lang.String resourceGroupID, Map<String, String> tags, java.lang.String vpcID, List<java.lang.String> vswitchIDs) {
+    public Platform(MachinePool defaultMachinePlatform, String privateZoneID, String region, String resourceGroupID, Map<String, String> tags, String vpcID, List<String> vswitchIDs) {
         super();
         this.defaultMachinePlatform = defaultMachinePlatform;
         this.privateZoneID = privateZoneID;
@@ -112,32 +112,32 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("privateZoneID")
-    public java.lang.String getPrivateZoneID() {
+    public String getPrivateZoneID() {
         return privateZoneID;
     }
 
     @JsonProperty("privateZoneID")
-    public void setPrivateZoneID(java.lang.String privateZoneID) {
+    public void setPrivateZoneID(String privateZoneID) {
         this.privateZoneID = privateZoneID;
     }
 
     @JsonProperty("region")
-    public java.lang.String getRegion() {
+    public String getRegion() {
         return region;
     }
 
     @JsonProperty("region")
-    public void setRegion(java.lang.String region) {
+    public void setRegion(String region) {
         this.region = region;
     }
 
     @JsonProperty("resourceGroupID")
-    public java.lang.String getResourceGroupID() {
+    public String getResourceGroupID() {
         return resourceGroupID;
     }
 
     @JsonProperty("resourceGroupID")
-    public void setResourceGroupID(java.lang.String resourceGroupID) {
+    public void setResourceGroupID(String resourceGroupID) {
         this.resourceGroupID = resourceGroupID;
     }
 
@@ -152,23 +152,23 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("vpcID")
-    public java.lang.String getVpcID() {
+    public String getVpcID() {
         return vpcID;
     }
 
     @JsonProperty("vpcID")
-    public void setVpcID(java.lang.String vpcID) {
+    public void setVpcID(String vpcID) {
         this.vpcID = vpcID;
     }
 
     @JsonProperty("vswitchIDs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getVswitchIDs() {
+    public List<String> getVswitchIDs() {
         return vswitchIDs;
     }
 
     @JsonProperty("vswitchIDs")
-    public void setVswitchIDs(List<java.lang.String> vswitchIDs) {
+    public void setVswitchIDs(List<String> vswitchIDs) {
         this.vswitchIDs = vswitchIDs;
     }
 
@@ -183,12 +183,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/aws/v1/Platform.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/aws/v1/Platform.java
@@ -68,30 +68,30 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
 {
 
     @JsonProperty("amiID")
-    private java.lang.String amiID;
+    private String amiID;
     @JsonProperty("defaultMachinePlatform")
     private MachinePool defaultMachinePlatform;
     @JsonProperty("experimentalPropagateUserTags")
     private Boolean experimentalPropagateUserTags;
     @JsonProperty("hostedZone")
-    private java.lang.String hostedZone;
+    private String hostedZone;
     @JsonProperty("lbType")
-    private java.lang.String lbType;
+    private String lbType;
     @JsonProperty("propagateUserTags")
     private Boolean propagateUserTags;
     @JsonProperty("region")
-    private java.lang.String region;
+    private String region;
     @JsonProperty("serviceEndpoints")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ServiceEndpoint> serviceEndpoints = new ArrayList<ServiceEndpoint>();
     @JsonProperty("subnets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> subnets = new ArrayList<java.lang.String>();
+    private List<String> subnets = new ArrayList<String>();
     @JsonProperty("userTags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> userTags = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -100,7 +100,7 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     public Platform() {
     }
 
-    public Platform(java.lang.String amiID, MachinePool defaultMachinePlatform, Boolean experimentalPropagateUserTags, java.lang.String hostedZone, java.lang.String lbType, Boolean propagateUserTags, java.lang.String region, List<ServiceEndpoint> serviceEndpoints, List<java.lang.String> subnets, Map<String, String> userTags) {
+    public Platform(String amiID, MachinePool defaultMachinePlatform, Boolean experimentalPropagateUserTags, String hostedZone, String lbType, Boolean propagateUserTags, String region, List<ServiceEndpoint> serviceEndpoints, List<String> subnets, Map<String, String> userTags) {
         super();
         this.amiID = amiID;
         this.defaultMachinePlatform = defaultMachinePlatform;
@@ -115,12 +115,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("amiID")
-    public java.lang.String getAmiID() {
+    public String getAmiID() {
         return amiID;
     }
 
     @JsonProperty("amiID")
-    public void setAmiID(java.lang.String amiID) {
+    public void setAmiID(String amiID) {
         this.amiID = amiID;
     }
 
@@ -145,22 +145,22 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("hostedZone")
-    public java.lang.String getHostedZone() {
+    public String getHostedZone() {
         return hostedZone;
     }
 
     @JsonProperty("hostedZone")
-    public void setHostedZone(java.lang.String hostedZone) {
+    public void setHostedZone(String hostedZone) {
         this.hostedZone = hostedZone;
     }
 
     @JsonProperty("lbType")
-    public java.lang.String getLbType() {
+    public String getLbType() {
         return lbType;
     }
 
     @JsonProperty("lbType")
-    public void setLbType(java.lang.String lbType) {
+    public void setLbType(String lbType) {
         this.lbType = lbType;
     }
 
@@ -175,12 +175,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("region")
-    public java.lang.String getRegion() {
+    public String getRegion() {
         return region;
     }
 
     @JsonProperty("region")
-    public void setRegion(java.lang.String region) {
+    public void setRegion(String region) {
         this.region = region;
     }
 
@@ -197,12 +197,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
 
     @JsonProperty("subnets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getSubnets() {
+    public List<String> getSubnets() {
         return subnets;
     }
 
     @JsonProperty("subnets")
-    public void setSubnets(List<java.lang.String> subnets) {
+    public void setSubnets(List<String> subnets) {
         this.subnets = subnets;
     }
 
@@ -227,12 +227,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/azure/v1/Platform.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/azure/v1/Platform.java
@@ -69,34 +69,34 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
 {
 
     @JsonProperty("armEndpoint")
-    private java.lang.String armEndpoint;
+    private String armEndpoint;
     @JsonProperty("baseDomainResourceGroupName")
-    private java.lang.String baseDomainResourceGroupName;
+    private String baseDomainResourceGroupName;
     @JsonProperty("cloudName")
-    private java.lang.String cloudName;
+    private String cloudName;
     @JsonProperty("clusterOSImage")
-    private java.lang.String clusterOSImage;
+    private String clusterOSImage;
     @JsonProperty("computeSubnet")
-    private java.lang.String computeSubnet;
+    private String computeSubnet;
     @JsonProperty("controlPlaneSubnet")
-    private java.lang.String controlPlaneSubnet;
+    private String controlPlaneSubnet;
     @JsonProperty("defaultMachinePlatform")
     private MachinePool defaultMachinePlatform;
     @JsonProperty("networkResourceGroupName")
-    private java.lang.String networkResourceGroupName;
+    private String networkResourceGroupName;
     @JsonProperty("outboundType")
-    private java.lang.String outboundType;
+    private String outboundType;
     @JsonProperty("region")
-    private java.lang.String region;
+    private String region;
     @JsonProperty("resourceGroupName")
-    private java.lang.String resourceGroupName;
+    private String resourceGroupName;
     @JsonProperty("userTags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> userTags = new LinkedHashMap<String, String>();
     @JsonProperty("virtualNetwork")
-    private java.lang.String virtualNetwork;
+    private String virtualNetwork;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -105,7 +105,7 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     public Platform() {
     }
 
-    public Platform(java.lang.String armEndpoint, java.lang.String baseDomainResourceGroupName, java.lang.String cloudName, java.lang.String clusterOSImage, java.lang.String computeSubnet, java.lang.String controlPlaneSubnet, MachinePool defaultMachinePlatform, java.lang.String networkResourceGroupName, java.lang.String outboundType, java.lang.String region, java.lang.String resourceGroupName, Map<String, String> userTags, java.lang.String virtualNetwork) {
+    public Platform(String armEndpoint, String baseDomainResourceGroupName, String cloudName, String clusterOSImage, String computeSubnet, String controlPlaneSubnet, MachinePool defaultMachinePlatform, String networkResourceGroupName, String outboundType, String region, String resourceGroupName, Map<String, String> userTags, String virtualNetwork) {
         super();
         this.armEndpoint = armEndpoint;
         this.baseDomainResourceGroupName = baseDomainResourceGroupName;
@@ -123,62 +123,62 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("armEndpoint")
-    public java.lang.String getArmEndpoint() {
+    public String getArmEndpoint() {
         return armEndpoint;
     }
 
     @JsonProperty("armEndpoint")
-    public void setArmEndpoint(java.lang.String armEndpoint) {
+    public void setArmEndpoint(String armEndpoint) {
         this.armEndpoint = armEndpoint;
     }
 
     @JsonProperty("baseDomainResourceGroupName")
-    public java.lang.String getBaseDomainResourceGroupName() {
+    public String getBaseDomainResourceGroupName() {
         return baseDomainResourceGroupName;
     }
 
     @JsonProperty("baseDomainResourceGroupName")
-    public void setBaseDomainResourceGroupName(java.lang.String baseDomainResourceGroupName) {
+    public void setBaseDomainResourceGroupName(String baseDomainResourceGroupName) {
         this.baseDomainResourceGroupName = baseDomainResourceGroupName;
     }
 
     @JsonProperty("cloudName")
-    public java.lang.String getCloudName() {
+    public String getCloudName() {
         return cloudName;
     }
 
     @JsonProperty("cloudName")
-    public void setCloudName(java.lang.String cloudName) {
+    public void setCloudName(String cloudName) {
         this.cloudName = cloudName;
     }
 
     @JsonProperty("clusterOSImage")
-    public java.lang.String getClusterOSImage() {
+    public String getClusterOSImage() {
         return clusterOSImage;
     }
 
     @JsonProperty("clusterOSImage")
-    public void setClusterOSImage(java.lang.String clusterOSImage) {
+    public void setClusterOSImage(String clusterOSImage) {
         this.clusterOSImage = clusterOSImage;
     }
 
     @JsonProperty("computeSubnet")
-    public java.lang.String getComputeSubnet() {
+    public String getComputeSubnet() {
         return computeSubnet;
     }
 
     @JsonProperty("computeSubnet")
-    public void setComputeSubnet(java.lang.String computeSubnet) {
+    public void setComputeSubnet(String computeSubnet) {
         this.computeSubnet = computeSubnet;
     }
 
     @JsonProperty("controlPlaneSubnet")
-    public java.lang.String getControlPlaneSubnet() {
+    public String getControlPlaneSubnet() {
         return controlPlaneSubnet;
     }
 
     @JsonProperty("controlPlaneSubnet")
-    public void setControlPlaneSubnet(java.lang.String controlPlaneSubnet) {
+    public void setControlPlaneSubnet(String controlPlaneSubnet) {
         this.controlPlaneSubnet = controlPlaneSubnet;
     }
 
@@ -193,42 +193,42 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("networkResourceGroupName")
-    public java.lang.String getNetworkResourceGroupName() {
+    public String getNetworkResourceGroupName() {
         return networkResourceGroupName;
     }
 
     @JsonProperty("networkResourceGroupName")
-    public void setNetworkResourceGroupName(java.lang.String networkResourceGroupName) {
+    public void setNetworkResourceGroupName(String networkResourceGroupName) {
         this.networkResourceGroupName = networkResourceGroupName;
     }
 
     @JsonProperty("outboundType")
-    public java.lang.String getOutboundType() {
+    public String getOutboundType() {
         return outboundType;
     }
 
     @JsonProperty("outboundType")
-    public void setOutboundType(java.lang.String outboundType) {
+    public void setOutboundType(String outboundType) {
         this.outboundType = outboundType;
     }
 
     @JsonProperty("region")
-    public java.lang.String getRegion() {
+    public String getRegion() {
         return region;
     }
 
     @JsonProperty("region")
-    public void setRegion(java.lang.String region) {
+    public void setRegion(String region) {
         this.region = region;
     }
 
     @JsonProperty("resourceGroupName")
-    public java.lang.String getResourceGroupName() {
+    public String getResourceGroupName() {
         return resourceGroupName;
     }
 
     @JsonProperty("resourceGroupName")
-    public void setResourceGroupName(java.lang.String resourceGroupName) {
+    public void setResourceGroupName(String resourceGroupName) {
         this.resourceGroupName = resourceGroupName;
     }
 
@@ -243,12 +243,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("virtualNetwork")
-    public java.lang.String getVirtualNetwork() {
+    public String getVirtualNetwork() {
         return virtualNetwork;
     }
 
     @JsonProperty("virtualNetwork")
-    public void setVirtualNetwork(java.lang.String virtualNetwork) {
+    public void setVirtualNetwork(String virtualNetwork) {
         this.virtualNetwork = virtualNetwork;
     }
 
@@ -263,12 +263,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/openstack/v1/Platform.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/openstack/v1/Platform.java
@@ -78,49 +78,49 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
 {
 
     @JsonProperty("apiFloatingIP")
-    private java.lang.String apiFloatingIP;
+    private String apiFloatingIP;
     @JsonProperty("apiVIP")
-    private java.lang.String apiVIP;
+    private String apiVIP;
     @JsonProperty("apiVIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> apiVIPs = new ArrayList<java.lang.String>();
+    private List<String> apiVIPs = new ArrayList<String>();
     @JsonProperty("cloud")
-    private java.lang.String cloud;
+    private String cloud;
     @JsonProperty("clusterOSImage")
-    private java.lang.String clusterOSImage;
+    private String clusterOSImage;
     @JsonProperty("clusterOSImageProperties")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> clusterOSImageProperties = new LinkedHashMap<String, String>();
     @JsonProperty("computeFlavor")
-    private java.lang.String computeFlavor;
+    private String computeFlavor;
     @JsonProperty("defaultMachinePlatform")
     private MachinePool defaultMachinePlatform;
     @JsonProperty("externalDNS")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> externalDNS = new ArrayList<java.lang.String>();
+    private List<String> externalDNS = new ArrayList<String>();
     @JsonProperty("externalNetwork")
-    private java.lang.String externalNetwork;
+    private String externalNetwork;
     @JsonProperty("ingressFloatingIP")
-    private java.lang.String ingressFloatingIP;
+    private String ingressFloatingIP;
     @JsonProperty("ingressVIP")
-    private java.lang.String ingressVIP;
+    private String ingressVIP;
     @JsonProperty("ingressVIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> ingressVIPs = new ArrayList<java.lang.String>();
+    private List<String> ingressVIPs = new ArrayList<String>();
     @JsonProperty("lbFloatingIP")
-    private java.lang.String lbFloatingIP;
+    private String lbFloatingIP;
     @JsonProperty("loadBalancer")
     private OpenStackPlatformLoadBalancer loadBalancer;
     @JsonProperty("machinesSubnet")
-    private java.lang.String machinesSubnet;
+    private String machinesSubnet;
     @JsonProperty("octaviaSupport")
-    private java.lang.String octaviaSupport;
+    private String octaviaSupport;
     @JsonProperty("region")
-    private java.lang.String region;
+    private String region;
     @JsonProperty("trunkSupport")
-    private java.lang.String trunkSupport;
+    private String trunkSupport;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -129,7 +129,7 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     public Platform() {
     }
 
-    public Platform(java.lang.String apiFloatingIP, java.lang.String apiVIP, List<java.lang.String> apiVIPs, java.lang.String cloud, java.lang.String clusterOSImage, Map<String, String> clusterOSImageProperties, java.lang.String computeFlavor, MachinePool defaultMachinePlatform, List<java.lang.String> externalDNS, java.lang.String externalNetwork, java.lang.String ingressFloatingIP, java.lang.String ingressVIP, List<java.lang.String> ingressVIPs, java.lang.String lbFloatingIP, OpenStackPlatformLoadBalancer loadBalancer, java.lang.String machinesSubnet, java.lang.String octaviaSupport, java.lang.String region, java.lang.String trunkSupport) {
+    public Platform(String apiFloatingIP, String apiVIP, List<String> apiVIPs, String cloud, String clusterOSImage, Map<String, String> clusterOSImageProperties, String computeFlavor, MachinePool defaultMachinePlatform, List<String> externalDNS, String externalNetwork, String ingressFloatingIP, String ingressVIP, List<String> ingressVIPs, String lbFloatingIP, OpenStackPlatformLoadBalancer loadBalancer, String machinesSubnet, String octaviaSupport, String region, String trunkSupport) {
         super();
         this.apiFloatingIP = apiFloatingIP;
         this.apiVIP = apiVIP;
@@ -153,53 +153,53 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("apiFloatingIP")
-    public java.lang.String getApiFloatingIP() {
+    public String getApiFloatingIP() {
         return apiFloatingIP;
     }
 
     @JsonProperty("apiFloatingIP")
-    public void setApiFloatingIP(java.lang.String apiFloatingIP) {
+    public void setApiFloatingIP(String apiFloatingIP) {
         this.apiFloatingIP = apiFloatingIP;
     }
 
     @JsonProperty("apiVIP")
-    public java.lang.String getApiVIP() {
+    public String getApiVIP() {
         return apiVIP;
     }
 
     @JsonProperty("apiVIP")
-    public void setApiVIP(java.lang.String apiVIP) {
+    public void setApiVIP(String apiVIP) {
         this.apiVIP = apiVIP;
     }
 
     @JsonProperty("apiVIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getApiVIPs() {
+    public List<String> getApiVIPs() {
         return apiVIPs;
     }
 
     @JsonProperty("apiVIPs")
-    public void setApiVIPs(List<java.lang.String> apiVIPs) {
+    public void setApiVIPs(List<String> apiVIPs) {
         this.apiVIPs = apiVIPs;
     }
 
     @JsonProperty("cloud")
-    public java.lang.String getCloud() {
+    public String getCloud() {
         return cloud;
     }
 
     @JsonProperty("cloud")
-    public void setCloud(java.lang.String cloud) {
+    public void setCloud(String cloud) {
         this.cloud = cloud;
     }
 
     @JsonProperty("clusterOSImage")
-    public java.lang.String getClusterOSImage() {
+    public String getClusterOSImage() {
         return clusterOSImage;
     }
 
     @JsonProperty("clusterOSImage")
-    public void setClusterOSImage(java.lang.String clusterOSImage) {
+    public void setClusterOSImage(String clusterOSImage) {
         this.clusterOSImage = clusterOSImage;
     }
 
@@ -214,12 +214,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("computeFlavor")
-    public java.lang.String getComputeFlavor() {
+    public String getComputeFlavor() {
         return computeFlavor;
     }
 
     @JsonProperty("computeFlavor")
-    public void setComputeFlavor(java.lang.String computeFlavor) {
+    public void setComputeFlavor(String computeFlavor) {
         this.computeFlavor = computeFlavor;
     }
 
@@ -234,63 +234,63 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("externalDNS")
-    public List<java.lang.String> getExternalDNS() {
+    public List<String> getExternalDNS() {
         return externalDNS;
     }
 
     @JsonProperty("externalDNS")
-    public void setExternalDNS(List<java.lang.String> externalDNS) {
+    public void setExternalDNS(List<String> externalDNS) {
         this.externalDNS = externalDNS;
     }
 
     @JsonProperty("externalNetwork")
-    public java.lang.String getExternalNetwork() {
+    public String getExternalNetwork() {
         return externalNetwork;
     }
 
     @JsonProperty("externalNetwork")
-    public void setExternalNetwork(java.lang.String externalNetwork) {
+    public void setExternalNetwork(String externalNetwork) {
         this.externalNetwork = externalNetwork;
     }
 
     @JsonProperty("ingressFloatingIP")
-    public java.lang.String getIngressFloatingIP() {
+    public String getIngressFloatingIP() {
         return ingressFloatingIP;
     }
 
     @JsonProperty("ingressFloatingIP")
-    public void setIngressFloatingIP(java.lang.String ingressFloatingIP) {
+    public void setIngressFloatingIP(String ingressFloatingIP) {
         this.ingressFloatingIP = ingressFloatingIP;
     }
 
     @JsonProperty("ingressVIP")
-    public java.lang.String getIngressVIP() {
+    public String getIngressVIP() {
         return ingressVIP;
     }
 
     @JsonProperty("ingressVIP")
-    public void setIngressVIP(java.lang.String ingressVIP) {
+    public void setIngressVIP(String ingressVIP) {
         this.ingressVIP = ingressVIP;
     }
 
     @JsonProperty("ingressVIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getIngressVIPs() {
+    public List<String> getIngressVIPs() {
         return ingressVIPs;
     }
 
     @JsonProperty("ingressVIPs")
-    public void setIngressVIPs(List<java.lang.String> ingressVIPs) {
+    public void setIngressVIPs(List<String> ingressVIPs) {
         this.ingressVIPs = ingressVIPs;
     }
 
     @JsonProperty("lbFloatingIP")
-    public java.lang.String getLbFloatingIP() {
+    public String getLbFloatingIP() {
         return lbFloatingIP;
     }
 
     @JsonProperty("lbFloatingIP")
-    public void setLbFloatingIP(java.lang.String lbFloatingIP) {
+    public void setLbFloatingIP(String lbFloatingIP) {
         this.lbFloatingIP = lbFloatingIP;
     }
 
@@ -305,42 +305,42 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonProperty("machinesSubnet")
-    public java.lang.String getMachinesSubnet() {
+    public String getMachinesSubnet() {
         return machinesSubnet;
     }
 
     @JsonProperty("machinesSubnet")
-    public void setMachinesSubnet(java.lang.String machinesSubnet) {
+    public void setMachinesSubnet(String machinesSubnet) {
         this.machinesSubnet = machinesSubnet;
     }
 
     @JsonProperty("octaviaSupport")
-    public java.lang.String getOctaviaSupport() {
+    public String getOctaviaSupport() {
         return octaviaSupport;
     }
 
     @JsonProperty("octaviaSupport")
-    public void setOctaviaSupport(java.lang.String octaviaSupport) {
+    public void setOctaviaSupport(String octaviaSupport) {
         this.octaviaSupport = octaviaSupport;
     }
 
     @JsonProperty("region")
-    public java.lang.String getRegion() {
+    public String getRegion() {
         return region;
     }
 
     @JsonProperty("region")
-    public void setRegion(java.lang.String region) {
+    public void setRegion(String region) {
         this.region = region;
     }
 
     @JsonProperty("trunkSupport")
-    public java.lang.String getTrunkSupport() {
+    public String getTrunkSupport() {
         return trunkSupport;
     }
 
     @JsonProperty("trunkSupport")
-    public void setTrunkSupport(java.lang.String trunkSupport) {
+    public void setTrunkSupport(String trunkSupport) {
         this.trunkSupport = trunkSupport;
     }
 
@@ -355,12 +355,12 @@ public class Platform implements Editable<PlatformBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-installer/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-installer/src/main/resources/schema/kube-schema.json
@@ -228,7 +228,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -261,7 +261,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -591,7 +591,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "vpcID": {
           "type": "string"
@@ -724,7 +724,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -889,7 +889,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "virtualNetwork": {
           "type": "string"
@@ -1741,7 +1741,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "computeFlavor": {
           "type": "string"

--- a/kubernetes-model-generator/openshift-model-installer/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-installer/src/main/resources/schema/validation-schema.json
@@ -228,7 +228,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -261,7 +261,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -591,7 +591,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "vpcID": {
           "type": "string"
@@ -724,7 +724,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -889,7 +889,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "virtualNetwork": {
           "type": "string"
@@ -1741,7 +1741,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "computeFlavor": {
           "type": "string"
@@ -3401,30 +3401,20 @@
     },
     "machinepool": {
       "properties": {
-        "confidentialCompute": {
+        "memoryGiB": {
+          "type": "integer"
+        },
+        "procType": {
           "type": "string"
         },
-        "onHostMaintenance": {
+        "processors": {
+          "$ref": "#/definitions/k8s_io_apimachinery_pkg_util_intstr_IntOrString",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.IntOrString"
+        },
+        "sysType": {
           "type": "string"
         },
-        "osDisk": {
-          "$ref": "#/definitions/os_installer_gcp_v1_OSDisk",
-          "existingJavaType": "io.fabric8.openshift.api.model.installer.gcp.v1.OSDisk"
-        },
-        "secureBoot": {
-          "type": "string"
-        },
-        "tags": {
-          "type": "array",
-          "javaOmitEmpty": true,
-          "items": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        },
-        "zones": {
+        "volumeIDs": {
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
@@ -3650,7 +3640,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -3683,7 +3673,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -3731,8 +3721,15 @@
     },
     "osdisk": {
       "properties": {
+        "diskEncryptionSet": {
+          "$ref": "#/definitions/os_installer_azure_v1_DiskEncryptionSet",
+          "existingJavaType": "io.fabric8.openshift.api.model.installer.azure.v1.DiskEncryptionSet"
+        },
         "diskSizeGB": {
           "type": "integer"
+        },
+        "diskType": {
+          "type": "string"
         }
       },
       "additionalProperties": true
@@ -3790,18 +3787,6 @@
     },
     "platform": {
       "properties": {
-        "armEndpoint": {
-          "type": "string"
-        },
-        "baseDomainResourceGroupName": {
-          "type": "string"
-        },
-        "cloudName": {
-          "type": "string"
-        },
-        "clusterOSImage": {
-          "type": "string"
-        },
         "computeSubnet": {
           "type": "string"
         },
@@ -3809,29 +3794,26 @@
           "type": "string"
         },
         "defaultMachinePlatform": {
-          "$ref": "#/definitions/os_installer_azure_v1_MachinePool",
-          "existingJavaType": "io.fabric8.openshift.api.model.installer.azure.v1.MachinePool"
+          "$ref": "#/definitions/os_installer_gcp_v1_MachinePool",
+          "existingJavaType": "io.fabric8.openshift.api.model.installer.gcp.v1.MachinePool"
         },
-        "networkResourceGroupName": {
+        "licenses": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "network": {
           "type": "string"
         },
-        "outboundType": {
+        "networkProjectID": {
+          "type": "string"
+        },
+        "projectID": {
           "type": "string"
         },
         "region": {
-          "type": "string"
-        },
-        "resourceGroupName": {
-          "type": "string"
-        },
-        "userTags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
-        },
-        "virtualNetwork": {
           "type": "string"
         }
       },

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1/ControlPlaneMachineSetTemplateObjectMeta.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1/ControlPlaneMachineSetTemplateObjectMeta.java
@@ -64,7 +64,7 @@ public class ControlPlaneMachineSetTemplateObjectMeta implements Editable<Contro
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -110,12 +110,12 @@ public class ControlPlaneMachineSetTemplateObjectMeta implements Editable<Contro
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1alpha1/NetworkParam.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1alpha1/NetworkParam.java
@@ -69,14 +69,14 @@ public class NetworkParam implements Editable<NetworkParamBuilder> , KubernetesR
     @JsonProperty("filter")
     private Filter filter;
     @JsonProperty("fixedIp")
-    private java.lang.String fixedIp;
+    private String fixedIp;
     @JsonProperty("noAllowedAddressPairs")
     private Boolean noAllowedAddressPairs;
     @JsonProperty("portSecurity")
     private Boolean portSecurity;
     @JsonProperty("portTags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> portTags = new ArrayList<java.lang.String>();
+    private List<String> portTags = new ArrayList<String>();
     @JsonProperty("profile")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> profile = new LinkedHashMap<String, String>();
@@ -84,11 +84,11 @@ public class NetworkParam implements Editable<NetworkParamBuilder> , KubernetesR
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<SubnetParam> subnets = new ArrayList<SubnetParam>();
     @JsonProperty("uuid")
-    private java.lang.String uuid;
+    private String uuid;
     @JsonProperty("vnicType")
-    private java.lang.String vnicType;
+    private String vnicType;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -97,7 +97,7 @@ public class NetworkParam implements Editable<NetworkParamBuilder> , KubernetesR
     public NetworkParam() {
     }
 
-    public NetworkParam(Filter filter, java.lang.String fixedIp, Boolean noAllowedAddressPairs, Boolean portSecurity, List<java.lang.String> portTags, Map<String, String> profile, List<SubnetParam> subnets, java.lang.String uuid, java.lang.String vnicType) {
+    public NetworkParam(Filter filter, String fixedIp, Boolean noAllowedAddressPairs, Boolean portSecurity, List<String> portTags, Map<String, String> profile, List<SubnetParam> subnets, String uuid, String vnicType) {
         super();
         this.filter = filter;
         this.fixedIp = fixedIp;
@@ -121,12 +121,12 @@ public class NetworkParam implements Editable<NetworkParamBuilder> , KubernetesR
     }
 
     @JsonProperty("fixedIp")
-    public java.lang.String getFixedIp() {
+    public String getFixedIp() {
         return fixedIp;
     }
 
     @JsonProperty("fixedIp")
-    public void setFixedIp(java.lang.String fixedIp) {
+    public void setFixedIp(String fixedIp) {
         this.fixedIp = fixedIp;
     }
 
@@ -152,12 +152,12 @@ public class NetworkParam implements Editable<NetworkParamBuilder> , KubernetesR
 
     @JsonProperty("portTags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getPortTags() {
+    public List<String> getPortTags() {
         return portTags;
     }
 
     @JsonProperty("portTags")
-    public void setPortTags(List<java.lang.String> portTags) {
+    public void setPortTags(List<String> portTags) {
         this.portTags = portTags;
     }
 
@@ -183,22 +183,22 @@ public class NetworkParam implements Editable<NetworkParamBuilder> , KubernetesR
     }
 
     @JsonProperty("uuid")
-    public java.lang.String getUuid() {
+    public String getUuid() {
         return uuid;
     }
 
     @JsonProperty("uuid")
-    public void setUuid(java.lang.String uuid) {
+    public void setUuid(String uuid) {
         this.uuid = uuid;
     }
 
     @JsonProperty("vnicType")
-    public java.lang.String getVnicType() {
+    public String getVnicType() {
         return vnicType;
     }
 
     @JsonProperty("vnicType")
-    public void setVnicType(java.lang.String vnicType) {
+    public void setVnicType(String vnicType) {
         this.vnicType = vnicType;
     }
 
@@ -213,12 +213,12 @@ public class NetworkParam implements Editable<NetworkParamBuilder> , KubernetesR
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1alpha1/OpenstackProviderSpec.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1alpha1/OpenstackProviderSpec.java
@@ -96,30 +96,30 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "machine.openshift.io/v1alpha1";
+    private String apiVersion = "machine.openshift.io/v1alpha1";
     @JsonProperty("availabilityZone")
-    private java.lang.String availabilityZone;
+    private String availabilityZone;
     @JsonProperty("cloudName")
-    private java.lang.String cloudName;
+    private String cloudName;
     @JsonProperty("cloudsSecret")
     private SecretReference cloudsSecret;
     @JsonProperty("configDrive")
     private Boolean configDrive;
     @JsonProperty("flavor")
-    private java.lang.String flavor;
+    private String flavor;
     @JsonProperty("floatingIP")
-    private java.lang.String floatingIP;
+    private String floatingIP;
     @JsonProperty("image")
-    private java.lang.String image;
+    private String image;
     @JsonProperty("keyName")
-    private java.lang.String keyName;
+    private String keyName;
     /**
      * 
      * (Required)
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "OpenstackProviderSpec";
+    private String kind = "OpenstackProviderSpec";
     @JsonProperty("metadata")
     private io.fabric8.kubernetes.api.model.ObjectMeta metadata;
     @JsonProperty("networks")
@@ -129,30 +129,30 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PortOpts> ports = new ArrayList<PortOpts>();
     @JsonProperty("primarySubnet")
-    private java.lang.String primarySubnet;
+    private String primarySubnet;
     @JsonProperty("rootVolume")
     private RootVolume rootVolume;
     @JsonProperty("securityGroups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<SecurityGroupParam> securityGroups = new ArrayList<SecurityGroupParam>();
     @JsonProperty("serverGroupID")
-    private java.lang.String serverGroupID;
+    private String serverGroupID;
     @JsonProperty("serverGroupName")
-    private java.lang.String serverGroupName;
+    private String serverGroupName;
     @JsonProperty("serverMetadata")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> serverMetadata = new LinkedHashMap<String, String>();
     @JsonProperty("sshUserName")
-    private java.lang.String sshUserName;
+    private String sshUserName;
     @JsonProperty("tags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> tags = new ArrayList<java.lang.String>();
+    private List<String> tags = new ArrayList<String>();
     @JsonProperty("trunk")
     private Boolean trunk;
     @JsonProperty("userDataSecret")
     private SecretReference userDataSecret;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -161,7 +161,7 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
     public OpenstackProviderSpec() {
     }
 
-    public OpenstackProviderSpec(java.lang.String apiVersion, java.lang.String availabilityZone, java.lang.String cloudName, SecretReference cloudsSecret, Boolean configDrive, java.lang.String flavor, java.lang.String floatingIP, java.lang.String image, java.lang.String keyName, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, List<NetworkParam> networks, List<PortOpts> ports, java.lang.String primarySubnet, RootVolume rootVolume, List<SecurityGroupParam> securityGroups, java.lang.String serverGroupID, java.lang.String serverGroupName, Map<String, String> serverMetadata, java.lang.String sshUserName, List<java.lang.String> tags, Boolean trunk, SecretReference userDataSecret) {
+    public OpenstackProviderSpec(String apiVersion, String availabilityZone, String cloudName, SecretReference cloudsSecret, Boolean configDrive, String flavor, String floatingIP, String image, String keyName, String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, List<NetworkParam> networks, List<PortOpts> ports, String primarySubnet, RootVolume rootVolume, List<SecurityGroupParam> securityGroups, String serverGroupID, String serverGroupName, Map<String, String> serverMetadata, String sshUserName, List<String> tags, Boolean trunk, SecretReference userDataSecret) {
         super();
         this.apiVersion = apiVersion;
         this.availabilityZone = availabilityZone;
@@ -194,7 +194,7 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -204,27 +204,27 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
     @JsonProperty("availabilityZone")
-    public java.lang.String getAvailabilityZone() {
+    public String getAvailabilityZone() {
         return availabilityZone;
     }
 
     @JsonProperty("availabilityZone")
-    public void setAvailabilityZone(java.lang.String availabilityZone) {
+    public void setAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
     }
 
     @JsonProperty("cloudName")
-    public java.lang.String getCloudName() {
+    public String getCloudName() {
         return cloudName;
     }
 
     @JsonProperty("cloudName")
-    public void setCloudName(java.lang.String cloudName) {
+    public void setCloudName(String cloudName) {
         this.cloudName = cloudName;
     }
 
@@ -249,42 +249,42 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
     }
 
     @JsonProperty("flavor")
-    public java.lang.String getFlavor() {
+    public String getFlavor() {
         return flavor;
     }
 
     @JsonProperty("flavor")
-    public void setFlavor(java.lang.String flavor) {
+    public void setFlavor(String flavor) {
         this.flavor = flavor;
     }
 
     @JsonProperty("floatingIP")
-    public java.lang.String getFloatingIP() {
+    public String getFloatingIP() {
         return floatingIP;
     }
 
     @JsonProperty("floatingIP")
-    public void setFloatingIP(java.lang.String floatingIP) {
+    public void setFloatingIP(String floatingIP) {
         this.floatingIP = floatingIP;
     }
 
     @JsonProperty("image")
-    public java.lang.String getImage() {
+    public String getImage() {
         return image;
     }
 
     @JsonProperty("image")
-    public void setImage(java.lang.String image) {
+    public void setImage(String image) {
         this.image = image;
     }
 
     @JsonProperty("keyName")
-    public java.lang.String getKeyName() {
+    public String getKeyName() {
         return keyName;
     }
 
     @JsonProperty("keyName")
-    public void setKeyName(java.lang.String keyName) {
+    public void setKeyName(String keyName) {
         this.keyName = keyName;
     }
 
@@ -294,7 +294,7 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -304,7 +304,7 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -341,12 +341,12 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
     }
 
     @JsonProperty("primarySubnet")
-    public java.lang.String getPrimarySubnet() {
+    public String getPrimarySubnet() {
         return primarySubnet;
     }
 
     @JsonProperty("primarySubnet")
-    public void setPrimarySubnet(java.lang.String primarySubnet) {
+    public void setPrimarySubnet(String primarySubnet) {
         this.primarySubnet = primarySubnet;
     }
 
@@ -372,22 +372,22 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
     }
 
     @JsonProperty("serverGroupID")
-    public java.lang.String getServerGroupID() {
+    public String getServerGroupID() {
         return serverGroupID;
     }
 
     @JsonProperty("serverGroupID")
-    public void setServerGroupID(java.lang.String serverGroupID) {
+    public void setServerGroupID(String serverGroupID) {
         this.serverGroupID = serverGroupID;
     }
 
     @JsonProperty("serverGroupName")
-    public java.lang.String getServerGroupName() {
+    public String getServerGroupName() {
         return serverGroupName;
     }
 
     @JsonProperty("serverGroupName")
-    public void setServerGroupName(java.lang.String serverGroupName) {
+    public void setServerGroupName(String serverGroupName) {
         this.serverGroupName = serverGroupName;
     }
 
@@ -402,23 +402,23 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
     }
 
     @JsonProperty("sshUserName")
-    public java.lang.String getSshUserName() {
+    public String getSshUserName() {
         return sshUserName;
     }
 
     @JsonProperty("sshUserName")
-    public void setSshUserName(java.lang.String sshUserName) {
+    public void setSshUserName(String sshUserName) {
         this.sshUserName = sshUserName;
     }
 
     @JsonProperty("tags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getTags() {
+    public List<String> getTags() {
         return tags;
     }
 
     @JsonProperty("tags")
-    public void setTags(List<java.lang.String> tags) {
+    public void setTags(List<String> tags) {
         this.tags = tags;
     }
 
@@ -453,12 +453,12 @@ public class OpenstackProviderSpec implements Editable<OpenstackProviderSpecBuil
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1alpha1/PortOpts.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1alpha1/PortOpts.java
@@ -79,39 +79,39 @@ public class PortOpts implements Editable<PortOptsBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<AddressPair> allowedAddressPairs = new ArrayList<AddressPair>();
     @JsonProperty("description")
-    private java.lang.String description;
+    private String description;
     @JsonProperty("fixedIPs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<FixedIPs> fixedIPs = new ArrayList<FixedIPs>();
     @JsonProperty("hostID")
-    private java.lang.String hostID;
+    private String hostID;
     @JsonProperty("macAddress")
-    private java.lang.String macAddress;
+    private String macAddress;
     @JsonProperty("nameSuffix")
-    private java.lang.String nameSuffix;
+    private String nameSuffix;
     @JsonProperty("networkID")
-    private java.lang.String networkID;
+    private String networkID;
     @JsonProperty("portSecurity")
     private Boolean portSecurity;
     @JsonProperty("profile")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> profile = new LinkedHashMap<String, String>();
     @JsonProperty("projectID")
-    private java.lang.String projectID;
+    private String projectID;
     @JsonProperty("securityGroups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> securityGroups = new ArrayList<java.lang.String>();
+    private List<String> securityGroups = new ArrayList<String>();
     @JsonProperty("tags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> tags = new ArrayList<java.lang.String>();
+    private List<String> tags = new ArrayList<String>();
     @JsonProperty("tenantID")
-    private java.lang.String tenantID;
+    private String tenantID;
     @JsonProperty("trunk")
     private Boolean trunk;
     @JsonProperty("vnicType")
-    private java.lang.String vnicType;
+    private String vnicType;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -120,7 +120,7 @@ public class PortOpts implements Editable<PortOptsBuilder> , KubernetesResource
     public PortOpts() {
     }
 
-    public PortOpts(Boolean adminStateUp, List<AddressPair> allowedAddressPairs, java.lang.String description, List<FixedIPs> fixedIPs, java.lang.String hostID, java.lang.String macAddress, java.lang.String nameSuffix, java.lang.String networkID, Boolean portSecurity, Map<String, String> profile, java.lang.String projectID, List<java.lang.String> securityGroups, List<java.lang.String> tags, java.lang.String tenantID, Boolean trunk, java.lang.String vnicType) {
+    public PortOpts(Boolean adminStateUp, List<AddressPair> allowedAddressPairs, String description, List<FixedIPs> fixedIPs, String hostID, String macAddress, String nameSuffix, String networkID, Boolean portSecurity, Map<String, String> profile, String projectID, List<String> securityGroups, List<String> tags, String tenantID, Boolean trunk, String vnicType) {
         super();
         this.adminStateUp = adminStateUp;
         this.allowedAddressPairs = allowedAddressPairs;
@@ -162,12 +162,12 @@ public class PortOpts implements Editable<PortOptsBuilder> , KubernetesResource
     }
 
     @JsonProperty("description")
-    public java.lang.String getDescription() {
+    public String getDescription() {
         return description;
     }
 
     @JsonProperty("description")
-    public void setDescription(java.lang.String description) {
+    public void setDescription(String description) {
         this.description = description;
     }
 
@@ -183,42 +183,42 @@ public class PortOpts implements Editable<PortOptsBuilder> , KubernetesResource
     }
 
     @JsonProperty("hostID")
-    public java.lang.String getHostID() {
+    public String getHostID() {
         return hostID;
     }
 
     @JsonProperty("hostID")
-    public void setHostID(java.lang.String hostID) {
+    public void setHostID(String hostID) {
         this.hostID = hostID;
     }
 
     @JsonProperty("macAddress")
-    public java.lang.String getMacAddress() {
+    public String getMacAddress() {
         return macAddress;
     }
 
     @JsonProperty("macAddress")
-    public void setMacAddress(java.lang.String macAddress) {
+    public void setMacAddress(String macAddress) {
         this.macAddress = macAddress;
     }
 
     @JsonProperty("nameSuffix")
-    public java.lang.String getNameSuffix() {
+    public String getNameSuffix() {
         return nameSuffix;
     }
 
     @JsonProperty("nameSuffix")
-    public void setNameSuffix(java.lang.String nameSuffix) {
+    public void setNameSuffix(String nameSuffix) {
         this.nameSuffix = nameSuffix;
     }
 
     @JsonProperty("networkID")
-    public java.lang.String getNetworkID() {
+    public String getNetworkID() {
         return networkID;
     }
 
     @JsonProperty("networkID")
-    public void setNetworkID(java.lang.String networkID) {
+    public void setNetworkID(String networkID) {
         this.networkID = networkID;
     }
 
@@ -243,44 +243,44 @@ public class PortOpts implements Editable<PortOptsBuilder> , KubernetesResource
     }
 
     @JsonProperty("projectID")
-    public java.lang.String getProjectID() {
+    public String getProjectID() {
         return projectID;
     }
 
     @JsonProperty("projectID")
-    public void setProjectID(java.lang.String projectID) {
+    public void setProjectID(String projectID) {
         this.projectID = projectID;
     }
 
     @JsonProperty("securityGroups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getSecurityGroups() {
+    public List<String> getSecurityGroups() {
         return securityGroups;
     }
 
     @JsonProperty("securityGroups")
-    public void setSecurityGroups(List<java.lang.String> securityGroups) {
+    public void setSecurityGroups(List<String> securityGroups) {
         this.securityGroups = securityGroups;
     }
 
     @JsonProperty("tags")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getTags() {
+    public List<String> getTags() {
         return tags;
     }
 
     @JsonProperty("tags")
-    public void setTags(List<java.lang.String> tags) {
+    public void setTags(List<String> tags) {
         this.tags = tags;
     }
 
     @JsonProperty("tenantID")
-    public java.lang.String getTenantID() {
+    public String getTenantID() {
         return tenantID;
     }
 
     @JsonProperty("tenantID")
-    public void setTenantID(java.lang.String tenantID) {
+    public void setTenantID(String tenantID) {
         this.tenantID = tenantID;
     }
 
@@ -295,12 +295,12 @@ public class PortOpts implements Editable<PortOptsBuilder> , KubernetesResource
     }
 
     @JsonProperty("vnicType")
-    public java.lang.String getVnicType() {
+    public String getVnicType() {
         return vnicType;
     }
 
     @JsonProperty("vnicType")
-    public void setVnicType(java.lang.String vnicType) {
+    public void setVnicType(String vnicType) {
         this.vnicType = vnicType;
     }
 
@@ -315,12 +315,12 @@ public class PortOpts implements Editable<PortOptsBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/ObjectMeta.java
+++ b/kubernetes-model-generator/openshift-model-machine/src/generated/java/io/fabric8/openshift/api/model/machine/v1beta1/ObjectMeta.java
@@ -67,19 +67,19 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> annotations = new LinkedHashMap<String, String>();
     @JsonProperty("generateName")
-    private java.lang.String generateName;
+    private String generateName;
     @JsonProperty("labels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("namespace")
-    private java.lang.String namespace;
+    private String namespace;
     @JsonProperty("ownerReferences")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<OwnerReference> ownerReferences = new ArrayList<OwnerReference>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -88,7 +88,7 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     public ObjectMeta() {
     }
 
-    public ObjectMeta(Map<String, String> annotations, java.lang.String generateName, Map<String, String> labels, java.lang.String name, java.lang.String namespace, List<OwnerReference> ownerReferences) {
+    public ObjectMeta(Map<String, String> annotations, String generateName, Map<String, String> labels, String name, String namespace, List<OwnerReference> ownerReferences) {
         super();
         this.annotations = annotations;
         this.generateName = generateName;
@@ -109,12 +109,12 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     }
 
     @JsonProperty("generateName")
-    public java.lang.String getGenerateName() {
+    public String getGenerateName() {
         return generateName;
     }
 
     @JsonProperty("generateName")
-    public void setGenerateName(java.lang.String generateName) {
+    public void setGenerateName(String generateName) {
         this.generateName = generateName;
     }
 
@@ -129,22 +129,22 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
     @JsonProperty("namespace")
-    public java.lang.String getNamespace() {
+    public String getNamespace() {
         return namespace;
     }
 
     @JsonProperty("namespace")
-    public void setNamespace(java.lang.String namespace) {
+    public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
 
@@ -170,12 +170,12 @@ public class ObjectMeta implements Editable<ObjectMetaBuilder> , KubernetesResou
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-machine/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-machine/src/main/resources/schema/kube-schema.json
@@ -156,7 +156,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -284,7 +284,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -317,7 +317,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -939,14 +939,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1218,7 +1218,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "subnets": {
           "type": "array",
@@ -1325,7 +1325,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sshUserName": {
           "type": "string"
@@ -1397,7 +1397,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "projectID": {
           "type": "string"
@@ -2147,7 +2147,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "generateName": {
           "type": "string"
@@ -2157,7 +2157,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"

--- a/kubernetes-model-generator/openshift-model-machine/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-machine/src/main/resources/schema/validation-schema.json
@@ -156,7 +156,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -284,7 +284,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -317,7 +317,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -939,14 +939,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1218,7 +1218,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "subnets": {
           "type": "array",
@@ -1325,7 +1325,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sshUserName": {
           "type": "string"
@@ -1397,7 +1397,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "projectID": {
           "type": "string"
@@ -2147,7 +2147,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "generateName": {
           "type": "string"
@@ -2157,7 +2157,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -2451,11 +2451,10 @@
         "message": {
           "type": "string"
         },
-        "observedGeneration": {
-          "type": "integer",
-          "existingJavaType": "Long"
-        },
         "reason": {
+          "type": "string"
+        },
+        "severity": {
           "type": "string"
         },
         "status": {
@@ -2599,14 +2598,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -2808,7 +2807,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -3325,7 +3324,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "subnets": {
           "type": "array",
@@ -3387,7 +3386,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -3420,7 +3419,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -3596,7 +3595,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "sshUserName": {
           "type": "string"
@@ -3688,7 +3687,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "projectID": {
           "type": "string"

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/ControllerConfigSpec.java
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/generated/java/io/fabric8/openshift/api/model/machineconfig/v1/ControllerConfigSpec.java
@@ -82,21 +82,21 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
 {
 
     @JsonProperty("additionalTrustBundle")
-    private java.lang.String additionalTrustBundle;
+    private String additionalTrustBundle;
     @JsonProperty("baseOSContainerImage")
-    private java.lang.String baseOSContainerImage;
+    private String baseOSContainerImage;
     @JsonProperty("baseOSExtensionsContainerImage")
-    private java.lang.String baseOSExtensionsContainerImage;
+    private String baseOSExtensionsContainerImage;
     @JsonProperty("cloudProviderCAData")
-    private java.lang.String cloudProviderCAData;
+    private String cloudProviderCAData;
     @JsonProperty("cloudProviderConfig")
-    private java.lang.String cloudProviderConfig;
+    private String cloudProviderConfig;
     @JsonProperty("clusterDNSIP")
-    private java.lang.String clusterDNSIP;
+    private String clusterDNSIP;
     @JsonProperty("dns")
     private DNS dns;
     @JsonProperty("etcdDiscoveryDomain")
-    private java.lang.String etcdDiscoveryDomain;
+    private String etcdDiscoveryDomain;
     @JsonProperty("imageRegistryBundleData")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ImageRegistryBundle> imageRegistryBundleData = new ArrayList<ImageRegistryBundle>();
@@ -109,27 +109,27 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     @JsonProperty("infra")
     private Infrastructure infra;
     @JsonProperty("ipFamilies")
-    private java.lang.String ipFamilies;
+    private String ipFamilies;
     @JsonProperty("kubeAPIServerServingCAData")
-    private java.lang.String kubeAPIServerServingCAData;
+    private String kubeAPIServerServingCAData;
     @JsonProperty("network")
     private NetworkInfo network;
     @JsonProperty("networkType")
-    private java.lang.String networkType;
+    private String networkType;
     @JsonProperty("osImageURL")
-    private java.lang.String osImageURL;
+    private String osImageURL;
     @JsonProperty("platform")
-    private java.lang.String platform;
+    private String platform;
     @JsonProperty("proxy")
     private ProxyStatus proxy;
     @JsonProperty("pullSecret")
     private io.fabric8.kubernetes.api.model.ObjectReference pullSecret;
     @JsonProperty("releaseImage")
-    private java.lang.String releaseImage;
+    private String releaseImage;
     @JsonProperty("rootCAData")
-    private java.lang.String rootCAData;
+    private String rootCAData;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -138,7 +138,7 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     public ControllerConfigSpec() {
     }
 
-    public ControllerConfigSpec(java.lang.String additionalTrustBundle, java.lang.String baseOSContainerImage, java.lang.String baseOSExtensionsContainerImage, java.lang.String cloudProviderCAData, java.lang.String cloudProviderConfig, java.lang.String clusterDNSIP, DNS dns, java.lang.String etcdDiscoveryDomain, List<ImageRegistryBundle> imageRegistryBundleData, List<ImageRegistryBundle> imageRegistryBundleUserData, Map<String, String> images, Infrastructure infra, java.lang.String ipFamilies, java.lang.String kubeAPIServerServingCAData, NetworkInfo network, java.lang.String networkType, java.lang.String osImageURL, java.lang.String platform, ProxyStatus proxy, io.fabric8.kubernetes.api.model.ObjectReference pullSecret, java.lang.String releaseImage, java.lang.String rootCAData) {
+    public ControllerConfigSpec(String additionalTrustBundle, String baseOSContainerImage, String baseOSExtensionsContainerImage, String cloudProviderCAData, String cloudProviderConfig, String clusterDNSIP, DNS dns, String etcdDiscoveryDomain, List<ImageRegistryBundle> imageRegistryBundleData, List<ImageRegistryBundle> imageRegistryBundleUserData, Map<String, String> images, Infrastructure infra, String ipFamilies, String kubeAPIServerServingCAData, NetworkInfo network, String networkType, String osImageURL, String platform, ProxyStatus proxy, io.fabric8.kubernetes.api.model.ObjectReference pullSecret, String releaseImage, String rootCAData) {
         super();
         this.additionalTrustBundle = additionalTrustBundle;
         this.baseOSContainerImage = baseOSContainerImage;
@@ -165,62 +165,62 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     }
 
     @JsonProperty("additionalTrustBundle")
-    public java.lang.String getAdditionalTrustBundle() {
+    public String getAdditionalTrustBundle() {
         return additionalTrustBundle;
     }
 
     @JsonProperty("additionalTrustBundle")
-    public void setAdditionalTrustBundle(java.lang.String additionalTrustBundle) {
+    public void setAdditionalTrustBundle(String additionalTrustBundle) {
         this.additionalTrustBundle = additionalTrustBundle;
     }
 
     @JsonProperty("baseOSContainerImage")
-    public java.lang.String getBaseOSContainerImage() {
+    public String getBaseOSContainerImage() {
         return baseOSContainerImage;
     }
 
     @JsonProperty("baseOSContainerImage")
-    public void setBaseOSContainerImage(java.lang.String baseOSContainerImage) {
+    public void setBaseOSContainerImage(String baseOSContainerImage) {
         this.baseOSContainerImage = baseOSContainerImage;
     }
 
     @JsonProperty("baseOSExtensionsContainerImage")
-    public java.lang.String getBaseOSExtensionsContainerImage() {
+    public String getBaseOSExtensionsContainerImage() {
         return baseOSExtensionsContainerImage;
     }
 
     @JsonProperty("baseOSExtensionsContainerImage")
-    public void setBaseOSExtensionsContainerImage(java.lang.String baseOSExtensionsContainerImage) {
+    public void setBaseOSExtensionsContainerImage(String baseOSExtensionsContainerImage) {
         this.baseOSExtensionsContainerImage = baseOSExtensionsContainerImage;
     }
 
     @JsonProperty("cloudProviderCAData")
-    public java.lang.String getCloudProviderCAData() {
+    public String getCloudProviderCAData() {
         return cloudProviderCAData;
     }
 
     @JsonProperty("cloudProviderCAData")
-    public void setCloudProviderCAData(java.lang.String cloudProviderCAData) {
+    public void setCloudProviderCAData(String cloudProviderCAData) {
         this.cloudProviderCAData = cloudProviderCAData;
     }
 
     @JsonProperty("cloudProviderConfig")
-    public java.lang.String getCloudProviderConfig() {
+    public String getCloudProviderConfig() {
         return cloudProviderConfig;
     }
 
     @JsonProperty("cloudProviderConfig")
-    public void setCloudProviderConfig(java.lang.String cloudProviderConfig) {
+    public void setCloudProviderConfig(String cloudProviderConfig) {
         this.cloudProviderConfig = cloudProviderConfig;
     }
 
     @JsonProperty("clusterDNSIP")
-    public java.lang.String getClusterDNSIP() {
+    public String getClusterDNSIP() {
         return clusterDNSIP;
     }
 
     @JsonProperty("clusterDNSIP")
-    public void setClusterDNSIP(java.lang.String clusterDNSIP) {
+    public void setClusterDNSIP(String clusterDNSIP) {
         this.clusterDNSIP = clusterDNSIP;
     }
 
@@ -235,12 +235,12 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     }
 
     @JsonProperty("etcdDiscoveryDomain")
-    public java.lang.String getEtcdDiscoveryDomain() {
+    public String getEtcdDiscoveryDomain() {
         return etcdDiscoveryDomain;
     }
 
     @JsonProperty("etcdDiscoveryDomain")
-    public void setEtcdDiscoveryDomain(java.lang.String etcdDiscoveryDomain) {
+    public void setEtcdDiscoveryDomain(String etcdDiscoveryDomain) {
         this.etcdDiscoveryDomain = etcdDiscoveryDomain;
     }
 
@@ -285,22 +285,22 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     }
 
     @JsonProperty("ipFamilies")
-    public java.lang.String getIpFamilies() {
+    public String getIpFamilies() {
         return ipFamilies;
     }
 
     @JsonProperty("ipFamilies")
-    public void setIpFamilies(java.lang.String ipFamilies) {
+    public void setIpFamilies(String ipFamilies) {
         this.ipFamilies = ipFamilies;
     }
 
     @JsonProperty("kubeAPIServerServingCAData")
-    public java.lang.String getKubeAPIServerServingCAData() {
+    public String getKubeAPIServerServingCAData() {
         return kubeAPIServerServingCAData;
     }
 
     @JsonProperty("kubeAPIServerServingCAData")
-    public void setKubeAPIServerServingCAData(java.lang.String kubeAPIServerServingCAData) {
+    public void setKubeAPIServerServingCAData(String kubeAPIServerServingCAData) {
         this.kubeAPIServerServingCAData = kubeAPIServerServingCAData;
     }
 
@@ -315,32 +315,32 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     }
 
     @JsonProperty("networkType")
-    public java.lang.String getNetworkType() {
+    public String getNetworkType() {
         return networkType;
     }
 
     @JsonProperty("networkType")
-    public void setNetworkType(java.lang.String networkType) {
+    public void setNetworkType(String networkType) {
         this.networkType = networkType;
     }
 
     @JsonProperty("osImageURL")
-    public java.lang.String getOsImageURL() {
+    public String getOsImageURL() {
         return osImageURL;
     }
 
     @JsonProperty("osImageURL")
-    public void setOsImageURL(java.lang.String osImageURL) {
+    public void setOsImageURL(String osImageURL) {
         this.osImageURL = osImageURL;
     }
 
     @JsonProperty("platform")
-    public java.lang.String getPlatform() {
+    public String getPlatform() {
         return platform;
     }
 
     @JsonProperty("platform")
-    public void setPlatform(java.lang.String platform) {
+    public void setPlatform(String platform) {
         this.platform = platform;
     }
 
@@ -365,22 +365,22 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     }
 
     @JsonProperty("releaseImage")
-    public java.lang.String getReleaseImage() {
+    public String getReleaseImage() {
         return releaseImage;
     }
 
     @JsonProperty("releaseImage")
-    public void setReleaseImage(java.lang.String releaseImage) {
+    public void setReleaseImage(String releaseImage) {
         this.releaseImage = releaseImage;
     }
 
     @JsonProperty("rootCAData")
-    public java.lang.String getRootCAData() {
+    public String getRootCAData() {
         return rootCAData;
     }
 
     @JsonProperty("rootCAData")
-    public void setRootCAData(java.lang.String rootCAData) {
+    public void setRootCAData(String rootCAData) {
         this.rootCAData = rootCAData;
     }
 
@@ -395,12 +395,12 @@ public class ControllerConfigSpec implements Editable<ControllerConfigSpecBuilde
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/main/resources/schema/kube-schema.json
@@ -112,7 +112,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -240,7 +240,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -273,7 +273,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -988,7 +988,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2275,7 +2275,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "infra": {
           "$ref": "#/definitions/os_config_v1_Infrastructure",

--- a/kubernetes-model-generator/openshift-model-machineconfig/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-machineconfig/src/main/resources/schema/validation-schema.json
@@ -112,7 +112,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -240,7 +240,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -273,7 +273,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -988,7 +988,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2275,7 +2275,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "infra": {
           "$ref": "#/definitions/os_config_v1_Infrastructure",
@@ -3450,7 +3450,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "infra": {
           "$ref": "#/definitions/os_config_v1_Infrastructure",
@@ -3622,7 +3622,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -3985,7 +3985,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -4457,7 +4457,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -4490,7 +4490,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/imageregistry/operator/v1/ImageRegistrySpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/imageregistry/operator/v1/ImageRegistrySpec.java
@@ -96,7 +96,7 @@ public class ImageRegistrySpec implements Editable<ImageRegistrySpecBuilder> , K
     private java.lang.String managementState;
     @JsonProperty("nodeSelector")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private Map<String, String> nodeSelector = new LinkedHashMap<String, String>();
+    private Map<java.lang.String, java.lang.String> nodeSelector = new LinkedHashMap<java.lang.String, java.lang.String>();
     @JsonProperty("observedConfig")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Object> observedConfig = new LinkedHashMap<String, Object>();
@@ -138,7 +138,7 @@ public class ImageRegistrySpec implements Editable<ImageRegistrySpecBuilder> , K
     public ImageRegistrySpec() {
     }
 
-    public ImageRegistrySpec(Affinity affinity, Boolean defaultRoute, Boolean disableRedirect, java.lang.String httpSecret, java.lang.String logLevel, Long logging, java.lang.String managementState, Map<String, String> nodeSelector, Map<String, Object> observedConfig, java.lang.String operatorLogLevel, ImageRegistryConfigProxy proxy, Boolean readOnly, Integer replicas, ImageRegistryConfigRequests requests, io.fabric8.kubernetes.api.model.ResourceRequirements resources, java.lang.String rolloutStrategy, List<ImageRegistryConfigRoute> routes, ImageRegistryConfigStorage storage, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, Map<String, Object> unsupportedConfigOverrides) {
+    public ImageRegistrySpec(Affinity affinity, Boolean defaultRoute, Boolean disableRedirect, java.lang.String httpSecret, java.lang.String logLevel, Long logging, java.lang.String managementState, Map<java.lang.String, java.lang.String> nodeSelector, Map<String, Object> observedConfig, java.lang.String operatorLogLevel, ImageRegistryConfigProxy proxy, Boolean readOnly, Integer replicas, ImageRegistryConfigRequests requests, io.fabric8.kubernetes.api.model.ResourceRequirements resources, java.lang.String rolloutStrategy, List<ImageRegistryConfigRoute> routes, ImageRegistryConfigStorage storage, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, Map<String, Object> unsupportedConfigOverrides) {
         super();
         this.affinity = affinity;
         this.defaultRoute = defaultRoute;
@@ -234,12 +234,12 @@ public class ImageRegistrySpec implements Editable<ImageRegistrySpecBuilder> , K
     }
 
     @JsonProperty("nodeSelector")
-    public Map<String, String> getNodeSelector() {
+    public Map<java.lang.String, java.lang.String> getNodeSelector() {
         return nodeSelector;
     }
 
     @JsonProperty("nodeSelector")
-    public void setNodeSelector(Map<String, String> nodeSelector) {
+    public void setNodeSelector(Map<java.lang.String, java.lang.String> nodeSelector) {
         this.nodeSelector = nodeSelector;
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/main/resources/schema/kube-schema.json
@@ -274,7 +274,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -402,7 +402,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -435,7 +435,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -990,7 +990,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -998,7 +998,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -2032,7 +2032,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "observedConfig": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/main/resources/schema/validation-schema.json
@@ -274,7 +274,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -402,7 +402,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -435,7 +435,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -990,7 +990,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -998,7 +998,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -2032,7 +2032,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "observedConfig": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
@@ -4800,7 +4800,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "observedConfig": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
@@ -4975,7 +4975,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -5412,7 +5412,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -5445,7 +5445,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -5987,7 +5987,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -5995,7 +5995,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/AlertmanagerSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/AlertmanagerSpec.java
@@ -108,7 +108,7 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
 
     @JsonProperty("additionalPeers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> additionalPeers = new ArrayList<java.lang.String>();
+    private List<String> additionalPeers = new ArrayList<String>();
     @JsonProperty("affinity")
     private Affinity affinity;
     @JsonProperty("alertmanagerConfigMatcherStrategy")
@@ -122,34 +122,34 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     @JsonProperty("automountServiceAccountToken")
     private Boolean automountServiceAccountToken;
     @JsonProperty("baseImage")
-    private java.lang.String baseImage;
+    private String baseImage;
     @JsonProperty("clusterAdvertiseAddress")
-    private java.lang.String clusterAdvertiseAddress;
+    private String clusterAdvertiseAddress;
     @JsonProperty("clusterGossipInterval")
-    private java.lang.String clusterGossipInterval;
+    private String clusterGossipInterval;
     @JsonProperty("clusterPeerTimeout")
-    private java.lang.String clusterPeerTimeout;
+    private String clusterPeerTimeout;
     @JsonProperty("clusterPushpullInterval")
-    private java.lang.String clusterPushpullInterval;
+    private String clusterPushpullInterval;
     @JsonProperty("configMaps")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> configMaps = new ArrayList<java.lang.String>();
+    private List<String> configMaps = new ArrayList<String>();
     @JsonProperty("configSecret")
-    private java.lang.String configSecret;
+    private String configSecret;
     @JsonProperty("containers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.kubernetes.api.model.Container> containers = new ArrayList<io.fabric8.kubernetes.api.model.Container>();
     @JsonProperty("externalUrl")
-    private java.lang.String externalUrl;
+    private String externalUrl;
     @JsonProperty("forceEnableClusterMode")
     private Boolean forceEnableClusterMode;
     @JsonProperty("hostAliases")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<HostAlias> hostAliases = new ArrayList<HostAlias>();
     @JsonProperty("image")
-    private java.lang.String image;
+    private String image;
     @JsonProperty("imagePullPolicy")
-    private java.lang.String imagePullPolicy;
+    private String imagePullPolicy;
     @JsonProperty("imagePullSecrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets = new ArrayList<io.fabric8.kubernetes.api.model.LocalObjectReference>();
@@ -159,9 +159,9 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     @JsonProperty("listenLocal")
     private Boolean listenLocal;
     @JsonProperty("logFormat")
-    private java.lang.String logFormat;
+    private String logFormat;
     @JsonProperty("logLevel")
-    private java.lang.String logLevel;
+    private String logLevel;
     @JsonProperty("minReadySeconds")
     private Integer minReadySeconds;
     @JsonProperty("nodeSelector")
@@ -172,30 +172,30 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     @JsonProperty("podMetadata")
     private EmbeddedObjectMetadata podMetadata;
     @JsonProperty("portName")
-    private java.lang.String portName;
+    private String portName;
     @JsonProperty("priorityClassName")
-    private java.lang.String priorityClassName;
+    private String priorityClassName;
     @JsonProperty("replicas")
     private Integer replicas;
     @JsonProperty("resources")
     private io.fabric8.kubernetes.api.model.ResourceRequirements resources;
     @JsonProperty("retention")
-    private java.lang.String retention;
+    private String retention;
     @JsonProperty("routePrefix")
-    private java.lang.String routePrefix;
+    private String routePrefix;
     @JsonProperty("secrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> secrets = new ArrayList<java.lang.String>();
+    private List<String> secrets = new ArrayList<String>();
     @JsonProperty("securityContext")
     private PodSecurityContext securityContext;
     @JsonProperty("serviceAccountName")
-    private java.lang.String serviceAccountName;
+    private String serviceAccountName;
     @JsonProperty("sha")
-    private java.lang.String sha;
+    private String sha;
     @JsonProperty("storage")
     private StorageSpec storage;
     @JsonProperty("tag")
-    private java.lang.String tag;
+    private String tag;
     @JsonProperty("tolerations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
@@ -203,7 +203,7 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<TopologySpreadConstraint> topologySpreadConstraints = new ArrayList<TopologySpreadConstraint>();
     @JsonProperty("version")
-    private java.lang.String version;
+    private String version;
     @JsonProperty("volumeMounts")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<VolumeMount> volumeMounts = new ArrayList<VolumeMount>();
@@ -213,7 +213,7 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     @JsonProperty("web")
     private AlertmanagerWebSpec web;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -222,7 +222,7 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     public AlertmanagerSpec() {
     }
 
-    public AlertmanagerSpec(List<java.lang.String> additionalPeers, Affinity affinity, AlertmanagerConfigMatcherStrategy alertmanagerConfigMatcherStrategy, io.fabric8.kubernetes.api.model.LabelSelector alertmanagerConfigNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector alertmanagerConfigSelector, AlertmanagerConfiguration alertmanagerConfiguration, Boolean automountServiceAccountToken, java.lang.String baseImage, java.lang.String clusterAdvertiseAddress, java.lang.String clusterGossipInterval, java.lang.String clusterPeerTimeout, java.lang.String clusterPushpullInterval, List<java.lang.String> configMaps, java.lang.String configSecret, List<io.fabric8.kubernetes.api.model.Container> containers, java.lang.String externalUrl, Boolean forceEnableClusterMode, List<HostAlias> hostAliases, java.lang.String image, java.lang.String imagePullPolicy, List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets, List<io.fabric8.kubernetes.api.model.Container> initContainers, Boolean listenLocal, java.lang.String logFormat, java.lang.String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, Boolean paused, EmbeddedObjectMetadata podMetadata, java.lang.String portName, java.lang.String priorityClassName, Integer replicas, io.fabric8.kubernetes.api.model.ResourceRequirements resources, java.lang.String retention, java.lang.String routePrefix, List<java.lang.String> secrets, PodSecurityContext securityContext, java.lang.String serviceAccountName, java.lang.String sha, StorageSpec storage, java.lang.String tag, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, java.lang.String version, List<VolumeMount> volumeMounts, List<Volume> volumes, AlertmanagerWebSpec web) {
+    public AlertmanagerSpec(List<String> additionalPeers, Affinity affinity, AlertmanagerConfigMatcherStrategy alertmanagerConfigMatcherStrategy, io.fabric8.kubernetes.api.model.LabelSelector alertmanagerConfigNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector alertmanagerConfigSelector, AlertmanagerConfiguration alertmanagerConfiguration, Boolean automountServiceAccountToken, String baseImage, String clusterAdvertiseAddress, String clusterGossipInterval, String clusterPeerTimeout, String clusterPushpullInterval, List<String> configMaps, String configSecret, List<io.fabric8.kubernetes.api.model.Container> containers, String externalUrl, Boolean forceEnableClusterMode, List<HostAlias> hostAliases, String image, String imagePullPolicy, List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets, List<io.fabric8.kubernetes.api.model.Container> initContainers, Boolean listenLocal, String logFormat, String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, Boolean paused, EmbeddedObjectMetadata podMetadata, String portName, String priorityClassName, Integer replicas, io.fabric8.kubernetes.api.model.ResourceRequirements resources, String retention, String routePrefix, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, String sha, StorageSpec storage, String tag, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, AlertmanagerWebSpec web) {
         super();
         this.additionalPeers = additionalPeers;
         this.affinity = affinity;
@@ -275,12 +275,12 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
 
     @JsonProperty("additionalPeers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getAdditionalPeers() {
+    public List<String> getAdditionalPeers() {
         return additionalPeers;
     }
 
     @JsonProperty("additionalPeers")
-    public void setAdditionalPeers(List<java.lang.String> additionalPeers) {
+    public void setAdditionalPeers(List<String> additionalPeers) {
         this.additionalPeers = additionalPeers;
     }
 
@@ -345,73 +345,73 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("baseImage")
-    public java.lang.String getBaseImage() {
+    public String getBaseImage() {
         return baseImage;
     }
 
     @JsonProperty("baseImage")
-    public void setBaseImage(java.lang.String baseImage) {
+    public void setBaseImage(String baseImage) {
         this.baseImage = baseImage;
     }
 
     @JsonProperty("clusterAdvertiseAddress")
-    public java.lang.String getClusterAdvertiseAddress() {
+    public String getClusterAdvertiseAddress() {
         return clusterAdvertiseAddress;
     }
 
     @JsonProperty("clusterAdvertiseAddress")
-    public void setClusterAdvertiseAddress(java.lang.String clusterAdvertiseAddress) {
+    public void setClusterAdvertiseAddress(String clusterAdvertiseAddress) {
         this.clusterAdvertiseAddress = clusterAdvertiseAddress;
     }
 
     @JsonProperty("clusterGossipInterval")
-    public java.lang.String getClusterGossipInterval() {
+    public String getClusterGossipInterval() {
         return clusterGossipInterval;
     }
 
     @JsonProperty("clusterGossipInterval")
-    public void setClusterGossipInterval(java.lang.String clusterGossipInterval) {
+    public void setClusterGossipInterval(String clusterGossipInterval) {
         this.clusterGossipInterval = clusterGossipInterval;
     }
 
     @JsonProperty("clusterPeerTimeout")
-    public java.lang.String getClusterPeerTimeout() {
+    public String getClusterPeerTimeout() {
         return clusterPeerTimeout;
     }
 
     @JsonProperty("clusterPeerTimeout")
-    public void setClusterPeerTimeout(java.lang.String clusterPeerTimeout) {
+    public void setClusterPeerTimeout(String clusterPeerTimeout) {
         this.clusterPeerTimeout = clusterPeerTimeout;
     }
 
     @JsonProperty("clusterPushpullInterval")
-    public java.lang.String getClusterPushpullInterval() {
+    public String getClusterPushpullInterval() {
         return clusterPushpullInterval;
     }
 
     @JsonProperty("clusterPushpullInterval")
-    public void setClusterPushpullInterval(java.lang.String clusterPushpullInterval) {
+    public void setClusterPushpullInterval(String clusterPushpullInterval) {
         this.clusterPushpullInterval = clusterPushpullInterval;
     }
 
     @JsonProperty("configMaps")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getConfigMaps() {
+    public List<String> getConfigMaps() {
         return configMaps;
     }
 
     @JsonProperty("configMaps")
-    public void setConfigMaps(List<java.lang.String> configMaps) {
+    public void setConfigMaps(List<String> configMaps) {
         this.configMaps = configMaps;
     }
 
     @JsonProperty("configSecret")
-    public java.lang.String getConfigSecret() {
+    public String getConfigSecret() {
         return configSecret;
     }
 
     @JsonProperty("configSecret")
-    public void setConfigSecret(java.lang.String configSecret) {
+    public void setConfigSecret(String configSecret) {
         this.configSecret = configSecret;
     }
 
@@ -427,12 +427,12 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("externalUrl")
-    public java.lang.String getExternalUrl() {
+    public String getExternalUrl() {
         return externalUrl;
     }
 
     @JsonProperty("externalUrl")
-    public void setExternalUrl(java.lang.String externalUrl) {
+    public void setExternalUrl(String externalUrl) {
         this.externalUrl = externalUrl;
     }
 
@@ -458,22 +458,22 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("image")
-    public java.lang.String getImage() {
+    public String getImage() {
         return image;
     }
 
     @JsonProperty("image")
-    public void setImage(java.lang.String image) {
+    public void setImage(String image) {
         this.image = image;
     }
 
     @JsonProperty("imagePullPolicy")
-    public java.lang.String getImagePullPolicy() {
+    public String getImagePullPolicy() {
         return imagePullPolicy;
     }
 
     @JsonProperty("imagePullPolicy")
-    public void setImagePullPolicy(java.lang.String imagePullPolicy) {
+    public void setImagePullPolicy(String imagePullPolicy) {
         this.imagePullPolicy = imagePullPolicy;
     }
 
@@ -510,22 +510,22 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("logFormat")
-    public java.lang.String getLogFormat() {
+    public String getLogFormat() {
         return logFormat;
     }
 
     @JsonProperty("logFormat")
-    public void setLogFormat(java.lang.String logFormat) {
+    public void setLogFormat(String logFormat) {
         this.logFormat = logFormat;
     }
 
     @JsonProperty("logLevel")
-    public java.lang.String getLogLevel() {
+    public String getLogLevel() {
         return logLevel;
     }
 
     @JsonProperty("logLevel")
-    public void setLogLevel(java.lang.String logLevel) {
+    public void setLogLevel(String logLevel) {
         this.logLevel = logLevel;
     }
 
@@ -570,22 +570,22 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("portName")
-    public java.lang.String getPortName() {
+    public String getPortName() {
         return portName;
     }
 
     @JsonProperty("portName")
-    public void setPortName(java.lang.String portName) {
+    public void setPortName(String portName) {
         this.portName = portName;
     }
 
     @JsonProperty("priorityClassName")
-    public java.lang.String getPriorityClassName() {
+    public String getPriorityClassName() {
         return priorityClassName;
     }
 
     @JsonProperty("priorityClassName")
-    public void setPriorityClassName(java.lang.String priorityClassName) {
+    public void setPriorityClassName(String priorityClassName) {
         this.priorityClassName = priorityClassName;
     }
 
@@ -610,33 +610,33 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("retention")
-    public java.lang.String getRetention() {
+    public String getRetention() {
         return retention;
     }
 
     @JsonProperty("retention")
-    public void setRetention(java.lang.String retention) {
+    public void setRetention(String retention) {
         this.retention = retention;
     }
 
     @JsonProperty("routePrefix")
-    public java.lang.String getRoutePrefix() {
+    public String getRoutePrefix() {
         return routePrefix;
     }
 
     @JsonProperty("routePrefix")
-    public void setRoutePrefix(java.lang.String routePrefix) {
+    public void setRoutePrefix(String routePrefix) {
         this.routePrefix = routePrefix;
     }
 
     @JsonProperty("secrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getSecrets() {
+    public List<String> getSecrets() {
         return secrets;
     }
 
     @JsonProperty("secrets")
-    public void setSecrets(List<java.lang.String> secrets) {
+    public void setSecrets(List<String> secrets) {
         this.secrets = secrets;
     }
 
@@ -651,22 +651,22 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("serviceAccountName")
-    public java.lang.String getServiceAccountName() {
+    public String getServiceAccountName() {
         return serviceAccountName;
     }
 
     @JsonProperty("serviceAccountName")
-    public void setServiceAccountName(java.lang.String serviceAccountName) {
+    public void setServiceAccountName(String serviceAccountName) {
         this.serviceAccountName = serviceAccountName;
     }
 
     @JsonProperty("sha")
-    public java.lang.String getSha() {
+    public String getSha() {
         return sha;
     }
 
     @JsonProperty("sha")
-    public void setSha(java.lang.String sha) {
+    public void setSha(String sha) {
         this.sha = sha;
     }
 
@@ -681,12 +681,12 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("tag")
-    public java.lang.String getTag() {
+    public String getTag() {
         return tag;
     }
 
     @JsonProperty("tag")
-    public void setTag(java.lang.String tag) {
+    public void setTag(String tag) {
         this.tag = tag;
     }
 
@@ -713,12 +713,12 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonProperty("version")
-    public java.lang.String getVersion() {
+    public String getVersion() {
         return version;
     }
 
     @JsonProperty("version")
-    public void setVersion(java.lang.String version) {
+    public void setVersion(String version) {
         this.version = version;
     }
 
@@ -765,12 +765,12 @@ public class AlertmanagerSpec implements Editable<AlertmanagerSpecBuilder> , Kub
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/EmbeddedObjectMetadata.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/EmbeddedObjectMetadata.java
@@ -65,9 +65,9 @@ public class EmbeddedObjectMetadata implements Editable<EmbeddedObjectMetadataBu
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -76,7 +76,7 @@ public class EmbeddedObjectMetadata implements Editable<EmbeddedObjectMetadataBu
     public EmbeddedObjectMetadata() {
     }
 
-    public EmbeddedObjectMetadata(Map<String, String> annotations, Map<String, String> labels, java.lang.String name) {
+    public EmbeddedObjectMetadata(Map<String, String> annotations, Map<String, String> labels, String name) {
         super();
         this.annotations = annotations;
         this.labels = labels;
@@ -104,12 +104,12 @@ public class EmbeddedObjectMetadata implements Editable<EmbeddedObjectMetadataBu
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -124,12 +124,12 @@ public class EmbeddedObjectMetadata implements Editable<EmbeddedObjectMetadataBu
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Endpoint.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Endpoint.java
@@ -83,7 +83,7 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     @JsonProperty("basicAuth")
     private BasicAuth basicAuth;
     @JsonProperty("bearerTokenFile")
-    private java.lang.String bearerTokenFile;
+    private String bearerTokenFile;
     @JsonProperty("bearerTokenSecret")
     private SecretKeySelector bearerTokenSecret;
     @JsonProperty("enableHttp2")
@@ -97,7 +97,7 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     @JsonProperty("honorTimestamps")
     private Boolean honorTimestamps;
     @JsonProperty("interval")
-    private java.lang.String interval;
+    private String interval;
     @JsonProperty("metricRelabelings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RelabelConfig> metricRelabelings = new ArrayList<RelabelConfig>();
@@ -107,24 +107,24 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, ArrayList<String>> params = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("path")
-    private java.lang.String path;
+    private String path;
     @JsonProperty("port")
-    private java.lang.String port;
+    private String port;
     @JsonProperty("proxyUrl")
-    private java.lang.String proxyUrl;
+    private String proxyUrl;
     @JsonProperty("relabelings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RelabelConfig> relabelings = new ArrayList<RelabelConfig>();
     @JsonProperty("scheme")
-    private java.lang.String scheme;
+    private String scheme;
     @JsonProperty("scrapeTimeout")
-    private java.lang.String scrapeTimeout;
+    private String scrapeTimeout;
     @JsonProperty("targetPort")
     private io.fabric8.kubernetes.api.model.IntOrString targetPort;
     @JsonProperty("tlsConfig")
     private TLSConfig tlsConfig;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -133,7 +133,7 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     public Endpoint() {
     }
 
-    public Endpoint(SafeAuthorization authorization, BasicAuth basicAuth, java.lang.String bearerTokenFile, SecretKeySelector bearerTokenSecret, Boolean enableHttp2, Boolean filterRunning, Boolean followRedirects, Boolean honorLabels, Boolean honorTimestamps, java.lang.String interval, List<RelabelConfig> metricRelabelings, OAuth2 oauth2, Map<String, ArrayList<String>> params, java.lang.String path, java.lang.String port, java.lang.String proxyUrl, List<RelabelConfig> relabelings, java.lang.String scheme, java.lang.String scrapeTimeout, io.fabric8.kubernetes.api.model.IntOrString targetPort, TLSConfig tlsConfig) {
+    public Endpoint(SafeAuthorization authorization, BasicAuth basicAuth, String bearerTokenFile, SecretKeySelector bearerTokenSecret, Boolean enableHttp2, Boolean filterRunning, Boolean followRedirects, Boolean honorLabels, Boolean honorTimestamps, String interval, List<RelabelConfig> metricRelabelings, OAuth2 oauth2, Map<String, ArrayList<String>> params, String path, String port, String proxyUrl, List<RelabelConfig> relabelings, String scheme, String scrapeTimeout, io.fabric8.kubernetes.api.model.IntOrString targetPort, TLSConfig tlsConfig) {
         super();
         this.authorization = authorization;
         this.basicAuth = basicAuth;
@@ -179,12 +179,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("bearerTokenFile")
-    public java.lang.String getBearerTokenFile() {
+    public String getBearerTokenFile() {
         return bearerTokenFile;
     }
 
     @JsonProperty("bearerTokenFile")
-    public void setBearerTokenFile(java.lang.String bearerTokenFile) {
+    public void setBearerTokenFile(String bearerTokenFile) {
         this.bearerTokenFile = bearerTokenFile;
     }
 
@@ -249,12 +249,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("interval")
-    public java.lang.String getInterval() {
+    public String getInterval() {
         return interval;
     }
 
     @JsonProperty("interval")
-    public void setInterval(java.lang.String interval) {
+    public void setInterval(String interval) {
         this.interval = interval;
     }
 
@@ -290,32 +290,32 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("path")
-    public java.lang.String getPath() {
+    public String getPath() {
         return path;
     }
 
     @JsonProperty("path")
-    public void setPath(java.lang.String path) {
+    public void setPath(String path) {
         this.path = path;
     }
 
     @JsonProperty("port")
-    public java.lang.String getPort() {
+    public String getPort() {
         return port;
     }
 
     @JsonProperty("port")
-    public void setPort(java.lang.String port) {
+    public void setPort(String port) {
         this.port = port;
     }
 
     @JsonProperty("proxyUrl")
-    public java.lang.String getProxyUrl() {
+    public String getProxyUrl() {
         return proxyUrl;
     }
 
     @JsonProperty("proxyUrl")
-    public void setProxyUrl(java.lang.String proxyUrl) {
+    public void setProxyUrl(String proxyUrl) {
         this.proxyUrl = proxyUrl;
     }
 
@@ -331,22 +331,22 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonProperty("scheme")
-    public java.lang.String getScheme() {
+    public String getScheme() {
         return scheme;
     }
 
     @JsonProperty("scheme")
-    public void setScheme(java.lang.String scheme) {
+    public void setScheme(String scheme) {
         this.scheme = scheme;
     }
 
     @JsonProperty("scrapeTimeout")
-    public java.lang.String getScrapeTimeout() {
+    public String getScrapeTimeout() {
         return scrapeTimeout;
     }
 
     @JsonProperty("scrapeTimeout")
-    public void setScrapeTimeout(java.lang.String scrapeTimeout) {
+    public void setScrapeTimeout(String scrapeTimeout) {
         this.scrapeTimeout = scrapeTimeout;
     }
 
@@ -381,12 +381,12 @@ public class Endpoint implements Editable<EndpointBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/OAuth2.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/OAuth2.java
@@ -72,11 +72,11 @@ public class OAuth2 implements Editable<OAuth2Builder> , KubernetesResource
     private Map<String, String> endpointParams = new LinkedHashMap<String, String>();
     @JsonProperty("scopes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> scopes = new ArrayList<java.lang.String>();
+    private List<String> scopes = new ArrayList<String>();
     @JsonProperty("tokenUrl")
-    private java.lang.String tokenUrl;
+    private String tokenUrl;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -85,7 +85,7 @@ public class OAuth2 implements Editable<OAuth2Builder> , KubernetesResource
     public OAuth2() {
     }
 
-    public OAuth2(SecretOrConfigMap clientId, SecretKeySelector clientSecret, Map<String, String> endpointParams, List<java.lang.String> scopes, java.lang.String tokenUrl) {
+    public OAuth2(SecretOrConfigMap clientId, SecretKeySelector clientSecret, Map<String, String> endpointParams, List<String> scopes, String tokenUrl) {
         super();
         this.clientId = clientId;
         this.clientSecret = clientSecret;
@@ -126,22 +126,22 @@ public class OAuth2 implements Editable<OAuth2Builder> , KubernetesResource
 
     @JsonProperty("scopes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getScopes() {
+    public List<String> getScopes() {
         return scopes;
     }
 
     @JsonProperty("scopes")
-    public void setScopes(List<java.lang.String> scopes) {
+    public void setScopes(List<String> scopes) {
         this.scopes = scopes;
     }
 
     @JsonProperty("tokenUrl")
-    public java.lang.String getTokenUrl() {
+    public String getTokenUrl() {
         return tokenUrl;
     }
 
     @JsonProperty("tokenUrl")
-    public void setTokenUrl(java.lang.String tokenUrl) {
+    public void setTokenUrl(String tokenUrl) {
         this.tokenUrl = tokenUrl;
     }
 
@@ -156,12 +156,12 @@ public class OAuth2 implements Editable<OAuth2Builder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PodMetricsEndpoint.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PodMetricsEndpoint.java
@@ -94,7 +94,7 @@ public class PodMetricsEndpoint implements Editable<PodMetricsEndpointBuilder> ,
     @JsonProperty("honorTimestamps")
     private Boolean honorTimestamps;
     @JsonProperty("interval")
-    private java.lang.String interval;
+    private String interval;
     @JsonProperty("metricRelabelings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RelabelConfig> metricRelabelings = new ArrayList<RelabelConfig>();
@@ -104,24 +104,24 @@ public class PodMetricsEndpoint implements Editable<PodMetricsEndpointBuilder> ,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, ArrayList<String>> params = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("path")
-    private java.lang.String path;
+    private String path;
     @JsonProperty("port")
-    private java.lang.String port;
+    private String port;
     @JsonProperty("proxyUrl")
-    private java.lang.String proxyUrl;
+    private String proxyUrl;
     @JsonProperty("relabelings")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RelabelConfig> relabelings = new ArrayList<RelabelConfig>();
     @JsonProperty("scheme")
-    private java.lang.String scheme;
+    private String scheme;
     @JsonProperty("scrapeTimeout")
-    private java.lang.String scrapeTimeout;
+    private String scrapeTimeout;
     @JsonProperty("targetPort")
     private io.fabric8.kubernetes.api.model.IntOrString targetPort;
     @JsonProperty("tlsConfig")
     private PodMetricsEndpointTLSConfig tlsConfig;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -130,7 +130,7 @@ public class PodMetricsEndpoint implements Editable<PodMetricsEndpointBuilder> ,
     public PodMetricsEndpoint() {
     }
 
-    public PodMetricsEndpoint(SafeAuthorization authorization, BasicAuth basicAuth, SecretKeySelector bearerTokenSecret, Boolean enableHttp2, Boolean filterRunning, Boolean followRedirects, Boolean honorLabels, Boolean honorTimestamps, java.lang.String interval, List<RelabelConfig> metricRelabelings, OAuth2 oauth2, Map<String, ArrayList<String>> params, java.lang.String path, java.lang.String port, java.lang.String proxyUrl, List<RelabelConfig> relabelings, java.lang.String scheme, java.lang.String scrapeTimeout, io.fabric8.kubernetes.api.model.IntOrString targetPort, PodMetricsEndpointTLSConfig tlsConfig) {
+    public PodMetricsEndpoint(SafeAuthorization authorization, BasicAuth basicAuth, SecretKeySelector bearerTokenSecret, Boolean enableHttp2, Boolean filterRunning, Boolean followRedirects, Boolean honorLabels, Boolean honorTimestamps, String interval, List<RelabelConfig> metricRelabelings, OAuth2 oauth2, Map<String, ArrayList<String>> params, String path, String port, String proxyUrl, List<RelabelConfig> relabelings, String scheme, String scrapeTimeout, io.fabric8.kubernetes.api.model.IntOrString targetPort, PodMetricsEndpointTLSConfig tlsConfig) {
         super();
         this.authorization = authorization;
         this.basicAuth = basicAuth;
@@ -235,12 +235,12 @@ public class PodMetricsEndpoint implements Editable<PodMetricsEndpointBuilder> ,
     }
 
     @JsonProperty("interval")
-    public java.lang.String getInterval() {
+    public String getInterval() {
         return interval;
     }
 
     @JsonProperty("interval")
-    public void setInterval(java.lang.String interval) {
+    public void setInterval(String interval) {
         this.interval = interval;
     }
 
@@ -276,32 +276,32 @@ public class PodMetricsEndpoint implements Editable<PodMetricsEndpointBuilder> ,
     }
 
     @JsonProperty("path")
-    public java.lang.String getPath() {
+    public String getPath() {
         return path;
     }
 
     @JsonProperty("path")
-    public void setPath(java.lang.String path) {
+    public void setPath(String path) {
         this.path = path;
     }
 
     @JsonProperty("port")
-    public java.lang.String getPort() {
+    public String getPort() {
         return port;
     }
 
     @JsonProperty("port")
-    public void setPort(java.lang.String port) {
+    public void setPort(String port) {
         this.port = port;
     }
 
     @JsonProperty("proxyUrl")
-    public java.lang.String getProxyUrl() {
+    public String getProxyUrl() {
         return proxyUrl;
     }
 
     @JsonProperty("proxyUrl")
-    public void setProxyUrl(java.lang.String proxyUrl) {
+    public void setProxyUrl(String proxyUrl) {
         this.proxyUrl = proxyUrl;
     }
 
@@ -317,22 +317,22 @@ public class PodMetricsEndpoint implements Editable<PodMetricsEndpointBuilder> ,
     }
 
     @JsonProperty("scheme")
-    public java.lang.String getScheme() {
+    public String getScheme() {
         return scheme;
     }
 
     @JsonProperty("scheme")
-    public void setScheme(java.lang.String scheme) {
+    public void setScheme(String scheme) {
         this.scheme = scheme;
     }
 
     @JsonProperty("scrapeTimeout")
-    public java.lang.String getScrapeTimeout() {
+    public String getScrapeTimeout() {
         return scrapeTimeout;
     }
 
     @JsonProperty("scrapeTimeout")
-    public void setScrapeTimeout(java.lang.String scrapeTimeout) {
+    public void setScrapeTimeout(String scrapeTimeout) {
         this.scrapeTimeout = scrapeTimeout;
     }
 
@@ -367,12 +367,12 @@ public class PodMetricsEndpoint implements Editable<PodMetricsEndpointBuilder> ,
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ProbeTargetStaticConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ProbeTargetStaticConfig.java
@@ -68,9 +68,9 @@ public class ProbeTargetStaticConfig implements Editable<ProbeTargetStaticConfig
     private List<RelabelConfig> relabelingConfigs = new ArrayList<RelabelConfig>();
     @JsonProperty("static")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> _static = new ArrayList<java.lang.String>();
+    private List<String> _static = new ArrayList<String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -79,7 +79,7 @@ public class ProbeTargetStaticConfig implements Editable<ProbeTargetStaticConfig
     public ProbeTargetStaticConfig() {
     }
 
-    public ProbeTargetStaticConfig(Map<String, String> labels, List<RelabelConfig> relabelingConfigs, List<java.lang.String> _static) {
+    public ProbeTargetStaticConfig(Map<String, String> labels, List<RelabelConfig> relabelingConfigs, List<String> _static) {
         super();
         this.labels = labels;
         this.relabelingConfigs = relabelingConfigs;
@@ -108,12 +108,12 @@ public class ProbeTargetStaticConfig implements Editable<ProbeTargetStaticConfig
     }
 
     @JsonProperty("static")
-    public List<java.lang.String> getStatic() {
+    public List<String> getStatic() {
         return _static;
     }
 
     @JsonProperty("static")
-    public void setStatic(List<java.lang.String> _static) {
+    public void setStatic(List<String> _static) {
         this._static = _static;
     }
 
@@ -128,12 +128,12 @@ public class ProbeTargetStaticConfig implements Editable<ProbeTargetStaticConfig
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusSpec.java
@@ -176,12 +176,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonProperty("arbitraryFSAccessThroughSMs")
     private ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs;
     @JsonProperty("baseImage")
-    private java.lang.String baseImage;
+    private String baseImage;
     @JsonProperty("bodySizeLimit")
-    private java.lang.String bodySizeLimit;
+    private String bodySizeLimit;
     @JsonProperty("configMaps")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> configMaps = new ArrayList<java.lang.String>();
+    private List<String> configMaps = new ArrayList<String>();
     @JsonProperty("containers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.kubernetes.api.model.Container> containers = new ArrayList<io.fabric8.kubernetes.api.model.Container>();
@@ -191,11 +191,11 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     private Boolean enableAdminAPI;
     @JsonProperty("enableFeatures")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> enableFeatures = new ArrayList<java.lang.String>();
+    private List<String> enableFeatures = new ArrayList<String>();
     @JsonProperty("enableRemoteWriteReceiver")
     private Boolean enableRemoteWriteReceiver;
     @JsonProperty("enforcedBodySizeLimit")
-    private java.lang.String enforcedBodySizeLimit;
+    private String enforcedBodySizeLimit;
     @JsonProperty("enforcedKeepDroppedTargets")
     private Long enforcedKeepDroppedTargets;
     @JsonProperty("enforcedLabelLimit")
@@ -205,13 +205,13 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonProperty("enforcedLabelValueLengthLimit")
     private Long enforcedLabelValueLengthLimit;
     @JsonProperty("enforcedNamespaceLabel")
-    private java.lang.String enforcedNamespaceLabel;
+    private String enforcedNamespaceLabel;
     @JsonProperty("enforcedSampleLimit")
     private Long enforcedSampleLimit;
     @JsonProperty("enforcedTargetLimit")
     private Long enforcedTargetLimit;
     @JsonProperty("evaluationInterval")
-    private java.lang.String evaluationInterval;
+    private String evaluationInterval;
     @JsonProperty("excludedFromEnforcement")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference> excludedFromEnforcement = new ArrayList<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference>();
@@ -221,7 +221,7 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> externalLabels = new LinkedHashMap<String, String>();
     @JsonProperty("externalUrl")
-    private java.lang.String externalUrl;
+    private String externalUrl;
     @JsonProperty("hostAliases")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<HostAlias> hostAliases = new ArrayList<HostAlias>();
@@ -230,9 +230,9 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonProperty("ignoreNamespaceSelectors")
     private Boolean ignoreNamespaceSelectors;
     @JsonProperty("image")
-    private java.lang.String image;
+    private String image;
     @JsonProperty("imagePullPolicy")
-    private java.lang.String imagePullPolicy;
+    private String imagePullPolicy;
     @JsonProperty("imagePullSecrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets = new ArrayList<io.fabric8.kubernetes.api.model.LocalObjectReference>();
@@ -250,9 +250,9 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonProperty("listenLocal")
     private Boolean listenLocal;
     @JsonProperty("logFormat")
-    private java.lang.String logFormat;
+    private String logFormat;
     @JsonProperty("logLevel")
-    private java.lang.String logLevel;
+    private String logLevel;
     @JsonProperty("minReadySeconds")
     private Integer minReadySeconds;
     @JsonProperty("nodeSelector")
@@ -272,24 +272,24 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     private io.fabric8.kubernetes.api.model.LabelSelector podMonitorSelector;
     @JsonProperty("podTargetLabels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> podTargetLabels = new ArrayList<java.lang.String>();
+    private List<String> podTargetLabels = new ArrayList<String>();
     @JsonProperty("portName")
-    private java.lang.String portName;
+    private String portName;
     @JsonProperty("priorityClassName")
-    private java.lang.String priorityClassName;
+    private String priorityClassName;
     @JsonProperty("probeNamespaceSelector")
     private io.fabric8.kubernetes.api.model.LabelSelector probeNamespaceSelector;
     @JsonProperty("probeSelector")
     private io.fabric8.kubernetes.api.model.LabelSelector probeSelector;
     @JsonProperty("prometheusExternalLabelName")
-    private java.lang.String prometheusExternalLabelName;
+    private String prometheusExternalLabelName;
     @JsonProperty("prometheusRulesExcludedFromEnforce")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce = new ArrayList<PrometheusRuleExcludeConfig>();
     @JsonProperty("query")
     private QuerySpec query;
     @JsonProperty("queryLogFile")
-    private java.lang.String queryLogFile;
+    private String queryLogFile;
     @JsonProperty("remoteRead")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RemoteReadSpec> remoteRead = new ArrayList<RemoteReadSpec>();
@@ -297,17 +297,17 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RemoteWriteSpec> remoteWrite = new ArrayList<RemoteWriteSpec>();
     @JsonProperty("replicaExternalLabelName")
-    private java.lang.String replicaExternalLabelName;
+    private String replicaExternalLabelName;
     @JsonProperty("replicas")
     private Integer replicas;
     @JsonProperty("resources")
     private io.fabric8.kubernetes.api.model.ResourceRequirements resources;
     @JsonProperty("retention")
-    private java.lang.String retention;
+    private String retention;
     @JsonProperty("retentionSize")
-    private java.lang.String retentionSize;
+    private String retentionSize;
     @JsonProperty("routePrefix")
-    private java.lang.String routePrefix;
+    private String routePrefix;
     @JsonProperty("ruleNamespaceSelector")
     private io.fabric8.kubernetes.api.model.LabelSelector ruleNamespaceSelector;
     @JsonProperty("ruleSelector")
@@ -321,28 +321,28 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonProperty("scrapeConfigSelector")
     private io.fabric8.kubernetes.api.model.LabelSelector scrapeConfigSelector;
     @JsonProperty("scrapeInterval")
-    private java.lang.String scrapeInterval;
+    private String scrapeInterval;
     @JsonProperty("scrapeTimeout")
-    private java.lang.String scrapeTimeout;
+    private String scrapeTimeout;
     @JsonProperty("secrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> secrets = new ArrayList<java.lang.String>();
+    private List<String> secrets = new ArrayList<String>();
     @JsonProperty("securityContext")
     private PodSecurityContext securityContext;
     @JsonProperty("serviceAccountName")
-    private java.lang.String serviceAccountName;
+    private String serviceAccountName;
     @JsonProperty("serviceMonitorNamespaceSelector")
     private io.fabric8.kubernetes.api.model.LabelSelector serviceMonitorNamespaceSelector;
     @JsonProperty("serviceMonitorSelector")
     private io.fabric8.kubernetes.api.model.LabelSelector serviceMonitorSelector;
     @JsonProperty("sha")
-    private java.lang.String sha;
+    private String sha;
     @JsonProperty("shards")
     private Integer shards;
     @JsonProperty("storage")
     private StorageSpec storage;
     @JsonProperty("tag")
-    private java.lang.String tag;
+    private String tag;
     @JsonProperty("targetLimit")
     private Long targetLimit;
     @JsonProperty("thanos")
@@ -358,7 +358,7 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonProperty("tsdb")
     private TSDBSpec tsdb;
     @JsonProperty("version")
-    private java.lang.String version;
+    private String version;
     @JsonProperty("volumeMounts")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<VolumeMount> volumeMounts = new ArrayList<VolumeMount>();
@@ -370,7 +370,7 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     @JsonProperty("web")
     private PrometheusWebSpec web;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -379,7 +379,7 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     public PrometheusSpec() {
     }
 
-    public PrometheusSpec(SecretKeySelector additionalAlertManagerConfigs, SecretKeySelector additionalAlertRelabelConfigs, List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, AlertingSpec alerting, Boolean allowOverlappingBlocks, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, java.lang.String baseImage, java.lang.String bodySizeLimit, List<java.lang.String> configMaps, List<io.fabric8.kubernetes.api.model.Container> containers, Boolean disableCompaction, Boolean enableAdminAPI, List<java.lang.String> enableFeatures, Boolean enableRemoteWriteReceiver, java.lang.String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, java.lang.String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, java.lang.String evaluationInterval, List<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference> excludedFromEnforcement, Exemplars exemplars, Map<String, String> externalLabels, java.lang.String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean ignoreNamespaceSelectors, java.lang.String image, java.lang.String imagePullPolicy, List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets, List<io.fabric8.kubernetes.api.model.Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, java.lang.String logFormat, java.lang.String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, EmbeddedObjectMetadata podMetadata, io.fabric8.kubernetes.api.model.LabelSelector podMonitorNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector podMonitorSelector, List<java.lang.String> podTargetLabels, java.lang.String portName, java.lang.String priorityClassName, io.fabric8.kubernetes.api.model.LabelSelector probeNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector probeSelector, java.lang.String prometheusExternalLabelName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, QuerySpec query, java.lang.String queryLogFile, List<RemoteReadSpec> remoteRead, List<RemoteWriteSpec> remoteWrite, java.lang.String replicaExternalLabelName, Integer replicas, io.fabric8.kubernetes.api.model.ResourceRequirements resources, java.lang.String retention, java.lang.String retentionSize, java.lang.String routePrefix, io.fabric8.kubernetes.api.model.LabelSelector ruleNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector ruleSelector, Rules rules, Long sampleLimit, io.fabric8.kubernetes.api.model.LabelSelector scrapeConfigNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector scrapeConfigSelector, java.lang.String scrapeInterval, java.lang.String scrapeTimeout, List<java.lang.String> secrets, PodSecurityContext securityContext, java.lang.String serviceAccountName, io.fabric8.kubernetes.api.model.LabelSelector serviceMonitorNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector serviceMonitorSelector, java.lang.String sha, Integer shards, StorageSpec storage, java.lang.String tag, Long targetLimit, ThanosSpec thanos, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, PrometheusTracingConfig tracingConfig, TSDBSpec tsdb, java.lang.String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
+    public PrometheusSpec(SecretKeySelector additionalAlertManagerConfigs, SecretKeySelector additionalAlertRelabelConfigs, List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, AlertingSpec alerting, Boolean allowOverlappingBlocks, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, String baseImage, String bodySizeLimit, List<String> configMaps, List<io.fabric8.kubernetes.api.model.Container> containers, Boolean disableCompaction, Boolean enableAdminAPI, List<String> enableFeatures, Boolean enableRemoteWriteReceiver, String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, String evaluationInterval, List<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference> excludedFromEnforcement, Exemplars exemplars, Map<String, String> externalLabels, String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean ignoreNamespaceSelectors, String image, String imagePullPolicy, List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets, List<io.fabric8.kubernetes.api.model.Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, String logFormat, String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, EmbeddedObjectMetadata podMetadata, io.fabric8.kubernetes.api.model.LabelSelector podMonitorNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector podMonitorSelector, List<String> podTargetLabels, String portName, String priorityClassName, io.fabric8.kubernetes.api.model.LabelSelector probeNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector probeSelector, String prometheusExternalLabelName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, QuerySpec query, String queryLogFile, List<RemoteReadSpec> remoteRead, List<RemoteWriteSpec> remoteWrite, String replicaExternalLabelName, Integer replicas, io.fabric8.kubernetes.api.model.ResourceRequirements resources, String retention, String retentionSize, String routePrefix, io.fabric8.kubernetes.api.model.LabelSelector ruleNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector ruleSelector, Rules rules, Long sampleLimit, io.fabric8.kubernetes.api.model.LabelSelector scrapeConfigNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector scrapeConfigSelector, String scrapeInterval, String scrapeTimeout, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, io.fabric8.kubernetes.api.model.LabelSelector serviceMonitorNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector serviceMonitorSelector, String sha, Integer shards, StorageSpec storage, String tag, Long targetLimit, ThanosSpec thanos, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, PrometheusTracingConfig tracingConfig, TSDBSpec tsdb, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
         super();
         this.additionalAlertManagerConfigs = additionalAlertManagerConfigs;
         this.additionalAlertRelabelConfigs = additionalAlertRelabelConfigs;
@@ -572,33 +572,33 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("baseImage")
-    public java.lang.String getBaseImage() {
+    public String getBaseImage() {
         return baseImage;
     }
 
     @JsonProperty("baseImage")
-    public void setBaseImage(java.lang.String baseImage) {
+    public void setBaseImage(String baseImage) {
         this.baseImage = baseImage;
     }
 
     @JsonProperty("bodySizeLimit")
-    public java.lang.String getBodySizeLimit() {
+    public String getBodySizeLimit() {
         return bodySizeLimit;
     }
 
     @JsonProperty("bodySizeLimit")
-    public void setBodySizeLimit(java.lang.String bodySizeLimit) {
+    public void setBodySizeLimit(String bodySizeLimit) {
         this.bodySizeLimit = bodySizeLimit;
     }
 
     @JsonProperty("configMaps")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getConfigMaps() {
+    public List<String> getConfigMaps() {
         return configMaps;
     }
 
     @JsonProperty("configMaps")
-    public void setConfigMaps(List<java.lang.String> configMaps) {
+    public void setConfigMaps(List<String> configMaps) {
         this.configMaps = configMaps;
     }
 
@@ -635,12 +635,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
 
     @JsonProperty("enableFeatures")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getEnableFeatures() {
+    public List<String> getEnableFeatures() {
         return enableFeatures;
     }
 
     @JsonProperty("enableFeatures")
-    public void setEnableFeatures(List<java.lang.String> enableFeatures) {
+    public void setEnableFeatures(List<String> enableFeatures) {
         this.enableFeatures = enableFeatures;
     }
 
@@ -655,12 +655,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("enforcedBodySizeLimit")
-    public java.lang.String getEnforcedBodySizeLimit() {
+    public String getEnforcedBodySizeLimit() {
         return enforcedBodySizeLimit;
     }
 
     @JsonProperty("enforcedBodySizeLimit")
-    public void setEnforcedBodySizeLimit(java.lang.String enforcedBodySizeLimit) {
+    public void setEnforcedBodySizeLimit(String enforcedBodySizeLimit) {
         this.enforcedBodySizeLimit = enforcedBodySizeLimit;
     }
 
@@ -705,12 +705,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("enforcedNamespaceLabel")
-    public java.lang.String getEnforcedNamespaceLabel() {
+    public String getEnforcedNamespaceLabel() {
         return enforcedNamespaceLabel;
     }
 
     @JsonProperty("enforcedNamespaceLabel")
-    public void setEnforcedNamespaceLabel(java.lang.String enforcedNamespaceLabel) {
+    public void setEnforcedNamespaceLabel(String enforcedNamespaceLabel) {
         this.enforcedNamespaceLabel = enforcedNamespaceLabel;
     }
 
@@ -735,12 +735,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("evaluationInterval")
-    public java.lang.String getEvaluationInterval() {
+    public String getEvaluationInterval() {
         return evaluationInterval;
     }
 
     @JsonProperty("evaluationInterval")
-    public void setEvaluationInterval(java.lang.String evaluationInterval) {
+    public void setEvaluationInterval(String evaluationInterval) {
         this.evaluationInterval = evaluationInterval;
     }
 
@@ -776,12 +776,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("externalUrl")
-    public java.lang.String getExternalUrl() {
+    public String getExternalUrl() {
         return externalUrl;
     }
 
     @JsonProperty("externalUrl")
-    public void setExternalUrl(java.lang.String externalUrl) {
+    public void setExternalUrl(String externalUrl) {
         this.externalUrl = externalUrl;
     }
 
@@ -817,22 +817,22 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("image")
-    public java.lang.String getImage() {
+    public String getImage() {
         return image;
     }
 
     @JsonProperty("image")
-    public void setImage(java.lang.String image) {
+    public void setImage(String image) {
         this.image = image;
     }
 
     @JsonProperty("imagePullPolicy")
-    public java.lang.String getImagePullPolicy() {
+    public String getImagePullPolicy() {
         return imagePullPolicy;
     }
 
     @JsonProperty("imagePullPolicy")
-    public void setImagePullPolicy(java.lang.String imagePullPolicy) {
+    public void setImagePullPolicy(String imagePullPolicy) {
         this.imagePullPolicy = imagePullPolicy;
     }
 
@@ -909,22 +909,22 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("logFormat")
-    public java.lang.String getLogFormat() {
+    public String getLogFormat() {
         return logFormat;
     }
 
     @JsonProperty("logFormat")
-    public void setLogFormat(java.lang.String logFormat) {
+    public void setLogFormat(String logFormat) {
         this.logFormat = logFormat;
     }
 
     @JsonProperty("logLevel")
-    public java.lang.String getLogLevel() {
+    public String getLogLevel() {
         return logLevel;
     }
 
     @JsonProperty("logLevel")
-    public void setLogLevel(java.lang.String logLevel) {
+    public void setLogLevel(String logLevel) {
         this.logLevel = logLevel;
     }
 
@@ -1010,32 +1010,32 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
 
     @JsonProperty("podTargetLabels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getPodTargetLabels() {
+    public List<String> getPodTargetLabels() {
         return podTargetLabels;
     }
 
     @JsonProperty("podTargetLabels")
-    public void setPodTargetLabels(List<java.lang.String> podTargetLabels) {
+    public void setPodTargetLabels(List<String> podTargetLabels) {
         this.podTargetLabels = podTargetLabels;
     }
 
     @JsonProperty("portName")
-    public java.lang.String getPortName() {
+    public String getPortName() {
         return portName;
     }
 
     @JsonProperty("portName")
-    public void setPortName(java.lang.String portName) {
+    public void setPortName(String portName) {
         this.portName = portName;
     }
 
     @JsonProperty("priorityClassName")
-    public java.lang.String getPriorityClassName() {
+    public String getPriorityClassName() {
         return priorityClassName;
     }
 
     @JsonProperty("priorityClassName")
-    public void setPriorityClassName(java.lang.String priorityClassName) {
+    public void setPriorityClassName(String priorityClassName) {
         this.priorityClassName = priorityClassName;
     }
 
@@ -1060,12 +1060,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("prometheusExternalLabelName")
-    public java.lang.String getPrometheusExternalLabelName() {
+    public String getPrometheusExternalLabelName() {
         return prometheusExternalLabelName;
     }
 
     @JsonProperty("prometheusExternalLabelName")
-    public void setPrometheusExternalLabelName(java.lang.String prometheusExternalLabelName) {
+    public void setPrometheusExternalLabelName(String prometheusExternalLabelName) {
         this.prometheusExternalLabelName = prometheusExternalLabelName;
     }
 
@@ -1091,12 +1091,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("queryLogFile")
-    public java.lang.String getQueryLogFile() {
+    public String getQueryLogFile() {
         return queryLogFile;
     }
 
     @JsonProperty("queryLogFile")
-    public void setQueryLogFile(java.lang.String queryLogFile) {
+    public void setQueryLogFile(String queryLogFile) {
         this.queryLogFile = queryLogFile;
     }
 
@@ -1123,12 +1123,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("replicaExternalLabelName")
-    public java.lang.String getReplicaExternalLabelName() {
+    public String getReplicaExternalLabelName() {
         return replicaExternalLabelName;
     }
 
     @JsonProperty("replicaExternalLabelName")
-    public void setReplicaExternalLabelName(java.lang.String replicaExternalLabelName) {
+    public void setReplicaExternalLabelName(String replicaExternalLabelName) {
         this.replicaExternalLabelName = replicaExternalLabelName;
     }
 
@@ -1153,32 +1153,32 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("retention")
-    public java.lang.String getRetention() {
+    public String getRetention() {
         return retention;
     }
 
     @JsonProperty("retention")
-    public void setRetention(java.lang.String retention) {
+    public void setRetention(String retention) {
         this.retention = retention;
     }
 
     @JsonProperty("retentionSize")
-    public java.lang.String getRetentionSize() {
+    public String getRetentionSize() {
         return retentionSize;
     }
 
     @JsonProperty("retentionSize")
-    public void setRetentionSize(java.lang.String retentionSize) {
+    public void setRetentionSize(String retentionSize) {
         this.retentionSize = retentionSize;
     }
 
     @JsonProperty("routePrefix")
-    public java.lang.String getRoutePrefix() {
+    public String getRoutePrefix() {
         return routePrefix;
     }
 
     @JsonProperty("routePrefix")
-    public void setRoutePrefix(java.lang.String routePrefix) {
+    public void setRoutePrefix(String routePrefix) {
         this.routePrefix = routePrefix;
     }
 
@@ -1243,33 +1243,33 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("scrapeInterval")
-    public java.lang.String getScrapeInterval() {
+    public String getScrapeInterval() {
         return scrapeInterval;
     }
 
     @JsonProperty("scrapeInterval")
-    public void setScrapeInterval(java.lang.String scrapeInterval) {
+    public void setScrapeInterval(String scrapeInterval) {
         this.scrapeInterval = scrapeInterval;
     }
 
     @JsonProperty("scrapeTimeout")
-    public java.lang.String getScrapeTimeout() {
+    public String getScrapeTimeout() {
         return scrapeTimeout;
     }
 
     @JsonProperty("scrapeTimeout")
-    public void setScrapeTimeout(java.lang.String scrapeTimeout) {
+    public void setScrapeTimeout(String scrapeTimeout) {
         this.scrapeTimeout = scrapeTimeout;
     }
 
     @JsonProperty("secrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getSecrets() {
+    public List<String> getSecrets() {
         return secrets;
     }
 
     @JsonProperty("secrets")
-    public void setSecrets(List<java.lang.String> secrets) {
+    public void setSecrets(List<String> secrets) {
         this.secrets = secrets;
     }
 
@@ -1284,12 +1284,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("serviceAccountName")
-    public java.lang.String getServiceAccountName() {
+    public String getServiceAccountName() {
         return serviceAccountName;
     }
 
     @JsonProperty("serviceAccountName")
-    public void setServiceAccountName(java.lang.String serviceAccountName) {
+    public void setServiceAccountName(String serviceAccountName) {
         this.serviceAccountName = serviceAccountName;
     }
 
@@ -1314,12 +1314,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("sha")
-    public java.lang.String getSha() {
+    public String getSha() {
         return sha;
     }
 
     @JsonProperty("sha")
-    public void setSha(java.lang.String sha) {
+    public void setSha(String sha) {
         this.sha = sha;
     }
 
@@ -1344,12 +1344,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("tag")
-    public java.lang.String getTag() {
+    public String getTag() {
         return tag;
     }
 
     @JsonProperty("tag")
-    public void setTag(java.lang.String tag) {
+    public void setTag(String tag) {
         this.tag = tag;
     }
 
@@ -1416,12 +1416,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonProperty("version")
-    public java.lang.String getVersion() {
+    public String getVersion() {
         return version;
     }
 
     @JsonProperty("version")
-    public void setVersion(java.lang.String version) {
+    public void setVersion(String version) {
         this.version = version;
     }
 
@@ -1478,12 +1478,12 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder> , Kuberne
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusTracingConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusTracingConfig.java
@@ -65,11 +65,11 @@ public class PrometheusTracingConfig implements Editable<PrometheusTracingConfig
 {
 
     @JsonProperty("clientType")
-    private java.lang.String clientType;
+    private String clientType;
     @JsonProperty("compression")
-    private java.lang.String compression;
+    private String compression;
     @JsonProperty("endpoint")
-    private java.lang.String endpoint;
+    private String endpoint;
     @JsonProperty("headers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> headers = new LinkedHashMap<String, String>();
@@ -78,11 +78,11 @@ public class PrometheusTracingConfig implements Editable<PrometheusTracingConfig
     @JsonProperty("samplingFraction")
     private Quantity samplingFraction;
     @JsonProperty("timeout")
-    private java.lang.String timeout;
+    private String timeout;
     @JsonProperty("tlsConfig")
     private TLSConfig tlsConfig;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -91,7 +91,7 @@ public class PrometheusTracingConfig implements Editable<PrometheusTracingConfig
     public PrometheusTracingConfig() {
     }
 
-    public PrometheusTracingConfig(java.lang.String clientType, java.lang.String compression, java.lang.String endpoint, Map<String, String> headers, Boolean insecure, Quantity samplingFraction, java.lang.String timeout, TLSConfig tlsConfig) {
+    public PrometheusTracingConfig(String clientType, String compression, String endpoint, Map<String, String> headers, Boolean insecure, Quantity samplingFraction, String timeout, TLSConfig tlsConfig) {
         super();
         this.clientType = clientType;
         this.compression = compression;
@@ -104,32 +104,32 @@ public class PrometheusTracingConfig implements Editable<PrometheusTracingConfig
     }
 
     @JsonProperty("clientType")
-    public java.lang.String getClientType() {
+    public String getClientType() {
         return clientType;
     }
 
     @JsonProperty("clientType")
-    public void setClientType(java.lang.String clientType) {
+    public void setClientType(String clientType) {
         this.clientType = clientType;
     }
 
     @JsonProperty("compression")
-    public java.lang.String getCompression() {
+    public String getCompression() {
         return compression;
     }
 
     @JsonProperty("compression")
-    public void setCompression(java.lang.String compression) {
+    public void setCompression(String compression) {
         this.compression = compression;
     }
 
     @JsonProperty("endpoint")
-    public java.lang.String getEndpoint() {
+    public String getEndpoint() {
         return endpoint;
     }
 
     @JsonProperty("endpoint")
-    public void setEndpoint(java.lang.String endpoint) {
+    public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
     }
 
@@ -164,12 +164,12 @@ public class PrometheusTracingConfig implements Editable<PrometheusTracingConfig
     }
 
     @JsonProperty("timeout")
-    public java.lang.String getTimeout() {
+    public String getTimeout() {
         return timeout;
     }
 
     @JsonProperty("timeout")
-    public void setTimeout(java.lang.String timeout) {
+    public void setTimeout(String timeout) {
         this.timeout = timeout;
     }
 
@@ -194,12 +194,12 @@ public class PrometheusTracingConfig implements Editable<PrometheusTracingConfig
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/RemoteReadSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/RemoteReadSpec.java
@@ -75,9 +75,9 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     @JsonProperty("basicAuth")
     private BasicAuth basicAuth;
     @JsonProperty("bearerToken")
-    private java.lang.String bearerToken;
+    private String bearerToken;
     @JsonProperty("bearerTokenFile")
-    private java.lang.String bearerTokenFile;
+    private String bearerTokenFile;
     @JsonProperty("filterExternalLabels")
     private Boolean filterExternalLabels;
     @JsonProperty("followRedirects")
@@ -86,24 +86,24 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> headers = new LinkedHashMap<String, String>();
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("oauth2")
     private OAuth2 oauth2;
     @JsonProperty("proxyUrl")
-    private java.lang.String proxyUrl;
+    private String proxyUrl;
     @JsonProperty("readRecent")
     private Boolean readRecent;
     @JsonProperty("remoteTimeout")
-    private java.lang.String remoteTimeout;
+    private String remoteTimeout;
     @JsonProperty("requiredMatchers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> requiredMatchers = new LinkedHashMap<String, String>();
     @JsonProperty("tlsConfig")
     private TLSConfig tlsConfig;
     @JsonProperty("url")
-    private java.lang.String url;
+    private String url;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -112,7 +112,7 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     public RemoteReadSpec() {
     }
 
-    public RemoteReadSpec(Authorization authorization, BasicAuth basicAuth, java.lang.String bearerToken, java.lang.String bearerTokenFile, Boolean filterExternalLabels, Boolean followRedirects, Map<String, String> headers, java.lang.String name, OAuth2 oauth2, java.lang.String proxyUrl, Boolean readRecent, java.lang.String remoteTimeout, Map<String, String> requiredMatchers, TLSConfig tlsConfig, java.lang.String url) {
+    public RemoteReadSpec(Authorization authorization, BasicAuth basicAuth, String bearerToken, String bearerTokenFile, Boolean filterExternalLabels, Boolean followRedirects, Map<String, String> headers, String name, OAuth2 oauth2, String proxyUrl, Boolean readRecent, String remoteTimeout, Map<String, String> requiredMatchers, TLSConfig tlsConfig, String url) {
         super();
         this.authorization = authorization;
         this.basicAuth = basicAuth;
@@ -152,22 +152,22 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     }
 
     @JsonProperty("bearerToken")
-    public java.lang.String getBearerToken() {
+    public String getBearerToken() {
         return bearerToken;
     }
 
     @JsonProperty("bearerToken")
-    public void setBearerToken(java.lang.String bearerToken) {
+    public void setBearerToken(String bearerToken) {
         this.bearerToken = bearerToken;
     }
 
     @JsonProperty("bearerTokenFile")
-    public java.lang.String getBearerTokenFile() {
+    public String getBearerTokenFile() {
         return bearerTokenFile;
     }
 
     @JsonProperty("bearerTokenFile")
-    public void setBearerTokenFile(java.lang.String bearerTokenFile) {
+    public void setBearerTokenFile(String bearerTokenFile) {
         this.bearerTokenFile = bearerTokenFile;
     }
 
@@ -202,12 +202,12 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -222,12 +222,12 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     }
 
     @JsonProperty("proxyUrl")
-    public java.lang.String getProxyUrl() {
+    public String getProxyUrl() {
         return proxyUrl;
     }
 
     @JsonProperty("proxyUrl")
-    public void setProxyUrl(java.lang.String proxyUrl) {
+    public void setProxyUrl(String proxyUrl) {
         this.proxyUrl = proxyUrl;
     }
 
@@ -242,12 +242,12 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     }
 
     @JsonProperty("remoteTimeout")
-    public java.lang.String getRemoteTimeout() {
+    public String getRemoteTimeout() {
         return remoteTimeout;
     }
 
     @JsonProperty("remoteTimeout")
-    public void setRemoteTimeout(java.lang.String remoteTimeout) {
+    public void setRemoteTimeout(String remoteTimeout) {
         this.remoteTimeout = remoteTimeout;
     }
 
@@ -272,12 +272,12 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     }
 
     @JsonProperty("url")
-    public java.lang.String getUrl() {
+    public String getUrl() {
         return url;
     }
 
     @JsonProperty("url")
-    public void setUrl(java.lang.String url) {
+    public void setUrl(String url) {
         this.url = url;
     }
 
@@ -292,12 +292,12 @@ public class RemoteReadSpec implements Editable<RemoteReadSpecBuilder> , Kuberne
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/RemoteWriteSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/RemoteWriteSpec.java
@@ -79,24 +79,24 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     @JsonProperty("basicAuth")
     private BasicAuth basicAuth;
     @JsonProperty("bearerToken")
-    private java.lang.String bearerToken;
+    private String bearerToken;
     @JsonProperty("bearerTokenFile")
-    private java.lang.String bearerTokenFile;
+    private String bearerTokenFile;
     @JsonProperty("headers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> headers = new LinkedHashMap<String, String>();
     @JsonProperty("metadataConfig")
     private MetadataConfig metadataConfig;
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("oauth2")
     private OAuth2 oauth2;
     @JsonProperty("proxyUrl")
-    private java.lang.String proxyUrl;
+    private String proxyUrl;
     @JsonProperty("queueConfig")
     private QueueConfig queueConfig;
     @JsonProperty("remoteTimeout")
-    private java.lang.String remoteTimeout;
+    private String remoteTimeout;
     @JsonProperty("sendExemplars")
     private Boolean sendExemplars;
     @JsonProperty("sendNativeHistograms")
@@ -106,12 +106,12 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     @JsonProperty("tlsConfig")
     private TLSConfig tlsConfig;
     @JsonProperty("url")
-    private java.lang.String url;
+    private String url;
     @JsonProperty("writeRelabelConfigs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RelabelConfig> writeRelabelConfigs = new ArrayList<RelabelConfig>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -120,7 +120,7 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     public RemoteWriteSpec() {
     }
 
-    public RemoteWriteSpec(Authorization authorization, BasicAuth basicAuth, java.lang.String bearerToken, java.lang.String bearerTokenFile, Map<String, String> headers, MetadataConfig metadataConfig, java.lang.String name, OAuth2 oauth2, java.lang.String proxyUrl, QueueConfig queueConfig, java.lang.String remoteTimeout, Boolean sendExemplars, Boolean sendNativeHistograms, Sigv4 sigv4, TLSConfig tlsConfig, java.lang.String url, List<RelabelConfig> writeRelabelConfigs) {
+    public RemoteWriteSpec(Authorization authorization, BasicAuth basicAuth, String bearerToken, String bearerTokenFile, Map<String, String> headers, MetadataConfig metadataConfig, String name, OAuth2 oauth2, String proxyUrl, QueueConfig queueConfig, String remoteTimeout, Boolean sendExemplars, Boolean sendNativeHistograms, Sigv4 sigv4, TLSConfig tlsConfig, String url, List<RelabelConfig> writeRelabelConfigs) {
         super();
         this.authorization = authorization;
         this.basicAuth = basicAuth;
@@ -162,22 +162,22 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     }
 
     @JsonProperty("bearerToken")
-    public java.lang.String getBearerToken() {
+    public String getBearerToken() {
         return bearerToken;
     }
 
     @JsonProperty("bearerToken")
-    public void setBearerToken(java.lang.String bearerToken) {
+    public void setBearerToken(String bearerToken) {
         this.bearerToken = bearerToken;
     }
 
     @JsonProperty("bearerTokenFile")
-    public java.lang.String getBearerTokenFile() {
+    public String getBearerTokenFile() {
         return bearerTokenFile;
     }
 
     @JsonProperty("bearerTokenFile")
-    public void setBearerTokenFile(java.lang.String bearerTokenFile) {
+    public void setBearerTokenFile(String bearerTokenFile) {
         this.bearerTokenFile = bearerTokenFile;
     }
 
@@ -202,12 +202,12 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -222,12 +222,12 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     }
 
     @JsonProperty("proxyUrl")
-    public java.lang.String getProxyUrl() {
+    public String getProxyUrl() {
         return proxyUrl;
     }
 
     @JsonProperty("proxyUrl")
-    public void setProxyUrl(java.lang.String proxyUrl) {
+    public void setProxyUrl(String proxyUrl) {
         this.proxyUrl = proxyUrl;
     }
 
@@ -242,12 +242,12 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     }
 
     @JsonProperty("remoteTimeout")
-    public java.lang.String getRemoteTimeout() {
+    public String getRemoteTimeout() {
         return remoteTimeout;
     }
 
     @JsonProperty("remoteTimeout")
-    public void setRemoteTimeout(java.lang.String remoteTimeout) {
+    public void setRemoteTimeout(String remoteTimeout) {
         this.remoteTimeout = remoteTimeout;
     }
 
@@ -292,12 +292,12 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     }
 
     @JsonProperty("url")
-    public java.lang.String getUrl() {
+    public String getUrl() {
         return url;
     }
 
     @JsonProperty("url")
-    public void setUrl(java.lang.String url) {
+    public void setUrl(String url) {
         this.url = url;
     }
 
@@ -323,12 +323,12 @@ public class RemoteWriteSpec implements Editable<RemoteWriteSpecBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Rule.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Rule.java
@@ -62,23 +62,23 @@ public class Rule implements Editable<RuleBuilder> , KubernetesResource
 {
 
     @JsonProperty("alert")
-    private java.lang.String alert;
+    private String alert;
     @JsonProperty("annotations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> annotations = new LinkedHashMap<String, String>();
     @JsonProperty("expr")
     private io.fabric8.kubernetes.api.model.IntOrString expr;
     @JsonProperty("for")
-    private java.lang.String _for;
+    private String _for;
     @JsonProperty("keep_firing_for")
-    private java.lang.String keepFiringFor;
+    private String keepFiringFor;
     @JsonProperty("labels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonProperty("record")
-    private java.lang.String record;
+    private String record;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -87,7 +87,7 @@ public class Rule implements Editable<RuleBuilder> , KubernetesResource
     public Rule() {
     }
 
-    public Rule(java.lang.String alert, Map<String, String> annotations, io.fabric8.kubernetes.api.model.IntOrString expr, java.lang.String _for, java.lang.String keepFiringFor, Map<String, String> labels, java.lang.String record) {
+    public Rule(String alert, Map<String, String> annotations, io.fabric8.kubernetes.api.model.IntOrString expr, String _for, String keepFiringFor, Map<String, String> labels, String record) {
         super();
         this.alert = alert;
         this.annotations = annotations;
@@ -99,12 +99,12 @@ public class Rule implements Editable<RuleBuilder> , KubernetesResource
     }
 
     @JsonProperty("alert")
-    public java.lang.String getAlert() {
+    public String getAlert() {
         return alert;
     }
 
     @JsonProperty("alert")
-    public void setAlert(java.lang.String alert) {
+    public void setAlert(String alert) {
         this.alert = alert;
     }
 
@@ -129,22 +129,22 @@ public class Rule implements Editable<RuleBuilder> , KubernetesResource
     }
 
     @JsonProperty("for")
-    public java.lang.String getFor() {
+    public String getFor() {
         return _for;
     }
 
     @JsonProperty("for")
-    public void setFor(java.lang.String _for) {
+    public void setFor(String _for) {
         this._for = _for;
     }
 
     @JsonProperty("keep_firing_for")
-    public java.lang.String getKeepFiringFor() {
+    public String getKeepFiringFor() {
         return keepFiringFor;
     }
 
     @JsonProperty("keep_firing_for")
-    public void setKeepFiringFor(java.lang.String keepFiringFor) {
+    public void setKeepFiringFor(String keepFiringFor) {
         this.keepFiringFor = keepFiringFor;
     }
 
@@ -159,12 +159,12 @@ public class Rule implements Editable<RuleBuilder> , KubernetesResource
     }
 
     @JsonProperty("record")
-    public java.lang.String getRecord() {
+    public String getRecord() {
         return record;
     }
 
     @JsonProperty("record")
-    public void setRecord(java.lang.String record) {
+    public void setRecord(String record) {
         this.record = record;
     }
 
@@ -179,12 +179,12 @@ public class Rule implements Editable<RuleBuilder> , KubernetesResource
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosRulerSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosRulerSpec.java
@@ -116,39 +116,39 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     private Affinity affinity;
     @JsonProperty("alertDropLabels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> alertDropLabels = new ArrayList<java.lang.String>();
+    private List<String> alertDropLabels = new ArrayList<String>();
     @JsonProperty("alertQueryUrl")
-    private java.lang.String alertQueryUrl;
+    private String alertQueryUrl;
     @JsonProperty("alertRelabelConfigFile")
-    private java.lang.String alertRelabelConfigFile;
+    private String alertRelabelConfigFile;
     @JsonProperty("alertRelabelConfigs")
     private SecretKeySelector alertRelabelConfigs;
     @JsonProperty("alertmanagersConfig")
     private SecretKeySelector alertmanagersConfig;
     @JsonProperty("alertmanagersUrl")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> alertmanagersUrl = new ArrayList<java.lang.String>();
+    private List<String> alertmanagersUrl = new ArrayList<String>();
     @JsonProperty("containers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.kubernetes.api.model.Container> containers = new ArrayList<io.fabric8.kubernetes.api.model.Container>();
     @JsonProperty("enforcedNamespaceLabel")
-    private java.lang.String enforcedNamespaceLabel;
+    private String enforcedNamespaceLabel;
     @JsonProperty("evaluationInterval")
-    private java.lang.String evaluationInterval;
+    private String evaluationInterval;
     @JsonProperty("excludedFromEnforcement")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference> excludedFromEnforcement = new ArrayList<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference>();
     @JsonProperty("externalPrefix")
-    private java.lang.String externalPrefix;
+    private String externalPrefix;
     @JsonProperty("grpcServerTlsConfig")
     private TLSConfig grpcServerTlsConfig;
     @JsonProperty("hostAliases")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<HostAlias> hostAliases = new ArrayList<HostAlias>();
     @JsonProperty("image")
-    private java.lang.String image;
+    private String image;
     @JsonProperty("imagePullPolicy")
-    private java.lang.String imagePullPolicy;
+    private String imagePullPolicy;
     @JsonProperty("imagePullSecrets")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets = new ArrayList<io.fabric8.kubernetes.api.model.LocalObjectReference>();
@@ -161,9 +161,9 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     @JsonProperty("listenLocal")
     private Boolean listenLocal;
     @JsonProperty("logFormat")
-    private java.lang.String logFormat;
+    private String logFormat;
     @JsonProperty("logLevel")
-    private java.lang.String logLevel;
+    private String logLevel;
     @JsonProperty("minReadySeconds")
     private Integer minReadySeconds;
     @JsonProperty("nodeSelector")
@@ -172,15 +172,15 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     @JsonProperty("objectStorageConfig")
     private SecretKeySelector objectStorageConfig;
     @JsonProperty("objectStorageConfigFile")
-    private java.lang.String objectStorageConfigFile;
+    private String objectStorageConfigFile;
     @JsonProperty("paused")
     private Boolean paused;
     @JsonProperty("podMetadata")
     private EmbeddedObjectMetadata podMetadata;
     @JsonProperty("portName")
-    private java.lang.String portName;
+    private String portName;
     @JsonProperty("priorityClassName")
-    private java.lang.String priorityClassName;
+    private String priorityClassName;
     @JsonProperty("prometheusRulesExcludedFromEnforce")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce = new ArrayList<PrometheusRuleExcludeConfig>();
@@ -188,15 +188,15 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     private SecretKeySelector queryConfig;
     @JsonProperty("queryEndpoints")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> queryEndpoints = new ArrayList<java.lang.String>();
+    private List<String> queryEndpoints = new ArrayList<String>();
     @JsonProperty("replicas")
     private Integer replicas;
     @JsonProperty("resources")
     private io.fabric8.kubernetes.api.model.ResourceRequirements resources;
     @JsonProperty("retention")
-    private java.lang.String retention;
+    private String retention;
     @JsonProperty("routePrefix")
-    private java.lang.String routePrefix;
+    private String routePrefix;
     @JsonProperty("ruleNamespaceSelector")
     private io.fabric8.kubernetes.api.model.LabelSelector ruleNamespaceSelector;
     @JsonProperty("ruleSelector")
@@ -204,7 +204,7 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     @JsonProperty("securityContext")
     private PodSecurityContext securityContext;
     @JsonProperty("serviceAccountName")
-    private java.lang.String serviceAccountName;
+    private String serviceAccountName;
     @JsonProperty("storage")
     private StorageSpec storage;
     @JsonProperty("tolerations")
@@ -216,9 +216,9 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     @JsonProperty("tracingConfig")
     private SecretKeySelector tracingConfig;
     @JsonProperty("tracingConfigFile")
-    private java.lang.String tracingConfigFile;
+    private String tracingConfigFile;
     @JsonProperty("version")
-    private java.lang.String version;
+    private String version;
     @JsonProperty("volumeMounts")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<VolumeMount> volumeMounts = new ArrayList<VolumeMount>();
@@ -226,7 +226,7 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Volume> volumes = new ArrayList<Volume>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -235,7 +235,7 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     public ThanosRulerSpec() {
     }
 
-    public ThanosRulerSpec(List<Argument> additionalArgs, Affinity affinity, List<java.lang.String> alertDropLabels, java.lang.String alertQueryUrl, java.lang.String alertRelabelConfigFile, SecretKeySelector alertRelabelConfigs, SecretKeySelector alertmanagersConfig, List<java.lang.String> alertmanagersUrl, List<io.fabric8.kubernetes.api.model.Container> containers, java.lang.String enforcedNamespaceLabel, java.lang.String evaluationInterval, List<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference> excludedFromEnforcement, java.lang.String externalPrefix, TLSConfig grpcServerTlsConfig, List<HostAlias> hostAliases, java.lang.String image, java.lang.String imagePullPolicy, List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets, List<io.fabric8.kubernetes.api.model.Container> initContainers, Map<String, String> labels, Boolean listenLocal, java.lang.String logFormat, java.lang.String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, SecretKeySelector objectStorageConfig, java.lang.String objectStorageConfigFile, Boolean paused, EmbeddedObjectMetadata podMetadata, java.lang.String portName, java.lang.String priorityClassName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, SecretKeySelector queryConfig, List<java.lang.String> queryEndpoints, Integer replicas, io.fabric8.kubernetes.api.model.ResourceRequirements resources, java.lang.String retention, java.lang.String routePrefix, io.fabric8.kubernetes.api.model.LabelSelector ruleNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector ruleSelector, PodSecurityContext securityContext, java.lang.String serviceAccountName, StorageSpec storage, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, SecretKeySelector tracingConfig, java.lang.String tracingConfigFile, java.lang.String version, List<VolumeMount> volumeMounts, List<Volume> volumes) {
+    public ThanosRulerSpec(List<Argument> additionalArgs, Affinity affinity, List<String> alertDropLabels, String alertQueryUrl, String alertRelabelConfigFile, SecretKeySelector alertRelabelConfigs, SecretKeySelector alertmanagersConfig, List<String> alertmanagersUrl, List<io.fabric8.kubernetes.api.model.Container> containers, String enforcedNamespaceLabel, String evaluationInterval, List<io.fabric8.openshift.api.model.monitoring.v1.ObjectReference> excludedFromEnforcement, String externalPrefix, TLSConfig grpcServerTlsConfig, List<HostAlias> hostAliases, String image, String imagePullPolicy, List<io.fabric8.kubernetes.api.model.LocalObjectReference> imagePullSecrets, List<io.fabric8.kubernetes.api.model.Container> initContainers, Map<String, String> labels, Boolean listenLocal, String logFormat, String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, SecretKeySelector objectStorageConfig, String objectStorageConfigFile, Boolean paused, EmbeddedObjectMetadata podMetadata, String portName, String priorityClassName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, SecretKeySelector queryConfig, List<String> queryEndpoints, Integer replicas, io.fabric8.kubernetes.api.model.ResourceRequirements resources, String retention, String routePrefix, io.fabric8.kubernetes.api.model.LabelSelector ruleNamespaceSelector, io.fabric8.kubernetes.api.model.LabelSelector ruleSelector, PodSecurityContext securityContext, String serviceAccountName, StorageSpec storage, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, SecretKeySelector tracingConfig, String tracingConfigFile, String version, List<VolumeMount> volumeMounts, List<Volume> volumes) {
         super();
         this.additionalArgs = additionalArgs;
         this.affinity = affinity;
@@ -312,32 +312,32 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
 
     @JsonProperty("alertDropLabels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getAlertDropLabels() {
+    public List<String> getAlertDropLabels() {
         return alertDropLabels;
     }
 
     @JsonProperty("alertDropLabels")
-    public void setAlertDropLabels(List<java.lang.String> alertDropLabels) {
+    public void setAlertDropLabels(List<String> alertDropLabels) {
         this.alertDropLabels = alertDropLabels;
     }
 
     @JsonProperty("alertQueryUrl")
-    public java.lang.String getAlertQueryUrl() {
+    public String getAlertQueryUrl() {
         return alertQueryUrl;
     }
 
     @JsonProperty("alertQueryUrl")
-    public void setAlertQueryUrl(java.lang.String alertQueryUrl) {
+    public void setAlertQueryUrl(String alertQueryUrl) {
         this.alertQueryUrl = alertQueryUrl;
     }
 
     @JsonProperty("alertRelabelConfigFile")
-    public java.lang.String getAlertRelabelConfigFile() {
+    public String getAlertRelabelConfigFile() {
         return alertRelabelConfigFile;
     }
 
     @JsonProperty("alertRelabelConfigFile")
-    public void setAlertRelabelConfigFile(java.lang.String alertRelabelConfigFile) {
+    public void setAlertRelabelConfigFile(String alertRelabelConfigFile) {
         this.alertRelabelConfigFile = alertRelabelConfigFile;
     }
 
@@ -363,12 +363,12 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
 
     @JsonProperty("alertmanagersUrl")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getAlertmanagersUrl() {
+    public List<String> getAlertmanagersUrl() {
         return alertmanagersUrl;
     }
 
     @JsonProperty("alertmanagersUrl")
-    public void setAlertmanagersUrl(List<java.lang.String> alertmanagersUrl) {
+    public void setAlertmanagersUrl(List<String> alertmanagersUrl) {
         this.alertmanagersUrl = alertmanagersUrl;
     }
 
@@ -384,22 +384,22 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("enforcedNamespaceLabel")
-    public java.lang.String getEnforcedNamespaceLabel() {
+    public String getEnforcedNamespaceLabel() {
         return enforcedNamespaceLabel;
     }
 
     @JsonProperty("enforcedNamespaceLabel")
-    public void setEnforcedNamespaceLabel(java.lang.String enforcedNamespaceLabel) {
+    public void setEnforcedNamespaceLabel(String enforcedNamespaceLabel) {
         this.enforcedNamespaceLabel = enforcedNamespaceLabel;
     }
 
     @JsonProperty("evaluationInterval")
-    public java.lang.String getEvaluationInterval() {
+    public String getEvaluationInterval() {
         return evaluationInterval;
     }
 
     @JsonProperty("evaluationInterval")
-    public void setEvaluationInterval(java.lang.String evaluationInterval) {
+    public void setEvaluationInterval(String evaluationInterval) {
         this.evaluationInterval = evaluationInterval;
     }
 
@@ -415,12 +415,12 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("externalPrefix")
-    public java.lang.String getExternalPrefix() {
+    public String getExternalPrefix() {
         return externalPrefix;
     }
 
     @JsonProperty("externalPrefix")
-    public void setExternalPrefix(java.lang.String externalPrefix) {
+    public void setExternalPrefix(String externalPrefix) {
         this.externalPrefix = externalPrefix;
     }
 
@@ -446,22 +446,22 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("image")
-    public java.lang.String getImage() {
+    public String getImage() {
         return image;
     }
 
     @JsonProperty("image")
-    public void setImage(java.lang.String image) {
+    public void setImage(String image) {
         this.image = image;
     }
 
     @JsonProperty("imagePullPolicy")
-    public java.lang.String getImagePullPolicy() {
+    public String getImagePullPolicy() {
         return imagePullPolicy;
     }
 
     @JsonProperty("imagePullPolicy")
-    public void setImagePullPolicy(java.lang.String imagePullPolicy) {
+    public void setImagePullPolicy(String imagePullPolicy) {
         this.imagePullPolicy = imagePullPolicy;
     }
 
@@ -508,22 +508,22 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("logFormat")
-    public java.lang.String getLogFormat() {
+    public String getLogFormat() {
         return logFormat;
     }
 
     @JsonProperty("logFormat")
-    public void setLogFormat(java.lang.String logFormat) {
+    public void setLogFormat(String logFormat) {
         this.logFormat = logFormat;
     }
 
     @JsonProperty("logLevel")
-    public java.lang.String getLogLevel() {
+    public String getLogLevel() {
         return logLevel;
     }
 
     @JsonProperty("logLevel")
-    public void setLogLevel(java.lang.String logLevel) {
+    public void setLogLevel(String logLevel) {
         this.logLevel = logLevel;
     }
 
@@ -558,12 +558,12 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("objectStorageConfigFile")
-    public java.lang.String getObjectStorageConfigFile() {
+    public String getObjectStorageConfigFile() {
         return objectStorageConfigFile;
     }
 
     @JsonProperty("objectStorageConfigFile")
-    public void setObjectStorageConfigFile(java.lang.String objectStorageConfigFile) {
+    public void setObjectStorageConfigFile(String objectStorageConfigFile) {
         this.objectStorageConfigFile = objectStorageConfigFile;
     }
 
@@ -588,22 +588,22 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("portName")
-    public java.lang.String getPortName() {
+    public String getPortName() {
         return portName;
     }
 
     @JsonProperty("portName")
-    public void setPortName(java.lang.String portName) {
+    public void setPortName(String portName) {
         this.portName = portName;
     }
 
     @JsonProperty("priorityClassName")
-    public java.lang.String getPriorityClassName() {
+    public String getPriorityClassName() {
         return priorityClassName;
     }
 
     @JsonProperty("priorityClassName")
-    public void setPriorityClassName(java.lang.String priorityClassName) {
+    public void setPriorityClassName(String priorityClassName) {
         this.priorityClassName = priorityClassName;
     }
 
@@ -630,12 +630,12 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
 
     @JsonProperty("queryEndpoints")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getQueryEndpoints() {
+    public List<String> getQueryEndpoints() {
         return queryEndpoints;
     }
 
     @JsonProperty("queryEndpoints")
-    public void setQueryEndpoints(List<java.lang.String> queryEndpoints) {
+    public void setQueryEndpoints(List<String> queryEndpoints) {
         this.queryEndpoints = queryEndpoints;
     }
 
@@ -660,22 +660,22 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("retention")
-    public java.lang.String getRetention() {
+    public String getRetention() {
         return retention;
     }
 
     @JsonProperty("retention")
-    public void setRetention(java.lang.String retention) {
+    public void setRetention(String retention) {
         this.retention = retention;
     }
 
     @JsonProperty("routePrefix")
-    public java.lang.String getRoutePrefix() {
+    public String getRoutePrefix() {
         return routePrefix;
     }
 
     @JsonProperty("routePrefix")
-    public void setRoutePrefix(java.lang.String routePrefix) {
+    public void setRoutePrefix(String routePrefix) {
         this.routePrefix = routePrefix;
     }
 
@@ -710,12 +710,12 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("serviceAccountName")
-    public java.lang.String getServiceAccountName() {
+    public String getServiceAccountName() {
         return serviceAccountName;
     }
 
     @JsonProperty("serviceAccountName")
-    public void setServiceAccountName(java.lang.String serviceAccountName) {
+    public void setServiceAccountName(String serviceAccountName) {
         this.serviceAccountName = serviceAccountName;
     }
 
@@ -762,22 +762,22 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonProperty("tracingConfigFile")
-    public java.lang.String getTracingConfigFile() {
+    public String getTracingConfigFile() {
         return tracingConfigFile;
     }
 
     @JsonProperty("tracingConfigFile")
-    public void setTracingConfigFile(java.lang.String tracingConfigFile) {
+    public void setTracingConfigFile(String tracingConfigFile) {
         this.tracingConfigFile = tracingConfigFile;
     }
 
     @JsonProperty("version")
-    public java.lang.String getVersion() {
+    public String getVersion() {
         return version;
     }
 
     @JsonProperty("version")
-    public void setVersion(java.lang.String version) {
+    public void setVersion(String version) {
         this.version = version;
     }
 
@@ -814,12 +814,12 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/SNSConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/SNSConfig.java
@@ -67,28 +67,28 @@ public class SNSConfig implements Editable<SNSConfigBuilder> , KubernetesResourc
 {
 
     @JsonProperty("apiURL")
-    private java.lang.String apiURL;
+    private String apiURL;
     @JsonProperty("attributes")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> attributes = new LinkedHashMap<String, String>();
     @JsonProperty("httpConfig")
     private HTTPConfig httpConfig;
     @JsonProperty("message")
-    private java.lang.String message;
+    private String message;
     @JsonProperty("phoneNumber")
-    private java.lang.String phoneNumber;
+    private String phoneNumber;
     @JsonProperty("sendResolved")
     private Boolean sendResolved;
     @JsonProperty("sigv4")
     private Sigv4 sigv4;
     @JsonProperty("subject")
-    private java.lang.String subject;
+    private String subject;
     @JsonProperty("targetARN")
-    private java.lang.String targetARN;
+    private String targetARN;
     @JsonProperty("topicARN")
-    private java.lang.String topicARN;
+    private String topicARN;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -97,7 +97,7 @@ public class SNSConfig implements Editable<SNSConfigBuilder> , KubernetesResourc
     public SNSConfig() {
     }
 
-    public SNSConfig(java.lang.String apiURL, Map<String, String> attributes, HTTPConfig httpConfig, java.lang.String message, java.lang.String phoneNumber, Boolean sendResolved, Sigv4 sigv4, java.lang.String subject, java.lang.String targetARN, java.lang.String topicARN) {
+    public SNSConfig(String apiURL, Map<String, String> attributes, HTTPConfig httpConfig, String message, String phoneNumber, Boolean sendResolved, Sigv4 sigv4, String subject, String targetARN, String topicARN) {
         super();
         this.apiURL = apiURL;
         this.attributes = attributes;
@@ -112,12 +112,12 @@ public class SNSConfig implements Editable<SNSConfigBuilder> , KubernetesResourc
     }
 
     @JsonProperty("apiURL")
-    public java.lang.String getApiURL() {
+    public String getApiURL() {
         return apiURL;
     }
 
     @JsonProperty("apiURL")
-    public void setApiURL(java.lang.String apiURL) {
+    public void setApiURL(String apiURL) {
         this.apiURL = apiURL;
     }
 
@@ -142,22 +142,22 @@ public class SNSConfig implements Editable<SNSConfigBuilder> , KubernetesResourc
     }
 
     @JsonProperty("message")
-    public java.lang.String getMessage() {
+    public String getMessage() {
         return message;
     }
 
     @JsonProperty("message")
-    public void setMessage(java.lang.String message) {
+    public void setMessage(String message) {
         this.message = message;
     }
 
     @JsonProperty("phoneNumber")
-    public java.lang.String getPhoneNumber() {
+    public String getPhoneNumber() {
         return phoneNumber;
     }
 
     @JsonProperty("phoneNumber")
-    public void setPhoneNumber(java.lang.String phoneNumber) {
+    public void setPhoneNumber(String phoneNumber) {
         this.phoneNumber = phoneNumber;
     }
 
@@ -182,32 +182,32 @@ public class SNSConfig implements Editable<SNSConfigBuilder> , KubernetesResourc
     }
 
     @JsonProperty("subject")
-    public java.lang.String getSubject() {
+    public String getSubject() {
         return subject;
     }
 
     @JsonProperty("subject")
-    public void setSubject(java.lang.String subject) {
+    public void setSubject(String subject) {
         this.subject = subject;
     }
 
     @JsonProperty("targetARN")
-    public java.lang.String getTargetARN() {
+    public String getTargetARN() {
         return targetARN;
     }
 
     @JsonProperty("targetARN")
-    public void setTargetARN(java.lang.String targetARN) {
+    public void setTargetARN(String targetARN) {
         this.targetARN = targetARN;
     }
 
     @JsonProperty("topicARN")
-    public java.lang.String getTopicARN() {
+    public String getTopicARN() {
         return topicARN;
     }
 
     @JsonProperty("topicARN")
-    public void setTopicARN(java.lang.String topicARN) {
+    public void setTopicARN(String topicARN) {
         this.topicARN = topicARN;
     }
 
@@ -222,12 +222,12 @@ public class SNSConfig implements Editable<SNSConfigBuilder> , KubernetesResourc
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/main/resources/schema/kube-schema.json
@@ -120,7 +120,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -248,7 +248,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -281,7 +281,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -689,7 +689,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1286,7 +1286,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -1810,7 +1810,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -1818,7 +1818,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -1826,7 +1826,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -2300,7 +2300,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -2308,7 +2308,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -2951,7 +2951,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -2959,7 +2959,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3524,7 +3524,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "paused": {
           "type": "boolean"
@@ -3857,7 +3857,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "externalUrl": {
           "type": "string"
@@ -3931,7 +3931,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "overrideHonorLabels": {
           "type": "boolean"
@@ -4141,14 +4141,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -4248,7 +4248,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "path": {
           "type": "string"
@@ -4462,7 +4462,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "scopes": {
           "type": "array",
@@ -4556,7 +4556,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "path": {
           "type": "string"
@@ -4953,7 +4953,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "relabelingConfigs": {
           "type": "array",
@@ -5306,7 +5306,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "externalUrl": {
           "type": "string"
@@ -5380,7 +5380,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "overrideHonorLabels": {
           "type": "boolean"
@@ -5665,7 +5665,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "insecure": {
           "type": "boolean"
@@ -5835,7 +5835,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -5858,7 +5858,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tlsConfig": {
           "$ref": "#/definitions/os_monitoring_v1_TLSConfig",
@@ -5896,7 +5896,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "metadataConfig": {
           "$ref": "#/definitions/os_monitoring_v1_MetadataConfig",
@@ -5962,7 +5962,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "expr": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_util_intstr_IntOrString",
@@ -5979,7 +5979,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "record": {
           "type": "string"
@@ -6547,7 +6547,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "listenLocal": {
           "type": "boolean"
@@ -6566,7 +6566,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "objectStorageConfig": {
           "$ref": "#/definitions/kubernetes_core_SecretKeySelector",
@@ -7682,7 +7682,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "httpConfig": {
           "$ref": "#/definitions/os_monitoring_v1alpha1_HTTPConfig",

--- a/kubernetes-model-generator/openshift-model-monitoring/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/main/resources/schema/validation-schema.json
@@ -120,7 +120,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -248,7 +248,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -281,7 +281,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -689,7 +689,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1286,7 +1286,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -1810,7 +1810,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -1818,7 +1818,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -1826,7 +1826,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -2300,7 +2300,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -2308,7 +2308,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -2951,7 +2951,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -2959,7 +2959,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3524,7 +3524,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "paused": {
           "type": "boolean"
@@ -3857,7 +3857,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "externalUrl": {
           "type": "string"
@@ -3931,7 +3931,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "overrideHonorLabels": {
           "type": "boolean"
@@ -4141,14 +4141,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -4248,7 +4248,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "path": {
           "type": "string"
@@ -4462,7 +4462,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "scopes": {
           "type": "array",
@@ -4556,7 +4556,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "path": {
           "type": "string"
@@ -4953,7 +4953,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "relabelingConfigs": {
           "type": "array",
@@ -5306,7 +5306,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "externalUrl": {
           "type": "string"
@@ -5380,7 +5380,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "overrideHonorLabels": {
           "type": "boolean"
@@ -5665,7 +5665,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "insecure": {
           "type": "boolean"
@@ -5835,7 +5835,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -5858,7 +5858,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tlsConfig": {
           "$ref": "#/definitions/os_monitoring_v1_TLSConfig",
@@ -5896,7 +5896,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "metadataConfig": {
           "$ref": "#/definitions/os_monitoring_v1_MetadataConfig",
@@ -5962,7 +5962,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "expr": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_util_intstr_IntOrString",
@@ -5979,7 +5979,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "record": {
           "type": "string"
@@ -6547,7 +6547,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "listenLocal": {
           "type": "boolean"
@@ -6566,7 +6566,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "objectStorageConfig": {
           "$ref": "#/definitions/kubernetes_core_SecretKeySelector",
@@ -7682,7 +7682,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "httpConfig": {
           "$ref": "#/definitions/os_monitoring_v1alpha1_HTTPConfig",
@@ -8621,7 +8621,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "paused": {
           "type": "boolean"
@@ -9149,7 +9149,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "externalUrl": {
           "type": "string"
@@ -9223,7 +9223,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "overrideHonorLabels": {
           "type": "boolean"
@@ -9658,7 +9658,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -9806,14 +9806,14 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -9915,7 +9915,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "path": {
           "type": "string"
@@ -10078,7 +10078,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -10465,7 +10465,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -10769,7 +10769,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "scopes": {
           "type": "array",
@@ -10802,7 +10802,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -10835,7 +10835,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -11167,7 +11167,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "allocatedResources": {
           "type": "object",
@@ -11175,7 +11175,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "capacity": {
           "type": "object",
@@ -11183,7 +11183,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "conditions": {
           "type": "array",
@@ -11372,7 +11372,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "path": {
           "type": "string"
@@ -11841,7 +11841,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "relabelingConfigs": {
           "type": "array",
@@ -12153,7 +12153,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "externalUrl": {
           "type": "string"
@@ -12227,7 +12227,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "overrideHonorLabels": {
           "type": "boolean"
@@ -12502,7 +12502,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "insecure": {
           "type": "boolean"
@@ -12865,7 +12865,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -12888,7 +12888,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tlsConfig": {
           "$ref": "#/definitions/os_monitoring_v1_TLSConfig",
@@ -12921,7 +12921,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "metadataConfig": {
           "$ref": "#/definitions/os_monitoring_v1_MetadataConfig",
@@ -13011,7 +13011,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -13019,7 +13019,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -13091,7 +13091,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "expr": {
           "$ref": "#/definitions/kubernetes_apimachinery_pkg_util_intstr_IntOrString",
@@ -13108,7 +13108,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "record": {
           "type": "string"
@@ -13736,7 +13736,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "httpConfig": {
           "$ref": "#/definitions/os_monitoring_v1alpha1_HTTPConfig",
@@ -14102,7 +14102,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "listenLocal": {
           "type": "boolean"
@@ -14121,7 +14121,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "objectStorageConfig": {
           "$ref": "#/definitions/kubernetes_core_SecretKeySelector",
@@ -14791,7 +14791,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -14799,7 +14799,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/DNSNodePlacement.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/DNSNodePlacement.java
@@ -67,7 +67,7 @@ public class DNSNodePlacement implements Editable<DNSNodePlacementBuilder> , Kub
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -114,12 +114,12 @@ public class DNSNodePlacement implements Editable<DNSNodePlacementBuilder> , Kub
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ImagePrunerSpec.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ImagePrunerSpec.java
@@ -85,14 +85,14 @@ public class ImagePrunerSpec implements Editable<ImagePrunerSpecBuilder> , Kuber
     @JsonProperty("keepYoungerThanDuration")
     private Duration keepYoungerThanDuration;
     @JsonProperty("logLevel")
-    private java.lang.String logLevel;
+    private String logLevel;
     @JsonProperty("nodeSelector")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> nodeSelector = new LinkedHashMap<String, String>();
     @JsonProperty("resources")
     private io.fabric8.kubernetes.api.model.ResourceRequirements resources;
     @JsonProperty("schedule")
-    private java.lang.String schedule;
+    private String schedule;
     @JsonProperty("successfulJobsHistoryLimit")
     private Integer successfulJobsHistoryLimit;
     @JsonProperty("suspend")
@@ -101,7 +101,7 @@ public class ImagePrunerSpec implements Editable<ImagePrunerSpecBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -110,7 +110,7 @@ public class ImagePrunerSpec implements Editable<ImagePrunerSpecBuilder> , Kuber
     public ImagePrunerSpec() {
     }
 
-    public ImagePrunerSpec(Affinity affinity, Integer failedJobsHistoryLimit, Boolean ignoreInvalidImageReferences, Integer keepTagRevisions, Long keepYoungerThan, Duration keepYoungerThanDuration, java.lang.String logLevel, Map<String, String> nodeSelector, io.fabric8.kubernetes.api.model.ResourceRequirements resources, java.lang.String schedule, Integer successfulJobsHistoryLimit, Boolean suspend, List<Toleration> tolerations) {
+    public ImagePrunerSpec(Affinity affinity, Integer failedJobsHistoryLimit, Boolean ignoreInvalidImageReferences, Integer keepTagRevisions, Long keepYoungerThan, Duration keepYoungerThanDuration, String logLevel, Map<String, String> nodeSelector, io.fabric8.kubernetes.api.model.ResourceRequirements resources, String schedule, Integer successfulJobsHistoryLimit, Boolean suspend, List<Toleration> tolerations) {
         super();
         this.affinity = affinity;
         this.failedJobsHistoryLimit = failedJobsHistoryLimit;
@@ -188,12 +188,12 @@ public class ImagePrunerSpec implements Editable<ImagePrunerSpecBuilder> , Kuber
     }
 
     @JsonProperty("logLevel")
-    public java.lang.String getLogLevel() {
+    public String getLogLevel() {
         return logLevel;
     }
 
     @JsonProperty("logLevel")
-    public void setLogLevel(java.lang.String logLevel) {
+    public void setLogLevel(String logLevel) {
         this.logLevel = logLevel;
     }
 
@@ -218,12 +218,12 @@ public class ImagePrunerSpec implements Editable<ImagePrunerSpecBuilder> , Kuber
     }
 
     @JsonProperty("schedule")
-    public java.lang.String getSchedule() {
+    public String getSchedule() {
         return schedule;
     }
 
     @JsonProperty("schedule")
-    public void setSchedule(java.lang.String schedule) {
+    public void setSchedule(String schedule) {
         this.schedule = schedule;
     }
 
@@ -269,12 +269,12 @@ public class ImagePrunerSpec implements Editable<ImagePrunerSpecBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ProxyConfig.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/generated/java/io/fabric8/openshift/api/model/operator/v1/ProxyConfig.java
@@ -60,14 +60,14 @@ public class ProxyConfig implements Editable<ProxyConfigBuilder> , KubernetesRes
 {
 
     @JsonProperty("bindAddress")
-    private java.lang.String bindAddress;
+    private String bindAddress;
     @JsonProperty("iptablesSyncPeriod")
-    private java.lang.String iptablesSyncPeriod;
+    private String iptablesSyncPeriod;
     @JsonProperty("proxyArguments")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, ArrayList<String>> proxyArguments = new LinkedHashMap<String, ArrayList<String>>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -76,7 +76,7 @@ public class ProxyConfig implements Editable<ProxyConfigBuilder> , KubernetesRes
     public ProxyConfig() {
     }
 
-    public ProxyConfig(java.lang.String bindAddress, java.lang.String iptablesSyncPeriod, Map<String, ArrayList<String>> proxyArguments) {
+    public ProxyConfig(String bindAddress, String iptablesSyncPeriod, Map<String, ArrayList<String>> proxyArguments) {
         super();
         this.bindAddress = bindAddress;
         this.iptablesSyncPeriod = iptablesSyncPeriod;
@@ -84,22 +84,22 @@ public class ProxyConfig implements Editable<ProxyConfigBuilder> , KubernetesRes
     }
 
     @JsonProperty("bindAddress")
-    public java.lang.String getBindAddress() {
+    public String getBindAddress() {
         return bindAddress;
     }
 
     @JsonProperty("bindAddress")
-    public void setBindAddress(java.lang.String bindAddress) {
+    public void setBindAddress(String bindAddress) {
         this.bindAddress = bindAddress;
     }
 
     @JsonProperty("iptablesSyncPeriod")
-    public java.lang.String getIptablesSyncPeriod() {
+    public String getIptablesSyncPeriod() {
         return iptablesSyncPeriod;
     }
 
     @JsonProperty("iptablesSyncPeriod")
-    public void setIptablesSyncPeriod(java.lang.String iptablesSyncPeriod) {
+    public void setIptablesSyncPeriod(String iptablesSyncPeriod) {
         this.iptablesSyncPeriod = iptablesSyncPeriod;
     }
 
@@ -124,12 +124,12 @@ public class ProxyConfig implements Editable<ProxyConfigBuilder> , KubernetesRes
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operator/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-operator/src/main/resources/schema/kube-schema.json
@@ -157,7 +157,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -285,7 +285,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -318,7 +318,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -842,7 +842,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -850,7 +850,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -974,7 +974,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1164,7 +1164,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "resources": {
           "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
@@ -2641,7 +2641,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -5471,7 +5471,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         }
       },
       "additionalProperties": true,

--- a/kubernetes-model-generator/openshift-model-operator/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-operator/src/main/resources/schema/validation-schema.json
@@ -157,7 +157,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -285,7 +285,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -318,7 +318,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -842,7 +842,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -850,7 +850,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -974,7 +974,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1164,7 +1164,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "resources": {
           "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
@@ -2641,7 +2641,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -5471,7 +5471,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         }
       },
       "additionalProperties": true,
@@ -7940,7 +7940,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "tolerations": {
           "type": "array",
@@ -8134,7 +8134,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -8679,7 +8679,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "resources": {
           "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
@@ -9648,7 +9648,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -10166,7 +10166,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -10199,7 +10199,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -10983,7 +10983,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         }
       },
       "additionalProperties": true
@@ -11094,7 +11094,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -11102,7 +11102,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/lifecyclemanager/v1/CSVDescription.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/lifecyclemanager/v1/CSVDescription.java
@@ -85,9 +85,9 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     @JsonProperty("customresourcedefinitions")
     private CustomResourceDefinitions customresourcedefinitions;
     @JsonProperty("description")
-    private java.lang.String description;
+    private String description;
     @JsonProperty("displayName")
-    private java.lang.String displayName;
+    private String displayName;
     @JsonProperty("icon")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Icon> icon = new ArrayList<Icon>();
@@ -96,7 +96,7 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     private List<InstallMode> installModes = new ArrayList<InstallMode>();
     @JsonProperty("keywords")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> keywords = new ArrayList<java.lang.String>();
+    private List<String> keywords = new ArrayList<String>();
     @JsonProperty("links")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<AppLink> links = new ArrayList<AppLink>();
@@ -104,9 +104,9 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Maintainer> maintainers = new ArrayList<Maintainer>();
     @JsonProperty("maturity")
-    private java.lang.String maturity;
+    private String maturity;
     @JsonProperty("minKubeVersion")
-    private java.lang.String minKubeVersion;
+    private String minKubeVersion;
     @JsonProperty("nativeApis")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<GroupVersionKind> nativeApis = new ArrayList<GroupVersionKind>();
@@ -114,11 +114,11 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     private AppLink provider;
     @JsonProperty("relatedImages")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> relatedImages = new ArrayList<java.lang.String>();
+    private List<String> relatedImages = new ArrayList<String>();
     @JsonProperty("version")
-    private java.lang.String version;
+    private String version;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -127,7 +127,7 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     public CSVDescription() {
     }
 
-    public CSVDescription(Map<String, String> annotations, APIServiceDefinitions apiservicedefinitions, CustomResourceDefinitions customresourcedefinitions, java.lang.String description, java.lang.String displayName, List<Icon> icon, List<InstallMode> installModes, List<java.lang.String> keywords, List<AppLink> links, List<Maintainer> maintainers, java.lang.String maturity, java.lang.String minKubeVersion, List<GroupVersionKind> nativeApis, AppLink provider, List<java.lang.String> relatedImages, java.lang.String version) {
+    public CSVDescription(Map<String, String> annotations, APIServiceDefinitions apiservicedefinitions, CustomResourceDefinitions customresourcedefinitions, String description, String displayName, List<Icon> icon, List<InstallMode> installModes, List<String> keywords, List<AppLink> links, List<Maintainer> maintainers, String maturity, String minKubeVersion, List<GroupVersionKind> nativeApis, AppLink provider, List<String> relatedImages, String version) {
         super();
         this.annotations = annotations;
         this.apiservicedefinitions = apiservicedefinitions;
@@ -178,22 +178,22 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     }
 
     @JsonProperty("description")
-    public java.lang.String getDescription() {
+    public String getDescription() {
         return description;
     }
 
     @JsonProperty("description")
-    public void setDescription(java.lang.String description) {
+    public void setDescription(String description) {
         this.description = description;
     }
 
     @JsonProperty("displayName")
-    public java.lang.String getDisplayName() {
+    public String getDisplayName() {
         return displayName;
     }
 
     @JsonProperty("displayName")
-    public void setDisplayName(java.lang.String displayName) {
+    public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
 
@@ -221,12 +221,12 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
 
     @JsonProperty("keywords")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getKeywords() {
+    public List<String> getKeywords() {
         return keywords;
     }
 
     @JsonProperty("keywords")
-    public void setKeywords(List<java.lang.String> keywords) {
+    public void setKeywords(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -253,22 +253,22 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     }
 
     @JsonProperty("maturity")
-    public java.lang.String getMaturity() {
+    public String getMaturity() {
         return maturity;
     }
 
     @JsonProperty("maturity")
-    public void setMaturity(java.lang.String maturity) {
+    public void setMaturity(String maturity) {
         this.maturity = maturity;
     }
 
     @JsonProperty("minKubeVersion")
-    public java.lang.String getMinKubeVersion() {
+    public String getMinKubeVersion() {
         return minKubeVersion;
     }
 
     @JsonProperty("minKubeVersion")
-    public void setMinKubeVersion(java.lang.String minKubeVersion) {
+    public void setMinKubeVersion(String minKubeVersion) {
         this.minKubeVersion = minKubeVersion;
     }
 
@@ -295,22 +295,22 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
 
     @JsonProperty("relatedImages")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getRelatedImages() {
+    public List<String> getRelatedImages() {
         return relatedImages;
     }
 
     @JsonProperty("relatedImages")
-    public void setRelatedImages(List<java.lang.String> relatedImages) {
+    public void setRelatedImages(List<String> relatedImages) {
         this.relatedImages = relatedImages;
     }
 
     @JsonProperty("version")
-    public java.lang.String getVersion() {
+    public String getVersion() {
         return version;
     }
 
     @JsonProperty("version")
-    public void setVersion(java.lang.String version) {
+    public void setVersion(String version) {
         this.version = version;
     }
 
@@ -325,12 +325,12 @@ public class CSVDescription implements Editable<CSVDescriptionBuilder> , Kuberne
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/ClusterServiceVersionSpec.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/ClusterServiceVersionSpec.java
@@ -90,9 +90,9 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     @JsonProperty("customresourcedefinitions")
     private CustomResourceDefinitions customresourcedefinitions;
     @JsonProperty("description")
-    private java.lang.String description;
+    private String description;
     @JsonProperty("displayName")
-    private java.lang.String displayName;
+    private String displayName;
     @JsonProperty("icon")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Icon> icon = new ArrayList<Icon>();
@@ -103,7 +103,7 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     private List<InstallMode> installModes = new ArrayList<InstallMode>();
     @JsonProperty("keywords")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> keywords = new ArrayList<java.lang.String>();
+    private List<String> keywords = new ArrayList<String>();
     @JsonProperty("labels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
@@ -114,9 +114,9 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Maintainer> maintainers = new ArrayList<Maintainer>();
     @JsonProperty("maturity")
-    private java.lang.String maturity;
+    private String maturity;
     @JsonProperty("minKubeVersion")
-    private java.lang.String minKubeVersion;
+    private String minKubeVersion;
     @JsonProperty("nativeAPIs")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<GroupVersionKind> nativeAPIs = new ArrayList<GroupVersionKind>();
@@ -126,19 +126,19 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<RelatedImage> relatedImages = new ArrayList<RelatedImage>();
     @JsonProperty("replaces")
-    private java.lang.String replaces;
+    private String replaces;
     @JsonProperty("selector")
     private io.fabric8.kubernetes.api.model.LabelSelector selector;
     @JsonProperty("skips")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> skips = new ArrayList<java.lang.String>();
+    private List<String> skips = new ArrayList<String>();
     @JsonProperty("version")
-    private java.lang.String version;
+    private String version;
     @JsonProperty("webhookdefinitions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<WebhookDescription> webhookdefinitions = new ArrayList<WebhookDescription>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -147,7 +147,7 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     public ClusterServiceVersionSpec() {
     }
 
-    public ClusterServiceVersionSpec(Map<String, String> annotations, APIServiceDefinitions apiservicedefinitions, CleanupSpec cleanup, CustomResourceDefinitions customresourcedefinitions, java.lang.String description, java.lang.String displayName, List<Icon> icon, NamedInstallStrategy install, List<InstallMode> installModes, List<java.lang.String> keywords, Map<String, String> labels, List<AppLink> links, List<Maintainer> maintainers, java.lang.String maturity, java.lang.String minKubeVersion, List<GroupVersionKind> nativeAPIs, AppLink provider, List<RelatedImage> relatedImages, java.lang.String replaces, io.fabric8.kubernetes.api.model.LabelSelector selector, List<java.lang.String> skips, java.lang.String version, List<WebhookDescription> webhookdefinitions) {
+    public ClusterServiceVersionSpec(Map<String, String> annotations, APIServiceDefinitions apiservicedefinitions, CleanupSpec cleanup, CustomResourceDefinitions customresourcedefinitions, String description, String displayName, List<Icon> icon, NamedInstallStrategy install, List<InstallMode> installModes, List<String> keywords, Map<String, String> labels, List<AppLink> links, List<Maintainer> maintainers, String maturity, String minKubeVersion, List<GroupVersionKind> nativeAPIs, AppLink provider, List<RelatedImage> relatedImages, String replaces, io.fabric8.kubernetes.api.model.LabelSelector selector, List<String> skips, String version, List<WebhookDescription> webhookdefinitions) {
         super();
         this.annotations = annotations;
         this.apiservicedefinitions = apiservicedefinitions;
@@ -215,22 +215,22 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     }
 
     @JsonProperty("description")
-    public java.lang.String getDescription() {
+    public String getDescription() {
         return description;
     }
 
     @JsonProperty("description")
-    public void setDescription(java.lang.String description) {
+    public void setDescription(String description) {
         this.description = description;
     }
 
     @JsonProperty("displayName")
-    public java.lang.String getDisplayName() {
+    public String getDisplayName() {
         return displayName;
     }
 
     @JsonProperty("displayName")
-    public void setDisplayName(java.lang.String displayName) {
+    public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
 
@@ -268,12 +268,12 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
 
     @JsonProperty("keywords")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getKeywords() {
+    public List<String> getKeywords() {
         return keywords;
     }
 
     @JsonProperty("keywords")
-    public void setKeywords(List<java.lang.String> keywords) {
+    public void setKeywords(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -310,22 +310,22 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     }
 
     @JsonProperty("maturity")
-    public java.lang.String getMaturity() {
+    public String getMaturity() {
         return maturity;
     }
 
     @JsonProperty("maturity")
-    public void setMaturity(java.lang.String maturity) {
+    public void setMaturity(String maturity) {
         this.maturity = maturity;
     }
 
     @JsonProperty("minKubeVersion")
-    public java.lang.String getMinKubeVersion() {
+    public String getMinKubeVersion() {
         return minKubeVersion;
     }
 
     @JsonProperty("minKubeVersion")
-    public void setMinKubeVersion(java.lang.String minKubeVersion) {
+    public void setMinKubeVersion(String minKubeVersion) {
         this.minKubeVersion = minKubeVersion;
     }
 
@@ -362,12 +362,12 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     }
 
     @JsonProperty("replaces")
-    public java.lang.String getReplaces() {
+    public String getReplaces() {
         return replaces;
     }
 
     @JsonProperty("replaces")
-    public void setReplaces(java.lang.String replaces) {
+    public void setReplaces(String replaces) {
         this.replaces = replaces;
     }
 
@@ -383,22 +383,22 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
 
     @JsonProperty("skips")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getSkips() {
+    public List<String> getSkips() {
         return skips;
     }
 
     @JsonProperty("skips")
-    public void setSkips(List<java.lang.String> skips) {
+    public void setSkips(List<String> skips) {
         this.skips = skips;
     }
 
     @JsonProperty("version")
-    public java.lang.String getVersion() {
+    public String getVersion() {
         return version;
     }
 
     @JsonProperty("version")
-    public void setVersion(java.lang.String version) {
+    public void setVersion(String version) {
         this.version = version;
     }
 
@@ -424,12 +424,12 @@ public class ClusterServiceVersionSpec implements Editable<ClusterServiceVersion
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/GrpcPodConfig.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/GrpcPodConfig.java
@@ -70,14 +70,14 @@ public class GrpcPodConfig implements Editable<GrpcPodConfigBuilder> , Kubernete
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> nodeSelector = new LinkedHashMap<String, String>();
     @JsonProperty("priorityClassName")
-    private java.lang.String priorityClassName;
+    private String priorityClassName;
     @JsonProperty("securityContextConfig")
-    private java.lang.String securityContextConfig;
+    private String securityContextConfig;
     @JsonProperty("tolerations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Toleration> tolerations = new ArrayList<Toleration>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -86,7 +86,7 @@ public class GrpcPodConfig implements Editable<GrpcPodConfigBuilder> , Kubernete
     public GrpcPodConfig() {
     }
 
-    public GrpcPodConfig(Affinity affinity, Map<String, String> nodeSelector, java.lang.String priorityClassName, java.lang.String securityContextConfig, List<Toleration> tolerations) {
+    public GrpcPodConfig(Affinity affinity, Map<String, String> nodeSelector, String priorityClassName, String securityContextConfig, List<Toleration> tolerations) {
         super();
         this.affinity = affinity;
         this.nodeSelector = nodeSelector;
@@ -116,22 +116,22 @@ public class GrpcPodConfig implements Editable<GrpcPodConfigBuilder> , Kubernete
     }
 
     @JsonProperty("priorityClassName")
-    public java.lang.String getPriorityClassName() {
+    public String getPriorityClassName() {
         return priorityClassName;
     }
 
     @JsonProperty("priorityClassName")
-    public void setPriorityClassName(java.lang.String priorityClassName) {
+    public void setPriorityClassName(String priorityClassName) {
         this.priorityClassName = priorityClassName;
     }
 
     @JsonProperty("securityContextConfig")
-    public java.lang.String getSecurityContextConfig() {
+    public String getSecurityContextConfig() {
         return securityContextConfig;
     }
 
     @JsonProperty("securityContextConfig")
-    public void setSecurityContextConfig(java.lang.String securityContextConfig) {
+    public void setSecurityContextConfig(String securityContextConfig) {
         this.securityContextConfig = securityContextConfig;
     }
 
@@ -157,12 +157,12 @@ public class GrpcPodConfig implements Editable<GrpcPodConfigBuilder> , Kubernete
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/StrategyDeploymentSpec.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/StrategyDeploymentSpec.java
@@ -63,11 +63,11 @@ public class StrategyDeploymentSpec implements Editable<StrategyDeploymentSpecBu
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> label = new LinkedHashMap<String, String>();
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("spec")
     private DeploymentSpec spec;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -76,7 +76,7 @@ public class StrategyDeploymentSpec implements Editable<StrategyDeploymentSpecBu
     public StrategyDeploymentSpec() {
     }
 
-    public StrategyDeploymentSpec(Map<String, String> label, java.lang.String name, DeploymentSpec spec) {
+    public StrategyDeploymentSpec(Map<String, String> label, String name, DeploymentSpec spec) {
         super();
         this.label = label;
         this.name = name;
@@ -94,12 +94,12 @@ public class StrategyDeploymentSpec implements Editable<StrategyDeploymentSpecBu
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -124,12 +124,12 @@ public class StrategyDeploymentSpec implements Editable<StrategyDeploymentSpecBu
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/SubscriptionConfig.java
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/generated/java/io/fabric8/openshift/api/model/operatorhub/v1alpha1/SubscriptionConfig.java
@@ -95,7 +95,7 @@ public class SubscriptionConfig implements Editable<SubscriptionConfigBuilder> ,
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Volume> volumes = new ArrayList<Volume>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -223,12 +223,12 @@ public class SubscriptionConfig implements Editable<SubscriptionConfigBuilder> ,
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/main/resources/schema/kube-schema.json
@@ -236,7 +236,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -364,7 +364,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -397,7 +397,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -980,7 +980,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1848,7 +1848,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -2756,7 +2756,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -2768,7 +2768,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3127,7 +3127,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3135,7 +3135,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3778,7 +3778,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3786,7 +3786,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4063,7 +4063,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "apiservicedefinitions": {
           "$ref": "#/definitions/os_operatorhub_v1alpha1_APIServiceDefinitions",
@@ -5395,7 +5395,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "apiservicedefinitions": {
           "$ref": "#/definitions/os_operatorhub_v1alpha1_APIServiceDefinitions",
@@ -5447,7 +5447,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "links": {
           "type": "array",
@@ -5690,7 +5690,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "priorityClassName": {
           "type": "string"
@@ -6253,7 +6253,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -6418,7 +6418,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "resources": {
           "$ref": "#/definitions/kubernetes_core_ResourceRequirements",

--- a/kubernetes-model-generator/openshift-model-operatorhub/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-operatorhub/src/main/resources/schema/validation-schema.json
@@ -236,7 +236,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -364,7 +364,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -397,7 +397,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -980,7 +980,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -1848,7 +1848,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -2756,7 +2756,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -2768,7 +2768,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3127,7 +3127,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3135,7 +3135,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3778,7 +3778,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3786,7 +3786,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4063,7 +4063,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "apiservicedefinitions": {
           "$ref": "#/definitions/os_operatorhub_v1alpha1_APIServiceDefinitions",
@@ -5395,7 +5395,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "apiservicedefinitions": {
           "$ref": "#/definitions/os_operatorhub_v1alpha1_APIServiceDefinitions",
@@ -5447,7 +5447,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "links": {
           "type": "array",
@@ -5690,7 +5690,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "priorityClassName": {
           "type": "string"
@@ -6253,7 +6253,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -6418,7 +6418,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "resources": {
           "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
@@ -7429,7 +7429,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "apiservicedefinitions": {
           "$ref": "#/definitions/os_operatorhub_v1alpha1_APIServiceDefinitions",
@@ -7481,7 +7481,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "links": {
           "type": "array",
@@ -7981,7 +7981,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -7993,7 +7993,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "apiservicedefinitions": {
           "$ref": "#/definitions/os_operatorhub_v1alpha1_APIServiceDefinitions",
@@ -8685,7 +8685,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -8815,7 +8815,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "priorityClassName": {
           "type": "string"
@@ -9208,7 +9208,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -9468,7 +9468,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -9501,7 +9501,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -10403,7 +10403,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -10415,7 +10415,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -10872,7 +10872,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -10880,7 +10880,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -11405,7 +11405,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -11544,7 +11544,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "resources": {
           "$ref": "#/definitions/kubernetes_core_ResourceRequirements",
@@ -12015,7 +12015,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -12023,7 +12023,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/openshift-model-storageversionmigrator/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-storageversionmigrator/src/main/resources/schema/kube-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-storageversionmigrator/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-storageversionmigrator/src/main/resources/schema/validation-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1035,7 +1035,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1068,7 +1068,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-tuned/src/generated/java/io/fabric8/openshift/api/model/tuned/v1/TunedRecommend.java
+++ b/kubernetes-model-generator/openshift-model-tuned/src/generated/java/io/fabric8/openshift/api/model/tuned/v1/TunedRecommend.java
@@ -73,9 +73,9 @@ public class TunedRecommend implements Editable<TunedRecommendBuilder> , Kuberne
     @JsonProperty("priority")
     private Long priority;
     @JsonProperty("profile")
-    private java.lang.String profile;
+    private String profile;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -84,7 +84,7 @@ public class TunedRecommend implements Editable<TunedRecommendBuilder> , Kuberne
     public TunedRecommend() {
     }
 
-    public TunedRecommend(Map<String, String> machineConfigLabels, List<TunedMatch> match, OperandConfig operand, Long priority, java.lang.String profile) {
+    public TunedRecommend(Map<String, String> machineConfigLabels, List<TunedMatch> match, OperandConfig operand, Long priority, String profile) {
         super();
         this.machineConfigLabels = machineConfigLabels;
         this.match = match;
@@ -135,12 +135,12 @@ public class TunedRecommend implements Editable<TunedRecommendBuilder> , Kuberne
     }
 
     @JsonProperty("profile")
-    public java.lang.String getProfile() {
+    public String getProfile() {
         return profile;
     }
 
     @JsonProperty("profile")
-    public void setProfile(java.lang.String profile) {
+    public void setProfile(String profile) {
         this.profile = profile;
     }
 
@@ -155,12 +155,12 @@ public class TunedRecommend implements Editable<TunedRecommendBuilder> , Kuberne
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-tuned/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-tuned/src/main/resources/schema/kube-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -780,7 +780,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "match": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-tuned/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-tuned/src/main/resources/schema/validation-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -780,7 +780,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "match": {
           "type": "array",
@@ -1085,7 +1085,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1118,7 +1118,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -1511,7 +1511,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "match": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model-whereabouts/src/generated/java/io/fabric8/openshift/api/model/whereabouts/v1alpha1/IPPoolSpec.java
+++ b/kubernetes-model-generator/openshift-model-whereabouts/src/generated/java/io/fabric8/openshift/api/model/whereabouts/v1alpha1/IPPoolSpec.java
@@ -61,9 +61,9 @@ public class IPPoolSpec implements Editable<IPPoolSpecBuilder> , KubernetesResou
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, IPAllocation> allocations = new LinkedHashMap<String, IPAllocation>();
     @JsonProperty("range")
-    private java.lang.String range;
+    private String range;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -72,7 +72,7 @@ public class IPPoolSpec implements Editable<IPPoolSpecBuilder> , KubernetesResou
     public IPPoolSpec() {
     }
 
-    public IPPoolSpec(Map<String, IPAllocation> allocations, java.lang.String range) {
+    public IPPoolSpec(Map<String, IPAllocation> allocations, String range) {
         super();
         this.allocations = allocations;
         this.range = range;
@@ -89,12 +89,12 @@ public class IPPoolSpec implements Editable<IPPoolSpecBuilder> , KubernetesResou
     }
 
     @JsonProperty("range")
-    public java.lang.String getRange() {
+    public String getRange() {
         return range;
     }
 
     @JsonProperty("range")
-    public void setRange(java.lang.String range) {
+    public void setRange(String range) {
         this.range = range;
     }
 
@@ -109,12 +109,12 @@ public class IPPoolSpec implements Editable<IPPoolSpecBuilder> , KubernetesResou
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model-whereabouts/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model-whereabouts/src/main/resources/schema/kube-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -571,7 +571,7 @@
             "$ref": "#/definitions/os_whereabouts_v1alpha1_IPAllocation",
             "existingJavaType": "io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation\u003e"
         },
         "range": {
           "type": "string"

--- a/kubernetes-model-generator/openshift-model-whereabouts/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model-whereabouts/src/main/resources/schema/validation-schema.json
@@ -192,7 +192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -225,7 +225,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -571,7 +571,7 @@
             "$ref": "#/definitions/os_whereabouts_v1alpha1_IPAllocation",
             "existingJavaType": "io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation\u003e"
         },
         "range": {
           "type": "string"
@@ -895,7 +895,7 @@
             "$ref": "#/definitions/os_whereabouts_v1alpha1_IPAllocation",
             "existingJavaType": "io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPAllocation\u003e"
         },
         "range": {
           "type": "string"
@@ -982,7 +982,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -1015,7 +1015,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BuildConfigSpec.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BuildConfigSpec.java
@@ -88,9 +88,9 @@ public class BuildConfigSpec implements Editable<BuildConfigSpecBuilder> , Kuber
     @JsonProperty("revision")
     private SourceRevision revision;
     @JsonProperty("runPolicy")
-    private java.lang.String runPolicy;
+    private String runPolicy;
     @JsonProperty("serviceAccount")
-    private java.lang.String serviceAccount;
+    private String serviceAccount;
     @JsonProperty("source")
     private BuildSource source;
     @JsonProperty("strategy")
@@ -101,7 +101,7 @@ public class BuildConfigSpec implements Editable<BuildConfigSpecBuilder> , Kuber
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<BuildTriggerPolicy> triggers = new ArrayList<BuildTriggerPolicy>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -110,7 +110,7 @@ public class BuildConfigSpec implements Editable<BuildConfigSpecBuilder> , Kuber
     public BuildConfigSpec() {
     }
 
-    public BuildConfigSpec(Long completionDeadlineSeconds, Integer failedBuildsHistoryLimit, Boolean mountTrustedCA, Map<String, String> nodeSelector, BuildOutput output, BuildPostCommitSpec postCommit, io.fabric8.kubernetes.api.model.ResourceRequirements resources, SourceRevision revision, java.lang.String runPolicy, java.lang.String serviceAccount, BuildSource source, BuildStrategy strategy, Integer successfulBuildsHistoryLimit, List<BuildTriggerPolicy> triggers) {
+    public BuildConfigSpec(Long completionDeadlineSeconds, Integer failedBuildsHistoryLimit, Boolean mountTrustedCA, Map<String, String> nodeSelector, BuildOutput output, BuildPostCommitSpec postCommit, io.fabric8.kubernetes.api.model.ResourceRequirements resources, SourceRevision revision, String runPolicy, String serviceAccount, BuildSource source, BuildStrategy strategy, Integer successfulBuildsHistoryLimit, List<BuildTriggerPolicy> triggers) {
         super();
         this.completionDeadlineSeconds = completionDeadlineSeconds;
         this.failedBuildsHistoryLimit = failedBuildsHistoryLimit;
@@ -209,22 +209,22 @@ public class BuildConfigSpec implements Editable<BuildConfigSpecBuilder> , Kuber
     }
 
     @JsonProperty("runPolicy")
-    public java.lang.String getRunPolicy() {
+    public String getRunPolicy() {
         return runPolicy;
     }
 
     @JsonProperty("runPolicy")
-    public void setRunPolicy(java.lang.String runPolicy) {
+    public void setRunPolicy(String runPolicy) {
         this.runPolicy = runPolicy;
     }
 
     @JsonProperty("serviceAccount")
-    public java.lang.String getServiceAccount() {
+    public String getServiceAccount() {
         return serviceAccount;
     }
 
     @JsonProperty("serviceAccount")
-    public void setServiceAccount(java.lang.String serviceAccount) {
+    public void setServiceAccount(String serviceAccount) {
         this.serviceAccount = serviceAccount;
     }
 
@@ -280,12 +280,12 @@ public class BuildConfigSpec implements Editable<BuildConfigSpecBuilder> , Kuber
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BuildSpec.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/BuildSpec.java
@@ -83,7 +83,7 @@ public class BuildSpec implements Editable<BuildSpecBuilder> , KubernetesResourc
     @JsonProperty("revision")
     private SourceRevision revision;
     @JsonProperty("serviceAccount")
-    private java.lang.String serviceAccount;
+    private String serviceAccount;
     @JsonProperty("source")
     private BuildSource source;
     @JsonProperty("strategy")
@@ -92,7 +92,7 @@ public class BuildSpec implements Editable<BuildSpecBuilder> , KubernetesResourc
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<BuildTriggerCause> triggeredBy = new ArrayList<BuildTriggerCause>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -101,7 +101,7 @@ public class BuildSpec implements Editable<BuildSpecBuilder> , KubernetesResourc
     public BuildSpec() {
     }
 
-    public BuildSpec(Long completionDeadlineSeconds, Boolean mountTrustedCA, Map<String, String> nodeSelector, BuildOutput output, BuildPostCommitSpec postCommit, io.fabric8.kubernetes.api.model.ResourceRequirements resources, SourceRevision revision, java.lang.String serviceAccount, BuildSource source, BuildStrategy strategy, List<BuildTriggerCause> triggeredBy) {
+    public BuildSpec(Long completionDeadlineSeconds, Boolean mountTrustedCA, Map<String, String> nodeSelector, BuildOutput output, BuildPostCommitSpec postCommit, io.fabric8.kubernetes.api.model.ResourceRequirements resources, SourceRevision revision, String serviceAccount, BuildSource source, BuildStrategy strategy, List<BuildTriggerCause> triggeredBy) {
         super();
         this.completionDeadlineSeconds = completionDeadlineSeconds;
         this.mountTrustedCA = mountTrustedCA;
@@ -187,12 +187,12 @@ public class BuildSpec implements Editable<BuildSpecBuilder> , KubernetesResourc
     }
 
     @JsonProperty("serviceAccount")
-    public java.lang.String getServiceAccount() {
+    public String getServiceAccount() {
         return serviceAccount;
     }
 
     @JsonProperty("serviceAccount")
-    public void setServiceAccount(java.lang.String serviceAccount) {
+    public void setServiceAccount(String serviceAccount) {
         this.serviceAccount = serviceAccount;
     }
 
@@ -238,12 +238,12 @@ public class BuildSpec implements Editable<BuildSpecBuilder> , KubernetesResourc
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterResourceQuotaSelector.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ClusterResourceQuotaSelector.java
@@ -62,7 +62,7 @@ public class ClusterResourceQuotaSelector implements Editable<ClusterResourceQuo
     @JsonProperty("labels")
     private io.fabric8.kubernetes.api.model.LabelSelector labels;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -108,12 +108,12 @@ public class ClusterResourceQuotaSelector implements Editable<ClusterResourceQuo
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentConfigRollback.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentConfigRollback.java
@@ -75,23 +75,23 @@ public class DeploymentConfigRollback implements Editable<DeploymentConfigRollba
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "apps.openshift.io/v1";
+    private String apiVersion = "apps.openshift.io/v1";
     /**
      * 
      * (Required)
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "DeploymentConfigRollback";
+    private String kind = "DeploymentConfigRollback";
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("spec")
     private DeploymentConfigRollbackSpec spec;
     @JsonProperty("updatedAnnotations")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> updatedAnnotations = new LinkedHashMap<String, String>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -100,7 +100,7 @@ public class DeploymentConfigRollback implements Editable<DeploymentConfigRollba
     public DeploymentConfigRollback() {
     }
 
-    public DeploymentConfigRollback(java.lang.String apiVersion, java.lang.String kind, java.lang.String name, DeploymentConfigRollbackSpec spec, Map<String, String> updatedAnnotations) {
+    public DeploymentConfigRollback(String apiVersion, String kind, String name, DeploymentConfigRollbackSpec spec, Map<String, String> updatedAnnotations) {
         super();
         this.apiVersion = apiVersion;
         this.kind = kind;
@@ -115,7 +115,7 @@ public class DeploymentConfigRollback implements Editable<DeploymentConfigRollba
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -125,7 +125,7 @@ public class DeploymentConfigRollback implements Editable<DeploymentConfigRollba
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
@@ -135,7 +135,7 @@ public class DeploymentConfigRollback implements Editable<DeploymentConfigRollba
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -145,17 +145,17 @@ public class DeploymentConfigRollback implements Editable<DeploymentConfigRollba
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -190,12 +190,12 @@ public class DeploymentConfigRollback implements Editable<DeploymentConfigRollba
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentConfigSpec.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentConfigSpec.java
@@ -86,7 +86,7 @@ public class DeploymentConfigSpec implements Editable<DeploymentConfigSpecBuilde
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<DeploymentTriggerPolicy> triggers = new ArrayList<DeploymentTriggerPolicy>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -209,12 +209,12 @@ public class DeploymentConfigSpec implements Editable<DeploymentConfigSpecBuilde
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentStrategy.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/DeploymentStrategy.java
@@ -79,9 +79,9 @@ public class DeploymentStrategy implements Editable<DeploymentStrategyBuilder> ,
     @JsonProperty("rollingParams")
     private RollingDeploymentStrategyParams rollingParams;
     @JsonProperty("type")
-    private java.lang.String type;
+    private String type;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -90,7 +90,7 @@ public class DeploymentStrategy implements Editable<DeploymentStrategyBuilder> ,
     public DeploymentStrategy() {
     }
 
-    public DeploymentStrategy(Long activeDeadlineSeconds, Map<String, String> annotations, CustomDeploymentStrategyParams customParams, Map<String, String> labels, RecreateDeploymentStrategyParams recreateParams, io.fabric8.kubernetes.api.model.ResourceRequirements resources, RollingDeploymentStrategyParams rollingParams, java.lang.String type) {
+    public DeploymentStrategy(Long activeDeadlineSeconds, Map<String, String> annotations, CustomDeploymentStrategyParams customParams, Map<String, String> labels, RecreateDeploymentStrategyParams recreateParams, io.fabric8.kubernetes.api.model.ResourceRequirements resources, RollingDeploymentStrategyParams rollingParams, String type) {
         super();
         this.activeDeadlineSeconds = activeDeadlineSeconds;
         this.annotations = annotations;
@@ -173,12 +173,12 @@ public class DeploymentStrategy implements Editable<DeploymentStrategyBuilder> ,
     }
 
     @JsonProperty("type")
-    public java.lang.String getType() {
+    public String getType() {
         return type;
     }
 
     @JsonProperty("type")
-    public void setType(java.lang.String type) {
+    public void setType(String type) {
         this.type = type;
     }
 
@@ -193,12 +193,12 @@ public class DeploymentStrategy implements Editable<DeploymentStrategyBuilder> ,
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Identity.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Identity.java
@@ -75,7 +75,7 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "user.openshift.io/v1";
+    private String apiVersion = "user.openshift.io/v1";
     @JsonProperty("extra")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> extra = new LinkedHashMap<String, String>();
@@ -85,17 +85,17 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "Identity";
+    private String kind = "Identity";
     @JsonProperty("metadata")
     private io.fabric8.kubernetes.api.model.ObjectMeta metadata;
     @JsonProperty("providerName")
-    private java.lang.String providerName;
+    private String providerName;
     @JsonProperty("providerUserName")
-    private java.lang.String providerUserName;
+    private String providerUserName;
     @JsonProperty("user")
     private io.fabric8.kubernetes.api.model.ObjectReference user;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -104,7 +104,7 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
     public Identity() {
     }
 
-    public Identity(java.lang.String apiVersion, Map<String, String> extra, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, java.lang.String providerName, java.lang.String providerUserName, io.fabric8.kubernetes.api.model.ObjectReference user) {
+    public Identity(String apiVersion, Map<String, String> extra, String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, String providerName, String providerUserName, io.fabric8.kubernetes.api.model.ObjectReference user) {
         super();
         this.apiVersion = apiVersion;
         this.extra = extra;
@@ -121,7 +121,7 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -131,7 +131,7 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
@@ -151,7 +151,7 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -161,7 +161,7 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -176,22 +176,22 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
     }
 
     @JsonProperty("providerName")
-    public java.lang.String getProviderName() {
+    public String getProviderName() {
         return providerName;
     }
 
     @JsonProperty("providerName")
-    public void setProviderName(java.lang.String providerName) {
+    public void setProviderName(String providerName) {
         this.providerName = providerName;
     }
 
     @JsonProperty("providerUserName")
-    public java.lang.String getProviderUserName() {
+    public String getProviderUserName() {
         return providerUserName;
     }
 
     @JsonProperty("providerUserName")
-    public void setProviderUserName(java.lang.String providerUserName) {
+    public void setProviderUserName(String providerUserName) {
         this.providerUserName = providerUserName;
     }
 
@@ -216,12 +216,12 @@ public class Identity implements Editable<IdentityBuilder> , HasMetadata
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageSignature.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/ImageSignature.java
@@ -107,7 +107,7 @@ public class ImageSignature implements Editable<ImageSignatureBuilder> , HasMeta
     private io.fabric8.kubernetes.api.model.ObjectMeta metadata;
     @JsonProperty("signedClaims")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private Map<String, String> signedClaims = new LinkedHashMap<String, String>();
+    private Map<java.lang.String, java.lang.String> signedClaims = new LinkedHashMap<java.lang.String, java.lang.String>();
     @JsonProperty("type")
     private java.lang.String type;
     @JsonIgnore
@@ -120,7 +120,7 @@ public class ImageSignature implements Editable<ImageSignatureBuilder> , HasMeta
     public ImageSignature() {
     }
 
-    public ImageSignature(java.lang.String apiVersion, List<SignatureCondition> conditions, java.lang.String content, String created, java.lang.String imageIdentity, SignatureIssuer issuedBy, SignatureSubject issuedTo, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, Map<String, String> signedClaims, java.lang.String type) {
+    public ImageSignature(java.lang.String apiVersion, List<SignatureCondition> conditions, java.lang.String content, String created, java.lang.String imageIdentity, SignatureIssuer issuedBy, SignatureSubject issuedTo, java.lang.String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, Map<java.lang.String, java.lang.String> signedClaims, java.lang.String type) {
         super();
         this.apiVersion = apiVersion;
         this.conditions = conditions;
@@ -247,12 +247,12 @@ public class ImageSignature implements Editable<ImageSignatureBuilder> , HasMeta
     }
 
     @JsonProperty("signedClaims")
-    public Map<String, String> getSignedClaims() {
+    public Map<java.lang.String, java.lang.String> getSignedClaims() {
         return signedClaims;
     }
 
     @JsonProperty("signedClaims")
-    public void setSignedClaims(Map<String, String> signedClaims) {
+    public void setSignedClaims(Map<java.lang.String, java.lang.String> signedClaims) {
         this.signedClaims = signedClaims;
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/TagReference.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/TagReference.java
@@ -71,13 +71,13 @@ public class TagReference implements Editable<TagReferenceBuilder> , KubernetesR
     @JsonProperty("importPolicy")
     private TagImportPolicy importPolicy;
     @JsonProperty("name")
-    private java.lang.String name;
+    private String name;
     @JsonProperty("reference")
     private Boolean reference;
     @JsonProperty("referencePolicy")
     private TagReferencePolicy referencePolicy;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -86,7 +86,7 @@ public class TagReference implements Editable<TagReferenceBuilder> , KubernetesR
     public TagReference() {
     }
 
-    public TagReference(Map<String, String> annotations, io.fabric8.kubernetes.api.model.ObjectReference from, Long generation, TagImportPolicy importPolicy, java.lang.String name, Boolean reference, TagReferencePolicy referencePolicy) {
+    public TagReference(Map<String, String> annotations, io.fabric8.kubernetes.api.model.ObjectReference from, Long generation, TagImportPolicy importPolicy, String name, Boolean reference, TagReferencePolicy referencePolicy) {
         super();
         this.annotations = annotations;
         this.from = from;
@@ -138,12 +138,12 @@ public class TagReference implements Editable<TagReferenceBuilder> , KubernetesR
     }
 
     @JsonProperty("name")
-    public java.lang.String getName() {
+    public String getName() {
         return name;
     }
 
     @JsonProperty("name")
-    public void setName(java.lang.String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -178,12 +178,12 @@ public class TagReference implements Editable<TagReferenceBuilder> , KubernetesR
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Template.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/Template.java
@@ -83,19 +83,19 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
      * 
      */
     @JsonProperty("apiVersion")
-    private java.lang.String apiVersion = "template.openshift.io/v1";
+    private String apiVersion = "template.openshift.io/v1";
     /**
      * 
      * (Required)
      * 
      */
     @JsonProperty("kind")
-    private java.lang.String kind = "Template";
+    private String kind = "Template";
     @JsonProperty("labels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, String> labels = new LinkedHashMap<String, String>();
     @JsonProperty("message")
-    private java.lang.String message;
+    private String message;
     @JsonProperty("metadata")
     private io.fabric8.kubernetes.api.model.ObjectMeta metadata;
     @JsonProperty("objects")
@@ -105,7 +105,7 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Parameter> parameters = new ArrayList<Parameter>();
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -114,7 +114,7 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
     public Template() {
     }
 
-    public Template(java.lang.String apiVersion, java.lang.String kind, Map<String, String> labels, java.lang.String message, io.fabric8.kubernetes.api.model.ObjectMeta metadata, List<HasMetadata> objects, List<Parameter> parameters) {
+    public Template(String apiVersion, String kind, Map<String, String> labels, String message, io.fabric8.kubernetes.api.model.ObjectMeta metadata, List<HasMetadata> objects, List<Parameter> parameters) {
         super();
         this.apiVersion = apiVersion;
         this.kind = kind;
@@ -131,7 +131,7 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
      * 
      */
     @JsonProperty("apiVersion")
-    public java.lang.String getApiVersion() {
+    public String getApiVersion() {
         return apiVersion;
     }
 
@@ -141,7 +141,7 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
      * 
      */
     @JsonProperty("apiVersion")
-    public void setApiVersion(java.lang.String apiVersion) {
+    public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
 
@@ -151,7 +151,7 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
      * 
      */
     @JsonProperty("kind")
-    public java.lang.String getKind() {
+    public String getKind() {
         return kind;
     }
 
@@ -161,7 +161,7 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
      * 
      */
     @JsonProperty("kind")
-    public void setKind(java.lang.String kind) {
+    public void setKind(String kind) {
         this.kind = kind;
     }
 
@@ -176,12 +176,12 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
     }
 
     @JsonProperty("message")
-    public java.lang.String getMessage() {
+    public String getMessage() {
         return message;
     }
 
     @JsonProperty("message")
-    public void setMessage(java.lang.String message) {
+    public void setMessage(String message) {
         this.message = message;
     }
 
@@ -227,12 +227,12 @@ public class Template implements Editable<TemplateBuilder> , HasMetadata, Namesp
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/TemplateInstanceRequester.java
+++ b/kubernetes-model-generator/openshift-model/src/generated/java/io/fabric8/openshift/api/model/TemplateInstanceRequester.java
@@ -66,13 +66,13 @@ public class TemplateInstanceRequester implements Editable<TemplateInstanceReque
     private Map<String, ArrayList<String>> extra = new LinkedHashMap<String, ArrayList<String>>();
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<java.lang.String> groups = new ArrayList<java.lang.String>();
+    private List<String> groups = new ArrayList<String>();
     @JsonProperty("uid")
-    private java.lang.String uid;
+    private String uid;
     @JsonProperty("username")
-    private java.lang.String username;
+    private String username;
     @JsonIgnore
-    private Map<java.lang.String, Object> additionalProperties = new LinkedHashMap<java.lang.String, Object>();
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
@@ -81,7 +81,7 @@ public class TemplateInstanceRequester implements Editable<TemplateInstanceReque
     public TemplateInstanceRequester() {
     }
 
-    public TemplateInstanceRequester(Map<String, ArrayList<String>> extra, List<java.lang.String> groups, java.lang.String uid, java.lang.String username) {
+    public TemplateInstanceRequester(Map<String, ArrayList<String>> extra, List<String> groups, String uid, String username) {
         super();
         this.extra = extra;
         this.groups = groups;
@@ -101,32 +101,32 @@ public class TemplateInstanceRequester implements Editable<TemplateInstanceReque
 
     @JsonProperty("groups")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<java.lang.String> getGroups() {
+    public List<String> getGroups() {
         return groups;
     }
 
     @JsonProperty("groups")
-    public void setGroups(List<java.lang.String> groups) {
+    public void setGroups(List<String> groups) {
         this.groups = groups;
     }
 
     @JsonProperty("uid")
-    public java.lang.String getUid() {
+    public String getUid() {
         return uid;
     }
 
     @JsonProperty("uid")
-    public void setUid(java.lang.String uid) {
+    public void setUid(String uid) {
         this.uid = uid;
     }
 
     @JsonProperty("username")
-    public java.lang.String getUsername() {
+    public String getUsername() {
         return username;
     }
 
     @JsonProperty("username")
-    public void setUsername(java.lang.String username) {
+    public void setUsername(String username) {
         this.username = username;
     }
 
@@ -141,12 +141,12 @@ public class TemplateInstanceRequester implements Editable<TemplateInstanceReque
     }
 
     @JsonAnyGetter
-    public Map<java.lang.String, Object> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperty(java.lang.String name, Object value) {
+    public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 

--- a/kubernetes-model-generator/openshift-model/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/openshift-model/src/main/resources/schema/kube-schema.json
@@ -239,7 +239,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -419,7 +419,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -452,7 +452,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -923,7 +923,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -969,7 +969,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "auth-provider": {
           "$ref": "#/definitions/kubernetes_config_AuthProviderConfig",
@@ -1026,7 +1026,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -1427,7 +1427,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2295,7 +2295,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3229,7 +3229,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -3241,7 +3241,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3592,7 +3592,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -3621,7 +3621,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -3629,7 +3629,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3655,7 +3655,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3663,7 +3663,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4347,7 +4347,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -4355,7 +4355,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -5720,7 +5720,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -6016,7 +6016,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -6323,7 +6323,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -7204,7 +7204,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -7263,7 +7263,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "strategy": {
           "$ref": "#/definitions/os_deploy_DeploymentStrategy",
@@ -7367,7 +7367,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "customParams": {
           "$ref": "#/definitions/os_deploy_CustomDeploymentStrategyParams",
@@ -7378,7 +7378,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "recreateParams": {
           "$ref": "#/definitions/os_deploy_RecreateDeploymentStrategyParams",
@@ -8098,7 +8098,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -8763,7 +8763,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "from": {
           "$ref": "#/definitions/kubernetes_core_ObjectReference",
@@ -9907,7 +9907,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
@@ -10904,7 +10904,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "message": {
           "type": "string"
@@ -11049,7 +11049,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -11226,7 +11226,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "kind": {
           "type": "string",

--- a/kubernetes-model-generator/openshift-model/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/openshift-model/src/main/resources/schema/validation-schema.json
@@ -239,7 +239,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -419,7 +419,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -452,7 +452,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -923,7 +923,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -969,7 +969,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "auth-provider": {
           "$ref": "#/definitions/kubernetes_config_AuthProviderConfig",
@@ -1026,7 +1026,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -1427,7 +1427,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -2295,7 +2295,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -3229,7 +3229,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -3241,7 +3241,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -3592,7 +3592,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -3621,7 +3621,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -3629,7 +3629,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -3655,7 +3655,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -3663,7 +3663,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -4347,7 +4347,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -4355,7 +4355,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true,
@@ -5720,7 +5720,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -6016,7 +6016,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -6323,7 +6323,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -7204,7 +7204,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true,
@@ -7263,7 +7263,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "strategy": {
           "$ref": "#/definitions/os_deploy_DeploymentStrategy",
@@ -7367,7 +7367,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "customParams": {
           "$ref": "#/definitions/os_deploy_CustomDeploymentStrategyParams",
@@ -7378,7 +7378,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "recreateParams": {
           "$ref": "#/definitions/os_deploy_RecreateDeploymentStrategyParams",
@@ -8098,7 +8098,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -8763,7 +8763,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "from": {
           "$ref": "#/definitions/kubernetes_core_ObjectReference",
@@ -9907,7 +9907,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
@@ -10904,7 +10904,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "message": {
           "type": "string"
@@ -11049,7 +11049,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -11226,7 +11226,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "kind": {
           "type": "string",
@@ -12041,7 +12041,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "auth-provider": {
           "$ref": "#/definitions/kubernetes_config_AuthProviderConfig",
@@ -12093,7 +12093,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "name": {
           "type": "string"
@@ -12366,7 +12366,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -12625,7 +12625,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -13118,7 +13118,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "labels": {
           "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
@@ -13335,7 +13335,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "output": {
           "$ref": "#/definitions/os_build_BuildOutput",
@@ -13799,7 +13799,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -14024,7 +14024,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -14073,7 +14073,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "strategy": {
           "$ref": "#/definitions/os_deploy_DeploymentStrategy",
@@ -14162,7 +14162,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "customParams": {
           "$ref": "#/definitions/os_deploy_CustomDeploymentStrategyParams",
@@ -14173,7 +14173,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "recreateParams": {
           "$ref": "#/definitions/os_deploy_RecreateDeploymentStrategyParams",
@@ -14872,7 +14872,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "readOnly": {
           "type": "boolean"
@@ -15367,7 +15367,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "kind": {
           "type": "string",
@@ -15720,7 +15720,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "type": {
           "type": "string"
@@ -16251,7 +16251,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         }
       },
       "additionalProperties": true
@@ -17103,7 +17103,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -17136,7 +17136,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "managedFields": {
           "type": "array",
@@ -17792,7 +17792,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "os": {
           "$ref": "#/definitions/kubernetes_core_PodOS",
@@ -17804,7 +17804,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "preemptionPolicy": {
           "type": "string"
@@ -18563,7 +18563,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "scopeSelector": {
           "$ref": "#/definitions/kubernetes_core_ScopeSelector",
@@ -18587,7 +18587,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "used": {
           "type": "object",
@@ -18595,7 +18595,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -18628,7 +18628,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -18636,7 +18636,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true
@@ -20128,7 +20128,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "from": {
           "$ref": "#/definitions/kubernetes_core_ObjectReference",
@@ -20192,7 +20192,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "existingJavaType": "java.util.Map\u003cString, String\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.lang.String\u003e"
         },
         "message": {
           "type": "string"
@@ -20308,7 +20308,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -20682,7 +20682,7 @@
               "type": "string"
             }
           },
-          "existingJavaType": "java.util.Map\u003cString, java.util.ArrayList\u003cString\u003e\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, java.util.ArrayList\u003cjava.lang.String\u003e\u003e"
         },
         "groups": {
           "type": "array",
@@ -21023,7 +21023,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         },
         "requests": {
           "type": "object",
@@ -21031,7 +21031,7 @@
             "$ref": "#/definitions/kubernetes_resource_Quantity",
             "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
           },
-          "existingJavaType": "java.util.Map\u003cString, io.fabric8.kubernetes.api.model.Quantity\u003e"
+          "existingJavaType": "java.util.Map\u003cjava.lang.String, io.fabric8.kubernetes.api.model.Quantity\u003e"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/pkg/schemagen/generate.go
+++ b/kubernetes-model-generator/pkg/schemagen/generate.go
@@ -152,6 +152,10 @@ func (g *schemaGenerator) javaTypeWrapPrimitive(t reflect.Type) string {
 		return "Float"
 	case "double":
 		return "Double"
+	case "string":
+		return "java.lang.String"
+	case "String":
+		return "java.lang.String"
 	default:
 		return typeName
 	}
@@ -390,7 +394,7 @@ func (g *schemaGenerator) getPropertyDescriptor(t reflect.Type, desc string, omi
 				MapValueType: g.getPropertyDescriptor(t.Elem(), desc, false),
 			},
 			ExistingJavaTypeDescriptor: &ExistingJavaTypeDescriptor{
-				ExistingJavaType: "java.util.Map<String, " + g.javaTypeWrapPrimitive(t.Elem()) + ">",
+				ExistingJavaType: "java.util.Map<java.lang.String, " + g.javaTypeWrapPrimitive(t.Elem()) + ">",
 			},
 		}
 	case reflect.Struct:
@@ -564,7 +568,7 @@ func (g *schemaGenerator) isSubresourceContainingMetadata(t reflect.Type) bool {
 		"MachineSpec",
 		"MachineTemplateSpec",
 		"ResourceClaimTemplateSpec",
-                "OpenShiftMachineV1Beta1MachineTemplate",
+		"OpenShiftMachineV1Beta1MachineTemplate",
 	}
 	return Contains(subResourcesContainingMetadataList, t.Name())
 }
@@ -606,7 +610,7 @@ func (g *schemaGenerator) isClusterScopedResource(t reflect.Type) bool {
 		"k8s.io/api/certificates/v1alpha1/ClusterTrustBundle",
 		"k8s.io/api/certificates/v1beta1/CertificateSigningRequest",
 		"k8s.io/api/certificates/v1/CertificateSigningRequest",
-                "k8s.io/api/storage/v1alpha1/VolumeAttributesClass",
+		"k8s.io/api/storage/v1alpha1/VolumeAttributesClass",
 		"k8s.io/api/storage/v1beta1/CSIDriver",
 		"k8s.io/api/storage/v1beta1/CSINode",
 		"k8s.io/api/storage/v1/CSIDriver",
@@ -695,8 +699,8 @@ func (g *schemaGenerator) isClusterScopedResource(t reflect.Type) bool {
 		"github.com/openshift/api/console/v1/ConsoleQuickStart",
 		"github.com/openshift/api/console/v1alpha1/ConsolePlugin",
 		"github.com/openshift/api/config/v1/Ingress",
-                "github.com/openshift/api/config/v1/ImageDigestMirrorSet",
-                "github.com/openshift/api/config/v1/ImageTagMirrorSet",
+		"github.com/openshift/api/config/v1/ImageDigestMirrorSet",
+		"github.com/openshift/api/config/v1/ImageTagMirrorSet",
 		"github.com/openshift/api/template/v1/BrokerTemplateInstance",
 		"github.com/openshift/api/helm/v1beta1/HelmChartRepository",
 		"github.com/openshift/api/network/v1/HostSubnet",


### PR DESCRIPTION
## Description

Generated Java classes all reference the java.lang.String type using a simplified String reference.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
