### PR TITLE
test:refactor: tests use KubernetesMockServer and EnableKubernetesMockClient

### DIFF
--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/agent/KlusterletAddonConfigTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/agent/KlusterletAddonConfigTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class KlusterletAddonConfigTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/ApplicationTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/ApplicationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ApplicationTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/ChannelTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/ChannelTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ChannelTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/GitOpsClusterTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/GitOpsClusterTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class GitOpsClusterTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/HelmReleaseTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/HelmReleaseTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class HelmReleaseTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/PlacementRuleTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/PlacementRuleTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class PlacementRuleTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/SubscriptionTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/apps/SubscriptionTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class SubscriptionTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/ManagedClusterSetBindingTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/ManagedClusterSetBindingTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ManagedClusterSetBindingTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/ManagedClusterSetTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/ManagedClusterSetTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ManagedClusterSetTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/ManagedClusterTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/ManagedClusterTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ManagedClusterTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/PlacementDecisionTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/PlacementDecisionTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class PlacementDecisionTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/PlacementTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/cluster/PlacementTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class PlacementTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/crud/ManagedClusterCrudTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/crud/ManagedClusterCrudTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient(crud = true)
 class ManagedClusterCrudTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/discovery/DiscoveredClusterTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/discovery/DiscoveredClusterTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class DiscoveredClusterTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/discovery/DiscoveryConfigTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/discovery/DiscoveryConfigTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class DiscoveryConfigTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/observability/MultiClusterObservabilityTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/observability/MultiClusterObservabilityTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class MultiClusterObservabilityTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/observability/ObservabilityAddonTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/observability/ObservabilityAddonTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ObservabilityAddonTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/operator/ClusterManagerTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/operator/ClusterManagerTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ClusterManagerTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/operator/KlusterletTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/operator/KlusterletTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class KlusterletTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/operator/MultiClusterHubTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/operator/MultiClusterHubTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class MultiClusterHubTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/policy/PlacementBindingTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/policy/PlacementBindingTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class PlacementBindingTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/policy/PolicyAutomationTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/policy/PolicyAutomationTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class PolicyAutomationTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/policy/PolicyTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/policy/PolicyTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class PolicyTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/search/SearchCustomizationTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/search/SearchCustomizationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class SearchCustomizationTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/search/SearchOperationTest.java
+++ b/extensions/open-cluster-management/tests/src/test/java/io/fabric8/openclustermanagement/test/search/SearchOperationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class SearchOperatorTest {
   private OpenClusterManagementClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/AdaptTest.java
+++ b/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/AdaptTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class AdaptTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @ParameterizedTest(name = "when server does not support {0}, then adapt = {1}")
   @CsvSource(value = {

--- a/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/AdminPolicyBasedExternalRouteTest.java
+++ b/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/AdminPolicyBasedExternalRouteTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class AdminPolicyBasedExternalRouteTest {
   private OpenVirtualNetworkingClient ovnClient;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressFirewallTest.java
+++ b/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressFirewallTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class EgressFirewallTest {
   private OpenVirtualNetworkingClient ovnClient;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressIPTest.java
+++ b/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressIPTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class EgressIPTest {
   private OpenVirtualNetworkingClient ovnClient;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressQoSTest.java
+++ b/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressQoSTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class EgressQoSTest {
   private OpenVirtualNetworkingClient ovnClient;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressServiceTest.java
+++ b/extensions/open-virtual-networking/tests/src/test/java/io/fabric8/ovn/client/mock/EgressServiceTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class EgressServiceTest {
   private OpenVirtualNetworkingClient ovnClient;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/ExpectationsTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/ExpectationsTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Kubernetes Mock Server Expectations")
 class ExpectationsTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
   private HttpClient httpClient;
   private HttpRequest.Builder request;

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class KubernetesMockServerTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @BeforeEach

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerStaticTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerStaticTests.java
@@ -15,14 +15,16 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OpenShiftMockServerExtensionClientAndServerStaticTests {
-  private static OpenShiftMockServer openShiftMockServer;
+  private static KubernetesMockServer openShiftMockServer;
   private static OpenShiftClient openShiftClient;
 
   @Test

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionClientAndServerTests.java
@@ -15,15 +15,17 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OpenShiftMockServerExtensionClientAndServerTests {
-  private OpenShiftMockServer openShiftMockServer;
-  private OpenShiftClient openShiftClient;
+  KubernetesMockServer openShiftMockServer;
+  OpenShiftClient openShiftClient;
 
   @Test
   void testMockServerAndClientAreInitialized() {

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionStaticTests.java
@@ -16,12 +16,13 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class OpenShiftMockServerExtensionStaticTests {
   static OpenShiftClient openShiftClient;
 

--- a/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
+++ b/junit/openshift-server-mock/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftMockServerExtensionTests.java
@@ -16,12 +16,13 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class OpenShiftMockServerExtensionTests {
   OpenShiftClient client;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/APIServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/APIServiceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient
 class APIServiceTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIDriverTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIDriverTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class CSIDriverTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSINodeTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSINodeTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class CSINodeTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIStorageCapacityTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIStorageCapacityTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class CSIStorageCapacityTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ControllerRevisionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ControllerRevisionTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class ControllerRevisionTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/FlowSchemaTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class FlowSchemaTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MixedCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MixedCrudTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MixedCrudTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @BeforeEach

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
@@ -46,7 +46,7 @@ class PodExecTest {
   private static PodStatus READY = new PodStatusBuilder().addNewCondition().withType("Ready").withStatus("True").endCondition()
       .build();
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @BeforeEach

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodSchedulingContextTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodSchedulingContextTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class PodSchedulingContextTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityLevelConfigurationTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class PriorityLevelConfigurationTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTemplateTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ResourceClaimTemplateTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ResourceClaimTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClassTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ResourceClassTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SelfSubjectReviewTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @EnableKubernetesMockClient
 class SelfSubjectReviewTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create_whenInvoked_shouldReturnObjectWithUpdatedStatus() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1Beta1SelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1Beta1SelfSubjectReviewTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @EnableKubernetesMockClient
 class V1Beta1SelfSubjectReviewTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create_whenInvoked_shouldReturnObjectWithUpdatedStatus() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CSIStorageCapacityTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CSIStorageCapacityTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class V1CSIStorageCapacityTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CronJobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CronJobTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient
 class V1CronJobTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EndpointSliceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EndpointSliceTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableKubernetesMockClient
 class V1EndpointSliceTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class V1EventsTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void testList() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1FlowSchemaTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class V1FlowSchemaTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PodDisruptionBudgetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PodDisruptionBudgetTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient
 class V1PodDisruptionBudgetTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityLevelConfigurationTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class V1PriorityLevelConfigurationTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1SelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1SelfSubjectReviewTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @EnableKubernetesMockClient
 class V1SelfSubjectReviewTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create_whenInvoked_shouldReturnObjectWithUpdatedStatus() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyBindingTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class V1ValidatingAdmissionPolicyBindingTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class V1ValidatingAdmissionPolicyTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class V1beta1EventsTest {
   private KubernetesClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void testList() {

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1ValidatingAdmissionPolicyBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1ValidatingAdmissionPolicyBindingTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class V1beta1ValidatingAdmissionPolicyBindingTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1ValidatingAdmissionPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1ValidatingAdmissionPolicyTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class V1beta1ValidatingAdmissionPolicyTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2FlowSchemaTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class V1beta2FlowSchemaTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2PriorityLevelConfigurationTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class V1beta2PriorityLevelConfigurationTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3FlowSchemaTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class V1beta3FlowSchemaTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3PriorityLevelConfigurationTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class V1beta3PriorityLevelConfigurationTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ValidatingAdmissionPolicyBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ValidatingAdmissionPolicyBindingTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class ValidatingAdmissionPolicyBindingTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ValidatingAdmissionPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ValidatingAdmissionPolicyTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @EnableKubernetesMockClient
 class ValidatingAdmissionPolicyTest {
 
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VisitResourcesTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VisitResourcesTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnableKubernetesMockClient
 class VisitResourcesTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttachmentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttachmentTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @EnableKubernetesMockClient
 class VolumeAttachmentTest {
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
   private KubernetesClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/APIRequestCountTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/APIRequestCountTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.miscellaneous.apiserver.v1.APIRequestCount;
 import io.fabric8.openshift.api.model.miscellaneous.apiserver.v1.APIRequestCountBuilder;
 import io.fabric8.openshift.api.model.miscellaneous.apiserver.v1.APIRequestCountList;
@@ -27,10 +29,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class APIRequestCountTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AlertmanagerConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AlertmanagerConfigTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.monitoring.v1alpha1.AlertmanagerConfig;
 import io.fabric8.openshift.api.model.monitoring.v1alpha1.AlertmanagerConfigBuilder;
 import io.fabric8.openshift.api.model.monitoring.v1alpha1.AlertmanagerConfigList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class AlertmanagerConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AuthenticationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AuthenticationTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.Authentication;
 import io.fabric8.openshift.api.model.config.v1.AuthenticationBuilder;
 import io.fabric8.openshift.api.model.config.v1.AuthenticationList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class AuthenticationTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BareMetalHostTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BareMetalHostTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.BareMetalHost;
 import io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.BareMetalHostBuilder;
 import io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.BareMetalHostList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class BareMetalHostTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BrokerTemplateInstanceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BrokerTemplateInstanceTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.BrokerTemplateInstance;
 import io.fabric8.openshift.api.model.BrokerTemplateInstanceBuilder;
 import io.fabric8.openshift.api.model.BrokerTemplateInstanceList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class BrokerTemplateInstanceTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.fabric8.openshift.api.model.BuildConfigList;
@@ -25,7 +26,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class BuildConfigCrudTest {
   OpenShiftClient client;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
@@ -17,6 +17,8 @@ package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildBuilder;
 import io.fabric8.openshift.api.model.BuildConfig;
@@ -42,10 +44,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class BuildConfigTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CatalogSourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CatalogSourceTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.CatalogSource;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.CatalogSourceBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.CatalogSourceList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class CatalogSourceTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CloudCredentialTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CloudCredentialTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.v1.CloudCredential;
 import io.fabric8.openshift.api.model.operator.v1.CloudCredentialBuilder;
 import io.fabric8.openshift.api.model.operator.v1.CloudCredentialList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class CloudCredentialTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterAutoscalerTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.autoscaling.v1.ClusterAutoscaler;
 import io.fabric8.openshift.api.model.autoscaling.v1.ClusterAutoscalerBuilder;
 import io.fabric8.openshift.api.model.autoscaling.v1.ClusterAutoscalerList;
@@ -26,9 +28,9 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterAutoscalerTest {
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
   private OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterCSIDriverTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterCSIDriverTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.v1.ClusterCSIDriver;
 import io.fabric8.openshift.api.model.operator.v1.ClusterCSIDriverBuilder;
 import io.fabric8.openshift.api.model.operator.v1.ClusterCSIDriverList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterCSIDriverTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterResourceQuotaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterResourceQuotaTest.java
@@ -17,6 +17,8 @@ package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceQuotaSpecBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.ClusterResourceQuota;
 import io.fabric8.openshift.api.model.ClusterResourceQuotaBuilder;
 import io.fabric8.openshift.api.model.ClusterResourceQuotaList;
@@ -32,10 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterResourceQuotaTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterRoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterRoleTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.ClusterRole;
 import io.fabric8.openshift.api.model.ClusterRoleBuilder;
 import io.fabric8.openshift.api.model.ClusterRoleList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterRoleTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterServiceVersionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterServiceVersionTest.java
@@ -15,16 +15,18 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.ClusterServiceVersion;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterServiceVersionTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void testLoad() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConfigTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.v1.Config;
 import io.fabric8.openshift.api.model.operator.v1.ConfigBuilder;
 import io.fabric8.openshift.api.model.operator.v1.ConfigList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleLinkTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleLinkTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.console.v1.ConsoleLink;
 import io.fabric8.openshift.api.model.console.v1.ConsoleLinkBuilder;
 import io.fabric8.openshift.api.model.console.v1.ConsoleLinkList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ConsoleLinkTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsolePluginTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsolePluginTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.console.v1.ConsolePlugin;
 import io.fabric8.openshift.api.model.console.v1.ConsolePluginBuilder;
 import io.fabric8.openshift.api.model.console.v1.ConsolePluginList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ConsolePluginTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleQuickStartTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleQuickStartTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.console.v1.ConsoleQuickStart;
 import io.fabric8.openshift.api.model.console.v1.ConsoleQuickStartBuilder;
 import io.fabric8.openshift.api.model.console.v1.ConsoleQuickStartList;
@@ -27,10 +29,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ConsoleQuickStartTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.Console;
 import io.fabric8.openshift.api.model.config.v1.ConsoleBuilder;
 import io.fabric8.openshift.api.model.config.v1.ConsoleList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ConsoleTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ContainerRuntimeConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ContainerRuntimeConfigTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.ContainerRuntimeConfig;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.ContainerRuntimeConfigBuilder;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.ContainerRuntimeConfigList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ContainerRuntimeConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControllerConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControllerConfigTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.InfrastructureBuilder;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.ControllerConfig;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.ControllerConfigBuilder;
@@ -27,10 +29,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ControllerConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CredentialsRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CredentialsRequestTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.miscellaneous.cloudcredential.v1.CredentialsRequest;
 import io.fabric8.openshift.api.model.miscellaneous.cloudcredential.v1.CredentialsRequestBuilder;
 import io.fabric8.openshift.api.model.miscellaneous.cloudcredential.v1.CredentialsRequestList;
@@ -27,10 +29,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class CredentialsRequestTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSRecordTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSRecordTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.ingress.v1.DNSRecord;
 import io.fabric8.openshift.api.model.operator.ingress.v1.DNSRecordBuilder;
 import io.fabric8.openshift.api.model.operator.ingress.v1.DNSRecordList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class DNSRecordTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.DNS;
 import io.fabric8.openshift.api.model.config.v1.DNSBuilder;
 import io.fabric8.openshift.api.model.config.v1.DNSList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class DNSTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigCrudTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigList;
@@ -27,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class DeploymentConfigCrudTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -23,6 +23,8 @@ import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.InputStreamPumper;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -49,10 +51,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class DeploymentConfigTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EgressRouterTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EgressRouterTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.network.v1.EgressRouter;
 import io.fabric8.openshift.api.model.operator.network.v1.EgressRouterBuilder;
 import io.fabric8.openshift.api.model.operator.network.v1.EgressRouterList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class EgressRouterTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EtcdTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EtcdTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.v1.Etcd;
 import io.fabric8.openshift.api.model.operator.v1.EtcdBuilder;
 import io.fabric8.openshift.api.model.operator.v1.EtcdList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class EtcdTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/FeatureGateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/FeatureGateTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.FeatureGate;
 import io.fabric8.openshift.api.model.config.v1.FeatureGateBuilder;
 import io.fabric8.openshift.api.model.config.v1.FeatureGateList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class FeatureGateTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
@@ -17,6 +17,8 @@ package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.Group;
 import io.fabric8.openshift.api.model.GroupBuilder;
 import io.fabric8.openshift.api.model.GroupList;
@@ -31,15 +33,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class GroupTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   NamespacedOpenShiftClient client;
 
   @BeforeEach
   void setUp() {
-    client = server.createOpenShiftClient();
+    client = server.createClient().adapt(NamespacedOpenShiftClient.class);
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/HelmChartRepositoryTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/HelmChartRepositoryTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.miscellaneous.helm.v1beta1.HelmChartRepository;
 import io.fabric8.openshift.api.model.miscellaneous.helm.v1beta1.HelmChartRepositoryBuilder;
 import io.fabric8.openshift.api.model.miscellaneous.helm.v1beta1.HelmChartRepositoryList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class HelmChartRepositoryTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IPPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IPPoolTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPPool;
 import io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPPoolBuilder;
 import io.fabric8.openshift.api.model.whereabouts.v1alpha1.IPPoolList;
@@ -27,10 +29,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class IPPoolTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IdentityTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IdentityTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.Identity;
 import io.fabric8.openshift.api.model.IdentityBuilder;
 import io.fabric8.openshift.api.model.IdentityList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class IdentityTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageContentSourcePolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageContentSourcePolicyTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.v1alpha1.ImageContentSourcePolicy;
 import io.fabric8.openshift.api.model.operator.v1alpha1.ImageContentSourcePolicyBuilder;
 import io.fabric8.openshift.api.model.operator.v1alpha1.ImageContentSourcePolicyList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImageContentSourcePolicyTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageDigestMirrorSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageDigestMirrorSetTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ImageDigestMirrorSetTest {
   private OpenShiftClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImagePrunerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImagePrunerTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.imageregistry.v1.ImagePruner;
 import io.fabric8.openshift.api.model.operator.imageregistry.v1.ImagePrunerBuilder;
 import io.fabric8.openshift.api.model.operator.imageregistry.v1.ImagePrunerList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImagePrunerTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageRegistryOperatorConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageRegistryOperatorConfigTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.imageregistry.v1.Config;
 import io.fabric8.openshift.api.model.operator.imageregistry.v1.ConfigBuilder;
 import io.fabric8.openshift.api.model.operator.imageregistry.v1.ConfigList;
@@ -27,10 +29,10 @@ import java.text.ParseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImageRegistryOperatorConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() throws ParseException {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageSignatureTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageSignatureTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.ImageSignature;
 import io.fabric8.openshift.api.model.ImageSignatureBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -25,10 +27,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImageSignatureTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImageTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImageTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.ImageStreamImage;
 import io.fabric8.openshift.api.model.ImageStreamImageBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -24,10 +26,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImageStreamImageTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImportTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImportTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.ImageStreamImport;
 import io.fabric8.openshift.api.model.ImageStreamImportBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -24,10 +26,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImageStreamImportTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamMappingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamMappingTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.ImageStreamMapping;
 import io.fabric8.openshift.api.model.ImageStreamMappingBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -24,10 +26,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImageStreamMappingTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamTagCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamTagCrudTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.openshift.api.model.ImageStreamTag;
 import io.fabric8.openshift.api.model.ImageStreamTagBuilder;
 import io.fabric8.openshift.api.model.ImageStreamTagList;
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class ImageStreamTagCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(ImageStreamTagCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagMirrorSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagMirrorSetTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class ImageTagMirrorSetTest {
   private OpenShiftClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.ImageTag;
 import io.fabric8.openshift.api.model.ImageTagBuilder;
 import io.fabric8.openshift.api.model.ImageTagList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ImageTagTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.Ingress;
 import io.fabric8.openshift.api.model.config.v1.IngressBuilder;
 import io.fabric8.openshift.api.model.config.v1.IngressList;
@@ -28,10 +30,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class IngressTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void load() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubeletConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubeletConfigTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.KubeletConfig;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.KubeletConfigBuilder;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.KubeletConfigList;
@@ -27,10 +29,10 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class KubeletConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubernetesOperationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubernetesOperationTest.java
@@ -18,16 +18,18 @@ package io.fabric8.openshift.client.server.mock;
 import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class KubernetesOperationTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineAutoscalerTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.autoscaling.v1beta1.MachineAutoscaler;
 import io.fabric8.openshift.api.model.autoscaling.v1beta1.MachineAutoscalerBuilder;
 import io.fabric8.openshift.api.model.autoscaling.v1beta1.MachineAutoscalerList;
@@ -26,9 +28,9 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class MachineAutoscalerTest {
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
   private OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigPoolTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.MachineConfigPool;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.MachineConfigPoolBuilder;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.MachineConfigPoolList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class MachineConfigPoolTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.MachineConfig;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.MachineConfigBuilder;
 import io.fabric8.openshift.api.model.machineconfiguration.v1.MachineConfigList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class MachineConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineHealthCheckTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineHealthCheckTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.machine.v1beta1.MachineHealthCheck;
 import io.fabric8.openshift.api.model.machine.v1beta1.MachineHealthCheckBuilder;
 import io.fabric8.openshift.api.model.machine.v1beta1.MachineHealthCheckList;
@@ -28,10 +30,10 @@ import java.text.ParseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class MachineHealthCheckTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() throws ParseException {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineSetTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.machine.v1beta1.MachineSet;
 import io.fabric8.openshift.api.model.machine.v1beta1.MachineSetBuilder;
 import io.fabric8.openshift.api.model.machine.v1beta1.MachineSetList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class MachineSetTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.machine.v1beta1.Machine;
 import io.fabric8.openshift.api.model.machine.v1beta1.MachineBuilder;
@@ -29,10 +31,10 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class MachineTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() throws IOException {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkAttachmentDefinitionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkAttachmentDefinitionTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.miscellaneous.cncf.cni.v1.NetworkAttachmentDefinition;
 import io.fabric8.openshift.api.model.miscellaneous.cncf.cni.v1.NetworkAttachmentDefinitionBuilder;
 import io.fabric8.openshift.api.model.miscellaneous.cncf.cni.v1.NetworkAttachmentDefinitionList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class NetworkAttachmentDefinitionTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.Network;
 import io.fabric8.openshift.api.model.config.v1.NetworkBuilder;
 import io.fabric8.openshift.api.model.config.v1.NetworkList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class NetworkTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientAuthorizationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientAuthorizationTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.OAuthClientAuthorization;
 import io.fabric8.openshift.api.model.OAuthClientAuthorizationBuilder;
 import io.fabric8.openshift.api.model.OAuthClientAuthorizationList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OAuthClientAuthorizationTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.OAuthClient;
 import io.fabric8.openshift.api.model.OAuthClientBuilder;
 import io.fabric8.openshift.api.model.OAuthClientList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OAuthClientTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OLMConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OLMConfigTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableKubernetesMockClient
 class OLMConfigTest {
   private OpenShiftClient client;
-  private KubernetesMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftVersionInfoTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftVersionInfoTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.client.VersionInfo;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.ClusterVersionBuilder;
 import io.fabric8.openshift.api.model.config.v1.ClusterVersionList;
 import io.fabric8.openshift.api.model.config.v1.ClusterVersionListBuilder;
@@ -28,9 +30,9 @@ import java.text.SimpleDateFormat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OpenShiftVersionInfoTest {
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.RoleBinding;
 import io.fabric8.openshift.api.model.RoleBindingBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -23,10 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OpenshiftRoleBindingTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   private RoleBinding expectedRoleBinding = new RoleBindingBuilder()

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.Role;
 import io.fabric8.openshift.api.model.RoleBuilder;
 import io.fabric8.openshift.api.model.RoleList;
@@ -27,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OpenshiftRoleTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorConditionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorConditionTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.ConditionBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorCondition;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorConditionBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorConditionList;
@@ -27,10 +29,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OperatorConditionTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorPKITest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorPKITest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.network.v1.OperatorPKI;
 import io.fabric8.openshift.api.model.operator.network.v1.OperatorPKIBuilder;
 import io.fabric8.openshift.api.model.operator.network.v1.OperatorPKIList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OperatorPKITest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operatorhub.v1.Operator;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OperatorTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OverlappingRangeIPReservationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OverlappingRangeIPReservationTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.whereabouts.v1alpha1.OverlappingRangeIPReservation;
 import io.fabric8.openshift.api.model.whereabouts.v1alpha1.OverlappingRangeIPReservationBuilder;
 import io.fabric8.openshift.api.model.whereabouts.v1alpha1.OverlappingRangeIPReservationList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class OverlappingRangeIPReservationTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PackageManifestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PackageManifestTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operatorhub.packages.v1.PackageManifest;
 import io.fabric8.openshift.api.model.operatorhub.packages.v1.PackageManifestBuilder;
 import io.fabric8.openshift.api.model.operatorhub.packages.v1.PackageManifestList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class PackageManifestTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodNetworkConnectivityCheckTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodNetworkConnectivityCheckTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.controlplane.v1alpha1.PodNetworkConnectivityCheck;
 import io.fabric8.openshift.api.model.operator.controlplane.v1alpha1.PodNetworkConnectivityCheckBuilder;
 import io.fabric8.openshift.api.model.operator.controlplane.v1alpha1.PodNetworkConnectivityCheckList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class PodNetworkConnectivityCheckTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicyReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicyReviewTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.PodSecurityPolicyReview;
 import io.fabric8.openshift.api.model.PodSecurityPolicyReviewBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -24,10 +26,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class PodSecurityPolicyReviewTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySelfSubjectReviewTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.PodSecurityPolicySelfSubjectReview;
 import io.fabric8.openshift.api.model.PodSecurityPolicySelfSubjectReviewBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -24,10 +26,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class PodSecurityPolicySelfSubjectReviewTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySubjectReviewTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.PodSecurityPolicySubjectReview;
 import io.fabric8.openshift.api.model.PodSecurityPolicySubjectReviewBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -24,10 +26,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class PodSecurityPolicySubjectReviewTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProbeTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProbeTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.monitoring.v1.Probe;
 import io.fabric8.openshift.api.model.monitoring.v1.ProbeBuilder;
 import io.fabric8.openshift.api.model.monitoring.v1.ProbeList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ProbeTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProfileTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProfileTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.tuned.v1.Profile;
 import io.fabric8.openshift.api.model.tuned.v1.ProfileBuilder;
 import io.fabric8.openshift.api.model.tuned.v1.ProfileList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ProfileTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectTest.java
@@ -17,6 +17,8 @@ package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.ProjectBuilder;
 import io.fabric8.openshift.api.model.ProjectList;
@@ -33,10 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ProjectTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusRuleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusRuleTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.monitoring.v1.PrometheusRule;
 import io.fabric8.openshift.api.model.monitoring.v1.PrometheusRuleBuilder;
 import io.fabric8.openshift.api.model.monitoring.v1.PrometheusRuleList;
@@ -30,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class PrometheusRuleTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusTest.java
@@ -17,6 +17,8 @@ package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.monitoring.v1.AlertingSpec;
 import io.fabric8.openshift.api.model.monitoring.v1.AlertmanagerEndpoints;
 import io.fabric8.openshift.api.model.monitoring.v1.AlertmanagerEndpointsBuilder;
@@ -35,10 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class PrometheusTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RangeAllocationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RangeAllocationTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.RangeAllocation;
 import io.fabric8.openshift.api.model.RangeAllocationBuilder;
 import io.fabric8.openshift.api.model.RangeAllocationList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class RangeAllocationTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingRestrictionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingRestrictionTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.RoleBindingRestriction;
 import io.fabric8.openshift.api.model.RoleBindingRestrictionBuilder;
 import io.fabric8.openshift.api.model.RoleBindingRestrictionList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class RoleBindingRestrictionTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.api.model.RouteList;
@@ -27,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class RouteCrudTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsCrudTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.openshift.api.model.SecurityContextConstraints;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsBuilder;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
@@ -29,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true)
 class SecurityContextConstraintsCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(SecurityContextConstraintsCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
@@ -17,6 +17,8 @@ package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.SecurityContextConstraints;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsBuilder;
 import io.fabric8.openshift.api.model.SecurityContextConstraintsList;
@@ -34,10 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class SecurityContextConstraintsTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ServiceMonitorTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ServiceMonitorTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
 import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitorBuilder;
 import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitorList;
@@ -30,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ServiceMonitorTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageStateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageStateTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.storageversionmigrator.v1alpha1.StorageState;
 import io.fabric8.openshift.api.model.storageversionmigrator.v1alpha1.StorageStateBuilder;
 import io.fabric8.openshift.api.model.storageversionmigrator.v1alpha1.StorageStateList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class StorageStateTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operator.v1.Storage;
 import io.fabric8.openshift.api.model.operator.v1.StorageBuilder;
 import io.fabric8.openshift.api.model.operator.v1.StorageList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class StorageTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageVersionMigrationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageVersionMigrationTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.storageversionmigrator.v1alpha1.StorageVersionMigration;
 import io.fabric8.openshift.api.model.storageversionmigrator.v1alpha1.StorageVersionMigrationBuilder;
 import io.fabric8.openshift.api.model.storageversionmigrator.v1alpha1.StorageVersionMigrationList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class StorageVersionMigrationTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.LocalResourceAccessReviewBuilder;
 import io.fabric8.openshift.api.model.LocalSubjectAccessReviewBuilder;
 import io.fabric8.openshift.api.model.ResourceAccessReviewBuilder;
@@ -36,15 +38,15 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class SubjectAccessReviewTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   NamespacedOpenShiftClient client;
 
   @BeforeEach
   void setUp() {
-    client = server.createOpenShiftClient();
+    client = server.createClient().adapt(NamespacedOpenShiftClient.class);
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubscriptionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubscriptionTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionList;
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class SubscriptionTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateInstanceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateInstanceTest.java
@@ -16,6 +16,8 @@
 package io.fabric8.openshift.client.server.mock;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.TemplateInstance;
 import io.fabric8.openshift.api.model.TemplateInstanceBuilder;
 import io.fabric8.openshift.api.model.TemplateInstanceList;
@@ -27,10 +29,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class TemplateInstanceTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -26,6 +26,8 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.IOHelpers;
 import io.fabric8.openshift.api.model.ParameterBuilder;
 import io.fabric8.openshift.api.model.Template;
@@ -53,10 +55,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class TemplateTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   OpenShiftClient client;
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ThanosRulerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ThanosRulerTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.monitoring.v1.ThanosRuler;
 import io.fabric8.openshift.api.model.monitoring.v1.ThanosRulerBuilder;
 import io.fabric8.openshift.api.model.monitoring.v1.ThanosRulerList;
@@ -27,10 +29,10 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ThanosRulerTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TunedTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TunedTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.tuned.v1.Tuned;
 import io.fabric8.openshift.api.model.tuned.v1.TunedBuilder;
 import io.fabric8.openshift.api.model.tuned.v1.TunedList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class TunedTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserIdentityMappingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserIdentityMappingTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.UserIdentityMapping;
 import io.fabric8.openshift.api.model.UserIdentityMappingBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -23,10 +25,10 @@ import org.junit.jupiter.api.Test;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class UserIdentityMappingTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void create() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserOAuthAccessTokenTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserOAuthAccessTokenTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.UserOAuthAccessToken;
 import io.fabric8.openshift.api.model.UserOAuthAccessTokenBuilder;
 import io.fabric8.openshift.api.model.UserOAuthAccessTokenList;
@@ -26,10 +28,10 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class UserOAuthAccessTokenTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserTest.java
@@ -15,12 +15,13 @@
  */
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.User;
 import io.fabric8.openshift.api.model.UserBuilder;
 import io.fabric8.openshift.api.model.UserList;
 import io.fabric8.openshift.api.model.UserListBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,16 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class UserTest {
 
-  OpenShiftMockServer server;
+  KubernetesMockServer server;
   NamespacedOpenShiftClient client;
-
-  @BeforeEach
-  void setUp() {
-    client = server.createOpenShiftClient();
-  }
 
   @Test
   void testList() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterClaimTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterClaimTest.java
@@ -15,13 +15,13 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.ClusterClaim;
 import io.fabric8.openshift.api.model.hive.v1.ClusterClaimBuilder;
 import io.fabric8.openshift.api.model.hive.v1.ClusterClaimList;
 import io.fabric8.openshift.api.model.hive.v1.ClusterClaimListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -29,10 +29,10 @@ import java.text.ParseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterClaimTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() throws ParseException {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeploymentTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeployment;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeploymentBuilder;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeploymentList;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeploymentListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterDeploymentTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeprovisionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeprovisionTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeprovision;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeprovisionBuilder;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeprovisionList;
 import io.fabric8.openshift.api.model.hive.v1.ClusterDeprovisionListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterDeprovisionTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterImageSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterImageSetTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.ClusterImageSet;
 import io.fabric8.openshift.api.model.hive.v1.ClusterImageSetBuilder;
 import io.fabric8.openshift.api.model.hive.v1.ClusterImageSetList;
 import io.fabric8.openshift.api.model.hive.v1.ClusterImageSetListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterImageSetTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterPoolTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.ClusterPool;
 import io.fabric8.openshift.api.model.hive.v1.ClusterPoolBuilder;
 import io.fabric8.openshift.api.model.hive.v1.ClusterPoolList;
 import io.fabric8.openshift.api.model.hive.v1.ClusterPoolListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterPoolTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterRelocateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterRelocateTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.ClusterRelocate;
 import io.fabric8.openshift.api.model.hive.v1.ClusterRelocateBuilder;
 import io.fabric8.openshift.api.model.hive.v1.ClusterRelocateList;
 import io.fabric8.openshift.api.model.hive.v1.ClusterRelocateListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class ClusterRelocateTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/DNSZoneTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/DNSZoneTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.DNSZone;
 import io.fabric8.openshift.api.model.hive.v1.DNSZoneBuilder;
 import io.fabric8.openshift.api.model.hive.v1.DNSZoneList;
 import io.fabric8.openshift.api.model.hive.v1.DNSZoneListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class DNSZoneTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/HiveConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/HiveConfigTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.HiveConfig;
 import io.fabric8.openshift.api.model.hive.v1.HiveConfigBuilder;
 import io.fabric8.openshift.api.model.hive.v1.HiveConfigList;
 import io.fabric8.openshift.api.model.hive.v1.HiveConfigListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class HiveConfigTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/MachinePoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/MachinePoolTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.MachinePool;
 import io.fabric8.openshift.api.model.hive.v1.MachinePoolBuilder;
 import io.fabric8.openshift.api.model.hive.v1.MachinePoolList;
 import io.fabric8.openshift.api.model.hive.v1.MachinePoolListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class MachinePoolTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncIdentityProviderTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncIdentityProviderTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.GitHubIdentityProviderBuilder;
 import io.fabric8.openshift.api.model.config.v1.IdentityProviderBuilder;
 import io.fabric8.openshift.api.model.hive.v1.SelectorSyncIdentityProvider;
@@ -22,18 +24,16 @@ import io.fabric8.openshift.api.model.hive.v1.SelectorSyncIdentityProviderBuilde
 import io.fabric8.openshift.api.model.hive.v1.SelectorSyncIdentityProviderList;
 import io.fabric8.openshift.api.model.hive.v1.SelectorSyncIdentityProviderListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class SelectorSyncIdentityProviderTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncSetTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.SelectorSyncSet;
 import io.fabric8.openshift.api.model.hive.v1.SelectorSyncSetBuilder;
 import io.fabric8.openshift.api.model.hive.v1.SelectorSyncSetList;
 import io.fabric8.openshift.api.model.hive.v1.SelectorSyncSetListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class SelectorSyncSetTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncIdentityProviderTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncIdentityProviderTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.config.v1.GitHubIdentityProviderBuilder;
 import io.fabric8.openshift.api.model.config.v1.IdentityProviderBuilder;
 import io.fabric8.openshift.api.model.hive.v1.SyncIdentityProvider;
@@ -22,18 +24,16 @@ import io.fabric8.openshift.api.model.hive.v1.SyncIdentityProviderBuilder;
 import io.fabric8.openshift.api.model.hive.v1.SyncIdentityProviderList;
 import io.fabric8.openshift.api.model.hive.v1.SyncIdentityProviderListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class SyncIdentityProviderTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncSetTest.java
@@ -15,23 +15,23 @@
  */
 package io.fabric8.openshift.client.server.mock.hive;
 
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.api.model.hive.v1.SyncSet;
 import io.fabric8.openshift.api.model.hive.v1.SyncSetBuilder;
 import io.fabric8.openshift.api.model.hive.v1.SyncSetList;
 import io.fabric8.openshift.api.model.hive.v1.SyncSetListBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.EnableOpenShiftMockClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableOpenShiftMockClient
+@EnableKubernetesMockClient
 class SyncSetTest {
   private OpenShiftClient client;
-  private OpenShiftMockServer server;
+  KubernetesMockServer server;
 
   @Test
   void get() {


### PR DESCRIPTION
## Description

Fixes #6364

Replaced usage of OpenShiftMockServer and EnableOpenShiftMockClient with vanilla Kubernetes alternatives.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
