### PR TITLE
feat: java-generator support for required spec and status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Fix #6802: Java generator support for required spec and status
 
 #### _**Note**_: Breaking changes
 

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JCRObject.java
@@ -16,12 +16,19 @@
 package io.fabric8.java.generator.nodes;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.SuperExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import io.fabric8.java.generator.Config;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
@@ -115,11 +122,25 @@ public class JCRObject extends JObject implements JObjectExtraAnnotations {
         ? new ClassOrInterfaceType().setName(type + "Spec")
         : jlVoid;
     fields.remove("spec");
+    if (required.contains("spec")) {
+      clz.addMethod("getSpec", Modifier.Keyword.PUBLIC)
+          .setType(spec)
+          .setBody(new BlockStmt().addStatement(new ReturnStmt(new MethodCallExpr(new SuperExpr(), "getSpec"))))
+          .addAnnotation(new NormalAnnotationExpr(new Name("java.lang.Override"), new NodeList<>()))
+          .addAnnotation(new NormalAnnotationExpr(new Name("io.fabric8.generator.annotation.Required"), new NodeList<>()));
+    }
 
     ClassOrInterfaceType status = (fields.containsKey("status"))
         ? new ClassOrInterfaceType().setName(type + "Status")
         : jlVoid;
     fields.remove("status");
+    if (required.contains("status")) {
+      clz.addMethod("getStatus", Modifier.Keyword.PUBLIC)
+          .setType(status)
+          .setBody(new BlockStmt().addStatement(new ReturnStmt(new MethodCallExpr(new SuperExpr(), "getStatus"))))
+          .addAnnotation(new NormalAnnotationExpr(new Name("java.lang.Override"), new NodeList<>()))
+          .addAnnotation(new NormalAnnotationExpr(new Name("io.fabric8.generator.annotation.Required"), new NodeList<>()));
+    }
 
     ClassOrInterfaceType crType = new ClassOrInterfaceType()
         .setName("io.fabric8.kubernetes.client.CustomResource")

--- a/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
+++ b/java-generator/core/src/main/java/io/fabric8/java/generator/nodes/JObject.java
@@ -48,7 +48,7 @@ public class JObject extends AbstractJSONSchema2Pojo implements JObjectExtraAnno
   protected final String className;
   protected final String pkg;
   protected final Map<String, AbstractJSONSchema2Pojo> fields;
-  private final Set<String> required;
+  protected final Set<String> required;
   private final Set<String> deprecated = new HashSet<>();
 
   private final boolean preserveUnknownFields;

--- a/java-generator/core/src/test/java/io/fabric8/java/generator/ApprovalTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/ApprovalTest.java
@@ -48,7 +48,9 @@ class ApprovalTest {
         Arguments.of("testCalicoIPPoolCrd", "calico-ippool-crd.yml", "IPPool", "CalicoIPPoolCr", new Config()),
         Arguments.of("testExistingJavaType", "existing-java-type-crd.yml", "ExistingJavaType", "ExistingJavaTypeCr",
             Config.builder().existingJavaTypes(Collections.singletonMap(
-                "org.test.v1.existingjavatypespec.Affinity", "io.fabric8.kubernetes.api.model.Affinity")).build()));
+                "org.test.v1.existingjavatypespec.Affinity", "io.fabric8.kubernetes.api.model.Affinity")).build()),
+        Arguments.of("testRequireSpecAndStatusCrd", "require-spec-and-status-crd.yml", "RequireSpecAndStatus",
+            "RequireSpecAndStatusJavaCr", new Config()));
   }
 
   @ParameterizedTest

--- a/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testRequireSpecAndStatusCrd.approved.txt
+++ b/java-generator/core/src/test/resources/io/fabric8/java/generator/approvals/ApprovalTest.generate_withValidCrd_shouldGeneratePojos.testRequireSpecAndStatusCrd.approved.txt
@@ -1,0 +1,40 @@
+RequireSpecAndStatusJavaCr[0] = package org.test.v1;
+
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1" , storage = true , served = true)
+@io.fabric8.kubernetes.model.annotation.Group("stable.example.com")
+@io.fabric8.kubernetes.model.annotation.Singular("requirespecandstatus")
+@io.fabric8.kubernetes.model.annotation.Plural("requirespecandstatuses")
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+public class RequireSpecAndStatus extends io.fabric8.kubernetes.client.CustomResource<org.test.v1.RequireSpecAndStatusSpec, org.test.v1.RequireSpecAndStatusStatus> implements io.fabric8.kubernetes.api.model.Namespaced {
+
+    @java.lang.Override()
+    @io.fabric8.generator.annotation.Required()
+    public org.test.v1.RequireSpecAndStatusSpec getSpec() {
+        return super.getSpec();
+    }
+
+    @java.lang.Override()
+    @io.fabric8.generator.annotation.Required()
+    public org.test.v1.RequireSpecAndStatusStatus getStatus() {
+        return super.getStatus();
+    }
+}
+
+RequireSpecAndStatusJavaCr[1] = package org.test.v1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+public class RequireSpecAndStatusSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+}
+
+RequireSpecAndStatusJavaCr[2] = package org.test.v1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+public class RequireSpecAndStatusStatus implements io.fabric8.kubernetes.api.model.KubernetesResource {
+}
+

--- a/java-generator/core/src/test/resources/require-spec-and-status-crd.yml
+++ b/java-generator/core/src/test/resources/require-spec-and-status-crd.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# java-package:org.sample
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: requirespecandstatus.stable.example.com
+spec:
+  group: stable.example.com
+  scope: Namespaced
+  names:
+    plural: requirespecandstatuses
+    singular: requirespecandstatus
+    kind: RequireSpecAndStatus
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+            - status
+          properties:
+            spec:
+              type: object
+            status:
+              type: object


### PR DESCRIPTION
## Description

Fixes #6802

Update Java generator to support generating required spec and status.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
