### PR TITLE
fix(openapi): java.lang packaged classes aren't added as imports

### DIFF
--- a/kubernetes-model-generator/openapi/maven-plugin/src/main/java/io/fabric8/kubernetes/schema/generator/ImportManager.java
+++ b/kubernetes-model-generator/openapi/maven-plugin/src/main/java/io/fabric8/kubernetes/schema/generator/ImportManager.java
@@ -26,9 +26,14 @@ public interface ImportManager {
 
   default void addImport(String importedClass) {
     // Only add import if it belongs to a different package
-    if (!Objects.equals(importedClass.substring(0, importedClass.lastIndexOf('.')), getPackageName())) {
-      getImports().add(importedClass);
+    if (Objects.equals(importedClass.substring(0, importedClass.lastIndexOf('.')), getPackageName())) {
+      return;
     }
+    // Do not import classes from java.lang
+    if (importedClass.substring(0, importedClass.lastIndexOf('.')).equals("java.lang")) {
+      return;
+    }
+    getImports().add(importedClass);
   }
 
   default void addAllImports(Collection<String> allImports) {

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/baremetal/v1/Platform.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/baremetal/v1/Platform.java
@@ -1,7 +1,6 @@
 
 package io.fabric8.openshift.api.model.installer.baremetal.v1;
 
-import java.lang.String;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/v1/ClusterNetworkEntry.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/v1/ClusterNetworkEntry.java
@@ -1,7 +1,6 @@
 
 package io.fabric8.openshift.api.model.installer.v1;
 
-import java.lang.String;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Generated;

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/v1/MachineNetworkEntry.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/v1/MachineNetworkEntry.java
@@ -1,7 +1,6 @@
 
 package io.fabric8.openshift.api.model.installer.v1;
 
-import java.lang.String;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Generated;

--- a/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/v1/Networking.java
+++ b/kubernetes-model-generator/openshift-model-installer/src/generated/java/io/fabric8/openshift/api/model/installer/v1/Networking.java
@@ -1,7 +1,6 @@
 
 package io.fabric8.openshift.api.model.installer.v1;
 
-import java.lang.String;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;


### PR DESCRIPTION
## Description

Relates to #6130

fix(openapi): java.lang packaged classes aren't added as imports

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
