### PR TITLE
fix: pod log request sinceTime param correctly encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 * Fix #6038: Support for Gradle configuration cache
 * Fix #6214: Java generator does not recognize fields in CRDs other than metadata, spec, and status
+* Fix #6459: Pod log request sinceTime param correctly encoded
 * Fix #6632: Mock server creationTimestamp and deletionTimestamp formatted consistently (ISO 8601)
 
 #### Improvements

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationContext.java
@@ -17,6 +17,7 @@ package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
+import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.URLUtils.URLBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -143,7 +144,8 @@ public class PodOperationContext {
     if (sinceSeconds != null) {
       sb.append("&sinceSeconds=").append(sinceSeconds);
     } else if (sinceTimestamp != null) {
-      sb.append("&sinceTime=").append(sinceTimestamp);
+      // https://github.com/fabric8io/kubernetes-client/issues/6459
+      sb.append("&sinceTime=").append(URLUtils.encodeToUTF(sinceTimestamp).replace("%3A", ":"));
     }
     if (tailingLines != null) {
       sb.append("&tailLines=").append(tailingLines);

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/LogTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/LogTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.behavior;
+
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.http.TestStandardHttpClient;
+import io.fabric8.kubernetes.client.http.TestStandardHttpClientFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Pod Log Behavior")
+class LogTest {
+
+  private TestStandardHttpClientFactory factory;
+  private KubernetesClient client;
+  private TestStandardHttpClient httpClient;
+
+  @BeforeEach
+  void setUp() {
+    factory = new TestStandardHttpClientFactory();
+    client = new KubernetesClientBuilder().withHttpClientFactory(factory).build();
+    httpClient = factory.getInstances().iterator().next();
+  }
+
+  @Nested
+  class WithReadyPod {
+
+    private String namespace = "default";
+    private String podName = "pod-get-log";
+
+    @BeforeEach
+    void setUp() {
+      namespace = "default";
+      podName = "with-ready-pod";
+      factory.expect("/api/v1/namespaces/" + namespace + "/pods", 200, client.getKubernetesSerialization().asJson(
+          new PodListBuilder()
+              .withNewMetadata().endMetadata()
+              .addToItems(new PodBuilder()
+                  .withNewMetadata().withName(podName).endMetadata()
+                  .withNewStatus().withPhase("Running").endStatus()
+                  .build())
+              .build()));
+    }
+
+    @Test
+    void getLog() {
+      factory.expect("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/log", 200, "log contents");
+      final var result = client.pods().inNamespace(namespace).withName(podName).getLog();
+      assertThat(result).isEqualTo("log contents");
+    }
+
+    @Test
+    // https://github.com/fabric8io/kubernetes-client/issues/6459
+    void getLogSinceTimeEncodesParameter() {
+      factory.expect("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/log", 200, "log contents");
+      final var result = client.pods().inNamespace(namespace).withName(podName).sinceTime("2024-10-16T14:36:58+02:00").getLog();
+      assertThat(result).isEqualTo("log contents");
+      assertThat(httpClient.getRecordedConsumeBytesDirects())
+          .last()
+          .extracting(r -> r.getRequest().uri().getRawQuery())
+          .asString()
+          .contains("sinceTime=2024-10-16T14:36:58%2B02:00");
+    }
+
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
@@ -199,7 +199,7 @@ class PodOperationUtilTest {
   }
 
   @Test
-  void testGetLog() {
+  void getLog() {
     // Given
     PodResource p1 = mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);
     PodResource p2 = mock(PodResource.class, Mockito.RETURNS_DEEP_STUBS);


### PR DESCRIPTION
## Description

Fixes #6459

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
