### PR TITLE
docs: update deprecated method chain to use final recommended method

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemReplacable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/ItemReplacable.java
@@ -22,7 +22,7 @@ public interface ItemReplacable<T> {
    *
    * @param item replacement
    * @return the replaced item from the api server
-   * @deprecated use resource(item).replaceStatus()
+   * @deprecated use resource(item).updateStatus()
    */
   @Deprecated
   T replaceStatus(T item);
@@ -32,7 +32,7 @@ public interface ItemReplacable<T> {
    *
    * @param item replacement
    * @return the replaced item from the api server
-   * @deprecated use resource(item).replace()
+   * @deprecated use resource(item).update()
    */
   @Deprecated
   T replace(T item);


### PR DESCRIPTION
## Description
The originally deprecated method suggested using another method that has since been deprecated as well. This documentation update ensures the correct and final method to use is clearly specified, avoiding confusion and unnecessary intermediate steps.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

