### PR TITLE
Fix jetty completion handling to forward failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix #6038: Support for Gradle configuration cache
 * Fix #6110: VolumeSource (and other file mode fields) in Octal are correctly interpreted
 * Fix #6215: Suppressing rejected execution exception for port forwarder
+* Fix #6197: JettyHttp client error handling improvements. 
 
 #### Improvements
 * Fix #6008: removing the optional dependency on bouncy castle

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPostTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPostTest.java
@@ -18,6 +18,8 @@ package io.fabric8.kubernetes.client.jdkhttp;
 import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.io.IOException;
+
 @SuppressWarnings("java:S2187")
 public class JdkHttpClientPostTest extends AbstractHttpPostTest {
   @Override
@@ -30,5 +32,10 @@ public class JdkHttpClientPostTest extends AbstractHttpPostTest {
     // Disabled
     // Apparently the JDK sets the Expect header to 100-Continue which is not according to spec.
     // We should consider overriding the header manually instead.
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return IOException.class;
   }
 }

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPutTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientPutTest.java
@@ -18,10 +18,17 @@ package io.fabric8.kubernetes.client.jdkhttp;
 import io.fabric8.kubernetes.client.http.AbstractHttpPutTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.io.IOException;
+
 @SuppressWarnings("java:S2187")
 public class JdkHttpClientPutTest extends AbstractHttpPutTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new JdkHttpClientFactory();
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return IOException.class;
   }
 }

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
@@ -72,7 +72,11 @@ public abstract class JettyAsyncResponseListener extends Response.Listener.Adapt
 
   @Override
   public void onComplete(Result result) {
-    asyncBodyDone.complete(null);
+    if (result.isSucceeded()) {
+      asyncBodyDone.complete(null);
+    } else {
+      asyncBodyDone.completeExceptionally(result.getRequestFailure());
+    }
   }
 
   public CompletableFuture<HttpResponse<AsyncBody>> listen(Request request) {

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
@@ -79,6 +79,11 @@ public abstract class JettyAsyncResponseListener extends Response.Listener.Adapt
     }
   }
 
+  @Override
+  public void onFailure(Response response, Throwable failure) {
+    asyncResponse.completeExceptionally(failure);
+  }
+
   public CompletableFuture<HttpResponse<AsyncBody>> listen(Request request) {
     request.send(this);
     return asyncResponse.thenApply(HttpResponse.class::cast);

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpPostTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpPostTest.java
@@ -18,10 +18,17 @@ package io.fabric8.kubernetes.client.jetty;
 import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.net.ConnectException;
+
 @SuppressWarnings("java:S2187")
 public class JettyHttpPostTest extends AbstractHttpPostTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new JettyHttpClientFactory();
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return ConnectException.class;
   }
 }

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpPutTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpPutTest.java
@@ -18,10 +18,17 @@ package io.fabric8.kubernetes.client.jetty;
 import io.fabric8.kubernetes.client.http.AbstractHttpPutTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.net.ConnectException;
+
 @SuppressWarnings("java:S2187")
 public class JettyHttpPutTest extends AbstractHttpPutTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new JettyHttpClientFactory();
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return ConnectException.class;
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPostTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPostTest.java
@@ -18,10 +18,17 @@ package io.fabric8.kubernetes.client.okhttp;
 import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.net.ConnectException;
+
 @SuppressWarnings("java:S2187")
 public class OkHttpPostTest extends AbstractHttpPostTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new OkHttpClientFactory();
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return ConnectException.class;
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPostTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPostTest.java
@@ -17,7 +17,9 @@ package io.fabric8.kubernetes.client.okhttp;
 
 import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
+import org.junit.jupiter.api.condition.OS;
 
+import java.io.InterruptedIOException;
 import java.net.ConnectException;
 
 @SuppressWarnings("java:S2187")
@@ -29,6 +31,10 @@ public class OkHttpPostTest extends AbstractHttpPostTest {
 
   @Override
   protected Class<? extends Exception> getConnectionFailedExceptionType() {
-    return ConnectException.class;
+    if (OS.WINDOWS.equals(OS.current())) {
+      return InterruptedIOException.class;
+    } else {
+      return ConnectException.class;
+    }
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPutTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPutTest.java
@@ -17,7 +17,9 @@ package io.fabric8.kubernetes.client.okhttp;
 
 import io.fabric8.kubernetes.client.http.AbstractHttpPutTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
+import org.junit.jupiter.api.condition.OS;
 
+import java.io.InterruptedIOException;
 import java.net.ConnectException;
 
 @SuppressWarnings("java:S2187")
@@ -29,6 +31,10 @@ public class OkHttpPutTest extends AbstractHttpPutTest {
 
   @Override
   protected Class<? extends Exception> getConnectionFailedExceptionType() {
-    return ConnectException.class;
+    if (OS.WINDOWS.equals(OS.current())) {
+      return InterruptedIOException.class;
+    } else {
+      return ConnectException.class;
+    }
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPutTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpPutTest.java
@@ -18,10 +18,17 @@ package io.fabric8.kubernetes.client.okhttp;
 import io.fabric8.kubernetes.client.http.AbstractHttpPutTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.net.ConnectException;
+
 @SuppressWarnings("java:S2187")
 public class OkHttpPutTest extends AbstractHttpPutTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new OkHttpClientFactory();
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return ConnectException.class;
   }
 }

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientPostTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientPostTest.java
@@ -18,11 +18,18 @@ package io.fabric8.kubernetes.client.vertx;
 import io.fabric8.kubernetes.client.http.AbstractHttpPostTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.net.ConnectException;
+
 @SuppressWarnings("java:S2187")
 public class VertxHttpClientPostTest extends AbstractHttpPostTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new VertxHttpClientFactory();
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return ConnectException.class;
   }
 
 }

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientPutTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientPutTest.java
@@ -18,10 +18,17 @@ package io.fabric8.kubernetes.client.vertx;
 import io.fabric8.kubernetes.client.http.AbstractHttpPutTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
+import java.net.ConnectException;
+
 @SuppressWarnings("java:S2187")
 public class VertxHttpClientPutTest extends AbstractHttpPutTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
     return new VertxHttpClientFactory();
+  }
+
+  @Override
+  protected Class<? extends Exception> getConnectionFailedExceptionType() {
+    return ConnectException.class;
   }
 }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/MockDispatcher.java
@@ -21,6 +21,7 @@ import io.fabric8.mockwebserver.dsl.HttpMethod;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
 
 import java.util.Collection;
 import java.util.Map;
@@ -34,6 +35,11 @@ public class MockDispatcher extends Dispatcher {
 
   public MockDispatcher(Map<ServerRequest, Queue<ServerResponse>> responses) {
     this.responses = responses;
+  }
+
+  @Override
+  public MockResponse peek() {
+    return new MockResponse().setSocketPolicy(SocketPolicy.EXPECT_CONTINUE);
   }
 
   @Override

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
@@ -23,9 +23,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,6 +52,8 @@ public abstract class AbstractHttpPostTest {
   }
 
   protected abstract HttpClient.Factory getHttpClientFactory();
+
+  protected abstract Class<? extends Exception> getConnectionFailedExceptionType();
 
   @Test
   @DisplayName("String body, should send a POST request with body")
@@ -148,4 +156,34 @@ public abstract class AbstractHttpPostTest {
           .isEqualTo("100-continue");
     }
   }
+
+  @Test
+  public void expectFailure() throws IOException, URISyntaxException {
+    try (final ServerSocket serverSocket = new ServerSocket(0);) {
+
+      try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
+        final URI uri = uriForPath(serverSocket, "/post-failing");
+        serverSocket.close();
+
+        // When
+        final CompletableFuture<HttpResponse<String>> response = client
+            .sendAsync(client.newHttpRequestBuilder()
+                .post("text/plain", new ByteArrayInputStream("A string body".getBytes(StandardCharsets.UTF_8)), -1)
+                .uri(uri)
+                .timeout(250, TimeUnit.MILLISECONDS)
+                .build(), String.class);
+
+        // Then
+        assertThat(response).failsWithin(30, TimeUnit.SECONDS)
+            .withThrowableOfType(ExecutionException.class)
+            .withCauseInstanceOf(getConnectionFailedExceptionType());
+      }
+    }
+  }
+
+  private static URI uriForPath(ServerSocket socket, String path) throws URISyntaxException {
+    final InetAddress httpServerAddress = socket.getInetAddress();
+    return new URI(String.format("http://%s:%s%s", httpServerAddress.getHostName(), socket.getLocalPort(), path));
+  }
+
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
@@ -159,7 +159,7 @@ public abstract class AbstractHttpPostTest {
 
   @Test
   public void expectFailure() throws IOException, URISyntaxException {
-    try (final ServerSocket serverSocket = new ServerSocket(0);) {
+    try (final ServerSocket serverSocket = new ServerSocket(0)) {
 
       try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
         final URI uri = uriForPath(serverSocket, "/post-failing");

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -160,7 +158,6 @@ public abstract class AbstractHttpPostTest {
   }
 
   @Test
-  @DisabledOnOs(OS.WINDOWS)
   public void expectFailure() throws IOException, URISyntaxException {
     try (final ServerSocket serverSocket = new ServerSocket(0)) {
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPostTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -158,6 +160,7 @@ public abstract class AbstractHttpPostTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   public void expectFailure() throws IOException, URISyntaxException {
     try (final ServerSocket serverSocket = new ServerSocket(0)) {
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPutTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPutTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -94,6 +96,7 @@ public abstract class AbstractHttpPutTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   public void expectFailure() throws IOException, URISyntaxException {
     try (final ServerSocket serverSocket = new ServerSocket(0)) {
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPutTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPutTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -96,7 +94,6 @@ public abstract class AbstractHttpPutTest {
   }
 
   @Test
-  @DisabledOnOs(OS.WINDOWS)
   public void expectFailure() throws IOException, URISyntaxException {
     try (final ServerSocket serverSocket = new ServerSocket(0)) {
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPutTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpPutTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractHttpPutTest {
 
   @Test
   public void expectFailure() throws IOException, URISyntaxException {
-    try (final ServerSocket serverSocket = new ServerSocket(0);) {
+    try (final ServerSocket serverSocket = new ServerSocket(0)) {
 
       try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
         final URI uri = uriForPath(serverSocket, "/put-failing");


### PR DESCRIPTION
## Description
When fixing #6143 it was observed that the Jetty client was not handling failures well. This PR fails the appropriate futures when failures are encountered.

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
