### PR TITLE
fix: provide primitive type setters for ConfigBuilder

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
@@ -81,4 +81,71 @@ public class ConfigFluent<A extends ConfigFluent<A>> extends SundrioConfigFluent
       this.withFile(instance.getFile());
     }
   }
+
+  // Fix #https://github.com/fabric8io/kubernetes-client/issues/6249
+  // Unboxed builder methods (should allow for the co-existience of <6.13.2 and 6.13.x)
+  public A withTrustCerts(boolean trustCerts) {
+    return this.withTrustCerts(Boolean.valueOf(trustCerts));
+  }
+
+  public A withDisableHostnameVerification(boolean disableHostnameVerification) {
+    return this.withDisableHostnameVerification(Boolean.valueOf(disableHostnameVerification));
+  }
+
+  public A withWebsocketPingInterval(long websocketPingInterval) {
+    return this.withWebsocketPingInterval(Long.valueOf(websocketPingInterval));
+  }
+
+  public A withConnectionTimeout(int connectionTimeout) {
+    return this.withConnectionTimeout(Integer.valueOf(connectionTimeout));
+  }
+
+  public A withMaxConcurrentRequests(int maxConcurrentRequests) {
+    return this.withMaxConcurrentRequests(Integer.valueOf(maxConcurrentRequests));
+  }
+
+  public A withWatchReconnectInterval(int watchReconnectInterval) {
+    return this.withWatchReconnectInterval(Integer.valueOf(watchReconnectInterval));
+  }
+
+  public A withWatchReconnectLimit(int watchReconnectLimit) {
+    return this.withWatchReconnectLimit(Integer.valueOf(watchReconnectLimit));
+  }
+
+  public A withUploadRequestTimeout(int uploadRequestTimeout) {
+    return this.withUploadRequestTimeout(Integer.valueOf(uploadRequestTimeout));
+  }
+
+  public A withRequestRetryBackoffLimit(int requestRetryBackoffLimit) {
+    return this.withRequestRetryBackoffLimit(Integer.valueOf(requestRetryBackoffLimit));
+  }
+
+  public A withRequestRetryBackoffInterval(int requestRetryBackoffInterval) {
+    return this.withRequestRetryBackoffInterval(Integer.valueOf(requestRetryBackoffInterval));
+  }
+
+  public A withRequestTimeout(int requestTimeout) {
+    return this.withRequestTimeout(Integer.valueOf(requestTimeout));
+  }
+
+  public A withScaleTimeout(long scaleTimeout) {
+    return this.withScaleTimeout(Long.valueOf(scaleTimeout));
+  }
+
+  public A withLoggingInterval(int loggingInterval) {
+    return this.withLoggingInterval(Integer.valueOf(loggingInterval));
+  }
+
+  public A withHttp2Disable(boolean http2Disable) {
+    return this.withHttp2Disable(Boolean.valueOf(http2Disable));
+  }
+
+  public A withOnlyHttpWatches(boolean onlyHttpWatches) {
+    return this.withOnlyHttpWatches(Boolean.valueOf(onlyHttpWatches));
+  }
+
+  public A withAutoConfigure(boolean autoConfigure) {
+    return this.withAutoConfigure(Boolean.valueOf(autoConfigure));
+  }
+
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigBuilderTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigBuilderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigBuilderTest {
+
+  @Test
+  void withPrimitiveValues() {
+    final ConfigBuilder configBuilder = new ConfigBuilder()
+        .withAutoConfigure(false)
+        .withTrustCerts(true)
+        .withDisableHostnameVerification(true)
+        .withWebsocketPingInterval(133701)
+        .withConnectionTimeout(133702)
+        .withMaxConcurrentRequests(133703)
+        .withWatchReconnectInterval(133704)
+        .withWatchReconnectLimit(133705)
+        .withUploadRequestTimeout(133706)
+        .withRequestRetryBackoffLimit(133707)
+        .withRequestRetryBackoffInterval(133708)
+        .withRequestTimeout(133709)
+        .withScaleTimeout(133710)
+        .withLoggingInterval(133711)
+        .withHttp2Disable(true)
+        .withOnlyHttpWatches(true);
+    assertThat(configBuilder.build())
+        .hasFieldOrPropertyWithValue("autoConfigure", Boolean.FALSE)
+        .hasFieldOrPropertyWithValue("trustCerts", Boolean.TRUE)
+        .hasFieldOrPropertyWithValue("disableHostnameVerification", Boolean.TRUE)
+        .hasFieldOrPropertyWithValue("websocketPingInterval", 133701L)
+        .hasFieldOrPropertyWithValue("connectionTimeout", 133702)
+        .hasFieldOrPropertyWithValue("maxConcurrentRequests", 133703)
+        .hasFieldOrPropertyWithValue("watchReconnectInterval", 133704)
+        .hasFieldOrPropertyWithValue("watchReconnectLimit", 133705)
+        .hasFieldOrPropertyWithValue("uploadRequestTimeout", 133706)
+        .hasFieldOrPropertyWithValue("requestRetryBackoffLimit", 133707)
+        .hasFieldOrPropertyWithValue("requestRetryBackoffInterval", 133708)
+        .hasFieldOrPropertyWithValue("requestTimeout", 133709)
+        .hasFieldOrPropertyWithValue("scaleTimeout", 133710L)
+        .hasFieldOrPropertyWithValue("loggingInterval", 133711)
+        .hasFieldOrPropertyWithValue("http2Disable", Boolean.TRUE)
+        .hasFieldOrPropertyWithValue("onlyHttpWatches", Boolean.TRUE);
+  }
+
+  @Test
+  void withBoxedValues() {
+    final ConfigBuilder configBuilder = new ConfigBuilder()
+        .withAutoConfigure(Boolean.FALSE)
+        .withTrustCerts(Boolean.TRUE)
+        .withDisableHostnameVerification(Boolean.TRUE)
+        .withWebsocketPingInterval(Long.valueOf(133701))
+        .withConnectionTimeout(Integer.valueOf(133702))
+        .withMaxConcurrentRequests(Integer.valueOf(133703))
+        .withWatchReconnectInterval(Integer.valueOf(133704))
+        .withWatchReconnectLimit(Integer.valueOf(133705))
+        .withUploadRequestTimeout(Integer.valueOf(133706))
+        .withRequestRetryBackoffLimit(Integer.valueOf(133707))
+        .withRequestRetryBackoffInterval(Integer.valueOf(133708))
+        .withRequestTimeout(Integer.valueOf(133709))
+        .withScaleTimeout(Long.valueOf(133710))
+        .withLoggingInterval(Integer.valueOf(133711))
+        .withHttp2Disable(Boolean.TRUE)
+        .withOnlyHttpWatches(Boolean.TRUE);
+    assertThat(configBuilder.build())
+        .hasFieldOrPropertyWithValue("autoConfigure", false)
+        .hasFieldOrPropertyWithValue("trustCerts", true)
+        .hasFieldOrPropertyWithValue("disableHostnameVerification", true)
+        .hasFieldOrPropertyWithValue("websocketPingInterval", 133701L)
+        .hasFieldOrPropertyWithValue("connectionTimeout", 133702)
+        .hasFieldOrPropertyWithValue("maxConcurrentRequests", 133703)
+        .hasFieldOrPropertyWithValue("watchReconnectInterval", 133704)
+        .hasFieldOrPropertyWithValue("watchReconnectLimit", 133705)
+        .hasFieldOrPropertyWithValue("uploadRequestTimeout", 133706)
+        .hasFieldOrPropertyWithValue("requestRetryBackoffLimit", 133707)
+        .hasFieldOrPropertyWithValue("requestRetryBackoffInterval", 133708)
+        .hasFieldOrPropertyWithValue("requestTimeout", 133709)
+        .hasFieldOrPropertyWithValue("scaleTimeout", 133710L)
+        .hasFieldOrPropertyWithValue("loggingInterval", 133711)
+        .hasFieldOrPropertyWithValue("http2Disable", true)
+        .hasFieldOrPropertyWithValue("onlyHttpWatches", true);
+  }
+
+}


### PR DESCRIPTION
## Description

fix: provide primitive type setters for ConfigBuilder

Related to #6249

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
