### PR TITLE
fix: Support for proxy authentication from proxy URL user info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #5264: Remove deprecated `Config.errorMessages` field
 * Fix #6008: removing the optional dependency on bouncy castle
 * Fix #6230: introduced Quantity.multiply(int) to allow for Quantity multiplication by an integer
+* Fix #6247: Support for proxy authentication from proxy URL user info
 * Fix #6281: use GitHub binary repo for Kube API Tests
 * Fix #6282: Allow annotated types with Pattern, Min, and Max with Lists and Maps and CRD generation
 * Fix #5480: Move `io.fabric8:zjsonpatch` to KubernetesClient project

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -123,10 +123,13 @@ public class HttpClientUtils {
     return interceptors;
   }
 
-  public static String basicCredentials(String username, String password) {
-    String usernameAndPassword = username + ":" + password;
+  public static String basicCredentials(String usernameAndPassword) {
     String encoded = Base64.getEncoder().encodeToString(usernameAndPassword.getBytes(StandardCharsets.UTF_8));
     return "Basic " + encoded;
+  }
+
+  public static String basicCredentials(String username, String password) {
+    return basicCredentials(username + ":" + password);
   }
 
   /**
@@ -227,6 +230,11 @@ public class HttpClientUtils {
 
       if (config.getProxyUsername() != null) {
         builder.proxyAuthorization(basicCredentials(config.getProxyUsername(), config.getProxyPassword()));
+      }
+
+      String userInfo = proxyUri.getUserInfo();
+      if (userInfo != null) {
+        builder.proxyAuthorization(basicCredentials(userInfo));
       }
 
       builder.proxyType(toProxyType(proxyUri.getScheme()));

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
@@ -91,6 +91,18 @@ class HttpClientUtilsTest {
   }
 
   @Test
+  void testConfigureProxyAuth() throws Exception {
+    Config config = new ConfigBuilder().withMasterUrl("http://localhost").withHttpProxy("http://user:password@192.168.0.1:8080")
+        .build();
+    Builder builder = Mockito.mock(HttpClient.Builder.class, Mockito.RETURNS_SELF);
+
+    HttpClientUtils.configureProxy(config, builder);
+
+    Mockito.verify(builder).proxyType(HttpClient.ProxyType.HTTP);
+    Mockito.verify(builder).proxyAuthorization("Basic dXNlcjpwYXNzd29yZA==");
+  }
+
+  @Test
   void testCreateApplicableInterceptors() {
     // Given
     Config config = new ConfigBuilder().build();


### PR DESCRIPTION
## Description

Uses authentication user info from proxy url. 

This support will make it much easier for keycloak to work with a proxy. @manusa will there be another 6.13 release?

cc @aboullos

closes: #6247

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
