### PR TITLE
fix (kubernetes-client-api) : `Config`'s `autoConfigure` should disable auto configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #6038: Support for Gradle configuration cache
 * Fix #6110: VolumeSource (and other file mode fields) in Octal are correctly interpreted
+* Fix #6137: `ConfigBuilder.withAutoConfigure` is not working
 * Fix #6215: Suppressing rejected execution exception for port forwarder
 * Fix #6197: JettyHttp client error handling improvements. 
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+
+import java.util.Optional;
+
+import static io.fabric8.kubernetes.client.Config.disableAutoConfig;
+
+public class ConfigBuilder extends ConfigFluent<ConfigBuilder> implements VisitableBuilder<Config, ConfigBuilder> {
+  public ConfigBuilder() {
+    this.fluent = this;
+  }
+
+  public ConfigBuilder(ConfigFluent<?> fluent) {
+    this.fluent = fluent;
+  }
+
+  public ConfigBuilder(ConfigFluent<?> fluent, Config instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public ConfigBuilder(Config instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+
+  ConfigFluent<?> fluent;
+
+  public Config build() {
+    Config buildable = new Config(fluent.getMasterUrl(), fluent.getApiVersion(), fluent.getNamespace(), fluent.getTrustCerts(),
+        fluent.getDisableHostnameVerification(), fluent.getCaCertFile(), fluent.getCaCertData(), fluent.getClientCertFile(),
+        fluent.getClientCertData(), fluent.getClientKeyFile(), fluent.getClientKeyData(), fluent.getClientKeyAlgo(),
+        fluent.getClientKeyPassphrase(), fluent.getUsername(), fluent.getPassword(), fluent.getOauthToken(),
+        fluent.getAutoOAuthToken(), fluent.getWatchReconnectInterval(), fluent.getWatchReconnectLimit(),
+        fluent.getConnectionTimeout(), fluent.getRequestTimeout(), fluent.getScaleTimeout(), fluent.getLoggingInterval(),
+        fluent.getMaxConcurrentRequests(), fluent.getMaxConcurrentRequestsPerHost(), fluent.getHttp2Disable(),
+        fluent.getHttpProxy(), fluent.getHttpsProxy(), fluent.getNoProxy(), fluent.getUserAgent(), fluent.getTlsVersions(),
+        fluent.getWebsocketPingInterval(), fluent.getProxyUsername(), fluent.getProxyPassword(), fluent.getTrustStoreFile(),
+        fluent.getTrustStorePassphrase(), fluent.getKeyStoreFile(), fluent.getKeyStorePassphrase(),
+        fluent.getImpersonateUsername(), fluent.getImpersonateGroups(), fluent.getImpersonateExtras(),
+        fluent.getOauthTokenProvider(), fluent.getCustomHeaders(), fluent.getRequestRetryBackoffLimit(),
+        fluent.getRequestRetryBackoffInterval(), fluent.getUploadRequestTimeout(), fluent.getOnlyHttpWatches(),
+        fluent.getCurrentContext(), fluent.getContexts(),
+        Optional.ofNullable(fluent.getAutoConfigure()).orElse(!disableAutoConfig()), true);
+    buildable.setAuthProvider(fluent.getAuthProvider());
+    buildable.setFile(fluent.getFile());
+    return buildable;
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+public class ConfigFluent<A extends ConfigFluent<A>> extends SundrioConfigFluent<A> {
+  public ConfigFluent() {
+    super();
+  }
+
+  public ConfigFluent(Config instance) {
+    super();
+    this.copyInstance(instance);
+  }
+
+  public void copyInstance(Config instance) {
+    if (instance != null) {
+      this.withMasterUrl(instance.getMasterUrl());
+      this.withApiVersion(instance.getApiVersion());
+      this.withNamespace(instance.getNamespace());
+      this.withTrustCerts(instance.isTrustCerts());
+      this.withDisableHostnameVerification(instance.isDisableHostnameVerification());
+      this.withCaCertFile(instance.getCaCertFile());
+      this.withCaCertData(instance.getCaCertData());
+      this.withClientCertFile(instance.getClientCertFile());
+      this.withClientCertData(instance.getClientCertData());
+      this.withClientKeyFile(instance.getClientKeyFile());
+      this.withClientKeyData(instance.getClientKeyData());
+      this.withClientKeyAlgo(instance.getClientKeyAlgo());
+      this.withClientKeyPassphrase(instance.getClientKeyPassphrase());
+      this.withUsername(instance.getUsername());
+      this.withPassword(instance.getPassword());
+      this.withOauthToken(instance.getOauthToken());
+      this.withAutoOAuthToken(instance.getAutoOAuthToken());
+      this.withWatchReconnectInterval(instance.getWatchReconnectInterval());
+      this.withWatchReconnectLimit(instance.getWatchReconnectLimit());
+      this.withConnectionTimeout(instance.getConnectionTimeout());
+      this.withRequestTimeout(instance.getRequestTimeout());
+      this.withScaleTimeout(instance.getScaleTimeout());
+      this.withLoggingInterval(instance.getLoggingInterval());
+      this.withMaxConcurrentRequests(instance.getMaxConcurrentRequests());
+      this.withMaxConcurrentRequestsPerHost(instance.getMaxConcurrentRequestsPerHost());
+      this.withHttp2Disable(instance.isHttp2Disable());
+      this.withHttpProxy(instance.getHttpProxy());
+      this.withHttpsProxy(instance.getHttpsProxy());
+      this.withNoProxy(instance.getNoProxy());
+      this.withUserAgent(instance.getUserAgent());
+      this.withTlsVersions(instance.getTlsVersions());
+      this.withWebsocketPingInterval(instance.getWebsocketPingInterval());
+      this.withProxyUsername(instance.getProxyUsername());
+      this.withProxyPassword(instance.getProxyPassword());
+      this.withTrustStoreFile(instance.getTrustStoreFile());
+      this.withTrustStorePassphrase(instance.getTrustStorePassphrase());
+      this.withKeyStoreFile(instance.getKeyStoreFile());
+      this.withKeyStorePassphrase(instance.getKeyStorePassphrase());
+      this.withImpersonateUsername(instance.getImpersonateUsername());
+      this.withImpersonateGroups(instance.getImpersonateGroups());
+      this.withImpersonateExtras(instance.getImpersonateExtras());
+      this.withOauthTokenProvider(instance.getOauthTokenProvider());
+      this.withCustomHeaders(instance.getCustomHeaders());
+      this.withRequestRetryBackoffLimit(instance.getRequestRetryBackoffLimit());
+      this.withRequestRetryBackoffInterval(instance.getRequestRetryBackoffInterval());
+      this.withUploadRequestTimeout(instance.getUploadRequestTimeout());
+      this.withOnlyHttpWatches(instance.isOnlyHttpWatches());
+      this.withCurrentContext(instance.getCurrentContext());
+      this.withContexts(instance.getContexts());
+      this.withAutoConfigure(instance.getAutoConfigure());
+      this.withAuthProvider(instance.getAuthProvider());
+      this.withFile(instance.getFile());
+    }
+  }
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/RequestConfig.java
@@ -37,22 +37,22 @@ public class RequestConfig {
   private String[] impersonateGroups = new String[0];
 
   private Map<String, List<String>> impersonateExtras = new HashMap<>();
-  private int watchReconnectInterval = 1000;
-  private int watchReconnectLimit = -1;
-  private int uploadRequestTimeout = DEFAULT_UPLOAD_REQUEST_TIMEOUT;
-  private int requestRetryBackoffLimit = DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
-  private int requestRetryBackoffInterval = DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL;
-  private int requestTimeout = DEFAULT_REQUEST_TIMEOUT;
-  private long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
-  private int loggingInterval = DEFAULT_LOGGING_INTERVAL;
+  private Integer watchReconnectInterval = 1000;
+  private Integer watchReconnectLimit = -1;
+  private Integer uploadRequestTimeout = DEFAULT_UPLOAD_REQUEST_TIMEOUT;
+  private Integer requestRetryBackoffLimit = DEFAULT_REQUEST_RETRY_BACKOFFLIMIT;
+  private Integer requestRetryBackoffInterval = DEFAULT_REQUEST_RETRY_BACKOFFINTERVAL;
+  private Integer requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private Long scaleTimeout = DEFAULT_SCALE_TIMEOUT;
+  private Integer loggingInterval = DEFAULT_LOGGING_INTERVAL;
 
   RequestConfig() {
   }
 
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
-  public RequestConfig(int watchReconnectLimit, int watchReconnectInterval, int requestTimeout,
-      long scaleTimeout, int loggingInterval, int requestRetryBackoffLimit,
-      int requestRetryBackoffInterval, int uploadRequestTimeout) {
+  public RequestConfig(Integer watchReconnectLimit, Integer watchReconnectInterval, Integer requestTimeout,
+      Long scaleTimeout, Integer loggingInterval, Integer requestRetryBackoffLimit,
+      Integer requestRetryBackoffInterval, Integer uploadRequestTimeout) {
     this.watchReconnectLimit = watchReconnectLimit;
     this.watchReconnectInterval = watchReconnectInterval;
     this.requestTimeout = requestTimeout;
@@ -63,67 +63,67 @@ public class RequestConfig {
     this.uploadRequestTimeout = uploadRequestTimeout;
   }
 
-  public int getWatchReconnectInterval() {
+  public Integer getWatchReconnectInterval() {
     return watchReconnectInterval;
   }
 
-  public void setWatchReconnectInterval(int watchReconnectInterval) {
+  public void setWatchReconnectInterval(Integer watchReconnectInterval) {
     this.watchReconnectInterval = watchReconnectInterval;
   }
 
-  public int getWatchReconnectLimit() {
+  public Integer getWatchReconnectLimit() {
     return watchReconnectLimit;
   }
 
-  public void setWatchReconnectLimit(int watchReconnectLimit) {
+  public void setWatchReconnectLimit(Integer watchReconnectLimit) {
     this.watchReconnectLimit = watchReconnectLimit;
   }
 
-  public int getRequestTimeout() {
+  public Integer getRequestTimeout() {
     return requestTimeout;
   }
 
-  public void setRequestTimeout(int requestTimeout) {
+  public void setRequestTimeout(Integer requestTimeout) {
     this.requestTimeout = requestTimeout;
   }
 
-  public int getRequestRetryBackoffLimit() {
+  public Integer getRequestRetryBackoffLimit() {
     return requestRetryBackoffLimit;
   }
 
-  public void setRequestRetryBackoffLimit(int requestRetryBackoffLimit) {
+  public void setRequestRetryBackoffLimit(Integer requestRetryBackoffLimit) {
     this.requestRetryBackoffLimit = requestRetryBackoffLimit;
   }
 
-  public int getRequestRetryBackoffInterval() {
+  public Integer getRequestRetryBackoffInterval() {
     return requestRetryBackoffInterval;
   }
 
-  public void setRequestRetryBackoffInterval(int requestRetryBackoffInterval) {
+  public void setRequestRetryBackoffInterval(Integer requestRetryBackoffInterval) {
     this.requestRetryBackoffInterval = requestRetryBackoffInterval;
   }
 
-  public int getUploadRequestTimeout() {
+  public Integer getUploadRequestTimeout() {
     return uploadRequestTimeout;
   }
 
-  public void setUploadRequestTimeout(int uploadRequestTimeout) {
+  public void setUploadRequestTimeout(Integer uploadRequestTimeout) {
     this.uploadRequestTimeout = uploadRequestTimeout;
   }
 
-  public long getScaleTimeout() {
+  public Long getScaleTimeout() {
     return scaleTimeout;
   }
 
-  public void setScaleTimeout(long scaleTimeout) {
+  public void setScaleTimeout(Long scaleTimeout) {
     this.scaleTimeout = scaleTimeout;
   }
 
-  public int getLoggingInterval() {
+  public Integer getLoggingInterval() {
     return loggingInterval;
   }
 
-  public void setLoggingInterval(int loggingInterval) {
+  public void setLoggingInterval(Integer loggingInterval) {
     this.loggingInterval = loggingInterval;
   }
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/SundrioConfig.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/SundrioConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.NamedContext;
+import io.fabric8.kubernetes.client.http.TlsVersion;
+import io.sundr.builder.annotations.Buildable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is necessary to be able to autogenerate a builder for the Config class using Sundrio while providing
+ * specific behavior for the build() method.
+ *
+ * This way we can extend the default SundrioConfigBuilder, overriding the build method and enabling autoconfiguration only in
+ * this case.
+ *
+ * The builder is also capable of having a state of the Config with null values (no defaults or autoconfigured).
+ *
+ * The end purpose is for users to actually use the builder to override the default values or autoconfigured ones
+ * by providing their values through the builder withXxx accessors
+ */
+class SundrioConfig extends Config {
+  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
+  public SundrioConfig(String masterUrl, String apiVersion, String namespace, Boolean trustCerts,
+      Boolean disableHostnameVerification,
+      String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile,
+      String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password,
+      String oauthToken, String autoOAuthToken, Integer watchReconnectInterval, Integer watchReconnectLimit,
+      Integer connectionTimeout,
+      Integer requestTimeout,
+      Long scaleTimeout, Integer loggingInterval, Integer maxConcurrentRequests, Integer maxConcurrentRequestsPerHost,
+      Boolean http2Disable, String httpProxy, String httpsProxy, String[] noProxy,
+      String userAgent, TlsVersion[] tlsVersions, Long websocketPingInterval, String proxyUsername,
+      String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase,
+      String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras,
+      OAuthTokenProvider oauthTokenProvider, Map<String, String> customHeaders, Integer requestRetryBackoffLimit,
+      Integer requestRetryBackoffInterval, Integer uploadRequestTimeout, Boolean onlyHttpWatches, NamedContext currentContext,
+      List<NamedContext> contexts, Boolean autoConfigure) {
+    super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData,
+        clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username,
+        password, oauthToken, autoOAuthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout,
+        scaleTimeout, loggingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, http2Disable,
+        httpProxy, httpsProxy, noProxy, userAgent, tlsVersions, websocketPingInterval, proxyUsername, proxyPassword,
+        trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups,
+        impersonateExtras, oauthTokenProvider, customHeaders, requestRetryBackoffLimit, requestRetryBackoffInterval,
+        uploadRequestTimeout, onlyHttpWatches, currentContext, contexts, autoConfigure, true);
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigConstructorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigConstructorTest.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.client.http.TlsVersion;
+import io.fabric8.kubernetes.client.utils.Utils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+class ConfigConstructorTest {
+  @Test
+  @DisplayName("empty configuration, no default values, no auto configured values")
+  void emptyConfiguration() {
+    // Given + When
+    Config config = new Config(null, null, null, null, null,
+        null, null, null, null, null,
+        null, null, null, null, null,
+        null, null, null, null, null,
+        null, null, null, null,
+        null,
+        null, null, null, null,
+        null, null, null,
+        null,
+        null, null, null, null, null,
+        null, null, null,
+        null, null, null,
+        null, null, null, null,
+        null, null, false);
+
+    // Then
+    assertThat(config)
+        .isNotNull()
+        .satisfies(c -> assertThat(c.getTrustCerts()).isNull())
+        .satisfies(c -> assertThat(c.getDisableHostnameVerification()).isNull())
+        .hasFieldOrPropertyWithValue("masterUrl", null)
+        .hasFieldOrPropertyWithValue("namespace", null)
+        .hasFieldOrPropertyWithValue("username", null)
+        .hasFieldOrPropertyWithValue("password", null)
+        .hasFieldOrPropertyWithValue("caCertFile", null)
+        .hasFieldOrPropertyWithValue("caCertData", null)
+        .hasFieldOrPropertyWithValue("clientCertFile", null)
+        .hasFieldOrPropertyWithValue("clientCertData", null)
+        .hasFieldOrPropertyWithValue("clientKeyFile", null)
+        .hasFieldOrPropertyWithValue("clientKeyData", null)
+        .hasFieldOrPropertyWithValue("clientKeyAlgo", null)
+        .hasFieldOrPropertyWithValue("clientKeyPassphrase", null)
+        .hasFieldOrPropertyWithValue("httpProxy", null)
+        .hasFieldOrPropertyWithValue("watchReconnectInterval", null)
+        .hasFieldOrPropertyWithValue("watchReconnectLimit", null)
+        .hasFieldOrPropertyWithValue("loggingInterval", null)
+        .hasFieldOrPropertyWithValue("requestTimeout", null)
+        .hasFieldOrPropertyWithValue("requestConfig.uploadRequestTimeout", null)
+        .hasFieldOrPropertyWithValue("tlsVersions", null)
+        .hasFieldOrPropertyWithValue("trustStoreFile", null)
+        .hasFieldOrPropertyWithValue("trustStorePassphrase", null)
+        .hasFieldOrPropertyWithValue("keyStoreFile", null)
+        .hasFieldOrPropertyWithValue("keyStorePassphrase", null)
+        .hasFieldOrPropertyWithValue("maxConcurrentRequests", null)
+        .hasFieldOrPropertyWithValue("maxConcurrentRequestsPerHost", null)
+        .hasFieldOrPropertyWithValue("websocketPingInterval", null)
+        .hasFieldOrPropertyWithValue("connectionTimeout", null)
+        .hasFieldOrPropertyWithValue("scaleTimeout", null)
+        .hasFieldOrPropertyWithValue("watchReconnectInterval", null)
+        .hasFieldOrPropertyWithValue("http2Disable", null)
+        .hasFieldOrPropertyWithValue("httpsProxy", null)
+        .hasFieldOrPropertyWithValue("proxyUsername", null)
+        .hasFieldOrPropertyWithValue("proxyPassword", null)
+        .hasFieldOrPropertyWithValue("noProxy", null)
+        .hasFieldOrPropertyWithValue("autoOAuthToken", null);
+  }
+
+  @Nested
+  @DisplayName("Config default values initialization with system properties for auto configuration")
+  class DefaultValues {
+    @BeforeEach
+    void setUp() {
+      System.setProperty("kubernetes.master", "http://autoconfigured-master:80");
+      System.setProperty("kubernetes.namespace", "autoconfigured-namespace");
+      System.setProperty("kubernetes.auth.token", "autoconfigured-token");
+      System.setProperty("kubernetes.auth.basic.username", "autoconfigured-user");
+      System.setProperty("kubernetes.auth.basic.password", "autoconfigured-pass");
+      System.setProperty("kubernetes.trust.certificates", "true");
+      System.setProperty("kubernetes.disable.hostname.verification", "true");
+      System.setProperty("kubernetes.certs.ca.file", "/autoconfigured-path/to/cert");
+      System.setProperty("kubernetes.certs.ca.data", "autoconfigured-cacertdata");
+      System.setProperty("kubernetes.certs.client.file", "/autoconfigured-path/to/clientcert");
+      System.setProperty("kubernetes.certs.client.data", "autoconfigured-clientcertdata");
+      System.setProperty("kubernetes.certs.client.key.file", "/autoconfigured-path/to/clientkey");
+      System.setProperty("kubernetes.certs.client.key.data", "autoconfigured-clientkeydata");
+      System.setProperty("kubernetes.certs.client.key.algo", "autoconfigured-algo");
+      System.setProperty("kubernetes.certs.client.key.passphrase", "autoconfigured-passphrase");
+      System.setProperty("kubernetes.certs.client.key.file", "/autoconfigured-path/to/clientkey");
+      System.setProperty("kubernetes.max.concurrent.requests", "120");
+      System.setProperty("kubernetes.max.concurrent.requests.per.host", "20");
+      System.setProperty("kubernetes.watch.reconnectInterval", "5000");
+      System.setProperty("kubernetes.watch.reconnectLimit", "5");
+      System.setProperty("kubernetes.request.timeout", "5000");
+      System.setProperty("http.proxy", "autoconfigured-httpProxy");
+      System.setProperty("kubernetes.tls.versions", "TLSv1.2,TLSv1.1");
+      System.setProperty("kubernetes.truststore.file", "/autoconfigured-path/to/truststore");
+      System.setProperty("kubernetes.truststore.passphrase", "autoconfigured-truststorePassphrase");
+      System.setProperty("kubernetes.keystore.file", "/autoconfigured-path/to/keystore");
+      System.setProperty("kubernetes.keystore.passphrase", "autoconfigured-keystorePassphrase");
+      System.setProperty("kubernetes.upload.request.timeout", "600000");
+      System.setProperty("kubernetes.websocket.ping.interval", "1000");
+      System.setProperty("kubernetes.connection.timeout", "1000");
+      System.setProperty("kubernetes.scale.timeout", "1000");
+      System.setProperty("https.proxy", "autoconfigured-httpsProxy");
+      System.setProperty("no.proxy", "autoconfigured-no-proxy-url1.io,autoconfigured-no-proxy-url2.io");
+      System.setProperty("proxy.username", "autoconfigured-proxyUsername");
+      System.setProperty("proxy.password", "autoconfigured-proxyPassword");
+    }
+
+    @AfterEach
+    void tearDown() {
+      System.clearProperty("kubernetes.master");
+      System.clearProperty("kubernetes.namespace");
+      System.clearProperty("kubernetes.auth.token");
+      System.clearProperty("kubernetes.auth.basic.username");
+      System.clearProperty("kubernetes.auth.basic.password");
+      System.clearProperty("kubernetes.trust.certificates");
+      System.clearProperty("kubernetes.disable.hostname.verification");
+      System.clearProperty("kubernetes.certs.ca.file");
+      System.clearProperty("kubernetes.certs.ca.data");
+      System.clearProperty("kubernetes.certs.client.file");
+      System.clearProperty("kubernetes.certs.client.data");
+      System.clearProperty("kubernetes.certs.client.key.file");
+      System.clearProperty("kubernetes.certs.client.key.data");
+      System.clearProperty("kubernetes.certs.client.key.algo");
+      System.clearProperty("kubernetes.certs.client.key.passphrase");
+      System.clearProperty("kubernetes.certs.client.key.file");
+      System.clearProperty("kubernetes.max.concurrent.requests");
+      System.clearProperty("kubernetes.max.concurrent.requests.per.host");
+      System.clearProperty("kubernetes.watch.reconnectInterval");
+      System.clearProperty("kubernetes.watch.reconnectLimit");
+      System.clearProperty("kubernetes.request.timeout");
+      System.clearProperty("http.proxy");
+      System.clearProperty("kubernetes.tls.versions");
+      System.clearProperty("kubernetes.truststore.file");
+      System.clearProperty("kubernetes.truststore.passphrase");
+      System.clearProperty("kubernetes.keystore.file");
+      System.clearProperty("kubernetes.keystore.passphrase");
+      System.clearProperty("kubernetes.upload.request.timeout");
+      System.clearProperty("kubernetes.websocket.ping.interval");
+      System.clearProperty("kubernetes.connection.timeout");
+      System.clearProperty("kubernetes.scale.timeout");
+      System.clearProperty("https.proxy");
+      System.clearProperty("no.proxy");
+      System.clearProperty("proxy.username");
+      System.clearProperty("proxy.password");
+    }
+
+    @Test
+    @DisplayName("when autoConfigure enabled, then auto configured values override default values")
+    void whenAutoConfigureEnabled_thenUseBothDefaultAndAutoConfiguredValues() {
+      // Given
+      // When
+      Config config = new Config(null, null, null, null, null,
+          null, null, null, null, null,
+          null, null, null, null, null,
+          null, null, null, null, null,
+          null, null, null, null,
+          null,
+          null, null, null, null,
+          null, null, null,
+          null,
+          null, null, null, null, null,
+          null, null, null,
+          null, null, null,
+          null, null, null, null,
+          null, true, true);
+
+      // Then
+      assertThat(config)
+          .isNotNull()
+          // Default values
+          .hasFieldOrPropertyWithValue("apiVersion", "v1")
+          .hasFieldOrPropertyWithValue("onlyHttpWatches", false)
+          .hasFieldOrPropertyWithValue("http2Disable", false)
+          .hasFieldOrPropertyWithValue("userAgent", "fabric8-kubernetes-client/" + Version.clientVersion())
+          // Auto Configured values
+          .hasFieldOrPropertyWithValue("trustCerts", true)
+          .hasFieldOrPropertyWithValue("disableHostnameVerification", true)
+          .hasFieldOrPropertyWithValue("masterUrl", "http://autoconfigured-master:80/")
+          .hasFieldOrPropertyWithValue("namespace", "autoconfigured-namespace")
+          .hasFieldOrPropertyWithValue("username", "autoconfigured-user")
+          .hasFieldOrPropertyWithValue("password", "autoconfigured-pass")
+          .hasFieldOrPropertyWithValue("caCertFile", "/autoconfigured-path/to/cert")
+          .hasFieldOrPropertyWithValue("caCertData", "autoconfigured-cacertdata")
+          .hasFieldOrPropertyWithValue("clientCertFile", "/autoconfigured-path/to/clientcert")
+          .hasFieldOrPropertyWithValue("clientCertData", "autoconfigured-clientcertdata")
+          .hasFieldOrPropertyWithValue("clientKeyFile", "/autoconfigured-path/to/clientkey")
+          .hasFieldOrPropertyWithValue("clientKeyData", "autoconfigured-clientkeydata")
+          .hasFieldOrPropertyWithValue("clientKeyAlgo", "autoconfigured-algo")
+          .hasFieldOrPropertyWithValue("clientKeyPassphrase", "autoconfigured-passphrase")
+          .hasFieldOrPropertyWithValue("httpProxy", "autoconfigured-httpProxy")
+          .hasFieldOrPropertyWithValue("watchReconnectInterval", 5000)
+          .hasFieldOrPropertyWithValue("watchReconnectLimit", 5)
+          .hasFieldOrPropertyWithValue("requestTimeout", 5000)
+          .hasFieldOrPropertyWithValue("requestConfig.uploadRequestTimeout", 600000)
+          .hasFieldOrPropertyWithValue("tlsVersions", new TlsVersion[] { TlsVersion.TLS_1_2, TlsVersion.TLS_1_1 })
+          .hasFieldOrPropertyWithValue("trustStoreFile", "/autoconfigured-path/to/truststore")
+          .hasFieldOrPropertyWithValue("trustStorePassphrase", "autoconfigured-truststorePassphrase")
+          .hasFieldOrPropertyWithValue("keyStoreFile", "/autoconfigured-path/to/keystore")
+          .hasFieldOrPropertyWithValue("keyStorePassphrase", "autoconfigured-keystorePassphrase")
+          .hasFieldOrPropertyWithValue("maxConcurrentRequests", 120)
+          .hasFieldOrPropertyWithValue("maxConcurrentRequestsPerHost", 20)
+          .hasFieldOrPropertyWithValue("websocketPingInterval", 1000L)
+          .hasFieldOrPropertyWithValue("connectionTimeout", 1000)
+          .hasFieldOrPropertyWithValue("scaleTimeout", 1000L)
+          .hasFieldOrPropertyWithValue("watchReconnectInterval", 5000)
+          .hasFieldOrPropertyWithValue("http2Disable", false)
+          .hasFieldOrPropertyWithValue("httpsProxy", "autoconfigured-httpsProxy")
+          .hasFieldOrPropertyWithValue("proxyUsername", "autoconfigured-proxyUsername")
+          .hasFieldOrPropertyWithValue("proxyPassword", "autoconfigured-proxyPassword")
+          .hasFieldOrPropertyWithValue("noProxy",
+              new String[] { "autoconfigured-no-proxy-url1.io", "autoconfigured-no-proxy-url2.io" })
+          .hasFieldOrPropertyWithValue("autoOAuthToken", "autoconfigured-token");
+    }
+
+    @Test
+    @DisplayName("when autoConfigure disabled, then auto configured values are ignored")
+    void whenAutoConfigureDisabled_thenOnlyUseDefaultValues() {
+      Config config = new Config(null, null, null, null, null,
+          null, null, null, null, null,
+          null, null, null, null, null,
+          null, null, null, null, null,
+          null, null, null, null,
+          null,
+          null, null, null, null,
+          null, null, null,
+          null,
+          null, null, null, null, null,
+          null, null, null,
+          null, null, null,
+          null, null, null, null,
+          null, false, true);
+
+      assertThat(config)
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("apiVersion", "v1")
+          .hasFieldOrPropertyWithValue("onlyHttpWatches", false)
+          .hasFieldOrPropertyWithValue("http2Disable", false)
+          .hasFieldOrPropertyWithValue("userAgent", "fabric8-kubernetes-client/" + Version.clientVersion())
+          .hasFieldOrPropertyWithValue("trustCerts", false)
+          .hasFieldOrPropertyWithValue("disableHostnameVerification", false)
+          .hasFieldOrPropertyWithValue("masterUrl", "https://kubernetes.default.svc/")
+          .hasFieldOrPropertyWithValue("namespace", null)
+          .hasFieldOrPropertyWithValue("username", null)
+          .hasFieldOrPropertyWithValue("password", null)
+          .hasFieldOrPropertyWithValue("caCertFile", null)
+          .hasFieldOrPropertyWithValue("caCertData", null)
+          .hasFieldOrPropertyWithValue("clientCertFile", null)
+          .hasFieldOrPropertyWithValue("clientCertData", null)
+          .hasFieldOrPropertyWithValue("clientKeyFile", null)
+          .hasFieldOrPropertyWithValue("clientKeyData", null)
+          .hasFieldOrPropertyWithValue("clientKeyAlgo", "RSA")
+          .hasFieldOrPropertyWithValue("clientKeyPassphrase", "changeit")
+          .hasFieldOrPropertyWithValue("httpProxy", null)
+          .hasFieldOrPropertyWithValue("watchReconnectInterval", 1000)
+          .hasFieldOrPropertyWithValue("watchReconnectLimit", -1)
+          .hasFieldOrPropertyWithValue("requestTimeout", 10000)
+          .hasFieldOrPropertyWithValue("requestConfig.uploadRequestTimeout", 120000)
+          .hasFieldOrPropertyWithValue("tlsVersions", new TlsVersion[] { TlsVersion.TLS_1_3, TlsVersion.TLS_1_2 })
+          .hasFieldOrPropertyWithValue("trustStoreFile", null)
+          .hasFieldOrPropertyWithValue("trustStorePassphrase", null)
+          .hasFieldOrPropertyWithValue("keyStoreFile", null)
+          .hasFieldOrPropertyWithValue("keyStorePassphrase", null)
+          .hasFieldOrPropertyWithValue("maxConcurrentRequests", 64)
+          .hasFieldOrPropertyWithValue("maxConcurrentRequestsPerHost", 5)
+          .hasFieldOrPropertyWithValue("websocketPingInterval", 30000L)
+          .hasFieldOrPropertyWithValue("connectionTimeout", 10000)
+          .hasFieldOrPropertyWithValue("scaleTimeout", 600000L)
+          .hasFieldOrPropertyWithValue("watchReconnectInterval", 1000)
+          .hasFieldOrPropertyWithValue("http2Disable", false)
+          .hasFieldOrPropertyWithValue("httpsProxy", null)
+          .hasFieldOrPropertyWithValue("proxyUsername", null)
+          .hasFieldOrPropertyWithValue("proxyPassword", null)
+          .hasFieldOrPropertyWithValue("noProxy", null)
+          .hasFieldOrPropertyWithValue("autoOAuthToken", null);
+    }
+  }
+
+  @Nested
+  @DisplayName("Config auto configured values initialization (autoConfigure=true)")
+  class AutoConfiguredValues {
+    @Nested
+    @DisplayName("(defaultValues=true)")
+    class DefaultValuesTrue {
+      @Test
+      @DisplayName("from system properties")
+      void configLoadedViaSystemProperties() {
+        try {
+          // Given
+          System.setProperty("kubernetes.master", "http://autoconfigured-master:80");
+          System.setProperty("kubernetes.namespace", "autoconfigured-namespace");
+          System.setProperty("kubernetes.auth.token", "autoconfigured-token");
+          System.setProperty("kubernetes.auth.basic.username", "autoconfigured-user");
+          System.setProperty("kubernetes.auth.basic.password", "autoconfigured-pass");
+          System.setProperty("kubernetes.trust.certificates", "true");
+          System.setProperty("kubernetes.disable.hostname.verification", "true");
+          System.setProperty("kubernetes.certs.ca.file", "/autoconfigured-path/to/cert");
+          System.setProperty("kubernetes.certs.ca.data", "autoconfigured-cacertdata");
+          System.setProperty("kubernetes.certs.client.file", "/autoconfigured-path/to/clientcert");
+          System.setProperty("kubernetes.certs.client.data", "autoconfigured-clientcertdata");
+          System.setProperty("kubernetes.certs.client.key.file", "/autoconfigured-path/to/clientkey");
+          System.setProperty("kubernetes.certs.client.key.data", "autoconfigured-clientkeydata");
+          System.setProperty("kubernetes.certs.client.key.algo", "autoconfigured-algo");
+          System.setProperty("kubernetes.certs.client.key.passphrase", "autoconfigured-passphrase");
+          System.setProperty("kubernetes.certs.client.key.file", "/autoconfigured-path/to/clientkey");
+          System.setProperty("kubernetes.max.concurrent.requests", "120");
+          System.setProperty("kubernetes.max.concurrent.requests.per.host", "20");
+          System.setProperty("kubernetes.watch.reconnectInterval", "5000");
+          System.setProperty("kubernetes.watch.reconnectLimit", "5");
+          System.setProperty("kubernetes.request.timeout", "5000");
+          System.setProperty("http.proxy", "autoconfigured-httpProxy");
+          System.setProperty("kubernetes.tls.versions", "TLSv1.2,TLSv1.1");
+          System.setProperty("kubernetes.truststore.file", "/autoconfigured-path/to/truststore");
+          System.setProperty("kubernetes.truststore.passphrase", "autoconfigured-truststorePassphrase");
+          System.setProperty("kubernetes.keystore.file", "/autoconfigured-path/to/keystore");
+          System.setProperty("kubernetes.keystore.passphrase", "autoconfigured-keystorePassphrase");
+          System.setProperty("kubernetes.upload.request.timeout", "600000");
+          System.setProperty("kubernetes.websocket.ping.interval", "1000");
+          System.setProperty("kubernetes.connection.timeout", "1000");
+          System.setProperty("kubernetes.scale.timeout", "1000");
+          System.setProperty("https.proxy", "autoconfigured-httpsProxy");
+          System.setProperty("no.proxy", "autoconfigured-no-proxy-url1.io,autoconfigured-no-proxy-url2.io");
+          System.setProperty("proxy.username", "autoconfigured-proxyUsername");
+          System.setProperty("proxy.password", "autoconfigured-proxyPassword");
+
+          // When
+          Config config = new Config(null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null,
+              null,
+              null, null, null, null,
+              null, null, null,
+              null,
+              null, null, null, null, null,
+              null, null, null,
+              null, null, null,
+              null, null, null, null,
+              null, true, true);
+
+          // Then
+          assertThat(config)
+              .isNotNull()
+              // Default values
+              .hasFieldOrPropertyWithValue("apiVersion", "v1")
+              .hasFieldOrPropertyWithValue("onlyHttpWatches", false)
+              .hasFieldOrPropertyWithValue("http2Disable", false)
+              .hasFieldOrPropertyWithValue("userAgent", "fabric8-kubernetes-client/" + Version.clientVersion())
+              // Auto Configured values
+              .hasFieldOrPropertyWithValue("trustCerts", true)
+              .hasFieldOrPropertyWithValue("disableHostnameVerification", true)
+              .hasFieldOrPropertyWithValue("masterUrl", "http://autoconfigured-master:80/")
+              .hasFieldOrPropertyWithValue("namespace", "autoconfigured-namespace")
+              .hasFieldOrPropertyWithValue("username", "autoconfigured-user")
+              .hasFieldOrPropertyWithValue("password", "autoconfigured-pass")
+              .hasFieldOrPropertyWithValue("caCertFile", "/autoconfigured-path/to/cert")
+              .hasFieldOrPropertyWithValue("caCertData", "autoconfigured-cacertdata")
+              .hasFieldOrPropertyWithValue("clientCertFile", "/autoconfigured-path/to/clientcert")
+              .hasFieldOrPropertyWithValue("clientCertData", "autoconfigured-clientcertdata")
+              .hasFieldOrPropertyWithValue("clientKeyFile", "/autoconfigured-path/to/clientkey")
+              .hasFieldOrPropertyWithValue("clientKeyData", "autoconfigured-clientkeydata")
+              .hasFieldOrPropertyWithValue("clientKeyAlgo", "autoconfigured-algo")
+              .hasFieldOrPropertyWithValue("clientKeyPassphrase", "autoconfigured-passphrase")
+              .hasFieldOrPropertyWithValue("httpProxy", "autoconfigured-httpProxy")
+              .hasFieldOrPropertyWithValue("watchReconnectInterval", 5000)
+              .hasFieldOrPropertyWithValue("watchReconnectLimit", 5)
+              .hasFieldOrPropertyWithValue("requestTimeout", 5000)
+              .hasFieldOrPropertyWithValue("requestConfig.uploadRequestTimeout", 600000)
+              .hasFieldOrPropertyWithValue("tlsVersions", new TlsVersion[] { TlsVersion.TLS_1_2, TlsVersion.TLS_1_1 })
+              .hasFieldOrPropertyWithValue("trustStoreFile", "/autoconfigured-path/to/truststore")
+              .hasFieldOrPropertyWithValue("trustStorePassphrase", "autoconfigured-truststorePassphrase")
+              .hasFieldOrPropertyWithValue("keyStoreFile", "/autoconfigured-path/to/keystore")
+              .hasFieldOrPropertyWithValue("keyStorePassphrase", "autoconfigured-keystorePassphrase")
+              .hasFieldOrPropertyWithValue("maxConcurrentRequests", 120)
+              .hasFieldOrPropertyWithValue("maxConcurrentRequestsPerHost", 20)
+              .hasFieldOrPropertyWithValue("websocketPingInterval", 1000L)
+              .hasFieldOrPropertyWithValue("connectionTimeout", 1000)
+              .hasFieldOrPropertyWithValue("scaleTimeout", 1000L)
+              .hasFieldOrPropertyWithValue("watchReconnectInterval", 5000)
+              .hasFieldOrPropertyWithValue("http2Disable", false)
+              .hasFieldOrPropertyWithValue("httpsProxy", "autoconfigured-httpsProxy")
+              .hasFieldOrPropertyWithValue("proxyUsername", "autoconfigured-proxyUsername")
+              .hasFieldOrPropertyWithValue("proxyPassword", "autoconfigured-proxyPassword")
+              .hasFieldOrPropertyWithValue("noProxy",
+                  new String[] { "autoconfigured-no-proxy-url1.io", "autoconfigured-no-proxy-url2.io" })
+              .hasFieldOrPropertyWithValue("autoOAuthToken", "autoconfigured-token");
+        } finally {
+          System.clearProperty("kubernetes.master");
+          System.clearProperty("kubernetes.namespace");
+          System.clearProperty("kubernetes.auth.token");
+          System.clearProperty("kubernetes.auth.basic.username");
+          System.clearProperty("kubernetes.auth.basic.password");
+          System.clearProperty("kubernetes.trust.certificates");
+          System.clearProperty("kubernetes.disable.hostname.verification");
+          System.clearProperty("kubernetes.certs.ca.file");
+          System.clearProperty("kubernetes.certs.ca.data");
+          System.clearProperty("kubernetes.certs.client.file");
+          System.clearProperty("kubernetes.certs.client.data");
+          System.clearProperty("kubernetes.certs.client.key.file");
+          System.clearProperty("kubernetes.certs.client.key.data");
+          System.clearProperty("kubernetes.certs.client.key.algo");
+          System.clearProperty("kubernetes.certs.client.key.passphrase");
+          System.clearProperty("kubernetes.certs.client.key.file");
+          System.clearProperty("kubernetes.max.concurrent.requests");
+          System.clearProperty("kubernetes.max.concurrent.requests.per.host");
+          System.clearProperty("kubernetes.watch.reconnectInterval");
+          System.clearProperty("kubernetes.watch.reconnectLimit");
+          System.clearProperty("kubernetes.request.timeout");
+          System.clearProperty("http.proxy");
+          System.clearProperty("kubernetes.tls.versions");
+          System.clearProperty("kubernetes.truststore.file");
+          System.clearProperty("kubernetes.truststore.passphrase");
+          System.clearProperty("kubernetes.keystore.file");
+          System.clearProperty("kubernetes.keystore.passphrase");
+          System.clearProperty("kubernetes.upload.request.timeout");
+          System.clearProperty("kubernetes.websocket.ping.interval");
+          System.clearProperty("kubernetes.connection.timeout");
+          System.clearProperty("kubernetes.scale.timeout");
+          System.clearProperty("https.proxy");
+          System.clearProperty("no.proxy");
+          System.clearProperty("proxy.username");
+          System.clearProperty("proxy.password");
+        }
+      }
+
+      @Test
+      @DisplayName("from kube config")
+      void configLoadedViaKubeConfig() {
+        try {
+          // Given
+          String kubeConfigFilePath = Utils.filePath(ConfigConstructorTest.class.getResource("/test-kubeconfig"));
+          System.setProperty("kubeconfig", kubeConfigFilePath);
+          // When
+          Config config = new Config(null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null,
+              null,
+              null, null, null, null,
+              null, null, null,
+              null,
+              null, null, null, null, null,
+              null, null, null,
+              null, null, null,
+              null, null, null, null,
+              null, true, true);
+
+          // Then
+          assertThat(config)
+              .isNotNull()
+              .hasFieldOrPropertyWithValue("masterUrl", "https://172.28.128.4:8443/")
+              .hasFieldOrPropertyWithValue("trustCerts", true)
+              .hasFieldOrPropertyWithValue("namespace", "testns")
+              .hasFieldOrPropertyWithValue("autoOAuthToken", "token")
+              .satisfies(c -> Assertions.assertThat(c.getCaCertFile()).endsWith("testns/ca.pem".replace("/", File.separator)))
+              .satisfies(c -> Assertions.assertThat(new File(c.getCaCertFile())).isAbsolute())
+              .hasFieldOrPropertyWithValue("file", new File(kubeConfigFilePath));
+        } finally {
+          System.clearProperty("kubeconfig");
+        }
+      }
+
+      @Test
+      @DisplayName("from Service Account")
+      void configLoadedViaServiceAccount() {
+        try {
+          // Given
+          System.setProperty("kubeconfig", "/dev/null");
+          System.setProperty("kubernetes.auth.serviceAccount.token",
+              Utils.filePath(ConfigConstructorTest.class.getResource("/config-source-precedence/serviceaccount/token")));
+          System.setProperty("kubenamespace",
+              Utils.filePath(ConfigConstructorTest.class.getResource("/config-source-precedence/serviceaccount/namespace")));
+          // When
+          Config config = new Config(null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null, null,
+              null, null, null, null,
+              null,
+              null, null, null, null,
+              null, null, null,
+              null,
+              null, null, null, null, null,
+              null, null, null,
+              null, null, null,
+              null, null, null, null,
+              null, true, true);
+
+          // Then
+          assertThat(config)
+              .isNotNull()
+              .hasFieldOrPropertyWithValue("namespace", "namespace-from-mounted-serviceaccount")
+              .extracting(Config::getAutoOAuthToken)
+              .asString()
+              .contains("token-from-mounted-serviceaccount");
+        } finally {
+          System.clearProperty("kubeconfig");
+          System.clearProperty("kubernetes.auth.serviceAccount.token");
+          System.clearProperty("kubenamespace");
+        }
+      }
+    }
+
+    /*
+     * AutoConfiguration requires default values as System Property/Environment variable resolution needs specific defaults for
+     * property resolution,
+     * such as connection timeout and so on.
+     *
+     * This is not a problem as the Constructor is package private and is not exposed to the users.
+     */
+    @Nested
+    @DisplayName("(defaultValues=false)")
+    class DefaultValuesFalse {
+      @Test
+      @DisplayName("should throw exception")
+      void throwsException() {
+        try {
+          // Given
+          String kubeConfigFilePath = Utils.filePath(ConfigConstructorTest.class.getResource("/test-kubeconfig"));
+          System.setProperty("kubeconfig", kubeConfigFilePath);
+          // When
+          // Then
+          assertThatExceptionOfType(NullPointerException.class)
+              .isThrownBy(() -> new Config(null, null, null, null, null,
+                  null, null, null, null, null,
+                  null, null, null, null, null,
+                  null, null, null, null, null,
+                  null, null, null, null,
+                  null,
+                  null, null, null, null,
+                  null, null, null,
+                  null,
+                  null, null, null, null, null,
+                  null, null, null,
+                  null, null, null,
+                  null, null, null, null,
+                  null, true, false));
+        } finally {
+          System.clearProperty("kubeconfig");
+        }
+      }
+    }
+  }
+}

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigDisableAutoConfigurationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigDisableAutoConfigurationTest.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.client.http.TlsVersion;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -112,7 +111,7 @@ class ConfigDisableAutoConfigurationTest {
             .withWatchReconnectLimit(10)
             .withConnectionTimeout(1000)
             .withRequestTimeout(1000)
-            .withScaleTimeout(1000)
+            .withScaleTimeout(1000L)
             .withLoggingInterval(1000)
             .withWebsocketPingInterval(10000L)
             .withUploadRequestTimeout(1000)
@@ -214,7 +213,7 @@ class ConfigDisableAutoConfigurationTest {
             .withWatchReconnectLimit(10)
             .withConnectionTimeout(1000)
             .withRequestTimeout(1000)
-            .withScaleTimeout(1000)
+            .withScaleTimeout(1000L)
             .withLoggingInterval(1000)
             .withWebsocketPingInterval(10000L)
             .withUploadRequestTimeout(1000)
@@ -314,7 +313,7 @@ class ConfigDisableAutoConfigurationTest {
             .withWatchReconnectLimit(10)
             .withConnectionTimeout(1000)
             .withRequestTimeout(1000)
-            .withScaleTimeout(1000)
+            .withScaleTimeout(1000L)
             .withLoggingInterval(1000)
             .withWebsocketPingInterval(10000L)
             .withUploadRequestTimeout(1000)
@@ -361,7 +360,6 @@ class ConfigDisableAutoConfigurationTest {
   }
 
   @Nested
-  @Disabled("https://github.com/fabric8io/kubernetes-client/issues/6137")
   @DisplayName("With autoConfigure(false) in ConfigBuilder")
   class AutoConfigDisabledViaBuilder {
     private ConfigBuilder configBuilder;
@@ -431,7 +429,7 @@ class ConfigDisableAutoConfigurationTest {
             .withWatchReconnectLimit(10)
             .withConnectionTimeout(1000)
             .withRequestTimeout(1000)
-            .withScaleTimeout(1000)
+            .withScaleTimeout(1000L)
             .withLoggingInterval(1000)
             .withWebsocketPingInterval(10000L)
             .withUploadRequestTimeout(1000)
@@ -533,7 +531,7 @@ class ConfigDisableAutoConfigurationTest {
             .withWatchReconnectLimit(10)
             .withConnectionTimeout(1000)
             .withRequestTimeout(1000)
-            .withScaleTimeout(1000)
+            .withScaleTimeout(1000L)
             .withLoggingInterval(1000)
             .withWebsocketPingInterval(10000L)
             .withUploadRequestTimeout(1000)

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -953,7 +953,7 @@ class ConfigTest {
 
     // Then
     assertThat(emptyConfig)
-        .hasFieldOrPropertyWithValue("masterUrl", "https://kubernetes.default.svc")
+        .hasFieldOrPropertyWithValue("masterUrl", "https://kubernetes.default.svc/")
         .hasFieldOrPropertyWithValue("contexts", Collections.emptyList())
         .hasFieldOrPropertyWithValue("maxConcurrentRequests", 64)
         .hasFieldOrPropertyWithValue("maxConcurrentRequestsPerHost", 5)

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/SundrioConfigBuilderTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/SundrioConfigBuilderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class SundrioConfigBuilderTest {
+  @Test
+  void hasExpectedNumberOfFields() {
+    assertThat(Arrays.stream(SundrioConfigFluent.class.getDeclaredFields())
+        .filter(f -> !Modifier.isStatic(f.getModifiers()))
+        .collect(Collectors.toList()))
+        .withFailMessage("You've probably modified Config and SundrioConfig constructor annotated with @Buildable," +
+            "please update the ConfigFluent.copyInstance method too")
+        .hasSize(52);
+  }
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DisableAutoConfigurationIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/DisableAutoConfigurationIT.java
@@ -32,6 +32,32 @@ class DisableAutoConfigurationIT {
   KubernetesClient client;
 
   @Test
+  @DisplayName("with autoConfigure=false, then client should not load kubeconfig contents")
+  void givenConfigWithAutoConfigureDisabled_shouldNotLoadLocalKubeConfig() {
+    // Given + When
+    client = new KubernetesClientBuilder().withConfig(new ConfigBuilder()
+        .withAutoConfigure(false)
+        .withRequestRetryBackoffLimit(0)
+        .build()).build();
+
+    // Then
+    assertThat(client.getConfiguration())
+        .hasFieldOrPropertyWithValue("namespace", null)
+        .hasFieldOrPropertyWithValue("masterUrl", "https://kubernetes.default.svc/")
+        .hasFieldOrPropertyWithValue("contexts", Collections.emptyList())
+        .hasFieldOrPropertyWithValue("currentContext", null)
+        .hasFieldOrPropertyWithValue("username", null)
+        .hasFieldOrPropertyWithValue("clientCertFile", null)
+        .hasFieldOrPropertyWithValue("clientKeyFile", null)
+        .hasFieldOrPropertyWithValue("clientCertData", null)
+        .hasFieldOrPropertyWithValue("caCertFile", null)
+        .hasFieldOrPropertyWithValue("caCertData", null);
+    assertThatExceptionOfType(KubernetesClientException.class)
+        .isThrownBy(() -> client.pods().list())
+        .withMessageContaining("Operation: [list]  for kind: [Pod]  with name: [null]  in namespace: [null]  failed.");
+  }
+
+  @Test
   @DisplayName("kubernetes.disable.autoConfig=true, then client should not load kubeconfig contents")
   void givenDisableAutoConfigPropertyTrue_shouldNotLoadLocalKubeConfig() {
     try {

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -52,8 +52,8 @@ public class OpenShiftConfig extends Config {
   // dummy fields so that Builder is created correctly
   private String oapiVersion;
   private String openShiftUrl;
-  private long buildTimeout;
-  private boolean disableApiGroupCheck; //If group hasn't been explicitly set.
+  private Long buildTimeout;
+  private Boolean disableApiGroupCheck; //If group hasn't been explicitly set.
 
   //This is not meant to be used. This constructor is used only by the generated builder.
   OpenShiftConfig() {
@@ -73,22 +73,22 @@ public class OpenShiftConfig extends Config {
   @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false, refs = {
       @BuildableReference(Config.class) })
   public OpenShiftConfig(String openShiftUrl, String oapiVersion, String masterUrl, String apiVersion, String namespace,
-      boolean trustCerts, boolean disableHostnameVerification, String caCertFile, String caCertData,
+      Boolean trustCerts, Boolean disableHostnameVerification, String caCertFile, String caCertData,
       String clientCertFile,
       String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo,
       String clientKeyPassphrase,
-      String username, String password, String oauthToken, String autoOAuthToken, int watchReconnectInterval,
-      int watchReconnectLimit,
-      int connectionTimeout, int requestTimeout, long scaleTimeout, int loggingInterval,
-      int maxConcurrentRequests, int maxConcurrentRequestsPerHost, boolean http2Disable, String httpProxy,
+      String username, String password, String oauthToken, String autoOAuthToken, Integer watchReconnectInterval,
+      Integer watchReconnectLimit,
+      Integer connectionTimeout, Integer requestTimeout, Long scaleTimeout, Integer loggingInterval,
+      Integer maxConcurrentRequests, Integer maxConcurrentRequestsPerHost, Boolean http2Disable, String httpProxy,
       String httpsProxy,
       String[] noProxy, String userAgent, TlsVersion[] tlsVersions,
-      long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile,
+      Long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile,
       String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername,
       String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,
-      Map<String, String> customHeaders, int requestRetryBackoffLimit, int requestRetryBackoffInterval,
-      int uploadRequestTimeout, boolean onlyHttpWatches, long buildTimeout,
-      boolean disableApiGroupCheck, NamedContext currentContext, List<NamedContext> contexts) {
+      Map<String, String> customHeaders, Integer requestRetryBackoffLimit, Integer requestRetryBackoffInterval,
+      Integer uploadRequestTimeout, Boolean onlyHttpWatches, Long buildTimeout,
+      Boolean disableApiGroupCheck, NamedContext currentContext, List<NamedContext> contexts, Boolean autoConfigure) {
     super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData,
         clientCertFile,
         clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password,
@@ -100,7 +100,7 @@ public class OpenShiftConfig extends Config {
         impersonateExtras, oauthTokenProvider, customHeaders,
         requestRetryBackoffLimit,
         requestRetryBackoffInterval,
-        uploadRequestTimeout, onlyHttpWatches, currentContext, contexts);
+        uploadRequestTimeout, onlyHttpWatches, currentContext, contexts, autoConfigure);
     this.setOapiVersion(oapiVersion);
     this.setBuildTimeout(buildTimeout);
     this.setDisableApiGroupCheck(disableApiGroupCheck);
@@ -144,7 +144,8 @@ public class OpenShiftConfig extends Config {
         buildTimeout,
         false,
         kubernetesConfig.getCurrentContext(),
-        kubernetesConfig.getContexts());
+        kubernetesConfig.getContexts(),
+        kubernetesConfig.getAutoConfigure());
   }
 
   public static OpenShiftConfig wrap(Config config) {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/osgi/ManagedOpenShiftClient.java
@@ -131,7 +131,7 @@ public class ManagedOpenShiftClient extends NamespacedOpenShiftClientAdapter {
       builder.withOpenShiftUrl(URLUtils.join(builder.getMasterUrl(), "oapi", builder.getOapiVersion()));
     }
     if (properties.containsKey(OPENSHIFT_BUILD_TIMEOUT_SYSTEM_PROPERTY)) {
-      builder.withBuildTimeout(Integer.parseInt((String) properties.get(OPENSHIFT_BUILD_TIMEOUT_SYSTEM_PROPERTY)));
+      builder.withBuildTimeout(Long.parseLong((String) properties.get(OPENSHIFT_BUILD_TIMEOUT_SYSTEM_PROPERTY)));
     } else {
       builder.withBuildTimeout(DEFAULT_BUILD_TIMEOUT);
     }


### PR DESCRIPTION
## Description

Fix #6137 

`Config`'s autoConfigure field should behave as per expectations.

We need to make changes to ConfigBuilder and ConfigFluent in order to achieve this.
- Add a new Constructor with additional boolean arguments `autoConfigure` and   `shouldSetDefaultValues`
- Add a new package private class `SundrioConfig` that would extend `Config` for generating the Sundrio Builder for Config
- Move generated classes `ConfigBuilder` and `ConfigFluent` to `src/main/java`
   - `ConfigBuilder` would extend generated SundrioConfigBuilder and override the `build()` method by calling `disableAutoConfig()` if `autoConfigure` is not provided by the user. Earlier `ConfigBuidler` was calling `new Config()` (this was enabling auto configuration)
- Make all fields in Config and ResourceConfig classes use boxed types instead of primitive types so that we can distinguish whether user has configured them.



<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
