### PR TITLE
test(openapi): isNamespaced for resources with no metadata

### DIFF
--- a/kubernetes-model-generator/openapi/maven-plugin/src/test/java/io/fabric8/kubernetes/schema/generator/model/TemplateContextTest.java
+++ b/kubernetes-model-generator/openapi/maven-plugin/src/test/java/io/fabric8/kubernetes/schema/generator/model/TemplateContextTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -95,8 +96,22 @@ class TemplateContextTest {
   }
 
   @Test
+  void hasMetadata_podSpec() {
+    final Schema<?> schema = (Schema<?>) settings.getOpenAPI().getComponents().getSchemas().get("io.k8s.api.core.v1.PodSpec");
+    templateContext = new TemplateContext(settings, new AbstractMap.SimpleEntry<>("io.k8s.api.core.v1.PodSpec", schema));
+    assertFalse(templateContext.isHasMetadata());
+  }
+
+  @Test
   void kubernetesListType() {
     assertNull(templateContext.getKubernetesListType());
+  }
+
+  @Test
+  void kubernetesListType_podList() {
+    final Schema<?> schema = (Schema<?>) settings.getOpenAPI().getComponents().getSchemas().get("io.k8s.api.core.v1.PodList");
+    templateContext = new TemplateContext(settings, new AbstractMap.SimpleEntry<>("io.k8s.api.core.v1.PodList", schema));
+    assertEquals("Pod", templateContext.getKubernetesListType());
   }
 
   @Test
@@ -123,4 +138,22 @@ class TemplateContextTest {
     assertEquals(new HashSet<>(Arrays.asList("java.util.List", "java.util.Map")), templateContext.getContext().get("imports"));
   }
 
+  @Test
+  void isNamespaced() {
+    assertTrue(templateContext.isNamespaced());
+  }
+
+  @Test
+  void isNamespaced_node() {
+    final Schema<?> schema = (Schema<?>) settings.getOpenAPI().getComponents().getSchemas().get("io.k8s.api.core.v1.Node");
+    templateContext = new TemplateContext(settings, new AbstractMap.SimpleEntry<>("io.k8s.api.core.v1.Node", schema));
+    assertFalse(templateContext.isNamespaced());
+  }
+
+  @Test
+  void isNamespaced_podSpec() {
+    final Schema<?> schema = (Schema<?>) settings.getOpenAPI().getComponents().getSchemas().get("io.k8s.api.core.v1.PodSpec");
+    templateContext = new TemplateContext(settings, new AbstractMap.SimpleEntry<>("io.k8s.api.core.v1.PodSpec", schema));
+    assertFalse(templateContext.isNamespaced());
+  }
 }


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
