### PR TITLE
fix: renamed SettableBeanPropertyDelegate to SettableBeanPropertyDelegating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix #6138: Removed unused `io:fabric8:kubernetes-model` artifact
 * Fix #6156: Removed deprecated extension `io:fabric8:service-catalog`
 * Fix #6158: Removed deprecated methods from `io.fabric8.kubernetes.client.utils.IOHelpers`
+* Fix #6361: Renamed SettableBeanPropertyDelegate to SettableBeanPropertyDelegating
 
 ### 6.13.4 (2024-09-25)
 

--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/BeanPropertyWriterDelegate.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/BeanPropertyWriterDelegate.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
  *
  * <p>
  * This BeanPropertyWriter implementation is intended to be used in combination with
- * the {@link SettableBeanPropertyDelegate} to allow the propagation of deserialized properties that don't match the
+ * the {@link SettableBeanPropertyDelegating} to allow the propagation of deserialized properties that don't match the
  * target field types.
  */
 public class BeanPropertyWriterDelegate extends BeanPropertyWriter {

--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/SettableBeanPropertyDelegating.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/SettableBeanPropertyDelegating.java
@@ -39,12 +39,12 @@ import java.util.function.BooleanSupplier;
  * A fall-back mechanism is implemented in the deserializeAndSet methods to allow field values that don't match the
  * target type to be preserved in the anySetter method if exists.
  */
-public class SettableBeanPropertyDelegate extends SettableBeanProperty.Delegating {
+public class SettableBeanPropertyDelegating extends SettableBeanProperty.Delegating {
 
   private final SettableAnyProperty anySetter;
   private final transient BooleanSupplier useAnySetter;
 
-  SettableBeanPropertyDelegate(SettableBeanProperty delegate, SettableAnyProperty anySetter, BooleanSupplier useAnySetter) {
+  SettableBeanPropertyDelegating(SettableBeanProperty delegate, SettableAnyProperty anySetter, BooleanSupplier useAnySetter) {
     super(delegate);
     this.anySetter = anySetter;
     this.useAnySetter = useAnySetter;
@@ -55,7 +55,7 @@ public class SettableBeanPropertyDelegate extends SettableBeanProperty.Delegatin
    */
   @Override
   protected SettableBeanProperty withDelegate(SettableBeanProperty d) {
-    return new SettableBeanPropertyDelegate(d, anySetter, useAnySetter);
+    return new SettableBeanPropertyDelegating(d, anySetter, useAnySetter);
   }
 
   /**

--- a/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/UnmatchedFieldTypeModule.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/main/java/io/fabric8/kubernetes/model/jackson/UnmatchedFieldTypeModule.java
@@ -55,7 +55,7 @@ public class UnmatchedFieldTypeModule extends SimpleModule {
       public BeanDeserializerBuilder updateBuilder(DeserializationConfig config, BeanDescription beanDesc,
           BeanDeserializerBuilder builder) {
         builder.getProperties().forEachRemaining(p -> builder.addOrReplaceProperty(
-            new SettableBeanPropertyDelegate(p, builder.getAnySetter(), UnmatchedFieldTypeModule.this::useAnySetter) {
+            new SettableBeanPropertyDelegating(p, builder.getAnySetter(), UnmatchedFieldTypeModule.this::useAnySetter) {
             }, true));
         return builder;
       }

--- a/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/SettableBeanPropertyDelegatingTest.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/SettableBeanPropertyDelegatingTest.java
@@ -67,14 +67,14 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class SettableBeanPropertyDelegateTest {
+class SettableBeanPropertyDelegatingTest {
 
   private AtomicBoolean useAnySetter;
   private ObjectMapper objectMapper;
   private DefaultDeserializationContext deserializationContext;
   private SettableAnyProperty anySetter;
   private SettableBeanProperty intFieldProperty;
-  private SettableBeanPropertyDelegate intFieldPropertyDelegating;
+  private SettableBeanPropertyDelegating intFieldPropertyDelegating;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -104,7 +104,7 @@ class SettableBeanPropertyDelegateTest {
     intFieldProperty = testBeanDeserializer.findProperty("intField")
         .withValueDeserializer(NumberDeserializers.find(int.class, null));
     // Delegating SettableBeanProperty in test
-    intFieldPropertyDelegating = new SettableBeanPropertyDelegate(intFieldProperty, anySetter, useAnySetter::get);
+    intFieldPropertyDelegating = new SettableBeanPropertyDelegating(intFieldProperty, anySetter, useAnySetter::get);
 
   }
 
@@ -115,11 +115,11 @@ class SettableBeanPropertyDelegateTest {
     final SettableBeanProperty result = intFieldPropertyDelegating.withValueDeserializer(null);
     // Then
     assertThat(result)
-        .isInstanceOf(SettableBeanPropertyDelegate.class)
+        .isInstanceOf(SettableBeanPropertyDelegating.class)
         .isNotSameAs(intFieldPropertyDelegating)
         .hasFieldOrPropertyWithValue("anySetter", anySetter)
-        .asInstanceOf(InstanceOfAssertFactories.type(SettableBeanPropertyDelegate.class))
-        .extracting(SettableBeanPropertyDelegate::getDelegate)
+        .asInstanceOf(InstanceOfAssertFactories.type(SettableBeanPropertyDelegating.class))
+        .extracting(SettableBeanPropertyDelegating::getDelegate)
         .isInstanceOf(CreatorProperty.class)
         .isNotSameAs(intFieldProperty)
         .hasFieldOrPropertyWithValue("name", "intField");
@@ -132,11 +132,11 @@ class SettableBeanPropertyDelegateTest {
     final SettableBeanProperty result = intFieldPropertyDelegating.withName(new PropertyName("overriddenName"));
     // Then
     assertThat(result)
-        .isInstanceOf(SettableBeanPropertyDelegate.class)
+        .isInstanceOf(SettableBeanPropertyDelegating.class)
         .isNotSameAs(intFieldPropertyDelegating)
         .hasFieldOrPropertyWithValue("anySetter", anySetter)
-        .asInstanceOf(InstanceOfAssertFactories.type(SettableBeanPropertyDelegate.class))
-        .extracting(SettableBeanPropertyDelegate::getDelegate)
+        .asInstanceOf(InstanceOfAssertFactories.type(SettableBeanPropertyDelegating.class))
+        .extracting(SettableBeanPropertyDelegating::getDelegate)
         .isInstanceOf(CreatorProperty.class)
         .isNotSameAs(intFieldProperty)
         .hasFieldOrPropertyWithValue("name", "overriddenName");
@@ -149,11 +149,11 @@ class SettableBeanPropertyDelegateTest {
     final SettableBeanProperty result = intFieldPropertyDelegating.withNullProvider(null);
     // Then
     assertThat(result)
-        .isInstanceOf(SettableBeanPropertyDelegate.class)
+        .isInstanceOf(SettableBeanPropertyDelegating.class)
         .isNotSameAs(intFieldPropertyDelegating)
         .hasFieldOrPropertyWithValue("anySetter", anySetter)
-        .asInstanceOf(InstanceOfAssertFactories.type(SettableBeanPropertyDelegate.class))
-        .extracting(SettableBeanPropertyDelegate::getDelegate)
+        .asInstanceOf(InstanceOfAssertFactories.type(SettableBeanPropertyDelegating.class))
+        .extracting(SettableBeanPropertyDelegating::getDelegate)
         .isInstanceOf(CreatorProperty.class)
         .isNotSameAs(intFieldProperty)
         .hasFieldOrPropertyWithValue("name", "intField");
@@ -201,7 +201,7 @@ class SettableBeanPropertyDelegateTest {
         .findProperty(PropertyName.construct("intField"));
     final SettableBeanProperty fieldProperty = new FieldProperty(testPropertyFieldDefinition, testBeanJavaType, null,
         testBeanDescription.getClassAnnotations(), testPropertyFieldDefinition.getField());
-    final SettableBeanProperty fieldPropertyDelegating = new SettableBeanPropertyDelegate(fieldProperty, anySetter,
+    final SettableBeanProperty fieldPropertyDelegating = new SettableBeanPropertyDelegating(fieldProperty, anySetter,
         useAnySetter::get);
     assertThat(((AccessibleObject) fieldProperty.getMember().getMember()).isAccessible()).isFalse();
     // When
@@ -274,7 +274,7 @@ class SettableBeanPropertyDelegateTest {
         .findProperty(PropertyName.construct("intField"));
     final SettableBeanProperty fieldProperty = new FieldProperty(testPropertyFieldDefinition, testBeanJavaType, null,
         testBeanDescription.getClassAnnotations(), testPropertyFieldDefinition.getField());
-    final SettableBeanProperty fieldPropertyDelegating = new SettableBeanPropertyDelegate(fieldProperty, anySetter,
+    final SettableBeanProperty fieldPropertyDelegating = new SettableBeanPropertyDelegating(fieldProperty, anySetter,
         useAnySetter::get);
     // When
     final PropertyName result = fieldPropertyDelegating.getWrapperName();
@@ -458,7 +458,7 @@ class SettableBeanPropertyDelegateTest {
     @Test
     @DisplayName("deserializeSetAndReturn, with anySetter=null and throws Exception, should throw Exception")
     void deserializeSetAndReturnWithExceptionAndNullAnySetter() throws IOException {
-      intFieldPropertyDelegating = new SettableBeanPropertyDelegate(intFieldProperty, null, () -> true);
+      intFieldPropertyDelegating = new SettableBeanPropertyDelegating(intFieldProperty, null, () -> true);
       try (JsonParser parser = objectMapper.createParser("\"${a-placeholder}\"")) {
         final DefaultDeserializationContext ctx = deserializationContext
             .createInstance(deserializationContext.getConfig(), parser, null);
@@ -486,7 +486,7 @@ class SettableBeanPropertyDelegateTest {
           .collect(Collectors.toMap(ms -> ms, ms -> false));
       Stream.concat(
           Stream.of(SettableBeanProperty.Delegating.class.getDeclaredMethods()),
-          Stream.of(SettableBeanPropertyDelegate.class.getDeclaredMethods()))
+          Stream.of(SettableBeanPropertyDelegating.class.getDeclaredMethods()))
           .map(MethodSignature::from)
           .forEach(ms -> superclassMethods.computeIfPresent(ms, (k, v) -> true));
       assertThat(superclassMethods)


### PR DESCRIPTION
## Description

Fixes #6361

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
