### PR TITLE
fix(openapi): OpenAPI-generated class names don't have underscores

### DIFF
--- a/kubernetes-model-generator/openapi/maven-plugin/src/main/java/io/fabric8/kubernetes/schema/generator/schema/SchemaUtils.java
+++ b/kubernetes-model-generator/openapi/maven-plugin/src/main/java/io/fabric8/kubernetes/schema/generator/schema/SchemaUtils.java
@@ -174,7 +174,9 @@ public class SchemaUtils {
    * @return the simple class name associated to the provided Schema reference.
    */
   public static String refToClassName(String ref) {
-    return capitalize(ref.substring(ref.lastIndexOf('.') + 1));
+    return capitalize(ref.substring(ref.lastIndexOf('.') + 1))
+        // Remove underscores from Class Names, this doesn't look good in Java :)
+        .replace("_", "");
   }
 
   private String refToModelPackage(String ref) {


### PR DESCRIPTION
## Description

Relates to #6130

fix(openapi): OpenAPI-generated class names don't have underscores

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
