### PR TITLE
fix: withReadyWaitTimeout defaults to 0, which means no waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Fix #5351: Removed deprecated `io.fabric8:openshift-server-mock` artifact
 * Fix #6081: Moved Java baseline from 8 (1.8) to 11
 * Fix #6138: Removed unused `io:fabric8:kubernetes-model` artifact
+* Fix #6140: withReadyWaitTimeout defaults to 0, which means no waiting
 * Fix #6156: Removed deprecated extension `io:fabric8:service-catalog`
 * Fix #6158: Removed deprecated methods from `io.fabric8.kubernetes.client.utils.IOHelpers` class
 * Fix #6159: Removed deprecated `io.fabric8.kubernetes.client.utils.Utils.getPluralFromKind` method

--- a/doc/MIGRATION-v7.md
+++ b/doc/MIGRATION-v7.md
@@ -4,6 +4,7 @@
 - [Java baseline set to Java 11](#java-11)
 - [Vert.x as default HttpClient implementation](#vertx-httpclient)
 - [Bouncy Castle is no longer needed](#bouncy-castle)
+- [Default Pod wait until ready timeout changed to 0](#pod-wait-timeout)
 - [Config changes](#config-changes)
   - [Support for multiple kubeconfig files](#config-changes-multiple-kubeconfig)
 - [Model Changes](#model-changes)
@@ -55,6 +56,21 @@ It is also recommended (although not mandatory) to add an exclusion for the `io.
 The Bouncy Castle library is no longer needed as a dependency.
 In previous versions, this was an optional dependency needed for Elliptic Curve (EC) Keys.
 The Kubernetes client now uses the default Java security provider which should be enough to handle all scenarios.
+
+## Default Pod wait until ready timeout changed to 0 <a href="#pod-wait-timeout" id="pod-wait-timeout"/>
+
+The default timeout for Pod readiness has been changed from 5 seconds to 0 seconds.
+
+In previous versions, the default timeout for waiting until a Pod is ready was 5 seconds.
+This was causing issues in scenarios where the Pod was not marked as ready.
+For example, when the Pod contained an init container, it was impossible to wait for the Pod to be ready while performing operations on that container.
+
+We've changed the behavior to make Pod readiness waits opt-in.
+If you want to preserve the previous behavior, you can set the timeout with the `withReadyWaitTimeout` method.
+
+``` java
+client.pods().withName($podName).withReadyWaitTimeout(5000).getLog();
+```
 
 ## Config changes <a href="#config-changes" id="config-changes"/>
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/PodOperationContext.java
@@ -127,8 +127,8 @@ public class PodOperationContext {
     return this.toBuilder().dir(dir).build();
   }
 
-  public PodOperationContext withReadyWaitTimeout(Integer logWaitTimeout) {
-    return this.toBuilder().readyWaitTimeout(logWaitTimeout).build();
+  public PodOperationContext withReadyWaitTimeout(Integer readyWaitTimeout) {
+    return this.toBuilder().readyWaitTimeout(readyWaitTimeout).build();
   }
 
   public String getLogParameters() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -97,7 +97,7 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
     implements PodResource, EphemeralContainersResource, CopyOrReadable {
 
   public static final int HTTP_TOO_MANY_REQUESTS = 429;
-  public static final int DEFAULT_POD_READY_WAIT_TIMEOUT_MS = 5000;
+  public static final int DEFAULT_POD_READY_WAIT_TIMEOUT_MS = 0;
   private static final String[] EMPTY_COMMAND = { "/bin/sh", "-i" };
   public static final String DEFAULT_CONTAINER_ANNOTATION_NAME = "kubectl.kubernetes.io/default-container";
 
@@ -193,8 +193,8 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   }
 
   @Override
-  public PodOperationsImpl withReadyWaitTimeout(Integer logWaitTimeout) {
-    return new PodOperationsImpl(getContext().withReadyWaitTimeout(logWaitTimeout), context);
+  public PodOperationsImpl withReadyWaitTimeout(Integer readyWaitTimeout) {
+    return new PodOperationsImpl(getContext().withReadyWaitTimeout(readyWaitTimeout), context);
   }
 
   @Override


### PR DESCRIPTION
## Description

Fixes #6140
Fixes #5782

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
