### PR TITLE
fix: allowing no_proxy to use ipv6 values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugs
 
 * Fix #6747: Preventing websocket error logs when the client is closed
+* Fix #6781: Allowing ipv6 entries to work in NO_PROXY
 
 #### Improvements
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java
@@ -73,8 +73,9 @@ public class HttpClientUtils {
   private static final String HEADER_INTERCEPTOR = "HEADER";
   private static final String KUBERNETES_BACKWARDS_COMPATIBILITY_INTERCEPTOR_DISABLE = "kubernetes.backwardsCompatibilityInterceptor.disable";
   private static final String BACKWARDS_COMPATIBILITY_DISABLE_DEFAULT = "true";
-  private static final Pattern IPV4_PATTERN = Pattern.compile(
-      "(http://|https://)?(?<ipAddressOrSubnet>(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])(\\/([1-2]\\d|3[0-2]|\\d))?)(\\D+|$)");
+  private static final Pattern IP_PATTERN = Pattern.compile(
+      "(http(s?)://)?(?<ipAddressOrSubnet>((\\d{1,3}(.\\d{1,3}){3})|([a-f\\d]{1,4}(\\:[a-f\\d]{0,4}){2,7}))(/\\d+)?)",
+      Pattern.CASE_INSENSITIVE);
   private static final Pattern INVALID_HOST_PATTERN = Pattern.compile("[^\\da-zA-Z.\\-/:]+");
 
   private HttpClientUtils() {
@@ -296,8 +297,8 @@ public class HttpClientUtils {
   }
 
   private static Optional<String> extractIpAddressOrSubnet(String ipAddressOrSubnet) {
-    final Matcher ipMatcher = IPV4_PATTERN.matcher(ipAddressOrSubnet);
-    if (ipMatcher.find()) {
+    final Matcher ipMatcher = IP_PATTERN.matcher(ipAddressOrSubnet);
+    if (ipMatcher.matches()) {
       return Optional.of(ipMatcher.group("ipAddressOrSubnet"));
     }
     return Optional.empty();

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/HttpClientUtilsTest.java
@@ -189,6 +189,7 @@ class HttpClientUtilsTest {
           arguments("192.168.1.110", new String[] { "192.168.1.0/24" }),
           arguments("192.168.1.110", new String[] { "http://192.168.1.0/24" }),
           arguments("192.168.1.110", new String[] { "192.0.0.0/8" }),
+          arguments("2620:52:0:9c:0:0:0:1", new String[] { "2620:52:0:9c::/64" }),
           arguments("192.168.1.110", new String[] { "http://192.0.0.0/8" }));
     }
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/IpAddressMatcherTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/IpAddressMatcherTest.java
@@ -40,6 +40,8 @@ class IpAddressMatcherTest {
         arguments("192.168.10.110", "192.168.10.110"),
         arguments("192.168.1.0/8", "192.168.10.110"),
         arguments("192.168.1.0/24", "192.168.1.100"),
+        arguments("10.96.0.1", "0:0:0:0:0:ffff:0a60:0001"),
+        arguments("2620:52:0:9c::/64", "2620:52:0:9c:0:0:0:1"),
         arguments("0.0.0.0/0", "123.4.5.6"),
         arguments("0.0.0.0/0", "192.168.0.159"),
         arguments("192.168.0.159/0", "123.4.5.6"),
@@ -59,7 +61,6 @@ class IpAddressMatcherTest {
         arguments("192.168.1.0/24", "193.168.1.10"),
         arguments("192.168.1.0/24", "192.168.2.10"),
         arguments("192.168.1.0/8", "193.168.1.10"),
-        arguments("192.168.1.128/25", "192.168.1.104"),
-        arguments("kubernetes.default.svc", "kubernetes.default.svc"));
+        arguments("192.168.1.128/25", "192.168.1.104"));
   }
 }


### PR DESCRIPTION
## Description

ipv6 values are being excluded from no_proxy.

Also I don't see any reference for values starting with http(s), so we may want to remove that support.

closes: #6781

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
