### PR TITLE
fix: adds an additional printer column annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #6214: Java generator does not recognize fields in CRDs other than metadata, spec, and status
 
 #### Improvements
+* Fix #3069: added AdditionalPrinterColumn type annotation to completely specify additional printer columns
 * Fix #5264: Remove deprecated `Config.errorMessages` field
 * Fix #6008: removing the optional dependency on bouncy castle
 * Fix #6407: sundrio builder-annotations is not available via bom import

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractCustomResourceHandler.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractCustomResourceHandler.java
@@ -46,7 +46,7 @@ public abstract class AbstractCustomResourceHandler {
 
   protected void handlePrinterColumns(AbstractJsonSchema<?, ?> resolver, PrinterColumnHandler handler) {
     TreeMap<String, AnnotationMetadata> sortedCols = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    resolver.getAdditionalPrinterColumns().forEach(apc -> sortedCols.put(apc.path(), new AnnotationMetadata(apc, null)));
+    resolver.getAdditionalPrinterColumns().forEach(apc -> sortedCols.put(apc.jsonPath(), new AnnotationMetadata(apc, null)));
     sortedCols.putAll(resolver.getAllPaths(PrinterColumn.class));
     sortedCols.forEach((path, property) -> {
       if (property.annotation instanceof AdditionalPrinterColumn) {

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema.SchemaAddition
 import com.fasterxml.jackson.module.jsonSchema.types.ReferenceSchema;
 import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
 import com.fasterxml.jackson.module.jsonSchema.types.ValueTypeSchema;
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn;
 import io.fabric8.crd.generator.annotation.PreserveUnknownFields;
 import io.fabric8.crd.generator.annotation.PrinterColumn;
 import io.fabric8.crd.generator.annotation.SchemaFrom;
@@ -93,6 +94,7 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
   private ResolvingContext resolvingContext;
   private T root;
   private Set<String> dependentClasses = new HashSet<>();
+  private Set<AdditionalPrinterColumn> additionalPrinterColumns = new HashSet<>();
 
   public static class AnnotationMetadata {
     public final Annotation annotation;
@@ -141,6 +143,8 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
   private T resolveRoot(Class<?> definition) {
     InternalSchemaSwaps schemaSwaps = new InternalSchemaSwaps();
     JsonSchema schema = resolvingContext.toJsonSchema(definition);
+    consumeRepeatingAnnotation(definition, AdditionalPrinterColumn.class,
+        additionalPrinterColumns::add);
     if (schema instanceof GeneratorObjectSchema) {
       return resolveObject(new LinkedHashMap<>(), schemaSwaps, schema, "kind", "apiVersion", "metadata");
     }
@@ -597,5 +601,9 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
   protected abstract void addToValidationRules(T schema, List<V> validationRules);
 
   protected abstract T raw();
+
+  public Set<AdditionalPrinterColumn> getAdditionalPrinterColumns() {
+    return additionalPrinterColumns;
+  }
 
 }

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/CustomResourceHandler.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/CustomResourceHandler.java
@@ -69,6 +69,11 @@ public class CustomResourceHandler extends AbstractCustomResourceHandler {
     handlePrinterColumns(resolver, new PrinterColumnHandler() {
       @Override
       public void addPrinterColumn(String path, String column, String format, int priority, String type, String description) {
+        if (Utils.isNullOrEmpty(column)) {
+          column = path.substring(path.lastIndexOf(".") + 1).toUpperCase();
+        }
+        description = Utils.isNotNullOrEmpty(description) ? description : null;
+
         builder.addNewAdditionalPrinterColumn()
             .withType(type)
             .withName(column)

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/joke/JokeRequest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/joke/JokeRequest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crdv2.example.joke;
 
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -24,6 +25,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("samples.javaoperatorsdk.io")
 @Version("v1alpha1")
 @ShortNames("jr")
+@AdditionalPrinterColumn(name = "Age", path = ".metadata.creationTimestamp", getType = "date")
 public class JokeRequest extends CustomResource<JokeRequestSpec, JokeRequestStatus> implements Namespaced {
 
 }

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/joke/JokeRequest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/joke/JokeRequest.java
@@ -26,7 +26,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("samples.javaoperatorsdk.io")
 @Version("v1alpha1")
 @ShortNames("jr")
-@AdditionalPrinterColumn(name = "Age", path = ".metadata.creationTimestamp", type = Type.DATE)
+@AdditionalPrinterColumn(name = "Age", jsonPath = ".metadata.creationTimestamp", type = Type.DATE)
 public class JokeRequest extends CustomResource<JokeRequestSpec, JokeRequestStatus> implements Namespaced {
 
 }

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/joke/JokeRequest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/joke/JokeRequest.java
@@ -16,6 +16,7 @@
 package io.fabric8.crdv2.example.joke;
 
 import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn;
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn.Type;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -25,7 +26,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("samples.javaoperatorsdk.io")
 @Version("v1alpha1")
 @ShortNames("jr")
-@AdditionalPrinterColumn(name = "Age", path = ".metadata.creationTimestamp", getType = "date")
+@AdditionalPrinterColumn(name = "Age", path = ".metadata.creationTimestamp", type = Type.DATE)
 public class JokeRequest extends CustomResource<JokeRequestSpec, JokeRequestStatus> implements Namespaced {
 
 }

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CRDGeneratorTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CRDGeneratorTest.java
@@ -387,18 +387,23 @@ class CRDGeneratorTest {
       // printer columns should be ordered in the alphabetical order of their json path
       final List<CustomResourceColumnDefinition> printerColumns = version
           .getAdditionalPrinterColumns();
-      assertEquals(3, printerColumns.size());
+      assertEquals(4, printerColumns.size());
       CustomResourceColumnDefinition columnDefinition = printerColumns.get(0);
+      assertEquals("date", columnDefinition.getType());
+      assertEquals(".metadata.creationTimestamp", columnDefinition.getJsonPath());
+      assertEquals("Age", columnDefinition.getName());
+      assertEquals(0, columnDefinition.getPriority());
+      columnDefinition = printerColumns.get(1);
       assertEquals("string", columnDefinition.getType());
       assertEquals(".spec.category", columnDefinition.getJsonPath());
       assertEquals("jokeCategory", columnDefinition.getName());
       assertEquals(1, columnDefinition.getPriority());
-      columnDefinition = printerColumns.get(1);
+      columnDefinition = printerColumns.get(2);
       assertEquals("string", columnDefinition.getType());
       assertEquals(".spec.excluded", columnDefinition.getJsonPath());
       assertEquals("excludedTopics", columnDefinition.getName());
       assertEquals(0, columnDefinition.getPriority());
-      columnDefinition = printerColumns.get(2);
+      columnDefinition = printerColumns.get(3);
       assertEquals("string", columnDefinition.getType());
       assertEquals(".status.category", columnDefinition.getJsonPath());
       assertEquals("jokeCategory", columnDefinition.getName());

--- a/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
+++ b/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
@@ -22,27 +22,73 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines an additional printer column. Must be placed at the root of the custom resource.
+ * Defines an additional printer column. Must be placed at the root of the
+ * custom resource.
  */
 @Repeatable(AdditionalPrinterColumns.class)
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AdditionalPrinterColumn {
 
+  //https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#type
+  enum Type {
+
+    STRING("string"),
+    INTEGER("integer"),
+    NUMBER("number"),
+    BOOLEAN("boolean"),
+    DATE("date");
+
+    public final String value;
+
+    Type(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
+  // https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#format
+  enum Format {
+
+    NONE(""),
+    INT32("int32"),
+    INT64("int64"),
+    FLOAT("float"),
+    DOUBLE("double"),
+    BYTE("byte"),
+    DATE("date"),
+    DATE_TIME("date-time"),
+    PASSWORD("password");
+
+    public final String value;
+
+    Format(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
   /**
-   * The name of the column.
-   * An empty column name implies the use of the last path element
+   * The name of the column. An empty column name implies the use of the last path
+   * element
    *
-   * @return the column name, or empty string if the last path element should be used.
+   * @return the column name, or empty string if the last path element should be
+   *         used.
    */
   String name() default "";
 
   /**
    * The printer column format.
    *
-   * @return the format or empty string if no format is specified.
+   * @return the format or NONE if no format is specified.
    */
-  String format() default "";
+  Format format() default Format.NONE;
 
   /**
    * The printer column priority.
@@ -63,7 +109,7 @@ public @interface AdditionalPrinterColumn {
    * 
    * @return the type
    */
-  String getType();
+  Type type() default Type.STRING;
 
   /**
    * The description of the printer column

--- a/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
+++ b/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
@@ -102,7 +102,7 @@ public @interface AdditionalPrinterColumn {
    * 
    * @return
    */
-  String path();
+  String jsonPath();
 
   /**
    * The type of the printer column

--- a/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
+++ b/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines an additional printer column. Must be placed at the root of the custom resource.
+ */
+@Repeatable(AdditionalPrinterColumns.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdditionalPrinterColumn {
+
+  /**
+   * The name of the column.
+   * An empty column name implies the use of the last path element
+   *
+   * @return the column name, or empty string if the last path element should be used.
+   */
+  String name() default "";
+
+  /**
+   * The printer column format.
+   *
+   * @return the format or empty string if no format is specified.
+   */
+  String format() default "";
+
+  /**
+   * The printer column priority.
+   *
+   * @return the priority or 0 if no priority is specified.
+   */
+  int priority() default 0;
+
+  /**
+   * The JSON Path to the field
+   * 
+   * @return
+   */
+  String path();
+
+  /**
+   * The type of the printer column
+   * 
+   * @return the type
+   */
+  String getType();
+
+  /**
+   * The description of the printer column
+   * 
+   * @return the description
+   */
+  String getDescription() default "";
+}

--- a/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumns.java
+++ b/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumns.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A container for multiple {@link AdditionalPrinterColumn}s
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdditionalPrinterColumns {
+  AdditionalPrinterColumn[] value();
+}


### PR DESCRIPTION
## Description

closes: #3069

I believe the is the most straight-foward appraoch to adding general additional printer columns.

Other thoughts:
- we could reuse the existing PrinterColumn annotation. However I didn't like about that is that it mixes the usage models, so the javadocs / validations would need to be more extensive.
- allow the annotation to appear in other places. I think we'd at least need to auto-prefix the paths with the current path within the structure - we do have that as we're navigating over the object model. This can be easily added later if needed.
- it's not being extensively validated. For example we could check that the path provided is valid / actually exists.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
