### PR TITLE
fix(vertx): VertxHttpClient uses exclusive Vert.x instance by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #6747: Preventing websocket error logs when the client is closed
 * Fix #6781: Allowing ipv6 entries to work in NO_PROXY
 * Fix #6725: CRD generator missing type for GenericKubernetesResource
+* Fix #6792: VertxHttpClient uses exclusive Vert.x instance by default
 
 #### Improvements
 
@@ -14,7 +15,6 @@
 
 #### New Features
 * Fix #6802: Java generator support for required spec and status
-
 * Fix #5993: Support for Kubernetes v1.31 (elli)
 * Fix #6767: Support for Kubernetes v1.32 (penelope) 
 

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/InputStreamReadStream.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/InputStreamReadStream.java
@@ -41,7 +41,7 @@ class InputStreamReadStream implements ReadStream<Buffer> {
   private Handler<Void> endHandler;
   private byte[] bytes;
 
-  public InputStreamReadStream(VertxHttpRequest vertxHttpRequest, InputStream is, HttpClientRequest request) {
+  InputStreamReadStream(VertxHttpRequest vertxHttpRequest, InputStream is, HttpClientRequest request) {
     this.vertxHttpRequest = vertxHttpRequest;
     this.is = is;
     this.request = request;

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientFactory.java
@@ -17,60 +17,31 @@ package io.fabric8.kubernetes.client.vertx;
 
 import io.fabric8.kubernetes.client.Config;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.file.FileSystemOptions;
 import io.vertx.ext.web.client.WebClientOptions;
-
-import static io.vertx.core.spi.resolver.ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME;
 
 public class VertxHttpClientFactory implements io.fabric8.kubernetes.client.http.HttpClient.Factory {
 
-  private static final class VertxHolder {
-
-    private static final Vertx INSTANCE = createVertxInstance();
-
-    private static synchronized Vertx createVertxInstance() {
-      // We must disable the async DNS resolver as it can cause issues when resolving the Vault instance.
-      // This is done using the DISABLE_DNS_RESOLVER_PROP_NAME system property.
-      // The DNS resolver used by vert.x is configured during the (synchronous) initialization.
-      // So, we just need to disable the async resolver around the Vert.x instance creation.
-      final String originalValue = System.getProperty(DISABLE_DNS_RESOLVER_PROP_NAME);
-      Vertx vertx;
-      try {
-        System.setProperty(DISABLE_DNS_RESOLVER_PROP_NAME, "true");
-        vertx = Vertx.vertx(new VertxOptions()
-            .setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(false).setClassPathResolvingEnabled(false))
-            .setUseDaemonThread(true));
-      } finally {
-        // Restore the original value
-        if (originalValue == null) {
-          System.clearProperty(DISABLE_DNS_RESOLVER_PROP_NAME);
-        } else {
-          System.setProperty(DISABLE_DNS_RESOLVER_PROP_NAME, originalValue);
-        }
-      }
-      return vertx;
-    }
-  }
-
-  private final Vertx vertx;
+  final Vertx sharedVertx;
 
   public VertxHttpClientFactory() {
-    this(VertxHolder.INSTANCE);
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      if (vertx != null) {
-        vertx.close();
-      }
-    }));
+    this(null);
   }
 
-  public VertxHttpClientFactory(Vertx vertx) {
-    this.vertx = vertx;
+  /**
+   * Create a new instance of the factory that will reuse the provided {@link Vertx} instance.
+   * <p>
+   * It's the user's responsibility to manage the lifecycle of the provided Vert.x instance.
+   * Operations such as close, and so on are left on hands of the user.
+   *
+   * @param sharedVertx the Vertx instance to use.
+   */
+  public VertxHttpClientFactory(Vertx sharedVertx) {
+    this.sharedVertx = sharedVertx;
   }
 
   @Override
   public VertxHttpClientBuilder<VertxHttpClientFactory> newBuilder() {
-    return new VertxHttpClientBuilder<>(this, vertx);
+    return new VertxHttpClientBuilder<>(this, sharedVertx);
   }
 
   /**

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
@@ -32,7 +32,6 @@ import io.vertx.core.streams.ReadStream;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ class VertxHttpRequest {
 
   final Vertx vertx;
   private final RequestOptions options;
-  private StandardHttpRequest request;
+  private final StandardHttpRequest request;
 
   public VertxHttpRequest(Vertx vertx, RequestOptions options, StandardHttpRequest request) {
     this.vertx = vertx;
@@ -113,7 +112,7 @@ class VertxHttpRequest {
       };
       resp.handler(buffer -> {
         try {
-          consumer.consume(Arrays.asList(ByteBuffer.wrap(buffer.getBytes())), result);
+          consumer.consume(List.of(ByteBuffer.wrap(buffer.getBytes())), result);
         } catch (Exception e) {
           resp.request().reset();
           result.done().completeExceptionally(e);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -1289,7 +1289,7 @@ class DefaultSharedIndexInformerTest {
   }
 
   @Test
-  void testClientStopClosesInformer() throws InterruptedException {
+  void testClientStopClosesInformer() throws Exception {
     // Given
     setupMockServerExpectations(Animal.class, "ns1", this::getList,
         r -> new WatchEvent(getAnimal("red-panda", "Carnivora", r), "ADDED"), null, null);
@@ -1301,6 +1301,8 @@ class DefaultSharedIndexInformerTest {
         .runnableInformer(60 * WATCH_EVENT_EMIT_TIME);
 
     animalSharedIndexInformer.start();
+
+    await().atMost(10, TimeUnit.SECONDS).until(animalSharedIndexInformer::hasSynced);
 
     client.close();
 


### PR DESCRIPTION
## Description

Fixes #6792

A shared Vert.x instance can still be provided to the VertxHttpClientFactory.

This instance will be shared across the different VertxHttpClient instances.

It's responsibility of the user to handle the Vert.x shared instance lifecycle

/cc @shawkins 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
