### PR TITLE
Change rolling restart/pause/resume to use rfc6902 JSON patch

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
@@ -205,8 +205,9 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
     HashMap<String, Object> value = new HashMap<>();
     patch.put("op", "replace");
     patch.put("path", "/spec/template/metadata/annotations");
-    value.put("kubectl.kubernetes.io/restartedAt", new Date().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-    patch.put("value",  value);
+    value.put("kubectl.kubernetes.io/restartedAt",
+        new Date().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    patch.put("value", value);
     return Collections.singletonList(patch);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
@@ -45,10 +45,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -169,8 +169,8 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
     }
   }
 
-  private static <T> T applyPatch(Resource<T> resource, Map<String, Object> map, KubernetesSerialization serialization) {
-    return resource.patch(PatchContext.of(PatchType.STRATEGIC_MERGE), serialization.asJson(map));
+  private static <T> T applyPatch(Resource<T> resource, List<Object> list, KubernetesSerialization serialization) {
+    return resource.patch(PatchContext.of(PatchType.JSON), serialization.asJson(list));
   }
 
   public static <T extends HasMetadata> T resume(RollableScalableResourceOperation<T, ?, ?> resource) {
@@ -185,35 +185,29 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
     return applyPatch(resource, RollingUpdater.requestPayLoadForRolloutRestart(), resource.getKubernetesSerialization());
   }
 
-  public static Map<String, Object> requestPayLoadForRolloutPause() {
-    Map<String, Object> jsonPatchPayload = new HashMap<>();
-    Map<String, Object> spec = new HashMap<>();
-    spec.put("paused", true);
-    jsonPatchPayload.put("spec", spec);
-    return jsonPatchPayload;
+  public static List<Object> requestPayLoadForRolloutPause() {
+    HashMap<String, Object> patch = new HashMap<>();
+    patch.put("op", "add");
+    patch.put("path", "/spec/paused");
+    patch.put("value", true);
+    return Collections.singletonList(patch);
   }
 
-  public static Map<String, Object> requestPayLoadForRolloutResume() {
-    Map<String, Object> jsonPatchPayload = new HashMap<>();
-    Map<String, Object> spec = new HashMap<>();
-    spec.put("paused", null);
-    jsonPatchPayload.put("spec", spec);
-    return jsonPatchPayload;
+  public static List<Object> requestPayLoadForRolloutResume() {
+    HashMap<String, Object> patch = new HashMap<>();
+    patch.put("op", "remove");
+    patch.put("path", "/spec/paused");
+    return Collections.singletonList(patch);
   }
 
-  public static Map<String, Object> requestPayLoadForRolloutRestart() {
-    Map<String, Object> jsonPatchPayload = new HashMap<>();
-    Map<String, String> annotations = new HashMap<>();
-    annotations.put("kubectl.kubernetes.io/restartedAt",
-        new Date().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-    Map<String, Object> templateMetadata = new HashMap<>();
-    templateMetadata.put("annotations", annotations);
-    Map<String, Object> template = new HashMap<>();
-    template.put("metadata", templateMetadata);
-    Map<String, Object> deploymentSpec = new HashMap<>();
-    deploymentSpec.put("template", template);
-    jsonPatchPayload.put("spec", deploymentSpec);
-    return jsonPatchPayload;
+  public static List<Object> requestPayLoadForRolloutRestart() {
+    HashMap<String, Object> patch = new HashMap<>();
+    HashMap<String, Object> value = new HashMap<>();
+    patch.put("op", "replace");
+    patch.put("path", "/spec/template/metadata/annotations");
+    value.put("kubectl.kubernetes.io/restartedAt", new Date().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    patch.put("value",  value);
+    return Collections.singletonList(patch);
   }
 
   /**

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
@@ -132,22 +132,22 @@ class DeploymentCrudTest {
   void testPause() {
     // Given
     Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
-      .withName("d1")
-      .withNamespace("ns1")
-      .addToLabels("testKey", "testValue")
-      .endMetadata()
-      .withNewSpec()
-      .endSpec()
-      .build();
+        .withName("d1")
+        .withNamespace("ns1")
+        .addToLabels("testKey", "testValue")
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
     client.apps().deployments().inNamespace("ns1").create(deployment1);
 
     // When
     client.apps()
-      .deployments()
-      .inNamespace("ns1")
-      .withName("d1")
-      .rolling()
-      .pause();
+        .deployments()
+        .inNamespace("ns1")
+        .withName("d1")
+        .rolling()
+        .pause();
     Deployment updatedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
 
     // Then
@@ -160,23 +160,23 @@ class DeploymentCrudTest {
   void testRolloutResume() throws InterruptedException {
     // Given
     Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
-      .withName("d1")
-      .withNamespace("ns1")
-      .addToLabels("testKey", "testValue")
-      .endMetadata()
-      .withNewSpec()
-      .withPaused(true)
-      .endSpec()
-      .build();
+        .withName("d1")
+        .withNamespace("ns1")
+        .addToLabels("testKey", "testValue")
+        .endMetadata()
+        .withNewSpec()
+        .withPaused(true)
+        .endSpec()
+        .build();
     client.apps().deployments().inNamespace("ns1").create(deployment1);
 
     // When
     client.apps()
-      .deployments()
-      .inNamespace("ns1")
-      .withName("d1")
-      .rolling()
-      .resume();
+        .deployments()
+        .inNamespace("ns1")
+        .withName("d1")
+        .rolling()
+        .resume();
     Deployment updatedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
 
     // Then
@@ -189,31 +189,32 @@ class DeploymentCrudTest {
   void testRolloutRestart() throws InterruptedException {
     // Given
     Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
-      .withName("d1")
-      .withNamespace("ns1")
-      .addToLabels("testKey", "testValue")
-      .endMetadata()
-      .withNewSpec()
-      .withNewTemplate()
-      .withNewMetadata()
-      .addToAnnotations("", "")
-      .endMetadata()
-      .endTemplate()
-      .endSpec()
-      .build();
+        .withName("d1")
+        .withNamespace("ns1")
+        .addToLabels("testKey", "testValue")
+        .endMetadata()
+        .withNewSpec()
+        .withNewTemplate()
+        .withNewMetadata()
+        .addToAnnotations("", "")
+        .endMetadata()
+        .endTemplate()
+        .endSpec()
+        .build();
     client.apps().deployments().inNamespace("ns1").create(deployment1);
 
     // When
     client.apps()
-      .deployments()
-      .inNamespace("ns1")
-      .withName("d1")
-      .rolling()
-      .restart();
+        .deployments()
+        .inNamespace("ns1")
+        .withName("d1")
+        .rolling()
+        .restart();
     Deployment updatedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
 
     // Then
     assertNotNull(updatedDeployment);
-    assertNotNull(updatedDeployment.getSpec().getTemplate().getMetadata().getAnnotations().get("kubectl.kubernetes.io/restartedAt"));
+    assertNotNull(
+        updatedDeployment.getSpec().getTemplate().getMetadata().getAnnotations().get("kubectl.kubernetes.io/restartedAt"));
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient(crud = true)
@@ -124,5 +125,95 @@ class DeploymentCrudTest {
     assertNotNull(replacedDeployment);
     assertFalse(replacedDeployment.getMetadata().getLabels().isEmpty());
     assertEquals("one", replacedDeployment.getMetadata().getLabels().get("testKey"));
+  }
+
+  @Test
+  @DisplayName("Should pause resource")
+  void testPause() {
+    // Given
+    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+      .withName("d1")
+      .withNamespace("ns1")
+      .addToLabels("testKey", "testValue")
+      .endMetadata()
+      .withNewSpec()
+      .endSpec()
+      .build();
+    client.apps().deployments().inNamespace("ns1").create(deployment1);
+
+    // When
+    client.apps()
+      .deployments()
+      .inNamespace("ns1")
+      .withName("d1")
+      .rolling()
+      .pause();
+    Deployment updatedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
+
+    // Then
+    assertNotNull(updatedDeployment);
+    assertEquals(true, updatedDeployment.getSpec().getPaused());
+  }
+
+  @Test
+  @DisplayName("Should resume rollout")
+  void testRolloutResume() throws InterruptedException {
+    // Given
+    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+      .withName("d1")
+      .withNamespace("ns1")
+      .addToLabels("testKey", "testValue")
+      .endMetadata()
+      .withNewSpec()
+      .withPaused(true)
+      .endSpec()
+      .build();
+    client.apps().deployments().inNamespace("ns1").create(deployment1);
+
+    // When
+    client.apps()
+      .deployments()
+      .inNamespace("ns1")
+      .withName("d1")
+      .rolling()
+      .resume();
+    Deployment updatedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
+
+    // Then
+    assertNotNull(updatedDeployment);
+    assertNull(updatedDeployment.getSpec().getPaused());
+  }
+
+  @Test
+  @DisplayName("Should restart rollout")
+  void testRolloutRestart() throws InterruptedException {
+    // Given
+    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+      .withName("d1")
+      .withNamespace("ns1")
+      .addToLabels("testKey", "testValue")
+      .endMetadata()
+      .withNewSpec()
+      .withNewTemplate()
+      .withNewMetadata()
+      .addToAnnotations("", "")
+      .endMetadata()
+      .endTemplate()
+      .endSpec()
+      .build();
+    client.apps().deployments().inNamespace("ns1").create(deployment1);
+
+    // When
+    client.apps()
+      .deployments()
+      .inNamespace("ns1")
+      .withName("d1")
+      .rolling()
+      .restart();
+    Deployment updatedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
+
+    // Then
+    assertNotNull(updatedDeployment);
+    assertNotNull(updatedDeployment.getSpec().getTemplate().getMetadata().getAnnotations().get("kubectl.kubernetes.io/restartedAt"));
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -622,7 +622,7 @@ class DeploymentTest {
     // Then
     RecordedRequest recordedRequest = server.getLastRequest();
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertEquals("{\"spec\":{\"paused\":true}}", recordedRequest.getBody().readUtf8());
+    assertEquals("[{\"op\":\"add\",\"path\":\"/spec/paused\",\"value\":true}]", recordedRequest.getBody().readUtf8());
   }
 
   @Test
@@ -652,7 +652,7 @@ class DeploymentTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertNotNull(deployment);
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertEquals("{\"spec\":{\"paused\":null}}", recordedRequest.getBody().readUtf8());
+    assertEquals("[{\"op\":\"remove\",\"path\":\"/spec/paused\"}]", recordedRequest.getBody().readUtf8());
   }
 
   @Test


### PR DESCRIPTION
## Description
Change rolling restart/pause/resume to use rfc6902 JSON patch. 

Fixes #6658
Fixes #2516 

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

