### PR TITLE
test (kubernetes-server-mock) : Add disabled tests for handing Kubernetes list types

### DIFF
--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposerTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesResponseComposerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class KubernetesResponseComposerTest {
+  private KubernetesResponseComposer kubernetesResponseComposer;
+
+  @BeforeEach
+  void setUp() {
+    kubernetesResponseComposer = new KubernetesResponseComposer();
+  }
+
+  static Stream<Arguments> composeInput() {
+    return Stream.of(
+        // https://github.com/fabric8io/kubernetes-client/issues/6220
+        //        arguments("Secret", "SecretList"),
+        arguments("", "List"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("composeInput")
+  void compose_whenKindProvidedInListItem_shouldInferListKindCorrectly(String providedKind, String parsedListKind) {
+    // Given
+    Collection<String> collection = new ArrayList<>();
+    collection.add(String.format("{\"kind\": \"%s\", \"apiVersion\": \"v1\", \"metadata\": {}}", providedKind));
+
+    // When
+    String listString = kubernetesResponseComposer.compose(collection, "1");
+
+    // Then
+    assertThat(Serialization.unmarshal(listString, KubernetesResourceList.class))
+        .hasFieldOrPropertyWithValue("kind", parsedListKind);
+  }
+}

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/crud/KubernetesCrudDispatcherGetTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/crud/KubernetesCrudDispatcherGetTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock.crud;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class KubernetesCrudDispatcherGetTest extends KubernetesCrudDispatcherTestBase {
+
+  @Nested
+  class WithNoItems {
+
+    @BeforeEach
+    void clearItems() {
+      client.resources(ConfigMap.class).delete();
+    }
+
+    @Test
+    void singleItem() {
+      assertThat(client.configMaps().withName("config-map-1").get()).isNull();
+    }
+
+    @Test
+    @Disabled("#6220: Need to figure out a way to extract the singular from the plural form in URL")
+    void multipleItems_shouldReturnListObjectWithCorrectKind() {
+      // When
+      final ConfigMapList result = client.configMaps().list();
+      // Then
+      assertThat(result)
+          .hasFieldOrPropertyWithValue("kind", "ConfigMapList")
+          .extracting(ConfigMapList::getItems)
+          .asInstanceOf(InstanceOfAssertFactories.list(ConfigMap.class))
+          .isEmpty();
+    }
+
+  }
+
+  @Nested
+  class WithValidItems {
+
+    @BeforeEach
+    void addConsistentItems() {
+      for (int it = 0; it < 5; it++) {
+        client.resource(new ConfigMapBuilder().withNewMetadata().withName("config-map-" + it).endMetadata().build())
+            .createOr(NonDeletingOperation::update);
+      }
+    }
+
+    @Test
+    void singleItem() {
+      assertThat(client.configMaps().withName("config-map-1").get())
+          .isInstanceOf(ConfigMap.class);
+    }
+
+    @Test
+    @Disabled("#6220: Need to figure out a way to extract the singular from the plural form in URL")
+    void multipleItems_shouldReturnListObjectWithCorrectKind() {
+      // When
+      final ConfigMapList result = client.configMaps().list();
+      // Then
+      assertThat(result)
+          .hasFieldOrPropertyWithValue("kind", "ConfigMapList")
+          .extracting(ConfigMapList::getItems)
+          .asInstanceOf(InstanceOfAssertFactories.list(ConfigMap.class))
+          .extracting("kind")
+          .containsOnly("ConfigMap");
+    }
+  }
+
+  @Nested
+  class WithInvalidItems {
+    @BeforeEach
+    void addInvalidItems() throws Exception {
+      client.configMaps().resource(new ConfigMapBuilder()
+          .withKind("NotConfigMap")
+          .withNewMetadata().withName("NotConfigMap").endMetadata()
+          .build())
+          .create();
+      for (int it = 0; it < 5; it++) {
+        client.resource(new ConfigMapBuilder().withNewMetadata().withName("config-map-" + it).endMetadata().build())
+            .createOr(NonDeletingOperation::update);
+      }
+      client.getHttpClient().sendAsync(client.getHttpClient().newHttpRequestBuilder()
+          .uri(server.url("/api/v1/namespaces/test/configmaps"))
+          .post("application/json", "{\"kind\":\"NotConfigMap\"}")
+          .build(), String.class)
+          .get(10, TimeUnit.SECONDS);
+    }
+
+    @BeforeEach
+    void addConsistentItems() {
+      for (int it = 0; it < 10; it++) {
+        client.resource(new ConfigMapBuilder().withNewMetadata().withName("config-map-" + it).endMetadata().build())
+            .createOr(NonDeletingOperation::update);
+      }
+    }
+
+    @Test
+    void singleItem() {
+      assertThat(client.configMaps().withName("config-map-1").get())
+          .isInstanceOf(ConfigMap.class);
+    }
+
+    @Test
+    @Disabled("#6220: Need to figure out a way to extract the singular from the plural form in URL")
+    void multipleItems_shouldReturnListObjectWithCorrectKind() {
+      // When
+      final ConfigMapList result = client.configMaps().list();
+      // Then
+      assertThat(result)
+          .hasFieldOrPropertyWithValue("kind", "ConfigMapList")
+          .extracting(ConfigMapList::getItems)
+          .asInstanceOf(InstanceOfAssertFactories.list(ConfigMap.class))
+          .extracting("kind")
+          .containsOnly("ConfigMap");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Related to #6220 

KubernetesResponseComposer should infer list type from list items instead
    of returning a hardcoded `List` kind value. Added tests to provide
    desired expectations.

<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
Signed-off-by: Rohan Kumar <rohaan@redhat.com>