### PR TITLE
Expands the HTTP interceptor API to include a call back for failed connection attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix #6137: `ConfigBuilder.withAutoConfigure` is not working
 * Fix #6215: Suppressing rejected execution exception for port forwarder
 * Fix #6197: JettyHttp client error handling improvements. 
+* Fix #6143: Expands the HTTP interceptor API to include a call back for failed connection attempts
 
 #### Improvements
 * Fix #6008: removing the optional dependency on bouncy castle

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
@@ -19,6 +19,13 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A collection of callback methods invoked through the various stages of the HTTP request lifecycle.
+ * Each invocation of {@link Interceptor#before(BasicBuilder, HttpRequest, RequestTags)} will be matched with a call to one of
+ * {@link Interceptor#afterConnectionFailure(HttpRequest, Throwable)} or
+ * {@link Interceptor#after(HttpRequest, HttpResponse, AsyncBody.Consumer)}.
+ * Callbacks that lead to a request being sent allow for that request to be customised.
+ */
 public interface Interceptor {
 
   interface RequestTags {
@@ -63,7 +70,10 @@ public interface Interceptor {
   }
 
   /**
-   * Called after a websocket failure or by default from a normal request
+   * Called after a websocket failure or by default from a normal request.
+   * <p>
+   * Failure is determined by HTTP status code and will be invoked in addition to {@see Interceptor#after(HttpRequest,
+   * HttpResponse, AsyncBody.Consumer)}
    *
    * @param builder used to modify the request
    * @param response the failed response
@@ -75,7 +85,10 @@ public interface Interceptor {
 
   /**
    * Called after a non-websocket failure
-   *
+   * <p>
+   * Failure is determined by HTTP status code and will be invoked in addition to {@see Interceptor#after(HttpRequest,
+   * HttpResponse, AsyncBody.Consumer)}
+   * 
    * @param builder used to modify the request
    * @param response the failed response
    * @return true if the builder should be used to execute a new request

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
@@ -84,4 +84,15 @@ public interface Interceptor {
     return afterFailure((BasicBuilder) builder, response, tags);
   }
 
+  /**
+   * Called after a connection attempt fails.
+   * <p>
+   * This method will be invoked on each failed connection attempt so can be invoked multiple times for the same request.ID.
+   *
+   * @param request the HTTP request.
+   * @param failure the Java exception that caused the failure.
+   */
+  default void afterConnectionFailure(HttpRequest request, Throwable failure) {
+  }
+
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
@@ -100,7 +100,7 @@ public interface Interceptor {
   /**
    * Called after a connection attempt fails.
    * <p>
-   * This method will be invoked on each failed connection attempt so can be invoked multiple times for the same request.ID.
+   * This method will be invoked on each failed connection attempt.
    *
    * @param request the HTTP request.
    * @param failure the Java exception that caused the failure.

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/Interceptor.java
@@ -72,7 +72,7 @@ public interface Interceptor {
   /**
    * Called after a websocket failure or by default from a normal request.
    * <p>
-   * Failure is determined by HTTP status code and will be invoked in addition to {@see Interceptor#after(HttpRequest,
+   * Failure is determined by HTTP status code and will be invoked in addition to {@link Interceptor#after(HttpRequest,
    * HttpResponse, AsyncBody.Consumer)}
    *
    * @param builder used to modify the request
@@ -86,7 +86,7 @@ public interface Interceptor {
   /**
    * Called after a non-websocket failure
    * <p>
-   * Failure is determined by HTTP status code and will be invoked in addition to {@see Interceptor#after(HttpRequest,
+   * Failure is determined by HTTP status code and will be invoked in addition to {@link Interceptor#after(HttpRequest,
    * HttpResponse, AsyncBody.Consumer)}
    * 
    * @param builder used to modify the request

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java
@@ -177,24 +177,29 @@ public abstract class StandardHttpClient<C extends HttpClient, F extends HttpCli
               }
             }
           } else {
-            final Throwable finalThrowable;
-            if (throwable instanceof CompletionException) {
-              finalThrowable = throwable.getCause();
-            } else {
-              finalThrowable = throwable;
-            }
-            builder.interceptors.forEach((s, interceptor) -> interceptor.afterConnectionFailure(request, finalThrowable));
-            if (finalThrowable instanceof IOException) {
+            final Throwable actualCause = unwrapCompletionException(throwable);
+            builder.interceptors.forEach((s, interceptor) -> interceptor.afterConnectionFailure(request, actualCause));
+            if (actualCause instanceof IOException) {
               // TODO: may not be specific enough - incorrect ssl settings for example will get caught here
               LOG.debug(
                   String.format("HTTP operation on url: %s should be retried after %d millis because of IOException",
                       uri, retryInterval),
-                  finalThrowable);
+                  actualCause);
               return true;
             }
           }
           return false;
         });
+  }
+
+  static Throwable unwrapCompletionException(Throwable throwable) {
+    final Throwable actualCause;
+    if (throwable instanceof CompletionException) {
+      actualCause = throwable.getCause();
+    } else {
+      actualCause = throwable;
+    }
+    return actualCause;
   }
 
   static long retryAfterMillis(HttpResponse<?> httpResponse) {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -43,7 +43,7 @@ public abstract class AbstractInterceptorTest {
 
   @BeforeEach
   void startServer() {
-    server = new DefaultMockServer(false);
+    server = newMockServer();
     server.start();
   }
 
@@ -211,7 +211,7 @@ public abstract class AbstractInterceptorTest {
         .addOrReplaceInterceptor("test", new Interceptor() {
           @Override
           public void afterConnectionFailure(HttpRequest request, Throwable failure) {
-            server = new DefaultMockServer(false);
+            server = newMockServer();
             server.expect().withPath("/intercepted-url").andReturn(200, "This works").once();
             server.start(originalPort); // Need to restart on the original port as we can't alter the request during retry.
           }
@@ -475,4 +475,7 @@ public abstract class AbstractInterceptorTest {
         .containsEntry("test-header", Collections.singletonList("Test-Value-Override"));
   }
 
+  private static DefaultMockServer newMockServer() {
+    return new DefaultMockServer(false);
+  }
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractInterceptorTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -31,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -230,6 +232,37 @@ public abstract class AbstractInterceptorTest {
       // Then
       assertThat(response).succeedsWithin(Duration.of(30, ChronoUnit.SECONDS));
       assertThat(afterInvoked).extracting(CountDownLatch::getCount).isEqualTo(0L);
+    }
+  }
+
+  @Test
+  @DisplayName("afterConnectionFailure, completionExceptions are passed through")
+  public void afterConnectionFailureCompletionException() {
+    // Given
+    final CountDownLatch connectionFailureCallbackInvoked = new CountDownLatch(1);
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .connectTimeout(1, TimeUnit.SECONDS)
+        .addOrReplaceInterceptor("test", new Interceptor() {
+          @Override
+          public void afterConnectionFailure(HttpRequest request, Throwable failure) {
+            connectionFailureCallbackInvoked.countDown();
+          }
+        });
+    // When
+    try (HttpClient client = builder.build()) {
+      final CompletableFuture<HttpResponse<String>> response = client.sendAsync(client.newHttpRequestBuilder()
+          .timeout(1, TimeUnit.SECONDS)
+          .uri(server.url("/intercepted-url"))
+          .method("POST", "application/json", new InputStream() {
+            @Override
+            public int read() {
+              throw new CompletionException("boom time", null); // gets propagated by jetty but gets wrapped by OkHttp
+            }
+          }, 1L).build(), String.class);
+
+      // Then
+      assertThat(response).failsWithin(Duration.of(30, ChronoUnit.SECONDS));
+      assertThat(connectionFailureCallbackInvoked).extracting(CountDownLatch::getCount).isEqualTo(0L);
     }
   }
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.when;
 
 class StandardHttpClientTest {
 
+  public static final String IO_ERROR_MESSAGE = "IO woopsie";
   private TestStandardHttpClient client;
 
   @BeforeEach
@@ -281,4 +283,26 @@ class StandardHttpClientTest {
     assertTrue(client.isClosed());
   }
 
+  @Test
+  void shouldUnwrapCompletionException() {
+    // Given
+
+    // When
+    final Throwable throwable = StandardHttpClient
+        .unwrapCompletionException(new CompletionException(new IOException(IO_ERROR_MESSAGE)));
+
+    // Then
+    assertThat(throwable).isInstanceOf(IOException.class).hasMessage(IO_ERROR_MESSAGE);
+  }
+
+  @Test
+  void shouldNotUnwrapOtherExceptions() {
+    // Given
+
+    // When
+    final Throwable throwable = StandardHttpClient.unwrapCompletionException(new IOException(IO_ERROR_MESSAGE));
+
+    // Then
+    assertThat(throwable).isInstanceOf(IOException.class).hasMessage(IO_ERROR_MESSAGE);
+  }
 }


### PR DESCRIPTION
## Description

Expands the HTTP interceptor API to include a call back for failed connection attempts as discussed in #6143 

Fixes #6143

<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

Depends on the definition of breaking change as it adds a new `default` method to an interface which could be seen as a breaking change for any implementation that already has that method defined but practically speaking this is backwards compatible. 

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
