### PR TITLE
Remove deprecated bind/unbindResourceHandler methods from ManagedKubernetesClient

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -53,7 +53,6 @@ import static io.fabric8.kubernetes.client.Config.KUBERNETES_WEBSOCKET_PING_INTE
 
 @org.osgi.service.component.annotations.Component(configurationPid = "io.fabric8.kubernetes.client", name = "io.fabric8.kubernetes.client.osgi.ManagedKubernetesClient", scope = org.osgi.service.component.annotations.ServiceScope.SINGLETON, service = {
     KubernetesClient.class, NamespacedKubernetesClient.class }, reference = {
-        @org.osgi.service.component.annotations.Reference(name = "resourceHandler", service = io.fabric8.kubernetes.client.impl.ResourceHandler.class, cardinality = org.osgi.service.component.annotations.ReferenceCardinality.MULTIPLE, policy = org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC, bind = "bindResourceHandler", unbind = "unbindResourceHandler"),
         @org.osgi.service.component.annotations.Reference(name = "oAuthTokenProvider", service = OAuthTokenProvider.class, cardinality = org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL, policyOption = org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY, bind = "bindOAuthTokenProvider", unbind = "unbindOAuthTokenProvider"),
     }, configurationPolicy = org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE)
 public class ManagedKubernetesClient extends NamespacedKubernetesClientAdapter<KubernetesClientImpl> {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/osgi/ManagedKubernetesClient.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClientAdapter;
 import io.fabric8.kubernetes.client.OAuthTokenProvider;
 import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
-import io.fabric8.kubernetes.client.impl.ResourceHandler;
 
 import java.util.Map;
 
@@ -158,22 +157,6 @@ public class ManagedKubernetesClient extends NamespacedKubernetesClientAdapter<K
   @org.osgi.service.component.annotations.Deactivate
   public void deactivate() {
     this.close();
-  }
-
-  /**
-   * @deprecated ResourceHandlers to not need bound
-   */
-  @Deprecated
-  public void bindResourceHandler(ResourceHandler resourceHandler) {
-    // not used
-  }
-
-  /**
-   * @deprecated ResourceHandlers to not need bound
-   */
-  @Deprecated
-  public void unbindResourceHandler(ResourceHandler resourceHandler) {
-    // not used
   }
 
   public void bindOAuthTokenProvider(OAuthTokenProvider provider) {


### PR DESCRIPTION
## Description

Fixes #6626 

Removed unused deprecated methods from ManagedKubernetesClient

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)


## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
