### PR TITLE
CRD-Generator v2 migration notes

### DIFF
--- a/crd-generator/apt/README.md
+++ b/crd-generator/apt/README.md
@@ -1,6 +1,8 @@
 # CRD Generator Annotation Processor
 _Deprecated since 7.0.0_
 
+Please follow our [CRD Generator v2 Migration Guide](../../doc/CRD-generator-migration-v2.md) to replace it.
+
 ## Usage
 
 with Maven:

--- a/doc/CRD-generator-migration-v2.md
+++ b/doc/CRD-generator-migration-v2.md
@@ -32,6 +32,21 @@ annotation processor with your [tool of choice](#new-tooling).
 
 The API itself is not compatible but very similar.
 
+## Breaking Changes
+
+### New restrictions on annotations
+
+With CRD Generator v2 the following annotations are restricted to certain field types:
+
+- `@Min` and `@Max` are restricted to numeric fields
+- `@Pattern` is restricted to string fields
+
+### Migrating from v6
+
+In case you are migrating directly from fabric8/kubernetes-client v6, the following change affects you:
+
+The type of `format` in `@PrinterColumn` has changed from string to enum `PrinterColumnFormat`.
+
 ## New Tooling
 
 To replace the [CRD Generator annotation processor](../crd-generator/apt/README.md) you can use the following tools:
@@ -61,13 +76,6 @@ Read the Javadoc of the annotations and the [CRD Generator documentation](CRD-ge
 The `@Min` and `@Max` annotations have been extended with a second argument to define the inclusiveness.
 By default, the value in the annotation is meant to be inclusive like before.
 
-## New restrictions on annotations
-
-With CRD Generator v2 the following annotations are restricted to certain field types:
-
-- `@Min` and `@Max` are restricted to numeric fields
-- `@Pattern` is restricted to string fields
-
 ## Annotated Types
 
 `@Pattern`, `@Min`, `@Max` will be detected if they are used to annotate the type of a List or a Map.
@@ -96,10 +104,4 @@ myMap:
 Previously default values defined by `@Default` could only be used on string fields. 
 With CRD Generator v2 defaults can be set on numeric and boolean fields, too.
 In the same way is `@JsonProperty(defaultValue)` now working.
-
-## Migrating from v6
-
-In case you are migrating directly from fabric8/kubernetes-client v6, the following change affects you: 
-
-The type of `format` in `@PrinterColumn` has changed from string to enum `PrinterColumnFormat`.
 

--- a/doc/CRD-generator-migration-v2.md
+++ b/doc/CRD-generator-migration-v2.md
@@ -39,7 +39,7 @@ To replace the [CRD Generator annotation processor](../crd-generator/apt/README.
 - [CRD Generator Maven Plugin](../crd-generator/maven-plugin/README.md)
 - [CRD Generator CLI tool](../crd-generator/cli/README.md)
 
-The tools use the same core implementation, which means they should generate the same CRDs if similar configuration
+The tools use the same base, which means they should generate the same CRDs if similar configuration
 parameter are used. One of the enhancements of the new tooling is that they can be configured easily.
 Please read the README of the tool for details on usage and configuration.
 
@@ -54,7 +54,7 @@ since CRD Generator v1 won't get new features from now on.
 - `@AdditionalSelectableField`
 - `@Size`
 
-Please read the Javadoc of those annotations and the [CRD Generator documentation](CRD-generator.md) to get details.
+Read the Javadoc of the annotations and the [CRD Generator documentation](CRD-generator.md) to get details.
 
 ## `@Min` / `@Max` inclusiveness
 
@@ -68,9 +68,34 @@ With CRD Generator v2 the following annotations are restricted to certain field 
 - `@Min` and `@Max` are restricted to numeric fields
 - `@Pattern` is restricted to string fields
 
+## Annotated Types
+
+`@Pattern`, `@Min`, `@Max` will be detected if they are used to annotate the type of a List or a Map.
+
+Example:
+```java
+List<@Pattern("(a|b)") String> myList;
+Map<String, @Pattern("(a|b)") String> myMap;
+```
+Result:
+```yaml
+myList:
+  items:
+    pattern: "(a|b)+"
+    type: "string"
+  type: "array"
+myMap:
+  additionalProperties:
+    pattern: "(a|b)+"
+    type: "string"
+  type: "object"
+```
+
 ## Default values for CRD fields can be numeric or boolean
 
-TODO
+Previously default values defined by `@Default` could only be used on string fields. 
+With CRD Generator v2 defaults can be set on numeric and boolean fields, too.
+In the same way is `@JsonProperty(defaultValue)` now working.
 
 ## Migrating from v6
 

--- a/doc/CRD-generator-migration-v2.md
+++ b/doc/CRD-generator-migration-v2.md
@@ -18,7 +18,7 @@ _GA since 7.0.0_
 - **CRD Generator API v2** - `io.fabric8:crd-generator-api-v2`  
   _Core implementation of the new generator, based on [Jackson/jsonSchema](https://github.com/FasterXML/jackson-module-jsonSchema)._
 - **CRD Generator Collector** - `io.fabric8:crd-generator-collector`  
-  _Shared component to find compiled Custom Resource classes in directories and Jar files._
+  _Shared component to find and load compiled Custom Resource classes in directories and Jar files._
 - **CRD Generator Maven Plugin** - `io.fabric8:crd-generator-maven-plugin`   
   _Maven plugin that generates CRDs during the build process._
 - **CRD Generator CLI** - `io.fabric8:crd-generator-cli`    
@@ -28,23 +28,41 @@ _GA since 7.0.0_
 
 CRD Generator v1 and v2 are using **the same set of annotations**.  
 This means you can keep your code as is and replace just the CRD Generator
-annotation processor with [your tool of choice](#new-tooling).
+annotation processor with your [tool of choice](#new-tooling).
 
 The API itself is not compatible but very similar.
 
 ## New Tooling
 
-To replace the CRD Generator annotation processor you can use the following tools:
+To replace the [CRD Generator annotation processor](../crd-generator/apt/README.md) you can use the following tools:
 
 - [CRD Generator Maven Plugin](../crd-generator/maven-plugin/README.md)
 - [CRD Generator CLI tool](../crd-generator/cli/README.md)
 
-The tools use the same core implementation, which means they should generate the same CRDs if the similar configuration
+The tools use the same core implementation, which means they should generate the same CRDs if similar configuration
 parameter are used. One of the enhancements of the new tooling is that they can be configured easily.
 Please read the README of the tool for details on usage and configuration.
 
-## New annotations since 7.0.0
+## New annotations
 
-Several new annotations have been introduced since 7.0.0. They will be used only by the CRD Generator v2 implementation
+Several new annotations have been introduced since 7.0.0. They will be used by the **CRD Generator v2 implementation only**
 since CRD Generator v1 won't get new features from now on.
+
+- `@AdditionalPrinterColumn`
+- `@SelectableField`
+- `@AdditionalSelectableField`
+- `@Size`
+
+Please read the Javadoc of those annotations and the [CRD Generator documentation](CRD-generator.md) to get details.
+
+## Changed annotations
+
+The `@Min` and `@Max` annotations have been extended with a second argument to define the inclusiveness.
+By default, the value in the annotation is meant to be inclusive like before.
+
+### Migrating from v6
+
+In case you are migrating directly from fabric8/kubernetes-client v6, the following change affects you: 
+
+The type of `format` in `@PrinterColumn` has changed from string to enum `PrinterColumnFormat`.
 

--- a/doc/CRD-generator-migration-v2.md
+++ b/doc/CRD-generator-migration-v2.md
@@ -3,18 +3,20 @@
 ## Overview
 
 ### CRD Generator v1
+
 _Deprecated since 7.0.0_
 
 - **CRD Generator API v1** - `io.fabric8:crd-generator-api`  
-  _Core implementation of the old generator, based on sundrio_
+  _Core implementation of the old generator, based on [sundrio](https://github.com/sundrio/sundrio)._
 - **CRD Generator annotation processing tool (APT)** - `io.fabric8:crd-generator-apt`  
-  _Annotation processor which hooks into the build process_
+  _Annotation processor which hooks into the build process to generate CRDs._
 
 ### CRD Generator v2
+
 _GA since 7.0.0_
 
 - **CRD Generator API v2** - `io.fabric8:crd-generator-api-v2`  
-  _Core implementation of the generator, based on Jackson/JSON-Schema._
+  _Core implementation of the new generator, based on [Jackson/jsonSchema](https://github.com/FasterXML/jackson-module-jsonSchema)._
 - **CRD Generator Collector** - `io.fabric8:crd-generator-collector`  
   _Shared component to find compiled Custom Resource classes in directories and Jar files._
 - **CRD Generator Maven Plugin** - `io.fabric8:crd-generator-maven-plugin`   
@@ -22,4 +24,27 @@ _GA since 7.0.0_
 - **CRD Generator CLI** - `io.fabric8:crd-generator-cli`    
   _CLI tool that generates CRDs when executed._
 
+## API Compatibility
+
+CRD Generator v1 and v2 are using **the same set of annotations**.  
+This means you can keep your code as is and replace just the CRD Generator
+annotation processor with [your tool of choice](#new-tooling).
+
+The API itself is not compatible but very similar.
+
+## New Tooling
+
+To replace the CRD Generator annotation processor you can use the following tools:
+
+- [CRD Generator Maven Plugin](../crd-generator/maven-plugin/README.md)
+- [CRD Generator CLI tool](../crd-generator/cli/README.md)
+
+The tools use the same core implementation, which means they should generate the same CRDs if the similar configuration
+parameter are used. One of the enhancements of the new tooling is that they can be configured easily.
+Please read the README of the tool for details on usage and configuration.
+
+## New annotations since 7.0.0
+
+Several new annotations have been introduced since 7.0.0. They will be used only by the CRD Generator v2 implementation
+since CRD Generator v1 won't get new features from now on.
 

--- a/doc/CRD-generator-migration-v2.md
+++ b/doc/CRD-generator-migration-v2.md
@@ -1,0 +1,25 @@
+# Migration from CRD Generator v1 to CRD Generator v2
+
+## Overview
+
+### CRD Generator v1
+_Deprecated since 7.0.0_
+
+- **CRD Generator API v1** - `io.fabric8:crd-generator-api`  
+  _Core implementation of the old generator, based on sundrio_
+- **CRD Generator annotation processing tool (APT)** - `io.fabric8:crd-generator-apt`  
+  _Annotation processor which hooks into the build process_
+
+### CRD Generator v2
+_GA since 7.0.0_
+
+- **CRD Generator API v2** - `io.fabric8:crd-generator-api-v2`  
+  _Core implementation of the generator, based on Jackson/JSON-Schema._
+- **CRD Generator Collector** - `io.fabric8:crd-generator-collector`  
+  _Shared component to find compiled Custom Resource classes in directories and Jar files._
+- **CRD Generator Maven Plugin** - `io.fabric8:crd-generator-maven-plugin`   
+  _Maven plugin that generates CRDs during the build process._
+- **CRD Generator CLI** - `io.fabric8:crd-generator-cli`    
+  _CLI tool that generates CRDs when executed._
+
+

--- a/doc/CRD-generator-migration-v2.md
+++ b/doc/CRD-generator-migration-v2.md
@@ -48,6 +48,7 @@ Please read the README of the tool for details on usage and configuration.
 Several new annotations have been introduced since 7.0.0. They will be used by the **CRD Generator v2 implementation only**
 since CRD Generator v1 won't get new features from now on.
 
+- `@Categories`
 - `@AdditionalPrinterColumn`
 - `@SelectableField`
 - `@AdditionalSelectableField`
@@ -55,12 +56,23 @@ since CRD Generator v1 won't get new features from now on.
 
 Please read the Javadoc of those annotations and the [CRD Generator documentation](CRD-generator.md) to get details.
 
-## Changed annotations
+## `@Min` / `@Max` inclusiveness
 
 The `@Min` and `@Max` annotations have been extended with a second argument to define the inclusiveness.
 By default, the value in the annotation is meant to be inclusive like before.
 
-### Migrating from v6
+## New restrictions on annotations
+
+With CRD Generator v2 the following annotations are restricted to certain field types:
+
+- `@Min` and `@Max` are restricted to numeric fields
+- `@Pattern` is restricted to string fields
+
+## Default values for CRD fields can be numeric or boolean
+
+TODO
+
+## Migrating from v6
 
 In case you are migrating directly from fabric8/kubernetes-client v6, the following change affects you: 
 

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -4,13 +4,15 @@ The [CRD Generator annotation processing tool (APT)](../crd-generator/apt/README
 
 As a replacement, we're currently providing a new version of the API in `io.fabric8:crd-generator-api-v2` and a few tools to be able to leverage it in your projects.
 
+A migration guide can be found [here](CRD-generator-migration-v2.md). 
+
 The following list contains the available tooling:
 - [CRD Generator Maven Plugin](../crd-generator/maven-plugin/README.md): A Maven plugin that generates CRDs during the build process.
 - [CRD Generator CLI tool](../crd-generator/cli/README.md): A CLI tool that generates CRDs when executed.
 
 ## Quick start
 
-Add the CRD Generator plugin to your project or use the CLI tool:
+Add the CRD Generator plugin to your project:
 
 with Maven:
 

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -12,7 +12,7 @@ The following list contains the available tooling:
 
 ## Quick start
 
-Add the CRD Generator plugin to your project:
+Add the CRD Generator plugin to your project or use the CLI tool:
 
 with Maven:
 

--- a/doc/MIGRATION-v7.md
+++ b/doc/MIGRATION-v7.md
@@ -331,6 +331,6 @@ We are no longer supporting it.
 ### CRD Generator annotation processor deprecated <a href="#crd-generator-annotation-processor-deprecated" id="crd-generator-annotation-processor-deprecated"/>
 
 The CRD Generator annotation processing tool (APT) (`io.fabric8:crd-generator-apt`) and its API (`io.fabric8:crd-generator-api`) are being deprecated and will eventually be removed once we offer a complete replacement for all users.
-The CRD Generator API users should use the v2 version of the API ((`io.fabric8:crd-generator-api-v2`) instead. 
+The CRD Generator API users should use the v2 version of the API (`io.fabric8:crd-generator-api-v2`) instead. 
 
 You can find out more about its replacement in the [CRD Generator documentation](./CRD-generator.md)


### PR DESCRIPTION
## Description

Migration notes for users who want to switch to CRD Generator v2.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

