### PR TITLE
fix: removed deprecated `io.fabric8.kubernetes.client.Client.isAdaptable` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 * Fix #6158: Removed deprecated methods from `io.fabric8.kubernetes.client.utils.IOHelpers`
 * Fix #6361: Renamed SettableBeanPropertyDelegate to SettableBeanPropertyDelegating
 * Fix #6603: Removed deprecated `io.fabric8.openshift.api.model.runtime.RawExtension` class
+* Fix #6605: Removed deprecated `ApiVersionUtil` classes in extension modules
+* Fix #6609: Removed deprecated `io.fabric8.crd.generator.CRDInfo.getVersion` method
+* Fix #6612: Removed deprecated `io.fabric8.kubernetes.client.Client.isAdaptable` method
 
 ### 6.13.4 (2024-09-25)
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Client.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Client.java
@@ -33,17 +33,6 @@ import java.net.URL;
 public interface Client extends Closeable {
 
   /**
-   * Checks if the client can be adapted to another client type and if that target client is supported.
-   *
-   * @param type The target client class.
-   * @param <C> The target client type.
-   * @return Returns true if a working {@link io.fabric8.kubernetes.client.extension.ExtensionAdapter} is found.
-   * @deprecated if the client can test for support, then use adapt(type).isSupported() instead.
-   */
-  @Deprecated
-  <C extends Client> Boolean isAdaptable(Class<C> type);
-
-  /**
    * Checks the Kubernetes server for support for the given KubernetesResource type.
    *
    * <p>

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ClientAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ClientAdapter.java
@@ -59,11 +59,6 @@ public abstract class ClientAdapter<C extends ClientAdapter<C>> implements Clien
   }
 
   @Override
-  public <A extends Client> Boolean isAdaptable(Class<A> type) {
-    return client.isAdaptable(type);
-  }
-
-  @Override
   public <T extends KubernetesResource> boolean supports(Class<T> type) {
     return client.supports(type);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/BaseClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/impl/BaseClient.java
@@ -217,12 +217,6 @@ public abstract class BaseClient implements Client {
   }
 
   @Override
-  public <C extends Client> Boolean isAdaptable(Class<C> type) {
-    adapt(type);
-    return true;
-  }
-
-  @Override
   public <R extends KubernetesResource> boolean supports(Class<R> type) {
     final String typeApiVersion = HasMetadata.getApiVersion(type);
     if (matchingGroupPredicate != null) {

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/AdaptIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/AdaptIT.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("OSCI")
 @KubernetesTest(createEphemeralNamespace = false)
@@ -37,11 +36,5 @@ class AdaptIT {
   void testAdaptToOpenShift() {
     // When + Then
     assertNotNull(client.adapt(OpenShiftClient.class));
-  }
-
-  @Test
-  void testIsAdaptable() {
-    // When + Then
-    assertTrue(client.isAdaptable(OpenShiftClient.class));
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
@@ -31,7 +31,6 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.client.OpenShiftClient;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,11 +61,9 @@ class KubernetesMockServerTest {
   @Test
   void testOpenShiftSupport() {
     server.setUnsupported("openshift.io");
-    assertTrue(client.isAdaptable(OpenShiftClient.class));
     assertFalse(client.supports(Route.class));
     assertTrue(client.supports(Pod.class));
     server.reset();
-    assertTrue(client.isAdaptable(OpenShiftClient.class));
     assertTrue(client.supports(Route.class));
   }
 

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/impl/URLFromOpenshiftRouteImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/impl/URLFromOpenshiftRouteImpl.java
@@ -36,7 +36,7 @@ public class URLFromOpenshiftRouteImpl implements ServiceToURLProvider {
   public String getURL(Service service, String portName, String namespace, KubernetesClient client) {
     String serviceName = service.getMetadata().getName();
     ServicePort port = URLFromServiceUtil.getServicePortByName(service, portName);
-    if (port != null && port.getName() != null && client.isAdaptable(OpenShiftClient.class)) {
+    if (port != null && port.getName() != null) {
       try {
         String serviceProtocol = port.getProtocol();
         OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/AdaptTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/dsl/AdaptTest.java
@@ -23,19 +23,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AdaptTest {
-
-  @Test
-  void testAdaptDisabledCheck() {
-    // Given
-    OpenShiftClient client = new KubernetesClientBuilder()
-        .withConfig(new OpenShiftConfigBuilder().withDisableApiGroupCheck(true).build()).build().adapt(OpenShiftClient.class);
-
-    // When + Then
-    assertTrue(client.isAdaptable(OpenShiftClient.class));
-  }
 
   @Test
   void testAdaptDSLs() {


### PR DESCRIPTION
## Description

Fixes #6612

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
