### PR TITLE
ci: make javadoc with multiple threads

### DIFF
--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -50,4 +50,4 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Check Java Docs
-        run: ./mvnw ${MAVEN_ARGS} clean install javadoc:jar -DskipTests -Pjavadoc-test
+        run: make javadoc

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ sonar: clean
 	# $(MAVEN_ARGS) ---> -T 1C won't work with sonar analysis (yet)
 	mvn -Psonar install sonar:sonar
 
+.PHONY: javadoc
+javadoc: clean
+	mvn $(MAVEN_ARGS) install javadoc:jar -DskipTests -Pjavadoc-test
+
 .PHONY: format-license
 format-license:
 	mvn $(MAVEN_ARGS) -N license:format
@@ -68,6 +72,9 @@ format-license:
 .PHONY: format-java
 format-java:
 	mvn $(MAVEN_ARGS) spotless:apply -Pitests
+
+.PHONY: format
+format: format-license format-java
 
 .PHONY:
 quickly: clean


### PR DESCRIPTION
## Description

ci: make javadoc with multiple threads

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
