### PR TITLE
fix: fully encapsulating rejected execution handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Improvements
 
+* Fix #6863: ensuring SerialExecutor does not throw RejectedExecutionException to prevent unnecessary error logs
+
 #### Dependency Upgrade
 
 #### New Features

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/ProcessorStore.java
@@ -113,7 +113,7 @@ public class ProcessorStore<T extends HasMetadata> {
       }
     });
     if (cacheStateComplete != null) {
-      cacheStateComplete.accept(this.processor::executeIfPossible);
+      cacheStateComplete.accept(this.processor.getSerialExecutor()::execute);
     }
   }
 


### PR DESCRIPTION
## Description

throwing RejectedExecutionException was added to the SerialExecutor for consistency between the case when there was a local shutdown vs having the underlying executor shutdown. In every instance since then when this has come up we don't actually care about the work not being performed after shutdown - it's just a timing issue where we haven't check for shutdown prior to submitting the work. Rather than continue to change calling code, it seems better to just change the SerialExecutor contract and handle the rejections there.

closes: #6863

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
