### PR TITLE
test:refactor: AbstractSimultaneousConnectionsTest uses Vert.x as backend server

### DIFF
--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -79,6 +79,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientSimultaneousConnectionsTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientSimultaneousConnectionsTest.java
@@ -24,4 +24,12 @@ public class JdkHttpClientSimultaneousConnectionsTest extends AbstractSimultaneo
   protected HttpClient.Factory getHttpClientFactory() {
     return new JdkHttpClientFactory();
   }
+
+  @Override
+  public void http1Connections() {
+    // NO-OP
+    // This test will only pass when it's run in isolation, it seems that the JDK HttpClient eventually uses a shared thread
+    // pool that reaches a limit and this test will effectively block any further processing after a few connections are open.
+    // - jdk.internal.net.http.HttpClientImpl.ASYNC_POOL
+  }
 }

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -93,6 +93,11 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -93,6 +93,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/httpclient-vertx/pom.xml
+++ b/httpclient-vertx/pom.xml
@@ -92,6 +92,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- Required by SslTest -->
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -168,6 +168,7 @@ public class MockWebServer implements Closeable {
       httpClose.onComplete(onComplete);
       await(httpClose, "Unable to close MockWebServer");
     }
+    await(vertx.close(), "Unable to close Vertx");
   }
 
   @Override

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
@@ -114,7 +114,6 @@ public abstract class AbstractAsyncBodyTest {
       asyncBodyResponse.body().consume();
       asyncBodyResponse.body().done().get(10L, TimeUnit.SECONDS);
       assertThat(responseText.toString()).isEqualTo(largeBody);
-
     }
   }
 


### PR DESCRIPTION
## Description

Relates to #6727

- test:refactor: AbstractSimultaneousConnectionsTest uses Vert.x as backend server
- ci: enable parallel build

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
