### PR TITLE
fix(crd-generator): default values for CRD fields can be numeric or boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #6214: Java generator does not recognize fields in CRDs other than metadata, spec, and status
 * Fix #6459: Pod log request sinceTime param correctly encoded
 * Fix #6632: Mock server creationTimestamp and deletionTimestamp formatted consistently (ISO 8601)
+* Fix #6654: (crd-generator) default values for CRD fields can be numeric or boolean
 
 #### Improvements
 * Fix #3069: (crd-generator) Add `@AdditionalPrinterColumn` to specify a printer column by JSON path.

--- a/crd-generator/api-v2/pom.xml
+++ b/crd-generator/api-v2/pom.xml
@@ -35,7 +35,7 @@
       <artifactId>kubernetes-client-api</artifactId>
       <scope>compile</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jsonSchema</artifactId>
@@ -60,6 +60,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CRDUtils.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CRDUtils.java
@@ -16,10 +16,12 @@
 package io.fabric8.crdv2.generator;
 
 import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 
+import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,6 +30,7 @@ public class CRDUtils {
     throw new IllegalStateException("Utility class");
   }
 
+  @SuppressWarnings("LombokGetterMayBeUsed")
   public static class SpecAndStatus {
 
     private final String specClassName;
@@ -79,7 +82,7 @@ public class CRDUtils {
     Map<String, String> res = new HashMap<>();
     if (arr != null) {
       for (String e : arr) {
-        String[] splitted = e.split("\\=");
+        String[] splitted = e.split("=");
         if (splitted.length >= 2) {
           res.put(splitted[0], e.substring(splitted[0].length() + 1));
         } else {
@@ -91,4 +94,23 @@ public class CRDUtils {
     return res;
   }
 
+  static Object toTargetType(JavaType type, String value) {
+    if (type == null || value == null) {
+      return null;
+    }
+    try {
+      if (Number.class.isAssignableFrom(type.getRawClass()) || int.class.isAssignableFrom(type.getRawClass())
+          || long.class.isAssignableFrom(type.getRawClass()) || float.class.isAssignableFrom(type.getRawClass())
+          || double.class.isAssignableFrom(type.getRawClass())) {
+        return NumberFormat.getInstance().parse(value);
+      }
+      if (Boolean.class.isAssignableFrom(type.getRawClass()) || boolean.class.isAssignableFrom(type.getRawClass())) {
+        return Boolean.valueOf(value);
+      }
+    } catch (Exception ex) {
+      // NO OP
+    }
+    return value;
+
+  }
 }

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/JsonSchemaDefaultValueTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/JsonSchemaDefaultValueTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.generator.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import io.fabric8.generator.annotation.Default;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonSchemaDefaultValueTest {
+
+  private static final class ClassInTest {
+    @JsonProperty(defaultValue = "precedence-from-json-property")
+    @Default("precedence-from-default-annotation")
+    String precedence;
+
+    @JsonProperty
+    @Default("string-from-default-annotation")
+    String defaultAnnotationForString;
+
+    @JsonProperty(defaultValue = "true")
+    Boolean defaultValueForBoxedBoolean;
+
+    @JsonProperty
+    @Default("true")
+    Boolean defaultAnnotationForBoxedBoolean;
+
+    @JsonProperty(defaultValue = "true")
+    boolean defaultValueForBoolean;
+
+    @JsonProperty
+    @Default("true")
+    boolean defaultAnnotationForBoolean;
+
+    @JsonProperty(defaultValue = "1337")
+    int defaultValueForInt;
+
+    @JsonProperty(defaultValue = "1337L")
+    long defaultValueForLong;
+
+    @JsonProperty(defaultValue = "13.37")
+    float defaultValueForFloat;
+
+    @JsonProperty(defaultValue = "13.37d")
+    double defaultValueForDouble;
+  }
+
+  @Test
+  @DisplayName("JsonProperty default value should take precedence over Default annotation")
+  void precedence() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("precedence._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .extracting(JsonNode::asText)
+        .isEqualTo("precedence-from-json-property");
+  }
+
+  @Test
+  @DisplayName("Default annotation for String")
+  void stringFromDefaultAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultAnnotationForString._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .extracting(JsonNode::asText)
+        .isEqualTo("string-from-default-annotation");
+  }
+
+  @Test
+  @DisplayName("JsonProperty defaultValue annotation for boxed Boolean")
+  void booleanBoxedFromJsonPropertyAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultValueForBoxedBoolean._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(BooleanNode.class)
+        .extracting(JsonNode::asBoolean)
+        .isEqualTo(true);
+  }
+
+  @Test
+  @DisplayName("Default annotation for boxed Boolean")
+  void booleanBoxedFromDefaultAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultAnnotationForBoxedBoolean._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(BooleanNode.class)
+        .extracting(JsonNode::asBoolean)
+        .isEqualTo(true);
+  }
+
+  @Test
+  @DisplayName("JsonProperty defaultValue annotation for boolean")
+  void booleanFromJsonPropertyAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultValueForBoolean._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(BooleanNode.class)
+        .extracting(JsonNode::asBoolean)
+        .isEqualTo(true);
+  }
+
+  @Test
+  @DisplayName("Default annotation for boolean")
+  void booleanFromDefaultAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultAnnotationForBoolean._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(BooleanNode.class)
+        .extracting(JsonNode::asBoolean)
+        .isEqualTo(true);
+  }
+
+  @Test
+  @DisplayName("JsonProperty defaultValue annotation for int")
+  void intFromJsonPropertyAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultValueForInt._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(LongNode.class)
+        .extracting(JsonNode::asInt)
+        .isEqualTo(1337);
+  }
+
+  @Test
+  @DisplayName("JsonProperty defaultValue annotation for long")
+  void longFromJsonPropertyAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultValueForLong._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(LongNode.class)
+        .extracting(JsonNode::asLong)
+        .isEqualTo(1337L);
+  }
+
+  @Test
+  @DisplayName("JsonProperty defaultValue annotation for float")
+  void floatFromJsonPropertyAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultValueForFloat._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(DoubleNode.class)
+        .extracting(JsonNode::asDouble)
+        .isEqualTo(13.37);
+  }
+
+  @Test
+  @DisplayName("JsonProperty defaultValue annotation for double")
+  void doubleFromJsonPropertyAnnotation() {
+    assertThat(JsonSchema.from(ClassInTest.class).getProperties())
+        .extracting("defaultValueForDouble._default")
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
+        .isInstanceOf(DoubleNode.class)
+        .extracting(JsonNode::asDouble)
+        .isEqualTo(13.37);
+  }
+}

--- a/crd-generator/test/src/test/java/io/fabric8/crd/generator/approvaltests/annotated/AnnotatedSpec.java
+++ b/crd-generator/test/src/test/java/io/fabric8/crd/generator/approvaltests/annotated/AnnotatedSpec.java
@@ -42,6 +42,15 @@ public class AnnotatedSpec {
   private String defaultValue;
   @Default("my-value2")
   private String defaultValue2;
+  @JsonProperty(defaultValue = "true")
+  @Default("true") // compatibility with CRDGenerator-v1
+  private boolean defaultBoolean;
+  @JsonProperty(defaultValue = "1337")
+  @Default("1337") // compatibility with CRDGenerator-v1
+  private Integer defaultInteger;
+  @JsonProperty(defaultValue = "1337")
+  @Default("1337") // compatibility with CRDGenerator-v1
+  private int defaultInt;
   @Required
   private boolean emptySetter;
   @Required

--- a/crd-generator/test/src/test/resources/io/fabric8/crd/generator/approvaltests/CRDGeneratorApprovalTest.approvalTest.annotateds.samples.fabric8.io.v1.approved.yml
+++ b/crd-generator/test/src/test/resources/io/fabric8/crd/generator/approvaltests/CRDGeneratorApprovalTest.approvalTest.annotateds.samples.fabric8.io.v1.approved.yml
@@ -22,6 +22,15 @@ spec:
                 - "non"
                 - "oui"
                 type: "string"
+              defaultBoolean:
+                default: true
+                type: "boolean"
+              defaultInt:
+                default: 1337
+                type: "integer"
+              defaultInteger:
+                default: 1337
+                type: "integer"
               defaultValue:
                 default: "my-value"
                 type: "string"

--- a/crd-generator/test/src/test/resources/io/fabric8/crd/generator/approvaltests/CRDGeneratorApprovalTest.approvalTest.annotateds.samples.fabric8.io.v1beta1.approved.yml
+++ b/crd-generator/test/src/test/resources/io/fabric8/crd/generator/approvaltests/CRDGeneratorApprovalTest.approvalTest.annotateds.samples.fabric8.io.v1beta1.approved.yml
@@ -20,6 +20,15 @@ spec:
               - "non"
               - "oui"
               type: "string"
+            defaultBoolean:
+              default: true
+              type: "boolean"
+            defaultInt:
+              default: 1337
+              type: "integer"
+            defaultInteger:
+              default: 1337
+              type: "integer"
             defaultValue:
               default: "my-value"
               type: "string"


### PR DESCRIPTION
## Description

Fixes #6654 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
