### PR TITLE
fix: removing provided scope from the managed builder-annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Improvements
 * Fix #5264: Remove deprecated `Config.errorMessages` field
 * Fix #6008: removing the optional dependency on bouncy castle
+* Fix #6407: sundrio builder-annotations is not available via bom import
 * Fix #6230: introduced Quantity.multiply(int) to allow for Quantity multiplication by an integer
 * Fix #6281: use GitHub binary repo for Kube API Tests
 * Fix #6282: Allow annotated types with Pattern, Min, and Max with Lists and Maps and CRD generation

--- a/extensions/certmanager/client/pom.xml
+++ b/extensions/certmanager/client/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/certmanager/model-v1/pom.xml
+++ b/extensions/certmanager/model-v1/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/certmanager/model-v1alpha2/pom.xml
+++ b/extensions/certmanager/model-v1alpha2/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/certmanager/model-v1alpha3/pom.xml
+++ b/extensions/certmanager/model-v1alpha3/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/certmanager/model-v1beta1/pom.xml
+++ b/extensions/certmanager/model-v1beta1/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/chaosmesh/client/pom.xml
+++ b/extensions/chaosmesh/client/pom.xml
@@ -79,6 +79,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/chaosmesh/model/pom.xml
+++ b/extensions/chaosmesh/model/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/istio/client/pom.xml
+++ b/extensions/istio/client/pom.xml
@@ -55,6 +55,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/istio/model-v1alpha3/pom.xml
+++ b/extensions/istio/model-v1alpha3/pom.xml
@@ -53,6 +53,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/istio/model-v1beta1/pom.xml
+++ b/extensions/istio/model-v1beta1/pom.xml
@@ -50,6 +50,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/knative/client/pom.xml
+++ b/extensions/knative/client/pom.xml
@@ -55,6 +55,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/client/pom.xml
+++ b/extensions/open-cluster-management/client/pom.xml
@@ -111,6 +111,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-agent/pom.xml
+++ b/extensions/open-cluster-management/model-agent/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-apps/pom.xml
+++ b/extensions/open-cluster-management/model-apps/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-cluster/pom.xml
+++ b/extensions/open-cluster-management/model-cluster/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-discovery/pom.xml
+++ b/extensions/open-cluster-management/model-discovery/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-observability/pom.xml
+++ b/extensions/open-cluster-management/model-observability/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-operator/pom.xml
+++ b/extensions/open-cluster-management/model-operator/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-placementruleapps/pom.xml
+++ b/extensions/open-cluster-management/model-placementruleapps/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-policy/pom.xml
+++ b/extensions/open-cluster-management/model-policy/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-cluster-management/model-search/pom.xml
+++ b/extensions/open-cluster-management/model-search/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-virtual-networking/client/pom.xml
+++ b/extensions/open-virtual-networking/client/pom.xml
@@ -79,6 +79,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/open-virtual-networking/model-v1/pom.xml
+++ b/extensions/open-virtual-networking/model-v1/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/tekton/client/pom.xml
+++ b/extensions/tekton/client/pom.xml
@@ -55,6 +55,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/tekton/model-triggers-v1alpha1/pom.xml
+++ b/extensions/tekton/model-triggers-v1alpha1/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/tekton/model-triggers-v1beta1/pom.xml
+++ b/extensions/tekton/model-triggers-v1beta1/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/tekton/model-v1/pom.xml
+++ b/extensions/tekton/model-v1/pom.xml
@@ -43,6 +43,7 @@
       <dependency>
         <groupId>io.sundr</groupId>
         <artifactId>builder-annotations</artifactId>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>io.sundr</groupId>

--- a/extensions/tekton/model-v1alpha1/pom.xml
+++ b/extensions/tekton/model-v1alpha1/pom.xml
@@ -43,6 +43,7 @@
       <dependency>
         <groupId>io.sundr</groupId>
         <artifactId>builder-annotations</artifactId>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>io.sundr</groupId>

--- a/extensions/tekton/model-v1beta1/pom.xml
+++ b/extensions/tekton/model-v1beta1/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/verticalpodautoscaler/client/pom.xml
+++ b/extensions/verticalpodautoscaler/client/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/verticalpodautoscaler/model-v1/pom.xml
+++ b/extensions/verticalpodautoscaler/model-v1/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/volcano/client/pom.xml
+++ b/extensions/volcano/client/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/volcano/model-v1beta1/pom.xml
+++ b/extensions/volcano/model-v1beta1/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/volumesnapshot/client/pom.xml
+++ b/extensions/volumesnapshot/client/pom.xml
@@ -78,6 +78,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/extensions/volumesnapshot/model/pom.xml
+++ b/extensions/volumesnapshot/model/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/java-generator/core/pom.xml
+++ b/java-generator/core/pom.xml
@@ -50,7 +50,6 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
-      <version>${sundrio.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -170,6 +170,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -86,6 +86,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/kubernetes-model-generator/pom.xml
+++ b/kubernetes-model-generator/pom.xml
@@ -106,6 +106,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>

--- a/openshift-client-api/pom.xml
+++ b/openshift-client-api/pom.xml
@@ -116,6 +116,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -746,7 +746,6 @@
         <groupId>io.sundr</groupId>
         <artifactId>builder-annotations</artifactId>
         <version>${sundrio.version}</version>
-        <scope>provided</scope>
         <exclusions>
           <exclusion>
             <groupId>com.sun</groupId>


### PR DESCRIPTION
## Description
closes: #6407

The other approach is to introduce another pom that has all of the managed dependencies so that our root pom (or vice versa) can default the scope to provided. However this seems like a much larger change.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
