### PR TITLE
fix(openapi): don't expose private fields in OpenAPI spec

### DIFF
--- a/extensions/knative/model/src/generated/java/io/fabric8/knative/pkg/apis/ConditionSet.java
+++ b/extensions/knative/model/src/generated/java/io/fabric8/knative/pkg/apis/ConditionSet.java
@@ -1,16 +1,13 @@
 
 package io.fabric8.knative.pkg.apis;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -37,8 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "dependents",
-    "happy"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -65,47 +61,8 @@ import lombok.experimental.Accessors;
 public class ConditionSet implements Editable<ConditionSetBuilder> , KubernetesResource
 {
 
-    @JsonProperty("dependents")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> dependents = new ArrayList<>();
-    @JsonProperty("happy")
-    private String happy;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-
-    /**
-     * No args constructor for use in serialization
-     * 
-     */
-    public ConditionSet() {
-    }
-
-    public ConditionSet(List<String> dependents, String happy) {
-        super();
-        this.dependents = dependents;
-        this.happy = happy;
-    }
-
-    @JsonProperty("dependents")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getDependents() {
-        return dependents;
-    }
-
-    @JsonProperty("dependents")
-    public void setDependents(List<String> dependents) {
-        this.dependents = dependents;
-    }
-
-    @JsonProperty("happy")
-    public String getHappy() {
-        return happy;
-    }
-
-    @JsonProperty("happy")
-    public void setHappy(String happy) {
-        this.happy = happy;
-    }
 
     @JsonIgnore
     public ConditionSetBuilder edit() {

--- a/extensions/knative/model/src/generated/java/io/fabric8/knative/pkg/apis/FieldError.java
+++ b/extensions/knative/model/src/generated/java/io/fabric8/knative/pkg/apis/FieldError.java
@@ -40,8 +40,7 @@ import lombok.experimental.Accessors;
     "Details",
     "Level",
     "Message",
-    "Paths",
-    "errors"
+    "Paths"
 })
 @ToString
 @EqualsAndHashCode
@@ -77,9 +76,6 @@ public class FieldError implements Editable<FieldErrorBuilder> , KubernetesResou
     @JsonProperty("Paths")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<String> paths = new ArrayList<>();
-    @JsonProperty("errors")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<io.fabric8.knative.pkg.apis.FieldError> errors = new ArrayList<>();
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
@@ -90,13 +86,12 @@ public class FieldError implements Editable<FieldErrorBuilder> , KubernetesResou
     public FieldError() {
     }
 
-    public FieldError(String details, Integer level, String message, List<String> paths, List<io.fabric8.knative.pkg.apis.FieldError> errors) {
+    public FieldError(String details, Integer level, String message, List<String> paths) {
         super();
         this.details = details;
         this.level = level;
         this.message = message;
         this.paths = paths;
-        this.errors = errors;
     }
 
     @JsonProperty("Details")
@@ -138,17 +133,6 @@ public class FieldError implements Editable<FieldErrorBuilder> , KubernetesResou
     @JsonProperty("Paths")
     public void setPaths(List<String> paths) {
         this.paths = paths;
-    }
-
-    @JsonProperty("errors")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<io.fabric8.knative.pkg.apis.FieldError> getErrors() {
-        return errors;
-    }
-
-    @JsonProperty("errors")
-    public void setErrors(List<io.fabric8.knative.pkg.apis.FieldError> errors) {
-        this.errors = errors;
     }
 
     @JsonIgnore

--- a/extensions/tekton/model/src/generated/java/io/fabric8/tekton/triggers/v1alpha1/StatusError.java
+++ b/extensions/tekton/model/src/generated/java/io/fabric8/tekton/triggers/v1alpha1/StatusError.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -35,7 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "s"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -62,32 +61,8 @@ import lombok.experimental.Accessors;
 public class StatusError implements Editable<StatusErrorBuilder> , KubernetesResource
 {
 
-    @JsonProperty("s")
-    private Status s;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-
-    /**
-     * No args constructor for use in serialization
-     * 
-     */
-    public StatusError() {
-    }
-
-    public StatusError(Status s) {
-        super();
-        this.s = s;
-    }
-
-    @JsonProperty("s")
-    public Status getS() {
-        return s;
-    }
-
-    @JsonProperty("s")
-    public void setS(Status s) {
-        this.s = s;
-    }
 
     @JsonIgnore
     public StatusErrorBuilder edit() {

--- a/extensions/tekton/model/src/generated/java/io/fabric8/tekton/triggers/v1beta1/StatusError.java
+++ b/extensions/tekton/model/src/generated/java/io/fabric8/tekton/triggers/v1beta1/StatusError.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -35,7 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "s"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -62,32 +61,8 @@ import lombok.experimental.Accessors;
 public class StatusError implements Editable<StatusErrorBuilder> , KubernetesResource
 {
 
-    @JsonProperty("s")
-    private Status s;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-
-    /**
-     * No args constructor for use in serialization
-     * 
-     */
-    public StatusError() {
-    }
-
-    public StatusError(Status s) {
-        super();
-        this.s = s;
-    }
-
-    @JsonProperty("s")
-    public Status getS() {
-        return s;
-    }
-
-    @JsonProperty("s")
-    public void setS(Status s) {
-        this.s = s;
-    }
 
     @JsonIgnore
     public StatusErrorBuilder edit() {

--- a/kubernetes-model-generator/openapi/generator/cmd/openapi.go
+++ b/kubernetes-model-generator/openapi/generator/cmd/openapi.go
@@ -51,9 +51,9 @@ var modules = []module{
 	{outputName: "openshift-generated", getDefinitionsFunc: generated_openshift_openapi.GetOpenAPIDefinitions, patterns: packages.OpenShiftPackagePatterns},
 	{outputName: "dev.knative", getDefinitionsFunc: generated_knative_openapi.GetOpenAPIDefinitions, patterns: packages.KnativePackagePatterns},
 	{outputName: "dev.tekton", getDefinitionsFunc: generated_tekton_openapi.GetOpenAPIDefinitions, patterns: packages.TektonPackagePatterns},
+	//{outputName: "io.istio", getDefinitionsFunc: generated_istio_openapi.GetOpenAPIDefinitions, patterns: packages.IstioPackagePatterns},
 	{outputName: "io.k8s.autoscaling", getDefinitionsFunc: generated_autoscaling_openapi.GetOpenAPIDefinitions, patterns: packages.AutoscalingPackagePatterns},
 	{outputName: "io.k8s.storage.snapshot", getDefinitionsFunc: generated_volumesnapshot_openapi.GetOpenAPIDefinitions, patterns: packages.VolumeSnapshotPackagePatterns},
-	//{outputName: "io.istio", getDefinitionsFunc: generated_istio_openapi.GetOpenAPIDefinitions, patterns: packages.IstioPackagePatterns},
 	{outputName: "sh.volcano", getDefinitionsFunc: generated_volcano_openapi.GetOpenAPIDefinitions, patterns: packages.VolcanoPackagePatterns},
 }
 

--- a/kubernetes-model-generator/openapi/generator/pkg/packages/packages.go
+++ b/kubernetes-model-generator/openapi/generator/pkg/packages/packages.go
@@ -61,16 +61,15 @@ var ChaosMeshPackagePatterns = []string{
 }
 
 var IstioPackagePatterns = []string{
+	"istio.io/api/analysis/v...",
 	"istio.io/api/meta/v...",
+	"istio.io/api/security/v...",
 	"istio.io/api/type/v...",
 	"istio.io/client-go/pkg/apis/extensions/v...",
-	"istio.io/api/extensions/v...",
 	"istio.io/client-go/pkg/apis/networking/v...",
-	//"istio.io/api/networking/v...",
+	"istio.io/api/networking/v...",
 	"istio.io/client-go/pkg/apis/security/v...",
-	//"istio.io/api/security/v...",
 	"istio.io/client-go/pkg/apis/telemetry/v...",
-	"istio.io/api/telemetry/v...",
 }
 
 var KnativePackagePatterns = []string{

--- a/kubernetes-model-generator/openapi/generator/tools/generator/openapi.go
+++ b/kubernetes-model-generator/openapi/generator/tools/generator/openapi.go
@@ -36,7 +36,7 @@ var modules = []module{
 	{patterns: packages.AutoscalingPackagePatterns, outputName: "generated_autoscaling_openapi"},
 	// https://github.com/chaos-mesh/chaos-mesh/issues/4517
 	//{patterns: packages.ChaosMeshPackagePatterns, outputName: "generated_chaosmesh_openapi"},
-	//{patterns: packages.IstioPackagePatterns, outputName: "generated_istio_openapi"},
+	{patterns: packages.IstioPackagePatterns, outputName: "generated_istio_openapi"},
 	{patterns: packages.KnativePackagePatterns, outputName: "generated_knative_openapi"},
 	{patterns: packages.TektonPackagePatterns, outputName: "generated_tekton_openapi"},
 	{patterns: packages.VolcanoPackagePatterns, outputName: "generated_volcano_openapi"},

--- a/kubernetes-model-generator/openapi/schemas/dev.knative.json
+++ b/kubernetes-model-generator/openapi/schemas/dev.knative.json
@@ -7649,23 +7649,6 @@
     "dev.knative.pkg.apis.ConditionSet": {
       "description": "ConditionSet is an abstract collection of the possible ConditionType values that a particular resource might expose.  It also holds the \"happy condition\" for that resource, which we define to be one of Ready or Succeeded depending on whether it is a Living or Batch process respectively.",
       "type": "object",
-      "required": [
-        "happy",
-        "dependents"
-      ],
-      "properties": {
-        "dependents": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "default": ""
-          }
-        },
-        "happy": {
-          "type": "string",
-          "default": ""
-        }
-      },
       "x-fabric8-info": {
         "Type": "nested",
         "Group": "",
@@ -7680,8 +7663,7 @@
       "required": [
         "Message",
         "Paths",
-        "Level",
-        "errors"
+        "Level"
       ],
       "properties": {
         "Details": {
@@ -7706,13 +7688,6 @@
           "items": {
             "type": "string",
             "default": ""
-          }
-        },
-        "errors": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/dev.knative.pkg.apis.FieldError"
           }
         }
       },

--- a/kubernetes-model-generator/openapi/schemas/dev.tekton.json
+++ b/kubernetes-model-generator/openapi/schemas/dev.tekton.json
@@ -2006,15 +2006,6 @@
     },
     "dev.tekton.triggers.v1alpha1.StatusError": {
       "type": "object",
-      "required": [
-        "s"
-      ],
-      "properties": {
-        "s": {
-          "default": {},
-          "$ref": "#/definitions/dev.tekton.triggers.v1alpha1.Status"
-        }
-      },
       "x-fabric8-info": {
         "Type": "nested",
         "Group": "triggers.tekton.dev",
@@ -3171,15 +3162,6 @@
     },
     "dev.tekton.triggers.v1beta1.StatusError": {
       "type": "object",
-      "required": [
-        "s"
-      ],
-      "properties": {
-        "s": {
-          "default": {},
-          "$ref": "#/definitions/dev.tekton.triggers.v1beta1.Status"
-        }
-      },
       "x-fabric8-info": {
         "Type": "nested",
         "Group": "triggers.tekton.dev",

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SchemaSettingError.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SchemaSettingError.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -35,8 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "message",
-    "name"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -63,45 +61,8 @@ import lombok.experimental.Accessors;
 public class SchemaSettingError implements Editable<SchemaSettingErrorBuilder> , KubernetesResource
 {
 
-    @JsonProperty("message")
-    private String message;
-    @JsonProperty("name")
-    private String name;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-
-    /**
-     * No args constructor for use in serialization
-     * 
-     */
-    public SchemaSettingError() {
-    }
-
-    public SchemaSettingError(String message, String name) {
-        super();
-        this.message = message;
-        this.name = name;
-    }
-
-    @JsonProperty("message")
-    public String getMessage() {
-        return message;
-    }
-
-    @JsonProperty("message")
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
-    @JsonProperty("name")
-    public String getName() {
-        return name;
-    }
-
-    @JsonProperty("name")
-    public void setName(String name) {
-        this.name = name;
-    }
 
     @JsonIgnore
     public SchemaSettingErrorBuilder edit() {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/AuthorizationValidationError.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/AuthorizationValidationError.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -35,7 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "err"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -62,32 +61,8 @@ import lombok.experimental.Accessors;
 public class AuthorizationValidationError implements Editable<AuthorizationValidationErrorBuilder> , KubernetesResource
 {
 
-    @JsonProperty("err")
-    private String err;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-
-    /**
-     * No args constructor for use in serialization
-     * 
-     */
-    public AuthorizationValidationError() {
-    }
-
-    public AuthorizationValidationError(String err) {
-        super();
-        this.err = err;
-    }
-
-    @JsonProperty("err")
-    public String getErr() {
-        return err;
-    }
-
-    @JsonProperty("err")
-    public void setErr(String err) {
-        this.err = err;
-    }
 
     @JsonIgnore
     public AuthorizationValidationErrorBuilder edit() {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/OAuth2ValidationError.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/OAuth2ValidationError.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -35,7 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "err"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -62,32 +61,8 @@ import lombok.experimental.Accessors;
 public class OAuth2ValidationError implements Editable<OAuth2ValidationErrorBuilder> , KubernetesResource
 {
 
-    @JsonProperty("err")
-    private String err;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-
-    /**
-     * No args constructor for use in serialization
-     * 
-     */
-    public OAuth2ValidationError() {
-    }
-
-    public OAuth2ValidationError(String err) {
-        super();
-        this.err = err;
-    }
-
-    @JsonProperty("err")
-    public String getErr() {
-        return err;
-    }
-
-    @JsonProperty("err")
-    public void setErr(String err) {
-        this.err = err;
-    }
 
     @JsonIgnore
     public OAuth2ValidationErrorBuilder edit() {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ProbeTargetsValidationError.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ProbeTargetsValidationError.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -35,7 +34,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "err"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -62,32 +61,8 @@ import lombok.experimental.Accessors;
 public class ProbeTargetsValidationError implements Editable<ProbeTargetsValidationErrorBuilder> , KubernetesResource
 {
 
-    @JsonProperty("err")
-    private String err;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-
-    /**
-     * No args constructor for use in serialization
-     * 
-     */
-    public ProbeTargetsValidationError() {
-    }
-
-    public ProbeTargetsValidationError(String err) {
-        super();
-        this.err = err;
-    }
-
-    @JsonProperty("err")
-    public String getErr() {
-        return err;
-    }
-
-    @JsonProperty("err")
-    public void setErr(String err) {
-        this.err = err;
-    }
 
     @JsonIgnore
     public ProbeTargetsValidationErrorBuilder edit() {


### PR DESCRIPTION
## Description

Relates to #6130

fix(openapi): don't expose private fields in OpenAPI spec

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
