### PR TITLE
feat(crd-generator): Add CRD-Generator CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 #### New Features
 * Fix #6150: Config uses `proxy-url` in kubeconfig's cluster configuration
+* Fix #5944: (crd-generator) Add CRD-Generator Maven Plugin
+* Fix #5958: (crd-generator) Add CRD-Generator CLI Application
 * Fix #5719: io.fabric8:mockwebserver is now based on Vert.x
 
 #### _**Note**_: Breaking changes

--- a/crd-generator/cli/README.md
+++ b/crd-generator/cli/README.md
@@ -1,0 +1,98 @@
+# CRD-Generator CLI
+
+Generate Custom Resource Definitions (CRD) for Kubernetes from Java classes.
+
+## Install
+
+The CRD-Generator CLI is available for download on Sonatype at the link:
+
+```
+https://oss.sonatype.org/content/repositories/releases/io/fabric8/crd-generator-cli/<version>/crd-generator-cli-<version>.sh
+```
+
+Download the latest version with the following commands:
+
+```bash
+export VERSION=$(wget -q -O - https://github.com/fabric8io/kubernetes-client/releases/latest --header "Accept: application/json" | jq -r '.tag_name' | cut -c 2-)
+wget -O crd-gen https://oss.sonatype.org/content/repositories/releases/io/fabric8/crd-generator-cli/$VERSION/crd-generator-cli-$VERSION.sh
+chmod a+x crd-gen
+./crd-gen --version
+```
+
+Alternatively, if you already have [jbang](https://www.jbang.dev/) installed, you can run the CLI by using the following command:
+
+```bash
+jbang io.fabric8:crd-generator-cli:<version>
+```
+
+## Usage
+
+```
+crd-gen [-hVv] [--force-index] [--force-scan] [--implicit-preserve-unknown-fields] [--no-parallel]
+        [-o=<outputDirectory>] [-cp=<classpathElement>]... [--exclude-package=<package>]...
+        [--include-package=<package>]... <source>...
+
+Description:
+
+Fabric8 CRD-Generator
+Generate Custom Resource Definitions (CRD) for Kubernetes from Java classes.
+
+Parameters:
+      <source>...     A directory or JAR file to scan for Custom Resource classes, or a full qualified Custom Resource
+                        class name.
+
+Options:
+  -o, --output-dir=<outputDirectory>
+                      The output directory where the CRDs are emitted.
+                        Default: .
+      -cp, --classpath=<classpathElement>
+                      Additional classpath element, e.g. a dependency packaged as JAR file or a directory of class
+                        files.
+      --force-index   Create Jandex index even if the directory or JAR file contains an existing index.
+      --force-scan    Scan directories and JAR files even if Custom Resource classes are given.
+      --no-parallel   Disable parallel generation of CRDs.
+      --implicit-preserve-unknown-fields
+                      `x-kubernetes-preserve-unknown-fields: true` will be added on objects which contain an any-setter
+                        or any-getter.
+      --include-package=<package>
+                      Filter Custom Resource classes after scanning by package inclusions.
+      --exclude-package=<package>
+                      Filter Custom Resource classes after scanning by package exclusions.
+  -v                  Verbose mode. Helpful for troubleshooting.
+                      Multiple -v options increase the verbosity.
+  -h, --help          Show this help message and exit.
+  -V, --version       Print version information and exit.
+
+Exit Codes:
+   0   Successful execution
+   1   Unexpected error
+   2   Invalid input
+  70   Custom Resource class loading failed
+  80   No Custom Resource classes retained after filtering
+```
+
+### Examples
+
+**Generate CRDs for Custom Resource classes in a directory:**
+
+```bash
+crd-gen target/classes/
+```
+
+**Generate CRDs for Custom Resource classes in a JAR file:**
+
+```bash
+crd-gen my-jar-with-custom-resources.jar
+```
+
+**Generate CRD by using a single class only:**
+
+```bash
+crd-gen -cp target/classes/ com.example.MyCustomResource
+```
+
+**Generate CRD(s) by using multiple classes:**
+
+```bash
+crd-gen -cp target/classes/ com.example.v1.MyCustomResource com.example.v2.MyCustomResource
+```

--- a/crd-generator/cli/pom.xml
+++ b/crd-generator/cli/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>crd-generator-parent</artifactId>
+    <groupId>io.fabric8</groupId>
+    <version>7.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>crd-generator-cli</artifactId>
+  <name>Fabric8 :: CRD generator :: CLI</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>crd-generator-collector</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>info.picocli</groupId>
+              <artifactId>picocli-codegen</artifactId>
+              <version>${picocli.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>io.fabric8.crd.generator.cli.CRDGeneratorCLI</mainClass>
+                </transformer>
+              </transformers>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- now make the jar chmod +x style executable -->
+      <plugin>
+        <groupId>org.skife.maven</groupId>
+        <artifactId>really-executable-jar-maven-plugin</artifactId>
+        <configuration>
+          <flags>-Xmx1G</flags>
+          <programFile>crd-gen</programFile>
+          <attachProgramFile>true</attachProgramFile>
+        </configuration>
+
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>really-executable-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/crd-generator/cli/pom.xml
+++ b/crd-generator/cli/pom.xml
@@ -45,8 +45,16 @@
     </dependency>
 
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <!-- required because parent pom declares default scope to test -->
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <!-- required because parent pom declares default scope to test -->
+      <scope>compile</scope>
     </dependency>
 
     <dependency>

--- a/crd-generator/cli/pom.xml
+++ b/crd-generator/cli/pom.xml
@@ -32,6 +32,10 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
+      <artifactId>crd-generator-api-v2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
       <artifactId>crd-generator-collector</artifactId>
     </dependency>
 

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import io.fabric8.crd.generator.collector.CustomResourceCollector;
+import io.fabric8.crdv2.generator.CRDGenerationInfo;
+import io.fabric8.crdv2.generator.CRDGenerator;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * CRD-Generator Command Line Interface.
+ */
+// spotless:off
+@CommandLine.Command(
+  name = "crd-gen",
+  description = "@|bold Fabric8 CRD-Generator|@%n" +
+  "Generate Custom Resource Definitions (CRD) for Kubernetes from Java classes.",
+  exitCodeList = {
+    " 0:Successful execution",
+    " 1:Unexpected error",
+    " 2:Invalid input",
+    "70:Custom Resource class loading failed",
+    "80:No Custom Resource classes retained after filtering"
+  },
+  helpCommand = true,
+  mixinStandardHelpOptions = true,
+  usageHelpAutoWidth = true,
+  sortOptions = false,
+  versionProvider = KubernetesClientVersionProvider.class,
+  synopsisHeading = "%nUsage:%n%n",
+  descriptionHeading = "%nDescription:%n%n",
+  parameterListHeading = "%nParameters:%n",
+  optionListHeading = "%nOptions:%n",
+  exitCodeListHeading = "%nExit Codes:%n",
+  footerHeading = "%nExamples:%n",
+  footer = "  Generate CRDs for Custom Resource classes in a directory:%n" +
+           "    @|faint ${COMMAND-NAME} target/classes/|@%n" +
+           "  Generate CRDs for Custom Resource classes in a JAR file:%n" +
+           "    @|faint ${COMMAND-NAME} my-jar-with-custom-resources.jar|@%n" +
+           "  Generate CRD by using a single class only:%n" +
+           "    @|faint ${COMMAND-NAME} -cp target/classes/ com.example.MyCustomResource|@"
+)
+// spotless:on
+public class CRDGeneratorCLI implements Runnable {
+
+  private static final Logger log = LoggerFactory.getLogger(CRDGeneratorCLI.class);
+
+  private static final CRDGenerationInfo EMPTY_INFO = new CRDGenerationInfo();
+
+  private CRDGenerationInfo crdGenerationInfo = EMPTY_INFO;
+
+  private final Set<String> customResourceClassNames = new HashSet<>();
+  private final Set<File> filesToScan = new HashSet<>();
+
+  @CommandLine.Spec
+  CommandLine.Model.CommandSpec spec;
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"-o", "--output-dir"},
+    description = "The output directory where the CRDs are emitted.",
+    showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+  )
+  // spotless:on
+  File outputDirectory = new File(".");
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"-cp", "--classpath"},
+    paramLabel = "<classpathElement>",
+    description = "Additional classpath element, e.g. a dependency packaged as JAR file or a directory of class files."
+  )
+  // spotless:on
+  List<String> classpathElements = new ArrayList<>();
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"--force-index"},
+    description = "Create Jandex index even if the directory or JAR file contains an existing index.",
+    defaultValue = "false"
+  )
+  // spotless:on
+  Boolean forceIndex;
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"--force-scan"},
+    description = "Scan directories and JAR files even if Custom Resource classes are given.",
+    defaultValue = "false"
+  )
+  // spotless:on
+  Boolean forceScan;
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"--no-parallel"},
+    description = "Disable parallel generation of CRDs.",
+    defaultValue = "false"
+  )
+  // spotless:on
+  Boolean parallelDisabled;
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"--implicit-preserve-unknown-fields"},
+    description = "`x-kubernetes-preserve-unknown-fields: true` will be added on objects which contain an any-setter or any-getter.",
+    defaultValue = "false"
+  )
+  // spotless:on
+  Boolean implicitPreserveUnknownFields;
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"--include-package"},
+    paramLabel = "<package>",
+    description = "Filter Custom Resource classes after scanning by package inclusions."
+  )
+  // spotless:on
+  List<String> includedPackages = new LinkedList<>();
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"--exclude-package"},
+    paramLabel = "<package>",
+    description = "Filter Custom Resource classes after scanning by package exclusions."
+  )
+  // spotless:on
+  List<String> excludedPackages = new LinkedList<>();
+
+  // spotless:off
+  @CommandLine.Option(
+    names = {"-v"},
+    description = "Verbose mode. Helpful for troubleshooting.\nMultiple -v options increase the verbosity."
+  )
+  // spotless:on
+  List<Boolean> verbose = new LinkedList<>();
+
+  // spotless:off
+  @CommandLine.Parameters(
+    paramLabel = "<source>",
+    arity = "1..*",
+    converter = SourceParameterTypeConverter.class,
+    description = "A directory or JAR file to scan for Custom Resource classes, or a full qualified Custom Resource class name."
+  )
+  // spotless:on
+  void setParameters(List<SourceParameter> parameters) {
+    setCustomResourceClassNames(parameters);
+    setFilesToScan(parameters);
+  }
+
+  @Override
+  public void run() {
+    LoggingConfiguration.configureLogger(verbose);
+    List<String> allClasspathElements = getClasspathElements();
+
+    log.trace("Custom Resource Class Names: {}", customResourceClassNames);
+    log.trace("Files to scan: {}", filesToScan);
+    log.trace("Classpath: {}", allClasspathElements);
+
+    CustomResourceCollector customResourceCollector = new CustomResourceCollector()
+        .withClasspathElements(allClasspathElements)
+        .withFilesToScan(filesToScan)
+        .withForceIndex(forceIndex)
+        .withForceScan(forceScan)
+        .withCustomResourceClasses(customResourceClassNames)
+        .withIncludePackages(includedPackages)
+        .withExcludePackages(excludedPackages);
+
+    List<Class<? extends HasMetadata>> customResourceClasses = customResourceCollector.findCustomResourceClasses();
+
+    if (customResourceClasses.isEmpty()) {
+      throw new CustomResourceClassNotFoundException();
+    }
+
+    log.debug("Generating CRDs for {} Custom Resource classes", customResourceClasses.size());
+
+    File sanitizedOutputDirectory;
+    try {
+      sanitizedOutputDirectory = outputDirectory.getCanonicalFile();
+    } catch (IOException e) {
+      throw new RuntimeException("Could not get canonical file for " + outputDirectory, e);
+    }
+
+    try {
+      Files.createDirectories(sanitizedOutputDirectory.toPath());
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not create output directory at " + sanitizedOutputDirectory, e);
+    }
+
+    CRDGenerator crdGenerator = new CRDGenerator()
+        .customResourceClasses(customResourceClasses)
+        .withParallelGenerationEnabled(!parallelDisabled)
+        .withImplicitPreserveUnknownFields(implicitPreserveUnknownFields)
+        .inOutputDir(sanitizedOutputDirectory);
+
+    crdGenerationInfo = crdGenerator.detailedGenerate();
+    crdGenerationInfo.getCRDDetailsPerNameAndVersion().forEach((crdName, versionToInfo) -> {
+      getOut().printf("Generated CRD %s:%n", crdName);
+      versionToInfo.forEach(
+          (version, info) -> getOut().printf(" %s -> %s%n", version, info.getFilePath()));
+    });
+  }
+
+  CRDGenerationInfo getCrdGenerationInfo() {
+    return crdGenerationInfo;
+  }
+
+  String getDiagText() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("\n");
+
+    if (!customResourceClassNames.isEmpty()) {
+      sb.append("Custom Resource class names:\n");
+      customResourceClassNames.forEach(fqcn -> sb.append(" ").append(fqcn).append("\n"));
+    }
+    if (filesToScan.isEmpty()) {
+      sb.append("Scan Paths: []\n");
+    } else {
+      sb.append("Scan Paths:\n");
+      filesToScan.forEach(f -> sb.append(" ").append(f.getPath()).append("\n"));
+    }
+
+    List<String> classpathElements = getClasspathElements();
+    if (classpathElements.isEmpty()) {
+      sb.append("Classpath: []\n");
+    } else {
+      sb.append("\nClasspath:\n");
+      classpathElements.forEach(cpe -> sb.append(" ").append(cpe).append("\n"));
+    }
+    sb.append("\n");
+    return sb.toString();
+  }
+
+  private void setCustomResourceClassNames(List<SourceParameter> source) {
+    source.stream()
+        .filter(s -> s instanceof SourceParameter.CustomResourceClass)
+        .map(SourceParameter.CustomResourceClass.class::cast)
+        .map(SourceParameter.CustomResourceClass::getCustomResourceClass)
+        .forEach(customResourceClassNames::add);
+  }
+
+  private void setFilesToScan(List<SourceParameter> source) {
+    source.stream()
+        .filter(s -> s instanceof SourceParameter.FileToScan)
+        .map(SourceParameter.FileToScan.class::cast)
+        .map(SourceParameter.FileToScan::getFileToScan)
+        .forEach(filesToScan::add);
+  }
+
+  private List<String> getClasspathElements() {
+    List<String> allClasspathElements = new LinkedList<>(classpathElements);
+    // Add files to classpath elements to improve UX of the CLI:
+    // A scan target must be always in the classpath.
+    filesToScan.stream()
+        .map(File::getPath)
+        .forEach(allClasspathElements::add);
+
+    return allClasspathElements;
+  }
+
+  private PrintWriter getOut() {
+    return spec.commandLine().getOut();
+  }
+
+  public static void main(String[] args) {
+    System.exit(exec(args));
+  }
+
+  /**
+   * Entry point for the CLI, intended to be used if embedded in other applications. In comparison
+   * to {@link #main(String[])}, <code>System.exit()</code> won't be called.
+   *
+   * @param args arguments
+   * @return the exit code
+   */
+  public static int exec(String[] args) {
+    return createCommandLine()
+        .execute(args);
+  }
+
+  static CommandLine createCommandLine() {
+    return createCommandLine(new CRDGeneratorCLI());
+  }
+
+  static CommandLine createCommandLine(CRDGeneratorCLI crdGeneratorCLI) {
+    return new CommandLine(crdGeneratorCLI)
+        .setExecutionExceptionHandler(new CRDGeneratorExecutionExceptionHandler(crdGeneratorCLI));
+  }
+
+  /**
+   * Exception to indicate that no custom resource classes
+   * have been retained after scanning and filtering.
+   */
+  static class CustomResourceClassNotFoundException extends RuntimeException {
+    CustomResourceClassNotFoundException() {
+      super("No Custom Resource class retained after filtering");
+    }
+  }
+
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
@@ -314,24 +314,4 @@ public class CRDGeneratorCLI implements Runnable {
         .setExecutionExceptionHandler(new CRDGeneratorExecutionExceptionHandler(crdGeneratorCLI));
   }
 
-  /**
-   * Exception to indicate that no custom resource classes
-   * have been retained after scanning and filtering.
-   */
-  static class CustomResourceClassNotFoundException extends CRDGeneratorCliException {
-    CustomResourceClassNotFoundException() {
-      super("No Custom Resource class retained after filtering");
-    }
-  }
-
-  private static class CRDGeneratorCliException extends RuntimeException {
-    CRDGeneratorCliException(String message) {
-      super(message);
-    }
-
-    CRDGeneratorCliException(String message, Throwable cause) {
-      super(message, cause);
-    }
-  }
-
 }

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
@@ -311,7 +311,7 @@ public class CRDGeneratorCLI implements Runnable {
 
   static CommandLine createCommandLine(CRDGeneratorCLI crdGeneratorCLI) {
     return new CommandLine(crdGeneratorCLI)
-        .setExecutionExceptionHandler(new CRDGeneratorExecutionExceptionHandler(crdGeneratorCLI));
+        .setExecutionExceptionHandler(new CRDGeneratorExecutionExceptionHandler(crdGeneratorCLI::getDiagText));
   }
 
 }

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCLI.java
@@ -232,29 +232,43 @@ public class CRDGeneratorCLI implements Runnable {
     return crdGenerationInfo;
   }
 
-  String getDiagText() {
+  /**
+   * Get details as text about the internal state.
+   * 
+   * @return the debug text.
+   */
+  String getDebugText() {
+    final String lineSeparator = System.lineSeparator();
     StringBuilder sb = new StringBuilder();
-    sb.append("\n");
+    sb.append(lineSeparator);
 
     if (!customResourceClassNames.isEmpty()) {
-      sb.append("Custom Resource class names:\n");
-      customResourceClassNames.forEach(fqcn -> sb.append(" ").append(fqcn).append("\n"));
+      sb.append("Custom Resource class names:");
+      sb.append(lineSeparator);
+      customResourceClassNames.forEach(fqcn -> sb.append(" ").append(fqcn).append(lineSeparator));
+      sb.append(lineSeparator);
     }
     if (filesToScan.isEmpty()) {
-      sb.append("Scan Paths: []\n");
+      sb.append("Scan Paths: []");
+      sb.append(lineSeparator);
     } else {
-      sb.append("Scan Paths:\n");
-      filesToScan.forEach(f -> sb.append(" ").append(f.getPath()).append("\n"));
+      sb.append("Scan Paths:");
+      sb.append(lineSeparator);
+      filesToScan.forEach(f -> sb.append(" ").append(f.getPath()).append(lineSeparator));
+      sb.append(lineSeparator);
     }
 
     List<String> allClasspathElements = getClasspathElements();
     if (allClasspathElements.isEmpty()) {
-      sb.append("Classpath: []\n");
+      sb.append("Classpath: []");
+      sb.append(lineSeparator);
     } else {
-      sb.append("\nClasspath:\n");
-      allClasspathElements.forEach(cpe -> sb.append(" ").append(cpe).append("\n"));
+      sb.append("Classpath:");
+      sb.append(lineSeparator);
+      allClasspathElements.forEach(cpe -> sb.append(" ").append(cpe).append(lineSeparator));
+      sb.append(lineSeparator);
     }
-    sb.append("\n");
+    sb.append(lineSeparator);
     return sb.toString();
   }
 
@@ -311,7 +325,7 @@ public class CRDGeneratorCLI implements Runnable {
 
   static CommandLine createCommandLine(CRDGeneratorCLI crdGeneratorCLI) {
     return new CommandLine(crdGeneratorCLI)
-        .setExecutionExceptionHandler(new CRDGeneratorExecutionExceptionHandler(crdGeneratorCLI::getDiagText));
+        .setExecutionExceptionHandler(new CRDGeneratorExecutionExceptionHandler(crdGeneratorCLI::getDebugText));
   }
 
 }

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCliException.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCliException.java
@@ -1,0 +1,11 @@
+package io.fabric8.crd.generator.cli;
+
+class CRDGeneratorCliException extends RuntimeException {
+  CRDGeneratorCliException(String message) {
+    super(message);
+  }
+
+  CRDGeneratorCliException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCliException.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorCliException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.crd.generator.cli;
 
 class CRDGeneratorCliException extends RuntimeException {

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import io.fabric8.crd.generator.collector.CustomResourceClassLoaderException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(CRDGeneratorExecutionExceptionHandler.class);
+
+  private final CRDGeneratorCLI crdGeneratorCLI;
+
+  CRDGeneratorExecutionExceptionHandler(CRDGeneratorCLI crdGeneratorCLI) {
+    this.crdGeneratorCLI = crdGeneratorCLI;
+  }
+
+  @Override
+  public int handleExecutionException(
+      Exception ex,
+      CommandLine commandLine,
+      CommandLine.ParseResult fullParseResult) {
+
+    commandLine.getErr().println(ex.getMessage());
+
+    if (ex instanceof CustomResourceClassLoaderException) {
+      commandLine.getErr().println();
+      commandLine.getErr().println("The classloader could not load the Custom Resource class.\n" +
+          "Check the list of classpath elements and add further JAR archives " +
+          "or directories containing required classes " +
+          "e.g. with `-cp my-dep.jar` or `-cp target/classes/`.");
+      commandLine.getErr().print(crdGeneratorCLI.getDiagText());
+      return CRDGeneratorExitCode.CR_CLASS_LOADING;
+    }
+
+    if (ex instanceof CRDGeneratorCLI.CustomResourceClassNotFoundException) {
+      commandLine.getErr().println();
+      commandLine.getErr().println("Check JAR files and directories considered to be scanned " +
+          "as well as your filters. At least one Custom Resource class " +
+          "must be retained after filtering.");
+      commandLine.getErr().print(crdGeneratorCLI.getDiagText());
+      return CRDGeneratorExitCode.NO_CR_CLASSES_RETAINED;
+    }
+
+    if (log.isDebugEnabled()) {
+      commandLine.getErr().println(crdGeneratorCLI.getDiagText());
+    }
+
+    log.trace(ex.getMessage(), ex);
+    return CRDGeneratorExitCode.SOFTWARE;
+  }
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
@@ -48,7 +48,7 @@ class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExc
       return CRDGeneratorExitCode.CR_CLASS_LOADING;
     }
 
-    if (ex instanceof CRDGeneratorCLI.CustomResourceClassNotFoundException) {
+    if (ex instanceof CustomResourceClassNotFoundException) {
       commandLine.getErr().println();
       commandLine.getErr().println("Check JAR files and directories considered to be scanned " +
           "as well as your filters. At least one Custom Resource class " +

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
@@ -26,10 +26,10 @@ class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExc
 
   private static final Logger log = LoggerFactory.getLogger(CRDGeneratorExecutionExceptionHandler.class);
 
-  private final Supplier<String> diagTextSupplier;
+  private final Supplier<String> debugTextSupplier;
 
-  CRDGeneratorExecutionExceptionHandler(Supplier<String> diagTextSupplier) {
-    this.diagTextSupplier = diagTextSupplier;
+  CRDGeneratorExecutionExceptionHandler(Supplier<String> debugTextSupplier) {
+    this.debugTextSupplier = debugTextSupplier;
   }
 
   @Override
@@ -42,11 +42,13 @@ class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExc
 
     if (ex instanceof CustomResourceClassLoaderException) {
       commandLine.getErr().println();
-      commandLine.getErr().println("The classloader could not load the Custom Resource class.\n" +
+      commandLine.getErr().println("The classloader could not load the Custom Resource class.");
+      commandLine.getErr().println(
           "Check the list of classpath elements and add further JAR archives " +
-          "or directories containing required classes " +
-          "e.g. with `-cp my-dep.jar` or `-cp target/classes/`.");
-      commandLine.getErr().print(diagTextSupplier.get());
+              "or directories containing required classes " +
+              "e.g. with `-cp my-dep.jar` or `-cp target/classes/`.");
+      commandLine.getErr().print(debugTextSupplier.get());
+      commandLine.getErr().flush();
       return CRDGeneratorExitCode.CR_CLASS_LOADING;
     }
 
@@ -55,15 +57,17 @@ class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExc
       commandLine.getErr().println("Check JAR files and directories considered to be scanned " +
           "as well as your filters. At least one Custom Resource class " +
           "must be retained after filtering.");
-      commandLine.getErr().print(diagTextSupplier.get());
+      commandLine.getErr().print(debugTextSupplier.get());
+      commandLine.getErr().flush();
       return CRDGeneratorExitCode.NO_CR_CLASSES_RETAINED;
     }
 
     if (log.isDebugEnabled()) {
-      commandLine.getErr().println(diagTextSupplier.get());
+      commandLine.getErr().println(debugTextSupplier.get());
     }
 
     log.trace(ex.getMessage(), ex);
+    commandLine.getErr().flush();
     return CRDGeneratorExitCode.SOFTWARE;
   }
 }

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExecutionExceptionHandler.java
@@ -20,14 +20,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
+import java.util.function.Supplier;
+
 class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExceptionHandler {
 
   private static final Logger log = LoggerFactory.getLogger(CRDGeneratorExecutionExceptionHandler.class);
 
-  private final CRDGeneratorCLI crdGeneratorCLI;
+  private final Supplier<String> diagTextSupplier;
 
-  CRDGeneratorExecutionExceptionHandler(CRDGeneratorCLI crdGeneratorCLI) {
-    this.crdGeneratorCLI = crdGeneratorCLI;
+  CRDGeneratorExecutionExceptionHandler(Supplier<String> diagTextSupplier) {
+    this.diagTextSupplier = diagTextSupplier;
   }
 
   @Override
@@ -44,7 +46,7 @@ class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExc
           "Check the list of classpath elements and add further JAR archives " +
           "or directories containing required classes " +
           "e.g. with `-cp my-dep.jar` or `-cp target/classes/`.");
-      commandLine.getErr().print(crdGeneratorCLI.getDiagText());
+      commandLine.getErr().print(diagTextSupplier.get());
       return CRDGeneratorExitCode.CR_CLASS_LOADING;
     }
 
@@ -53,12 +55,12 @@ class CRDGeneratorExecutionExceptionHandler implements CommandLine.IExecutionExc
       commandLine.getErr().println("Check JAR files and directories considered to be scanned " +
           "as well as your filters. At least one Custom Resource class " +
           "must be retained after filtering.");
-      commandLine.getErr().print(crdGeneratorCLI.getDiagText());
+      commandLine.getErr().print(diagTextSupplier.get());
       return CRDGeneratorExitCode.NO_CR_CLASSES_RETAINED;
     }
 
     if (log.isDebugEnabled()) {
-      commandLine.getErr().println(crdGeneratorCLI.getDiagText());
+      commandLine.getErr().println(diagTextSupplier.get());
     }
 
     log.trace(ex.getMessage(), ex);

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExitCode.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CRDGeneratorExitCode.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import picocli.CommandLine;
+
+class CRDGeneratorExitCode {
+
+  static final int OK = CommandLine.ExitCode.OK;
+  static final int SOFTWARE = CommandLine.ExitCode.SOFTWARE;
+  static final int USAGE = CommandLine.ExitCode.USAGE;
+  static final int CR_CLASS_LOADING = 70;
+  static final int NO_CR_CLASSES_RETAINED = 80;
+
+  private CRDGeneratorExitCode() {
+  }
+
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CustomResourceClassNotFoundException.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CustomResourceClassNotFoundException.java
@@ -1,0 +1,11 @@
+package io.fabric8.crd.generator.cli;
+
+/**
+ * Exception to indicate that no custom resource classes have been retained after scanning and
+ * filtering.
+ */
+class CustomResourceClassNotFoundException extends CRDGeneratorCliException {
+  CustomResourceClassNotFoundException() {
+    super("No Custom Resource class retained after filtering");
+  }
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CustomResourceClassNotFoundException.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/CustomResourceClassNotFoundException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.crd.generator.cli;
 
 /**

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/KubernetesClientVersionProvider.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/KubernetesClientVersionProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import io.fabric8.kubernetes.client.Version;
+import picocli.CommandLine;
+
+class KubernetesClientVersionProvider implements CommandLine.IVersionProvider {
+  @Override
+  public String[] getVersion() {
+    return new String[] { Version.clientVersion() };
+  }
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/LoggingConfiguration.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/LoggingConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Utility class to configure log levels of underlying components.
+ */
+class LoggingConfiguration {
+
+  private LoggingConfiguration() {
+  }
+
+  static void configureLogger(List<Boolean> verbose) {
+    configureLogger(getBaseLogLevel(verbose));
+  }
+
+  private static void configureLogger(LogLevel baseLogLevel) {
+    setLogLevel("io.fabric8.crd.generator.cli", baseLogLevel.toLogbackLevel());
+    setLogLevel("io.fabric8.crd.generator.collector", baseLogLevel.toLogbackLevel());
+    setLogLevel("io.fabric8.crdv2.generator", baseLogLevel.toLogbackLevel());
+  }
+
+  private static void setLogLevel(String packageName, Level level) {
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger logger = loggerContext.getLogger(packageName);
+    logger.setLevel(level);
+  }
+
+  /**
+   * Derive the base log level from a list of verbose options.
+   *
+   * @return the base log level.
+   */
+  static LogLevel getBaseLogLevel(List<Boolean> verbose) {
+    switch (verbose.size()) {
+      case 1:
+        return LogLevel.INFO;
+      case 2:
+        return LogLevel.DEBUG;
+      default:
+        if (verbose.size() >= 3) {
+          return LogLevel.TRACE;
+        } else {
+          return LogLevel.WARN;
+        }
+    }
+  }
+
+  enum LogLevel {
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE;
+
+    Level toLogbackLevel() {
+      return Level.toLevel(name());
+    }
+  }
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/LoggingConfiguration.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/LoggingConfiguration.java
@@ -15,9 +15,8 @@
  */
 package io.fabric8.crd.generator.cli;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import java.util.List;
 
@@ -34,15 +33,13 @@ class LoggingConfiguration {
   }
 
   private static void configureLogger(LogLevel baseLogLevel) {
-    setLogLevel("io.fabric8.crd.generator.cli", baseLogLevel.toLogbackLevel());
-    setLogLevel("io.fabric8.crd.generator.collector", baseLogLevel.toLogbackLevel());
-    setLogLevel("io.fabric8.crdv2.generator", baseLogLevel.toLogbackLevel());
+    setLogLevel("io.fabric8.crd.generator.cli", baseLogLevel.toLog4jLevel());
+    setLogLevel("io.fabric8.crd.generator.collector", baseLogLevel.toLog4jLevel());
+    setLogLevel("io.fabric8.crdv2.generator", baseLogLevel.toLog4jLevel());
   }
 
   private static void setLogLevel(String packageName, Level level) {
-    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-    ch.qos.logback.classic.Logger logger = loggerContext.getLogger(packageName);
-    logger.setLevel(level);
+    Configurator.setLevel(packageName, level);
   }
 
   /**
@@ -71,8 +68,8 @@ class LoggingConfiguration {
     DEBUG,
     TRACE;
 
-    Level toLogbackLevel() {
-      return Level.toLevel(name());
+    Level toLog4jLevel() {
+      return Level.valueOf(name());
     }
   }
 }

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameter.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameter.java
@@ -24,26 +24,26 @@ interface SourceParameter {
 
   class FileToScan implements SourceParameter {
 
-    private final File fileToScan;
+    private final File value;
 
-    FileToScan(File fileToScan) {
-      this.fileToScan = fileToScan;
+    FileToScan(File value) {
+      this.value = value;
     }
 
-    public File getFileToScan() {
-      return fileToScan;
+    public File getValue() {
+      return value;
     }
   }
 
   class CustomResourceClass implements SourceParameter {
-    private final String customResourceClass;
+    private final String value;
 
-    CustomResourceClass(String customResourceClass) {
-      this.customResourceClass = customResourceClass;
+    CustomResourceClass(String value) {
+      this.value = value;
     }
 
-    public String getCustomResourceClass() {
-      return customResourceClass;
+    public String getValue() {
+      return value;
     }
   }
 }

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameter.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import java.io.File;
+
+/**
+ * A positional parameter.
+ */
+interface SourceParameter {
+
+  class FileToScan implements SourceParameter {
+
+    private final File fileToScan;
+
+    FileToScan(File fileToScan) {
+      this.fileToScan = fileToScan;
+    }
+
+    public File getFileToScan() {
+      return fileToScan;
+    }
+  }
+
+  class CustomResourceClass implements SourceParameter {
+    private final String customResourceClass;
+
+    CustomResourceClass(String customResourceClass) {
+      this.customResourceClass = customResourceClass;
+    }
+
+    public String getCustomResourceClass() {
+      return customResourceClass;
+    }
+  }
+}

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameterTypeConverter.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameterTypeConverter.java
@@ -28,21 +28,23 @@ class SourceParameterTypeConverter
       "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*");
 
   private static final Pattern FQCN_PATTERN = Pattern.compile(
-      "(" + VALID_JAVA_IDENTIFIER + "\\.)*" + VALID_JAVA_IDENTIFIER);
+      "(" + VALID_JAVA_IDENTIFIER + "\\.)*+" + VALID_JAVA_IDENTIFIER);
 
+  /**
+   * Checks, if the value is a valid full qualifying class name (FQCN).
+   *
+   * @param value the input value
+   * @return <code>true</code>, if valid.
+   */
   static boolean isFQCN(String value) {
     return FQCN_PATTERN.matcher(value).matches();
   }
 
   @Override
-  public SourceParameter convert(String value) {
+  public SourceParameter convert(String value) throws IOException {
     File f = new File(value);
     if (f.exists()) {
-      try {
-        return new SourceParameter.FileToScan(f.getCanonicalFile());
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      return new SourceParameter.FileToScan(f.getCanonicalFile());
     }
 
     if (isFQCN(value)) {

--- a/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameterTypeConverter.java
+++ b/crd-generator/cli/src/main/java/io/fabric8/crd/generator/cli/SourceParameterTypeConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+class SourceParameterTypeConverter
+    implements CommandLine.ITypeConverter<SourceParameter> {
+
+  private static final Pattern VALID_JAVA_IDENTIFIER = Pattern.compile(
+      "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*");
+
+  private static final Pattern FQCN_PATTERN = Pattern.compile(
+      "(" + VALID_JAVA_IDENTIFIER + "\\.)*" + VALID_JAVA_IDENTIFIER);
+
+  static boolean isFQCN(String value) {
+    return FQCN_PATTERN.matcher(value).matches();
+  }
+
+  @Override
+  public SourceParameter convert(String value) {
+    File f = new File(value);
+    if (f.exists()) {
+      try {
+        return new SourceParameter.FileToScan(f.getCanonicalFile());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    if (isFQCN(value)) {
+      return new SourceParameter.CustomResourceClass(value);
+    }
+
+    // fail fast if invalid input can be already detected here
+    throw new IllegalArgumentException(
+        "Not an existing file or a full qualified class name.");
+  }
+}

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/CRDGeneratorCLITest.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/CRDGeneratorCLITest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CRDGeneratorCLITest {
+
+  @Test
+  void givenVersion_thenOutputVersionAndGenerateNoCRDs() {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = new CommandLine(cliApp);
+    String[] args = new String[] {
+        "--version"
+    };
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.OK, exitCode);
+    assertEquals(0, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+  }
+
+  @Test
+  void givenSingleCRClassNameFromSameClasspath_thenGenerate(@TempDir Path tempDir) {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = CRDGeneratorCLI.createCommandLine(cliApp);
+    String[] args = new String[] {
+        "-o", tempDir.toString(),
+        "io.fabric8.crd.generator.cli.examples.basic.Basic"
+    };
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.OK, exitCode);
+    assertEquals(1, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+    assertTrue(Paths.get(tempDir.toString(), "basics.sample.fabric8.io-v1.yml").toFile().exists());
+  }
+
+  @Test
+  void givenSingleCRClassNameFromExternalClasspath_thenGenerate(@TempDir Path tempDir) {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = CRDGeneratorCLI.createCommandLine(cliApp);
+    String[] args = new String[] {
+        "--classpath", "../api-v2/target/test-classes/",
+        "-o", tempDir.toString(),
+        "io.fabric8.crdv2.example.basic.Basic"
+    };
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.OK, exitCode);
+    assertEquals(1, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+    assertTrue(Paths.get(tempDir.toString(), "basics.sample.fabric8.io-v1.yml").toFile().exists());
+  }
+
+  @Test
+  void givenClassesDirectory_thenScanAndGenerate(@TempDir Path tempDir) {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = CRDGeneratorCLI.createCommandLine(cliApp);
+    String[] args = new String[] {
+        "-o", tempDir.toString(),
+        "target/test-classes/"
+    };
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.OK, exitCode);
+    assertEquals(1, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+    assertTrue(Paths.get(tempDir.toString(), "basics.sample.fabric8.io-v1.yml").toFile().exists());
+  }
+
+  @Test
+  void givenNoInput_thenFailAndGenerateNoCRDs() {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = CRDGeneratorCLI.createCommandLine(cliApp);
+    String[] args = new String[] {};
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.USAGE, exitCode);
+    assertEquals(0, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+  }
+
+  @Test
+  void givenNotExistingCRClassName_thenFailAndGenerateNoCRDs() {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = CRDGeneratorCLI.createCommandLine(cliApp);
+    String[] args = new String[] {
+        // There is also no file named like that!
+        "com.example.NotExisting"
+    };
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.CR_CLASS_LOADING, exitCode);
+    assertEquals(0, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+  }
+
+  @Test
+  void givenClassesDirectoryButFilterByPackageInclusion_thenScanAndFail(@TempDir Path tempDir) {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = CRDGeneratorCLI.createCommandLine(cliApp);
+    String[] args = new String[] {
+        "-o", tempDir.toString(),
+        "--include-package", "not.existingpackage",
+        "target/test-classes/"
+    };
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.NO_CR_CLASSES_RETAINED, exitCode);
+    assertEquals(0, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+  }
+
+  @Test
+  void givenClassesDirectoryButFilterByPackageExclusion_thenScanAndFail(@TempDir Path tempDir) {
+    CRDGeneratorCLI cliApp = new CRDGeneratorCLI();
+    CommandLine cmd = CRDGeneratorCLI.createCommandLine(cliApp);
+    String[] args = new String[] {
+        "-o", tempDir.toString(),
+        // package contains a Custom Resource class
+        "--exclude-package", "io.fabric8.crd.generator.cli.examples",
+        "target/test-classes/"
+    };
+
+    int exitCode = cmd.execute(args);
+
+    assertEquals(CRDGeneratorExitCode.NO_CR_CLASSES_RETAINED, exitCode);
+    assertEquals(0, cliApp.getCrdGenerationInfo().numberOfGeneratedCRDs());
+  }
+
+  @Test
+  void givenHelp_whenExec_thenHelp() {
+    int exitCode = CRDGeneratorCLI.exec(new String[] { "--help" });
+    assertEquals(CRDGeneratorExitCode.OK, exitCode);
+  }
+}

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/LoggingConfigurationTest.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/LoggingConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LoggingConfigurationTest {
+
+  @Test
+  void givenNoVerbosity_thenLevelWarn() {
+    LoggingConfiguration.LogLevel level = LoggingConfiguration.getBaseLogLevel(Collections.emptyList());
+    assertEquals(LoggingConfiguration.LogLevel.WARN, level);
+  }
+
+  @Test
+  void given1Verbosity_thenLevelInfo() {
+    LoggingConfiguration.LogLevel level = LoggingConfiguration.getBaseLogLevel(Collections.singletonList(true));
+
+    assertEquals(LoggingConfiguration.LogLevel.INFO, level);
+  }
+
+  @Test
+  void given2Verbosity_thenLevelDebug() {
+    LoggingConfiguration.LogLevel level = LoggingConfiguration.getBaseLogLevel(Arrays.asList(true, true));
+
+    assertEquals(LoggingConfiguration.LogLevel.DEBUG, level);
+  }
+
+  @Test
+  void given3orMoreVerbosity_thenLevelTrace() {
+    LoggingConfiguration.LogLevel level = LoggingConfiguration.getBaseLogLevel(Arrays.asList(true, true, true));
+    assertEquals(LoggingConfiguration.LogLevel.TRACE, level);
+
+    level = LoggingConfiguration.getBaseLogLevel(Arrays.asList(true, true, true, true));
+    assertEquals(LoggingConfiguration.LogLevel.TRACE, level);
+
+    level = LoggingConfiguration.getBaseLogLevel(Arrays.asList(true, true, true, true, true));
+    assertEquals(LoggingConfiguration.LogLevel.TRACE, level);
+  }
+
+}

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/SourceArgumentConverterTest.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/SourceArgumentConverterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SourceArgumentConverterTest {
+
+  @Test
+  void givenValidCustomResourceClassArgument_thenConvertToCustomResourceClassArgument() {
+    SourceParameterTypeConverter converter = new SourceParameterTypeConverter();
+    SourceParameter sourceParameter = converter.convert("com.example.MyValidClassName");
+    assertInstanceOf(SourceParameter.CustomResourceClass.class, sourceParameter);
+    SourceParameter.CustomResourceClass customResourceClassArg = (SourceParameter.CustomResourceClass) sourceParameter;
+    assertEquals("com.example.MyValidClassName", customResourceClassArg.getCustomResourceClass());
+  }
+
+  @Test
+  void givenExistingFile_thenConvertToFileToScanArgument(@TempDir File tempDir) throws IOException {
+    File exampleFile = new File(tempDir, "example-file.txt");
+    Files.write(exampleFile.toPath(), Collections.singletonList("some-content"));
+
+    SourceParameterTypeConverter converter = new SourceParameterTypeConverter();
+    SourceParameter sourceParameter = converter.convert(exampleFile.getAbsolutePath());
+    assertInstanceOf(SourceParameter.FileToScan.class, sourceParameter);
+    SourceParameter.FileToScan fileToScanArg = (SourceParameter.FileToScan) sourceParameter;
+    assertEquals(exampleFile, fileToScanArg.getFileToScan());
+  }
+
+  @Test
+  void givenNotExistingFileAndInvalidCustomResourceClass_thenFail() {
+    SourceParameterTypeConverter converter = new SourceParameterTypeConverter();
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      converter.convert("Not-Existing.txt");
+    });
+  }
+
+  @Test
+  void givenValidClassName_whenCheckFQCN_thenTrue() {
+    assertTrue(SourceParameterTypeConverter.isFQCN("MyClass"));
+    assertTrue(SourceParameterTypeConverter.isFQCN("com.MyClass"));
+    assertTrue(SourceParameterTypeConverter.isFQCN("com.example.MyClass"));
+  }
+
+  @Test
+  void givenInvalidClassName_whenCheckFQCN_thenFalse() {
+    assertFalse(SourceParameterTypeConverter.isFQCN("com.my-example.MyClass"));
+    assertFalse(SourceParameterTypeConverter.isFQCN("com.example.My-Class"));
+  }
+}

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/SourceArgumentConverterTest.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/SourceArgumentConverterTest.java
@@ -43,7 +43,7 @@ class SourceArgumentConverterTest {
 
   @Test
   void givenExistingFile_thenConvertToFileToScanArgument(@TempDir File tempDir) throws IOException {
-    File exampleFile = new File(tempDir, "example-file.txt");
+    File exampleFile = new File(tempDir, "example-file.txt").getCanonicalFile();
     Files.write(exampleFile.toPath(), Collections.singletonList("some-content"));
 
     SourceParameterTypeConverter converter = new SourceParameterTypeConverter();

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/SourceArgumentConverterTest.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/SourceArgumentConverterTest.java
@@ -32,12 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SourceArgumentConverterTest {
 
   @Test
-  void givenValidCustomResourceClassArgument_thenConvertToCustomResourceClassArgument() {
+  void givenValidCustomResourceClassArgument_thenConvertToCustomResourceClassArgument()
+      throws IOException {
     SourceParameterTypeConverter converter = new SourceParameterTypeConverter();
     SourceParameter sourceParameter = converter.convert("com.example.MyValidClassName");
     assertInstanceOf(SourceParameter.CustomResourceClass.class, sourceParameter);
     SourceParameter.CustomResourceClass customResourceClassArg = (SourceParameter.CustomResourceClass) sourceParameter;
-    assertEquals("com.example.MyValidClassName", customResourceClassArg.getCustomResourceClass());
+    assertEquals("com.example.MyValidClassName", customResourceClassArg.getValue());
   }
 
   @Test
@@ -49,7 +50,7 @@ class SourceArgumentConverterTest {
     SourceParameter sourceParameter = converter.convert(exampleFile.getAbsolutePath());
     assertInstanceOf(SourceParameter.FileToScan.class, sourceParameter);
     SourceParameter.FileToScan fileToScanArg = (SourceParameter.FileToScan) sourceParameter;
-    assertEquals(exampleFile, fileToScanArg.getFileToScan());
+    assertEquals(exampleFile, fileToScanArg.getValue());
   }
 
   @Test

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/examples/basic/Basic.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/examples/basic/Basic.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli.examples.basic;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("sample.fabric8.io")
+@Version("v1alpha1")
+public class Basic extends CustomResource<BasicSpec, BasicStatus> implements Namespaced {
+
+}

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/examples/basic/BasicSpec.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/examples/basic/BasicSpec.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli.examples.basic;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class BasicSpec {
+  private int myInt;
+
+  public int getMyInt() {
+    return myInt;
+  }
+
+  public void setMyInt(int myInt) {
+    this.myInt = myInt;
+  }
+
+  private long myLong;
+
+  public long getMyLong() {
+    return myLong;
+  }
+
+  public void setMyLong(long myLong) {
+    this.myLong = myLong;
+  }
+
+  private double myDouble;
+
+  public double getMyDouble() {
+    return myDouble;
+  }
+
+  public void setMyDouble(long myDouble) {
+    this.myDouble = myDouble;
+  }
+
+  private float myFloat;
+
+  public float getMyFloat() {
+    return myFloat;
+  }
+
+  public void setMyFloat(long myFloat) {
+    this.myFloat = myFloat;
+  }
+
+  @JsonIgnore
+  public Class<?> clazz;
+}

--- a/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/examples/basic/BasicStatus.java
+++ b/crd-generator/cli/src/test/java/io/fabric8/crd/generator/cli/examples/basic/BasicStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.cli.examples.basic;
+
+public class BasicStatus {
+  private String message;
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/crd-generator/collector/pom.xml
+++ b/crd-generator/collector/pom.xml
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>crd-generator-api-v2</artifactId>
+      <artifactId>kubernetes-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>

--- a/crd-generator/maven-plugin/pom.xml
+++ b/crd-generator/maven-plugin/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
+      <artifactId>crd-generator-api-v2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
       <artifactId>crd-generator-collector</artifactId>
     </dependency>
 

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -36,6 +36,7 @@
     <module>apt</module>
     <module>collector</module>
     <module>maven-plugin</module>
+    <module>cli</module>
     <module>test</module>
     <module>test-apt</module>
   </modules>

--- a/java-generator/cli/pom.xml
+++ b/java-generator/cli/pom.xml
@@ -80,7 +80,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
         <executions>
             <execution>
                 <phase>package</phase>
@@ -114,7 +113,6 @@
     <plugin>
         <groupId>org.skife.maven</groupId>
         <artifactId>really-executable-jar-maven-plugin</artifactId>
-        <version>2.1.1</version>
         <configuration>
             <flags>-Xmx1G</flags>
             <programFile>java-gen</programFile>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
     <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
     <slf4j.version>2.0.16</slf4j.version>
     <log4j.version>2.24.1</log4j.version>
-    <logback.version>1.3.14</logback.version>
     <lombok.version>1.18.34</lombok.version>
     <snakeyaml.version>2.8</snakeyaml.version>
     <snakeyaml.bundle.version>2.2</snakeyaml.bundle.version> <!-- Transitive Jackson -->
@@ -843,11 +842,6 @@
         <artifactId>log4j-core</artifactId>
         <version>${log4j.version}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
     <slf4j.version>2.0.16</slf4j.version>
     <log4j.version>2.24.1</log4j.version>
-    <logback.version>1.5.6</logback.version>
+    <logback.version>1.3.14</logback.version>
     <lombok.version>1.18.34</lombok.version>
     <snakeyaml.version>2.8</snakeyaml.version>
     <snakeyaml.bundle.version>2.2</snakeyaml.bundle.version> <!-- Transitive Jackson -->

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
     <jackson.bundle.version>${jackson.version}</jackson.bundle.version>
     <slf4j.version>2.0.16</slf4j.version>
     <log4j.version>2.24.1</log4j.version>
+    <logback.version>1.5.6</logback.version>
     <lombok.version>1.18.34</lombok.version>
     <snakeyaml.version>2.8</snakeyaml.version>
     <snakeyaml.bundle.version>2.2</snakeyaml.bundle.version> <!-- Transitive Jackson -->
@@ -165,6 +166,7 @@
     <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
     <nexus-staging-maven-plugin>1.7.0</nexus-staging-maven-plugin>
     <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
+    <really-executable-jar-maven-plugin.version>2.1.1</really-executable-jar-maven-plugin.version>
 
     <!-- Other options -->
     <maven.compiler.source>11</maven.compiler.source>
@@ -843,6 +845,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
         <version>${vertx.version}</version>
@@ -1049,6 +1056,10 @@
           <version>${maven.resources.plugin.version}</version>
         </plugin>
         <plugin>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven.shade.plugin.version}</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-install-plugin</artifactId>
           <version>${maven.install.plugin.version}</version>
         </plugin>
@@ -1145,6 +1156,11 @@
           <version>${gradle-api-maven-plugin.version}</version>
           <extensions>true</extensions>
         </plugin>
+        <plugin>
+          <groupId>org.skife.maven</groupId>
+          <artifactId>really-executable-jar-maven-plugin</artifactId>
+          <version>${really-executable-jar-maven-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -1206,6 +1222,7 @@
               <file>ide-config/eclipse.importorder</file>
             </importOrder>
             <removeUnusedImports/>
+            <toggleOffOn/>
           </java>
           <groovy>
             <includes>

--- a/uberjar/pom.xml
+++ b/uberjar/pom.xml
@@ -250,7 +250,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${maven.shade.plugin.version}</version>
         <executions>
           <execution>
             <id>uberjar</id>


### PR DESCRIPTION
## Description

Fixes #5958
Relates to #5950

Add CRD-Generator CLI application (using api-v2).

Usage:
```
crd-gen [-hVv] [--force-index] [--force-scan] [--implicit-preserve-unknown-fields] [--no-parallel]
        [-o=<outputDirectory>] [-cp=<classpathElement>]... [--exclude-package=<package>]...
        [--include-package=<package>]... <source>...

Description:

Fabric8 CRD-Generator
Generate Custom Resource Definitions (CRD) for Kubernetes from Java classes.

Parameters:
      <source>...     A directory or JAR file to scan for Custom Resource classes, or a full qualified Custom Resource
                        class name.

Options:
  -o, --output-dir=<outputDirectory>
                      The output directory where the CRDs are emitted.
                        Default: .
      -cp, --classpath=<classpathElement>
                      Additional classpath element, e.g. a dependency packaged as JAR file or a directory of class
                        files.
      --force-index   Create Jandex index even if the directory or JAR file contains an existing index.
      --force-scan    Scan directories and JAR files even if Custom Resource classes are given.
      --no-parallel   Disable parallel generation of CRDs.
      --implicit-preserve-unknown-fields
                      `x-kubernetes-preserve-unknown-fields: true` will be added on objects which contain an any-setter
                        or any-getter.
      --include-package=<package>
                      Filter Custom Resource classes after scanning by package inclusions.
      --exclude-package=<package>
                      Filter Custom Resource classes after scanning by package exclusions.
  -v                  Verbose mode. Helpful for troubleshooting.
                      Multiple -v options increase the verbosity.
  -h, --help          Show this help message and exit.
  -V, --version       Print version information and exit.

Exit Codes:
   0   Successful execution
   1   Unexpected error
   2   Invalid input
  70   Custom Resource class loading failed
  80   No Custom Resource classes retained after filtering

Examples:
  Generate CRDs for Custom Resource classes in a directory:
    crd-gen target/classes/
  Generate CRDs for Custom Resource classes in a JAR file:
    crd-gen my-jar-with-custom-resources.jar
  Generate CRD by using a single class only:
    crd-gen -cp target/classes/ com.example.MyCustomResource
```


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
