### PR TITLE
test: remove unneeded KubernetesMockServer.createClient() calls

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MixedCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MixedCrudTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MixedCrudTest {
 
-  KubernetesMockServer server;
+  private KubernetesMockServer server;
   private KubernetesClient client;
 
   @BeforeEach

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -24,9 +24,9 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.api.model.policy.v1.EvictionBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.LocalPortForward;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.PortForward;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
@@ -83,15 +83,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 class PodTest {
 
   KubernetesMockServer server;
+  NamespacedKubernetesClient client;
 
   @TempDir
   Path tempDir;
 
-  private KubernetesClient client;
-
   @BeforeEach
   void setUp() {
-    client = server.createClient().inNamespace("test");
+    client = client.inNamespace("test");
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
@@ -24,7 +24,6 @@ import io.fabric8.openshift.api.model.GroupBuilder;
 import io.fabric8.openshift.api.model.GroupList;
 import io.fabric8.openshift.api.model.GroupListBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,11 +37,6 @@ class GroupTest {
 
   KubernetesMockServer server;
   NamespacedOpenShiftClient client;
-
-  @BeforeEach
-  void setUp() {
-    client = server.createClient().adapt(NamespacedOpenShiftClient.class);
-  }
 
   @Test
   void testList() {

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
@@ -30,7 +30,6 @@ import io.fabric8.openshift.api.model.SubjectAccessReviewResponseBuilder;
 import io.fabric8.openshift.api.model.SubjectRulesReview;
 import io.fabric8.openshift.api.model.SubjectRulesReviewBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
@@ -43,11 +42,6 @@ class SubjectAccessReviewTest {
 
   KubernetesMockServer server;
   NamespacedOpenShiftClient client;
-
-  @BeforeEach
-  void setUp() {
-    client = server.createClient().adapt(NamespacedOpenShiftClient.class);
-  }
 
   @Test
   void testCreate() {


### PR DESCRIPTION
## Description

test: remove unneeded KubernetesMockServer.createClient() calls

Relates to #6364

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
