### PR TITLE
refactor(config): persistKubeConfigIntoFile uses File instead of String

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/internal/KubeConfigUtils.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -181,10 +180,8 @@ public class KubeConfigUtils {
    * @param kubeConfigPath path to KUBECONFIG
    * @throws IOException in case of failure while writing to file
    */
-  public static void persistKubeConfigIntoFile(Config kubeConfig, String kubeConfigPath) throws IOException {
-    try (FileWriter writer = new FileWriter(kubeConfigPath)) {
-      writer.write(Serialization.asYaml(kubeConfig));
-    }
+  public static void persistKubeConfigIntoFile(Config kubeConfig, File kubeConfigPath) throws IOException {
+    Files.writeString(kubeConfigPath.toPath(), Serialization.asYaml(kubeConfig));
   }
 
   public static void merge(io.fabric8.kubernetes.client.Config clientConfig, Config kubeConfig, String context) {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/OpenIDConnectionUtils.java
@@ -215,7 +215,7 @@ public class OpenIDConnectionUtils {
         if (Utils.isNotNullOrEmpty(token)) {
           namedAuthInfo.getUser().setToken(token);
         }
-        KubeConfigUtils.persistKubeConfigIntoFile(kubeConfig, currentConfig.getFile().getAbsolutePath());
+        KubeConfigUtils.persistKubeConfigIntoFile(kubeConfig, currentConfig.getFile());
       } catch (Exception ex) {
         LOGGER.warn("oidc: failure while persisting new tokens into KUBECONFIG", ex);
       }


### PR DESCRIPTION
## Description

Relates to #6516

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
