### PR TITLE
test: improve reliability of mockwebserver websocket test (ws wait)

### DIFF
--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
@@ -182,7 +182,7 @@ class DefaultMockServerWebSocketTest extends Specification {
 		given: "A WebSocket expectation"
 		server.expect()
 				.withPath("/websocket")
-				.andUpgradeToWebSocket().open().done().always()
+				.andUpgradeToWebSocket().open().waitFor(10L).andEmit("done").done().always()
 		and:
 		def future = new CompletableFuture()
 		and: "A WebSocket request"
@@ -197,8 +197,9 @@ class DefaultMockServerWebSocketTest extends Specification {
 				future.complete(ws.result().headers().get("sec-websocket-protocol"))
 			}
 		}
-		if (wsReq.result() != null && wsReq.result().headers() != null) {
-			future.complete(wsReq.result().headers().get("sec-websocket-protocol"))
+		def currentResult = wsReq.result()
+		if (currentResult != null && currentResult.headers() != null) {
+			future.complete(currentResult.headers().get("sec-websocket-protocol"))
 		}
 		and: "An instance of AsyncConditions"
 		def async = new AsyncConditions(1)


### PR DESCRIPTION
## Description

test: improve reliability of mockwebserver websocket test (ws wait)

Fixes #6228

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
