### PR TITLE
fix: allowing the usage of authenticated http proxies for https

### DIFF
--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -115,7 +115,6 @@ public class JettyHttpClientBuilder
         sharedHttpClient.getAuthenticationStore()
             .addAuthentication(new BasicAuthentication(proxyUri, Authentication.ANY_REALM, userPassword[0], userPassword[1]));
       } else {
-        sharedHttpClient.getProxyConfiguration().addProxy(new HttpProxy(address, false));
         addProxyAuthInterceptor();
       }
     }

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientBuilder.java
@@ -24,18 +24,25 @@ import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.Socks4Proxy;
+import org.eclipse.jetty.client.Socks5Proxy;
+import org.eclipse.jetty.client.api.Authentication;
 import org.eclipse.jetty.client.dynamic.HttpClientTransportDynamic;
 import org.eclipse.jetty.client.http.HttpClientConnectionFactory;
 import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.http.ClientConnectionFactoryOverHTTP2;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.decodeBasicCredentials;
 
 public class JettyHttpClientBuilder
     extends StandardHttpClientBuilder<JettyHttpClient, JettyHttpClientFactory, JettyHttpClientBuilder> {
@@ -91,11 +98,26 @@ public class JettyHttpClientBuilder
         case SOCKS4:
           sharedHttpClient.getProxyConfiguration().addProxy(new Socks4Proxy(address, false));
           break;
+        case SOCKS5:
+          sharedHttpClient.getProxyConfiguration().addProxy(new Socks5Proxy(address, false));
+          break;
         default:
           throw new KubernetesClientException("Unsupported proxy type");
       }
-      sharedHttpClient.getProxyConfiguration().addProxy(new HttpProxy(address, false));
-      addProxyAuthInterceptor();
+      final String[] userPassword = decodeBasicCredentials(this.proxyAuthorization);
+      if (userPassword != null) {
+        URI proxyUri;
+        try {
+          proxyUri = new URI("http://" + proxyAddress.getHostString() + ":" + proxyAddress.getPort());
+        } catch (URISyntaxException e) {
+          throw KubernetesClientException.launderThrowable(e);
+        }
+        sharedHttpClient.getAuthenticationStore()
+            .addAuthentication(new BasicAuthentication(proxyUri, Authentication.ANY_REALM, userPassword[0], userPassword[1]));
+      } else {
+        sharedHttpClient.getProxyConfiguration().addProxy(new HttpProxy(address, false));
+        addProxyAuthInterceptor();
+      }
     }
     clientFactory.additionalConfig(sharedHttpClient, sharedWebSocketClient);
     return new JettyHttpClient(this, sharedHttpClient, sharedWebSocketClient);

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientProxyHttpsTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyHttpClientProxyHttpsTest.java
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client.okhttp;
+package io.fabric8.kubernetes.client.jetty;
 
-import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyTest;
+import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyHttpsTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("java:S2187")
-public class OkHttpClientProxyTest extends AbstractHttpClientProxyTest {
+public class JettyHttpClientProxyHttpsTest extends AbstractHttpClientProxyHttpsTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
-    return new OkHttpClientFactory();
-  }
-
-  @Override
-  protected void proxyConfigurationOtherAuthAddsRequiredHeaders() throws Exception {
-    // OkHttp uses a response intercept to add the auth proxy headers in case the original response failed
+    return new JettyHttpClientFactory();
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientProxyHttpsTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpClientProxyHttpsTest.java
@@ -15,18 +15,21 @@
  */
 package io.fabric8.kubernetes.client.okhttp;
 
-import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyTest;
+import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyHttpsTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
+import okhttp3.OkHttpClient.Builder;
 
 @SuppressWarnings("java:S2187")
-public class OkHttpClientProxyTest extends AbstractHttpClientProxyTest {
+public class OkHttpClientProxyHttpsTest extends AbstractHttpClientProxyHttpsTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
-    return new OkHttpClientFactory();
-  }
-
-  @Override
-  protected void proxyConfigurationOtherAuthAddsRequiredHeaders() throws Exception {
-    // OkHttp uses a response intercept to add the auth proxy headers in case the original response failed
+    return new OkHttpClientFactory() {
+      @Override
+      protected Builder newOkHttpClientBuilder() {
+        Builder builder = super.newOkHttpClientBuilder();
+        builder.hostnameVerifier((hostname, session) -> true);
+        return builder;
+      }
+    };
   }
 }

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientProxyHttpsTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientProxyHttpsTest.java
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client.okhttp;
+package io.fabric8.kubernetes.client.vertx;
 
-import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyTest;
+import io.fabric8.kubernetes.client.http.AbstractHttpClientProxyHttpsTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("java:S2187")
-public class OkHttpClientProxyTest extends AbstractHttpClientProxyTest {
+public class VertxHttpClientProxyHttpsTest extends AbstractHttpClientProxyHttpsTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
-    return new OkHttpClientFactory();
-  }
-
-  @Override
-  protected void proxyConfigurationOtherAuthAddsRequiredHeaders() throws Exception {
-    // OkHttp uses a response intercept to add the auth proxy headers in case the original response failed
+    return new VertxHttpClientFactory();
   }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -132,6 +132,24 @@ public class HttpClientUtils {
     return basicCredentials(username + ":" + password);
   }
 
+  public static String[] decodeBasicCredentials(String basicCredentials) {
+    if (basicCredentials == null) {
+      return null;
+    }
+    try {
+      final String encodedCredentials = basicCredentials.replaceFirst("Basic ", "");
+      final String decodedProxyAuthorization = new String(Base64.getDecoder().decode(encodedCredentials),
+          StandardCharsets.UTF_8);
+      final String[] userPassword = decodedProxyAuthorization.split(":");
+      if (userPassword.length == 2) {
+        return userPassword;
+      }
+    } catch (Exception ignored) {
+      // Ignored
+    }
+    return null;
+  }
+
   /**
    * @deprecated you should not need to call this method directly. Please create your own HttpClient.Factory
    *             should you need to customize your clients.

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientProxyHttpsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientProxyHttpsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.http;
+
+import io.fabric8.kubernetes.client.internal.SSLUtils;
+import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.DefaultMockServer;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
+import io.fabric8.mockwebserver.dsl.HttpMethod;
+import io.fabric8.mockwebserver.internal.MockDispatcher;
+import io.fabric8.mockwebserver.internal.MockSSLContextFactory;
+import io.fabric8.mockwebserver.internal.SimpleRequest;
+import io.fabric8.mockwebserver.internal.SimpleResponse;
+import io.fabric8.mockwebserver.utils.ResponseProvider;
+import okhttp3.Headers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.fabric8.kubernetes.client.utils.HttpClientUtils.basicCredentials;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractHttpClientProxyHttpsTest {
+
+  private static SocketPolicy defaultResponseSocketPolicy;
+  private static Map<ServerRequest, Queue<ServerResponse>> responses;
+  private static DefaultMockServer server;
+
+  @BeforeAll
+  static void beforeAll() {
+    defaultResponseSocketPolicy = SocketPolicy.KEEP_OPEN;
+    responses = new HashMap<>();
+    final MockWebServer okHttpMockWebServer = new MockWebServer();
+    final MockDispatcher dispatcher = new MockDispatcher(responses) {
+      @Override
+      public MockResponse peek() {
+        return new MockResponse().setSocketPolicy(defaultResponseSocketPolicy);
+      }
+    };
+    server = new DefaultMockServer(new Context(), okHttpMockWebServer, responses, dispatcher, true);
+    server.start();
+    okHttpMockWebServer.useHttps(MockSSLContextFactory.create().getSocketFactory(), true);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    server.shutdown();
+  }
+
+  protected abstract HttpClient.Factory getHttpClientFactory();
+
+  @Test
+  @DisplayName("Proxied HttpClient adds required headers to the request")
+  protected void proxyConfigurationAddsRequiredHeadersForHttps() throws Exception {
+    final AtomicReference<RecordedRequest> initialConnectRequest = new AtomicReference<>();
+    final ResponseProvider<String> bodyProvider = new ResponseProvider<String>() {
+
+      @Override
+      public String getBody(RecordedRequest request) {
+        return "";
+      }
+
+      @Override
+      public void setHeaders(Headers headers) {
+      }
+
+      @Override
+      public int getStatusCode(RecordedRequest request) {
+        defaultResponseSocketPolicy = SocketPolicy.UPGRADE_TO_SSL_AT_END; // for jetty to upgrade after the challenge
+        if (request.getHeader(StandardHttpHeaders.PROXY_AUTHORIZATION) != null) {
+          initialConnectRequest.compareAndSet(null, request);
+          return 200;
+        }
+        return 407;
+      }
+
+      @Override
+      public Headers getHeaders() {
+        return new Headers.Builder().add("Proxy-Authenticate", "Basic").build();
+      }
+
+    };
+    responses.computeIfAbsent(new SimpleRequest(HttpMethod.CONNECT, "/"), k -> new ArrayDeque<>())
+        .add(new SimpleResponse(true, bodyProvider, null, 0, TimeUnit.SECONDS));
+    // Given
+    final HttpClient.Builder builder = getHttpClientFactory().newBuilder()
+        .sslContext(null, SSLUtils.trustManagers(null, null, true, null, null))
+        .proxyAddress(new InetSocketAddress("localhost", server.getPort()))
+        .proxyAuthorization(basicCredentials("auth", "cred"));
+    try (HttpClient client = builder.build()) {
+      // When
+      client.sendAsync(client.newHttpRequestBuilder()
+          .uri(String.format("https://0.0.0.0:%s/not-found", server.getPort() + 1)).build(), String.class)
+          .get(30, TimeUnit.SECONDS);
+
+      // if it fails, then authorization was not set
+      assertThat(initialConnectRequest)
+          .doesNotHaveNullValue()
+          .hasValueMatching(r -> r.getHeader("Proxy-Authorization").equals("Basic YXV0aDpjcmVk"));
+    }
+  }
+}


### PR DESCRIPTION
## Description

Precedes (or supersedes) #6352 
Fixes #6350

This is an adaptation of #6352 with no breaking changes.

We can go forward with the changes in the HttpClient interfaces for proxy authorization credentials once this one is merged.

Please @shawkins, check everything aligns with the expected fix.

/cc @cescoffier

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
