### PR TITLE
feat: add functionality to multiply Quantity by a scalar value

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/Quantity.java
@@ -408,6 +408,18 @@ public class Quantity implements Serializable, Comparable<Quantity> {
     return op(y, BigDecimal::subtract);
   }
 
+  /**
+   * Multiplies the quantity by the specified scalar multiplicand.
+   *
+   * @param multiplicand the scalar value to multiply by
+   * @return a new Quantity resulting from the multiplication of this quantity by the scalar multiplicand
+   */
+  public Quantity multiply(int multiplicand) {
+    BigDecimal numericalAmount = getNumericalAmount();
+    numericalAmount = numericalAmount.multiply(BigDecimal.valueOf(multiplicand));
+    return fromNumericalAmount(numericalAmount, format);
+  }
+
   Quantity op(Quantity y, BiFunction<BigDecimal, BigDecimal, BigDecimal> func) {
     BigDecimal numericalAmount = this.getNumericalAmount();
     numericalAmount = func.apply(numericalAmount, y.getNumericalAmount());

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/QuantityTest.java
@@ -222,4 +222,12 @@ class QuantityTest {
     Quantity quantity = new Quantity("0Mi");
     assertThat(quantity.subtract(new Quantity("1Ki"))).isEqualTo(new Quantity("-1Ki"));
   }
+
+  @Test
+  void testMultiply() {
+    Quantity quantity = new Quantity("4Gi");
+    assertThat(quantity.multiply(0)).isEqualTo(new Quantity("0"));
+    assertThat(quantity.multiply(3)).isEqualTo(new Quantity("12Gi"));
+    assertThat(quantity.multiply(-3)).isEqualTo(new Quantity("-12Gi"));
+  }
 }


### PR DESCRIPTION
## Description
The Go client has added the ability to multiply a Quantity by a scalar value: kubernetes/kubernetes#117411. I think it would be useful to have this feature in the Java client as well.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
