### PR TITLE
doc : Update wrong exception type in Watcher `onClose` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ SecurityContextConstraints scc = new SecurityContextConstraintsBuilder()
 Use `io.fabric8.kubernetes.api.model.Event` as T for Watcher:
 
 ```java
-client.events().inAnyNamespace().watch(new Watcher<Event>() {
+client.events().inAnyNamespace().watch(new Watcher<>() {
 
   @Override
   public void eventReceived(Action action, Event resource) {
@@ -217,7 +217,7 @@ client.events().inAnyNamespace().watch(new Watcher<Event>() {
   }
 
   @Override
-  public void onClose(KubernetesClientException cause) {
+  public void onClose(WatcherException cause) {
     System.out.println("Watcher close due to " + cause);
   }
 
@@ -339,7 +339,7 @@ public void testInCrudMode() {
     assertEquals(1, podList.getItems().size());
 
     //WATCH
-    Watch watch = client.pods().inNamespace("ns1").withName("pod1").watch(new Watcher<Pod>() {
+    Watch watch = client.pods().inNamespace("ns1").withName("pod1").watch(new Watcher<>() {
         @Override
         public void eventReceived(Action action, Pod resource) {
             switch (action) {
@@ -352,7 +352,7 @@ public void testInCrudMode() {
         }
 
         @Override
-        public void onClose(KubernetesClientException cause) {
+        public void onClose(WatcherException cause) {
             closeLatch.countDown();
         }
     });


### PR DESCRIPTION
## Description
Fix #6280 

Since 6.x Watcher `onClose` has `WatcherException` argument not `KubernetesClientException`

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
