### PR TITLE
chore(deps): bump com.approvaltests:approvaltests from 24.3.0 to 24.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <junit.version>5.11.0</junit.version>
     <assertj.core.version>3.26.3</assertj.core.version>
     <awaitility.version>4.2.2</awaitility.version>
-    <approvaltests.version>24.3.0</approvaltests.version>
+    <approvaltests.version>24.5.0</approvaltests.version>
     <keycloak.version>25.0.5</keycloak.version><!-- Used by CRD Generator integration tests for verifications -->
     <mockito.version>4.11.0</mockito.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>


### PR DESCRIPTION
## Description

Bumps [com.approvaltests:approvaltests](https://github.com/approvals/ApprovalTests.Java) from 24.3.0 to 24.5.0.

Supersedes closes: #6255 
Relates to: https://github.com/approvals/ApprovalTests.Java/issues/546