### PR TITLE
ci : Add github action workflow for okd 4.14.0 cluster with crc

### DIFF
--- a/.github/workflows/e2e-crc-okd-tests.yml
+++ b/.github/workflows/e2e-crc-okd-tests.yml
@@ -1,0 +1,98 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: KubernetesClient E2E Tests (CRC-OKD)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'ide-config/**'
+      - '**.md'
+  schedule:
+    - cron: '0 4 * * *' # Every day at 4am
+
+concurrency:
+  group: single-instance-for-crc-okd-cluster
+  cancel-in-progress: true
+
+env:
+  IT_MODULE: kubernetes-itests
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e
+  SHELL: /bin/bash
+
+jobs:
+  openshift-kubernetes-distribution:
+    name: CRC ${{ matrix.crc }} / OKD ${{ matrix.okd }}
+    runs-on: ubuntu-24.04
+    if: github.repository == 'fabric8io/kubernetes-client'
+    strategy:
+      fail-fast: false
+      matrix:
+        # There is some problem with latest version of crc configured with okd preset. I
+        # wasn't able to run tests successfully on latest version of crc. See linked issue:
+        # https://github.com/crc-org/crc/issues/4382
+        # TODO: Update CRC version to latest when aforementioned issue gets resolved
+        # https://github.com/fabric8io/kubernetes-client/issues/6415
+        okd: [ v4.14.0 ]
+        crc: [ 2.32.0 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Install required virtualization software
+        run: |
+          sudo apt-get update
+          sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system
+          # This package may not be present depending on Ubuntu version
+          sudo apt install virtiofsd || true
+          sudo adduser $USER libvirt
+          sudo adduser $USER kvm
+          sudo usermod -a -G libvirt $USER
+      - name: Remove unwanted stuff to free up disk image
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          sudo docker image prune --all --force
+
+          sudo swapoff -a
+          sudo rm -f /mnt/swapfile
+      - name: Download CRC
+        run: |
+          wget https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/${{ matrix.crc }}/crc-linux-amd64.tar.xz
+          tar -xJf crc-linux-amd64.tar.xz
+          sudo cp crc-linux-${{ matrix.crc }}-amd64/crc /usr/local/bin/crc
+      - name: Set the crc config
+        run: |
+          crc config set preset okd
+          crc config set network-mode user
+      - name: Setup the crc
+        run: sudo -su $USER crc setup
+      - name: Start the crc
+        run: sudo -su $USER crc start
+      - name: Install Kubernetes Client
+        run: make quickly 
+      - name: Install and Run Integration Tests
+        run: sudo -su $USER ./mvnw ${MAVEN_ARGS} -Pitests -pl $IT_MODULE verify 

--- a/.github/workflows/e2e-crc-okd-tests.yml
+++ b/.github/workflows/e2e-crc-okd-tests.yml
@@ -14,15 +14,13 @@
 # limitations under the License.
 #
 
-name: KubernetesClient E2E Tests (CRC-OKD)
+name: E2E CRC-OKD Tests
 
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - 'doc/**'
-      - 'ide-config/**'
-      - '**.md'
+    paths:
+      - .github/workflows/e2e-crc-okd-tests.yml
   schedule:
     - cron: '0 4 * * *' # Every day at 4am
 
@@ -36,7 +34,7 @@ env:
   SHELL: /bin/bash
 
 jobs:
-  openshift-kubernetes-distribution:
+  e2e:
     name: CRC ${{ matrix.crc }} / OKD ${{ matrix.okd }}
     runs-on: ubuntu-24.04
     if: github.repository == 'fabric8io/kubernetes-client'
@@ -88,11 +86,11 @@ jobs:
         run: |
           crc config set preset okd
           crc config set network-mode user
-      - name: Setup the crc
+      - name: Setup CRC
         run: sudo -su $USER crc setup
-      - name: Start the crc
+      - name: Start CRC
         run: sudo -su $USER crc start
       - name: Install Kubernetes Client
-        run: make quickly 
+        run: make quickly
       - name: Install and Run Integration Tests
-        run: sudo -su $USER ./mvnw ${MAVEN_ARGS} -Pitests -pl $IT_MODULE verify 
+        run: ./mvnw ${MAVEN_ARGS} -Pitests -pl $IT_MODULE verify

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/APIVersionsIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/APIVersionsIT.java
@@ -40,7 +40,8 @@ class APIVersionsIT {
         .asInstanceOf(InstanceOfAssertFactories.list(ServerAddressByClientCIDR.class))
         .singleElement()
         .hasFieldOrPropertyWithValue("clientCIDR", "0.0.0.0/0")
-        .hasFieldOrPropertyWithValue("serverAddress",
-            String.format("%s:%d", client.getMasterUrl().getHost(), client.getMasterUrl().getPort()));
+        .extracting("serverAddress")
+        .asString()
+        .isNotBlank();
   }
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PluralizeIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/PluralizeIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -38,6 +39,10 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @RequireK8sVersionAtLeast(majorVersion = 1, minorVersion = 16)
 class PluralizeIT {
+
+  // This might be a mistake in OpenShift Aggregated Discovery API,
+  // The resource kind is ResourceAccessReview, and it's singularName is set as localresourceaccessreview
+  private static final String[] EXCEPTIONAL_SINGULAR_NAME = new String[] { "localresourceaccessreview" };
 
   @DisplayName("toPlural, should return argument's plural")
   @ParameterizedTest(name = "{index} {0}: ''{1}'' plural is ''{2}''")
@@ -66,7 +71,9 @@ class PluralizeIT {
         .map(ar -> arguments(
             ar.getKind(),
             // So far singularName field is always blank, we fall back to lower-cased kind
-            Utils.isNullOrEmpty(ar.getSingularName()) ? ar.getKind().toLowerCase(Locale.ROOT) : ar.getSingularName(),
+            Utils.isNullOrEmpty(ar.getSingularName()) || Arrays.asList(EXCEPTIONAL_SINGULAR_NAME).contains(ar.getSingularName())
+                ? ar.getKind().toLowerCase(Locale.ROOT)
+                : ar.getSingularName(),
             ar.getName()));
   }
 }

--- a/kubernetes-itests/src/test/resources/service-to-url-it-network-v1-ingress.yml
+++ b/kubernetes-itests/src/test/resources/service-to-url-it-network-v1-ingress.yml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-multiple-paths
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx-example
+  rules:
+    - host: foo.bar.com
+      http:
+        paths:
+          - path: /foo
+            pathType: Prefix
+            backend:
+              service:
+                name: svc2
+                port:
+                  number: 80
+          - path: /bar
+            pathType: Prefix
+            backend:
+              service:
+                name: s2
+                port:
+                  number: 80

--- a/kubernetes-itests/src/test/resources/service-to-url-it-network-v1-ingress.yml
+++ b/kubernetes-itests/src/test/resources/service-to-url-it-network-v1-ingress.yml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
## Description

Add workflow for OKD 4.14.0 for running Fabric8 Kubernetes Client E2E tests.

+ We create crc cluster with a custom okd preset, that creates a cluster based on [OpenShift Kubernetes Distribution](https://okd.io/)
+ CRC version is bound to OKD, for future upgrades we would need to bump CRC version.
+ I managed to get it working with CRC 2.32.0, I couldn't get it working with latest version of CRC, I've created https://github.com/crc-org/crc/issues/4382 on crc repository
+ Update existing tests for running on OpenShift Kubernetes Distribution 4.x:
   - add support for handing `networking.k8s.io/v1` Ingress in ServiceToURLIT, replace deprecated methods
   - Add an exception to PluralizeIT for `ResourceAccessReview` resource, OpenShift Aggregated Discovery API is returning `singularName` for this resource as `localresourceaccessreview`, that does not match test expectations
   - Relax assertion check in ApiVersionsIT to not match exact hostname for server address

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
Signed-off-by: Rohan Kumar <rohaan@redhat.com>