### PR TITLE
deps: remove unneeded net.javacrumbs.json-unit:json-unit-fluent dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ openapi-generate-schema:
 
 .PHONY: openapi-generate-java-classes
 openapi-generate-java-classes:
+	# Test dependency needed for model de/serialization validation
+	mvn $(MAVEN_ARGS) clean install -pl . -pl zjsonpatch
 	cd kubernetes-model-generator && mvn $(MAVEN_ARGS) -Pgenerate clean install
 	# TODO: run generate from extensions module root once all extensions are migrated
 	cd extensions && mvn $(MAVEN_ARGS) -N clean install

--- a/java-generator/it/src/main/java/io/fabric8/java/generator/testing/KubernetesResourceDiff.java
+++ b/java-generator/it/src/main/java/io/fabric8/java/generator/testing/KubernetesResourceDiff.java
@@ -40,7 +40,7 @@ public class KubernetesResourceDiff {
   private final String source1;
   private final String source2;
 
-  private ObjectMapper yamlMapper = new ObjectMapper(
+  private final ObjectMapper yamlMapper = new ObjectMapper(
       new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
 
   public KubernetesResourceDiff(String source1, String source2) {

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/test/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionReviewTest.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/test/java/io/fabric8/kubernetes/api/model/apiextensions/v1/ConversionReviewTest.java
@@ -17,28 +17,24 @@ package io.fabric8.kubernetes.api.model.apiextensions.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ConversionReviewTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
   void testDeserializationAndSerialization() throws Exception {
     // Given
     final String originalJson = Helper.loadJson("/valid-conversionreview.json");
-
-    // when
-    final ConversionReview conversionReview = objectMapper.readValue(originalJson, ConversionReview.class);
-    final String serializedJson = objectMapper.writeValueAsString(conversionReview);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    final ConversionReview conversionReview = mapper.readValue(originalJson, ConversionReview.class);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson),
+        mapper.readTree(mapper.writeValueAsString(conversionReview)));
+    // Then
+    assertThat(diff).isEmpty();
   }
-};
+}

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/src/test/java/io/fabric8/kubernetes/api/model/apiextensions/v1beta1/CustomResourceDefinitionTest.java
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/src/test/java/io/fabric8/kubernetes/api/model/apiextensions/v1beta1/CustomResourceDefinitionTest.java
@@ -18,19 +18,16 @@ package io.fabric8.kubernetes.api.model.apiextensions.v1beta1;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class CustomResourceDefinitionTest {
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
   public void testBuilder() {
@@ -68,48 +65,34 @@ class CustomResourceDefinitionTest {
   void testLoadFromJsonSchemaPropsOrBool() throws JsonProcessingException {
     // Given
     final String originalJson = Helper.loadJson("/valid-crd.json");
-
-    // when
-    final CustomResourceDefinition customResourceDefinition = objectMapper.readValue(originalJson,
+    final CustomResourceDefinition customResourceDefinition = mapper.readValue(originalJson,
         CustomResourceDefinition.class);
-    final String serializedJson = objectMapper.writeValueAsString(customResourceDefinition);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson),
+        mapper.readTree(mapper.writeValueAsString(customResourceDefinition)));
+    // Then
+    Assertions.assertThat(diff).isEmpty();
   }
 
   @Test
   void testLoadFromJsonSchemaPropsOrArray() throws JsonProcessingException {
     // Given
-    String jsonString = Helper.loadJson("/valid-crd-jsonschemapropsorarray.json");
-
+    final String originalJson = Helper.loadJson("/valid-crd-jsonschemapropsorarray.json");
+    final CustomResourceDefinition result = mapper.readValue(originalJson, CustomResourceDefinition.class);
     // When
-    CustomResourceDefinition result = objectMapper.readValue(jsonString, CustomResourceDefinition.class);
-    final String serializedJson = objectMapper.writeValueAsString(result);
-
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(result)));
     // Then
-    assertNotNull(result);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(jsonString);
+    Assertions.assertThat(diff).isEmpty();
   }
 
   @Test
   void testLoadFromJsonSchemaPropsOrStringArray() throws JsonProcessingException {
     // Given
-    String jsonString = Helper.loadJson("/valid-crd-jsonschemapropsorstringarray.json");
-
+    String originalJson = Helper.loadJson("/valid-crd-jsonschemapropsorstringarray.json");
+    CustomResourceDefinition result = mapper.readValue(originalJson, CustomResourceDefinition.class);
     // When
-    CustomResourceDefinition result = objectMapper.readValue(jsonString, CustomResourceDefinition.class);
-    final String serializedJson = objectMapper.writeValueAsString(result);
-
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(result)));
     // Then
-    assertNotNull(result);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(jsonString);
+    Assertions.assertThat(diff).isEmpty();
   }
 }

--- a/kubernetes-model-generator/kubernetes-model-apps/src/test/java/io/fabric8/kubernetes/api/model/apps/DeploymentTest.java
+++ b/kubernetes-model-generator/kubernetes-model-apps/src/test/java/io/fabric8/kubernetes/api/model/apps/DeploymentTest.java
@@ -22,15 +22,13 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -42,16 +40,13 @@ class DeploymentTest {
 
   @Test
   void kubernetesDeploymentTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-deployment.json");
-
-    // when
     final Deployment deployment = mapper.readValue(originalJson, Deployment.class);
-    final String serializedJson = mapper.writeValueAsString(deployment);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(deployment)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-core/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-core/pom.xml
@@ -123,11 +123,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/ConfigMapTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/ConfigMapTest.java
@@ -17,15 +17,13 @@ package io.fabric8.kubernetes.api.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -40,16 +38,13 @@ class ConfigMapTest {
 
   @Test
   void configMapTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-configMap.json");
-
-    // when
     final ConfigMap configMap = mapper.readValue(originalJson, ConfigMap.class);
-    final String serializedJson = mapper.writeValueAsString(configMap);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(configMap)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/EventTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/EventTest.java
@@ -18,13 +18,11 @@ package io.fabric8.kubernetes.api.model;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class EventTest {
 
@@ -37,15 +35,12 @@ class EventTest {
 
   @Test
   void testEventSerializationDeserialization() throws JsonProcessingException {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-event.json");
-
-    // when
     final Event event = mapper.readValue(originalJson, Event.class);
-    final String serializedJson = mapper.writeValueAsString(event);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(event)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 }

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/KubernetesListTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/KubernetesListTest.java
@@ -15,10 +15,9 @@
  */
 package io.fabric8.kubernetes.api.model;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -60,8 +59,8 @@ class KubernetesListTest {
     assertNotNull(kubernetesList.getApiVersion());
     assertEquals("v1", kubernetesList.getApiVersion());
     assertEquals("List", kubernetesList.getKind());
-    assertThat(kubernetesList.getItems(), CoreMatchers.hasItem(service));
-    assertThat(kubernetesList.getItems(), CoreMatchers.hasItem(replicationController));
+    assertThat(kubernetesList.getItems())
+        .contains(service, replicationController);
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/SecretTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/SecretTest.java
@@ -17,15 +17,13 @@ package io.fabric8.kubernetes.api.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -40,16 +38,13 @@ class SecretTest {
 
   @Test
   void secretTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-secret.json");
-
-    // when
     final Secret secret = mapper.readValue(originalJson, Secret.class);
-    final String serializedJson = mapper.writeValueAsString(secret);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(secret)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/ServiceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/ServiceTest.java
@@ -17,13 +17,11 @@ package io.fabric8.kubernetes.api.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -38,16 +36,13 @@ class ServiceTest {
 
   @Test
   void serviceTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-service.json");
-
-    // when
     final Service service = mapper.readValue(originalJson, Service.class);
-    final String serializedJson = mapper.writeValueAsString(service);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(service)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/kubernetes-model-discovery/src/test/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/EndpointSliceTest.java
+++ b/kubernetes-model-generator/kubernetes-model-discovery/src/test/java/io/fabric8/kubernetes/api/model/discovery/v1beta1/EndpointSliceTest.java
@@ -17,12 +17,10 @@ package io.fabric8.kubernetes.api.model.discovery.v1beta1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EndpointSliceTest {
@@ -30,21 +28,18 @@ class EndpointSliceTest {
 
   @Test
   void loadTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-endpointslice.json");
-
-    // when
     final EndpointSlice endpointSlice = mapper.readValue(originalJson, EndpointSlice.class);
-    final String serializedJson = mapper.writeValueAsString(endpointSlice);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(endpointSlice)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test
   void testBuilder() {
-    // Given + When      
+    // Given + When
     EndpointSlice endpointSlice = new EndpointSliceBuilder()
         .withNewMetadata()
         .withName("example-abc")

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/test/java/io/fabric8/kubernetes/api/model/rbac/RoleBindingTest.java
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/test/java/io/fabric8/kubernetes/api/model/rbac/RoleBindingTest.java
@@ -17,12 +17,10 @@ package io.fabric8.kubernetes.api.model.rbac;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RoleBindingTest {
 
@@ -30,26 +28,21 @@ public class RoleBindingTest {
 
   @Test
   public void kubernetesRoleBindingTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-roleBinding.json");
-
-    // when
     final RoleBinding kubernetesRoleBinding = mapper.readValue(originalJson, RoleBinding.class);
-    final String serializedJson = mapper.writeValueAsString(kubernetesRoleBinding);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson),
+        mapper.readTree(mapper.writeValueAsString(kubernetesRoleBinding)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test
   public void kubernetesRoleBuilderTest() throws Exception {
-
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-roleBinding.json");
-
-    // when
-    RoleBinding kubernetesRoleBinding = new RoleBindingBuilder()
+    final RoleBinding kubernetesRoleBinding = new RoleBindingBuilder()
         .withNewMetadata()
         .withName("read-jobs")
         .withNamespace("default")
@@ -66,12 +59,11 @@ public class RoleBindingTest {
             .withName("job-reader")
             .build())
         .build();
-
-    final String serializedJson = mapper.writeValueAsString(kubernetesRoleBinding);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson),
+        mapper.readTree(mapper.writeValueAsString(kubernetesRoleBinding)));
+    // Then
+    assertThat(diff).isEmpty();
 
   }
 }

--- a/kubernetes-model-generator/kubernetes-model-rbac/src/test/java/io/fabric8/kubernetes/api/model/rbac/RoleTest.java
+++ b/kubernetes-model-generator/kubernetes-model-rbac/src/test/java/io/fabric8/kubernetes/api/model/rbac/RoleTest.java
@@ -17,12 +17,10 @@ package io.fabric8.kubernetes.api.model.rbac;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RoleTest {
 
@@ -30,26 +28,20 @@ public class RoleTest {
 
   @Test
   public void kubernetesRoleTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-role.json");
-
-    // when
     final Role kubernetesRole = mapper.readValue(originalJson, Role.class);
-    final String serializedJson = mapper.writeValueAsString(kubernetesRole);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(kubernetesRole)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test
   public void kubernetesRoleBuilderTest() throws Exception {
-
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-role.json");
-
-    // when
-    Role kubernetesRole = new RoleBuilder()
+    final Role kubernetesRole = new RoleBuilder()
         .withNewMetadata()
         .withName("job-reader")
         .withNamespace("default")
@@ -64,12 +56,9 @@ public class RoleTest {
             .addToVerbs(2, "list")
             .build())
         .build();
-
-    final String serializedJson = mapper.writeValueAsString(kubernetesRole);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
-
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(kubernetesRole)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 }

--- a/kubernetes-model-generator/openshift-model-operator/src/test/java/io/fabric8/openshift/api/model/operator/network/v1/EgressRouterTest.java
+++ b/kubernetes-model-generator/openshift-model-operator/src/test/java/io/fabric8/openshift/api/model/operator/network/v1/EgressRouterTest.java
@@ -17,14 +17,12 @@ package io.fabric8.openshift.api.model.operator.network.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.model.util.Helper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -35,14 +33,11 @@ class EgressRouterTest {
   void deserializationAndSerializationShouldWorkAsExpected() throws IOException {
     // Given
     final String originalJson = Helper.loadJson("/valid-egressrouter.json");
-
-    // When
     final EgressRouter egressRouter = mapper.readValue(originalJson, EgressRouter.class);
-    final String serializedJson = mapper.writeValueAsString(egressRouter);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(egressRouter)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/BuildConfigTest.java
+++ b/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/BuildConfigTest.java
@@ -31,14 +31,12 @@ import io.fabric8.openshift.api.model.SecretBuildSourceBuilder;
 import io.fabric8.openshift.api.model.SourceBuildStrategyBuilder;
 import io.fabric8.openshift.api.model.SourceControlUserBuilder;
 import io.fabric8.openshift.api.model.WebHookTriggerBuilder;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,16 +47,13 @@ public class BuildConfigTest {
 
   @Test
   public void buildConfigTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-buildConfig.json");
-
-    // when
     final BuildConfig buildConfig = mapper.readValue(originalJson, BuildConfig.class);
-    final String serializedJson = mapper.writeValueAsString(buildConfig);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(buildConfig)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/ImageStreamImportTest.java
+++ b/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/ImageStreamImportTest.java
@@ -19,39 +19,32 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.openshift.api.model.ImageImportSpecBuilder;
 import io.fabric8.openshift.api.model.ImageStreamImport;
 import io.fabric8.openshift.api.model.ImageStreamImportBuilder;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ImageStreamImportTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
   public void imageStreamImportTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-imagestreamimport.json");
-
-    // when
     final ImageStreamImport imageStreamImport = mapper.readValue(originalJson, ImageStreamImport.class);
-    final String serializedJson = mapper.writeValueAsString(imageStreamImport);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson),
+        mapper.readTree(mapper.writeValueAsString(imageStreamImport)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test
   public void imageStreamImportBuilderTest() throws Exception {
-
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-imagestreamimport.json");
-
-    // when
     ImageStreamImport imageStreamImport = new ImageStreamImportBuilder()
         .withNewMetadata()
         .withName("test-isi")
@@ -93,12 +86,10 @@ public class ImageStreamImportTest {
         .endRepository()
         .endSpec()
         .build();
-
-    final String serializedJson = mapper.writeValueAsString(imageStreamImport);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
-
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson),
+        mapper.readTree(mapper.writeValueAsString(imageStreamImport)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 }

--- a/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/ImageStreamTagTest.java
+++ b/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/ImageStreamTagTest.java
@@ -22,12 +22,10 @@ import io.fabric8.openshift.api.model.ImageLayerBuilder;
 import io.fabric8.openshift.api.model.ImageLookupPolicyBuilder;
 import io.fabric8.openshift.api.model.ImageStreamTagBuilder;
 import io.fabric8.openshift.api.model.TagReferenceBuilder;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,16 +36,13 @@ public class ImageStreamTagTest {
 
   @Test
   public void imageStreamTagTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-ist.json");
-
-    // when
     final ImageStreamTag ist = mapper.readValue(originalJson, ImageStreamTag.class);
-    final String serializedJson = mapper.writeValueAsString(ist);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(ist)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test
@@ -123,7 +118,6 @@ public class ImageStreamTagTest {
     assertEquals("jenkins-slave", ist.getTag().getAnnotations().get("role"));
     assertEquals("jenkins-slave", ist.getTag().getAnnotations().get("slave-label"));
     assertEquals("Source", ist.getTag().getReferencePolicy().getType());
-
   }
 
 }

--- a/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/RouteTest.java
+++ b/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/kubernetes/api/model/RouteTest.java
@@ -19,12 +19,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.api.model.RouteTargetReferenceBuilder;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Test;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,16 +32,13 @@ public class RouteTest {
 
   @Test
   public void routeTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-route.json");
-
-    // when
     final Route route = mapper.readValue(originalJson, Route.class);
-    final String serializedJson = mapper.writeValueAsString(route);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT, IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson), mapper.readTree(mapper.writeValueAsString(route)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/openshift/api/model/DeploymentConfigRollbackTest.java
+++ b/kubernetes-model-generator/openshift-model/src/test/java/io/fabric8/openshift/api/model/DeploymentConfigRollbackTest.java
@@ -18,15 +18,13 @@ package io.fabric8.openshift.api.model;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Helper;
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.zjsonpatch.JsonDiff;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DeploymentConfigRollbackTest {
 
@@ -34,18 +32,15 @@ class DeploymentConfigRollbackTest {
 
   @Test
   void deploymentConfigRollbackTest() throws Exception {
-    // given
+    // Given
     final String originalJson = Helper.loadJson("/valid-deploymentConfigRollback.json");
-
-    // when
     final DeploymentConfigRollback deploymentConfigRollback = mapper.readValue(originalJson,
         DeploymentConfigRollback.class);
-    final String serializedJson = mapper.writeValueAsString(deploymentConfigRollback);
-
-    // then
-    assertThatJson(serializedJson).when(IGNORING_ARRAY_ORDER, TREATING_NULL_AS_ABSENT,
-        IGNORING_EXTRA_FIELDS)
-        .isEqualTo(originalJson);
+    // When
+    final var diff = JsonDiff.asJson(mapper.readTree(originalJson),
+        mapper.readTree(mapper.writeValueAsString(deploymentConfigRollback)));
+    // Then
+    assertThat(diff).isEmpty();
   }
 
   @Test

--- a/kubernetes-model-generator/openshift-model/src/test/resources/valid-ist.json
+++ b/kubernetes-model-generator/openshift-model/src/test/resources/valid-ist.json
@@ -2,6 +2,8 @@
   "apiVersion": "v1",
   "generation": 2,
   "image": {
+    "apiVersion": "v1",
+    "kind": "Image",
     "dockerImageLayers": [
       {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",

--- a/kubernetes-model-generator/pom.xml
+++ b/kubernetes-model-generator/pom.xml
@@ -116,6 +116,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>
@@ -125,10 +126,12 @@
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>transform-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>sundr-codegen-velocity-nodeps</artifactId>
+      <scope>provided</scope>
     </dependency>
     <!-- Test dependencies -->
     <dependency>
@@ -142,9 +145,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.javacrumbs.json-unit</groupId>
-      <artifactId>json-unit-fluent</artifactId>
-      <version>2.38.0</version>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>zjsonpatch</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -207,8 +207,8 @@
     <jsonschema2pojo.targetPackage>io.fabric8.kubernetes.api.model</jsonschema2pojo.targetPackage>
   </properties>
   <modules>
-    <module>kubernetes-model-generator</module>
     <module>zjsonpatch</module>
+    <module>kubernetes-model-generator</module>
     <module>kubernetes-client-api</module>
     <module>httpclient-jdk</module>
     <module>httpclient-jetty</module>


### PR DESCRIPTION
## Description

deps: remove unneeded net.javacrumbs.json-unit:json-unit-fluent dependency

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
