### PR TITLE
feat(mockwebserver): io.fabric8:mockwebserver has full support for HTTP/2

### DIFF
--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/http/ByteString.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/http/ByteString.java
@@ -21,7 +21,8 @@ import java.util.Objects;
 /**
  * Compatibility layer for OkHttp.
  *
- * @deprecated
+ * @deprecated used as parameter in {@link WebSocketListener} and {@link WebSocket}.
+ *             Alternative methods provided in those classes should be used instead.
  */
 public class ByteString {
 


### PR DESCRIPTION
## Description

Tests to ensure HTTP/2 is supported in the MockWebServer.

Closes #4193 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
