### PR TITLE
Improved documentation for ServerSideApply

### DIFF
--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -2399,7 +2399,7 @@ To create a new resource or update an existing one, you just need to call:
 DeploymentConfig dc = client.deploymentConfigs().inNamespace("default").resource(dcToCreate).serverSideApply();
 ```
 
-For resources that are updated by other [FieldManagers](https://kubernetes.io/docs/reference/using-api/server-side-apply/#managers), you will need to force your modifications:
+For resources that are updated by other [FieldManagers](https://kubernetes.io/docs/reference/using-api/server-side-apply/#managers), you will need to force your modifications when there is a conflict:
 
 ```java
 DeploymentConfig dc = client.deploymentConfigs().inNamespace("default").resource(dcToCreate).forceConflicts().serverSideApply();

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -2393,18 +2393,16 @@ try (KubernetesClient client = new KubernetesClientBuilder().build()) {
 
 #### Server Side Apply
 
-Basic usage of server side apply is available via Patchable.  At it's simplest you just need to call:
+To create a new resource or update an existing one, you just need to call:
 
 ```java
-client.services().withName("name").patch(PatchContext.of(PatchType.SERVER_SIDE_APPLY), service);
+DeploymentConfig dc = client.deploymentConfigs().inNamespace("default").resource(dcToCreate).serverSideApply();
 ```
 
-For any create or update.  This can be a good alternative to using createOrReplace as it is always a single api call and does not issue a replace/PUT which can be problematic.
-
-If the resources may be created or modified by something other than a fabric8 patch, you will need to force your modifications:
+For resources that are updated by other [FieldManagers](https://kubernetes.io/docs/reference/using-api/server-side-apply/#managers), you will need to force your modifications:
 
 ```java
-client.services().withName("name").patch(new PatchContext.Builder().withPatchType(PatchType.SERVER_SIDE_APPLY).withForce(true).build(), service);
+DeploymentConfig dc = client.deploymentConfigs().inNamespace("default").resource(dcToCreate).forceConflicts().serverSideApply();
 ```
 
 Please consult the Kubernetes server side apply documentation if you want to do more detailed field management or want to understand the full semantics of how the patches are merged.


### PR DESCRIPTION
## Description
* Updated cheatsheet example for `serverSideApply()`.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
