### PR TITLE
onClose callback for LogWatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Improvements
 * Fix #6863: ensuring SerialExecutor does not throw RejectedExecutionException to prevent unnecessary error logs
 * Fix #6763: (crd-generator) YAML output customization
+* Fix #6880: LogWatch interface provides listeners on close stream event 
 
 #### Dependency Upgrade
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/LogWatch.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/LogWatch.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.dsl;
 import java.io.Closeable;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.CompletionStage;
 
 public interface LogWatch extends Closeable {
 
@@ -28,6 +29,15 @@ public interface LogWatch extends Closeable {
    * @return the {@link InputStream} which must be read completely or closed
    */
   InputStream getOutput();
+
+  /**
+   * Returns a {@link CompletionStage} released when the log stream is closed.
+   * If the stream is closed due to an exception (cf onFailure),
+   * this exception will be passed as parameter, null otherwise
+   *
+   * @return a {@link CompletionStage} released when the log stream is closed
+   */
+  CompletionStage<Throwable> onClose();
 
   /**
    * Close the Watch.

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallbackTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallbackTest.java
@@ -1,0 +1,103 @@
+package io.fabric8.kubernetes.client.dsl.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.fabric8.kubernetes.client.http.AsyncBody;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.kubernetes.client.http.TestAsyncBody;
+import io.fabric8.kubernetes.client.http.TestHttpResponse;
+import io.fabric8.kubernetes.client.impl.BaseClient;
+import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
+
+public class LogWatchCallbackTest {
+  private OperationContext context;
+  private Executor executor = Executors.newFixedThreadPool(2);
+  private URL url;
+  private HttpClient httpClientMock;
+
+  @BeforeEach
+  public void setUp() throws MalformedURLException {
+    BaseClient mock = mock(BaseClient.class, Mockito.RETURNS_SELF);
+    Mockito.when(mock.adapt(BaseClient.class).getKubernetesSerialization()).thenReturn(new KubernetesSerialization());
+    final OperationContext context = new OperationContext().withClient(mock);
+    when(mock.getExecutor()).thenReturn(this.executor);
+    this.context = context;
+
+    this.url = new URL("http://url_called");
+    this.httpClientMock = spy(HttpClient.class);
+    var httpRequestMock = mock(HttpRequest.class);
+    var builderMock = mock(HttpRequest.Builder.class);
+
+    Mockito.when(httpClientMock.newHttpRequestBuilder()).thenReturn(builderMock);
+    Mockito.when(builderMock.url(url)).thenReturn(builderMock);
+    Mockito.when(builderMock.build()).thenReturn(httpRequestMock);
+
+  }
+
+  @Test
+  public void withOutputStreamCloseEventTest() throws InterruptedException {
+
+    var future = new CompletableFuture<HttpResponse<AsyncBody>>();
+    var reached = new CountDownLatch(1);
+
+    Mockito.when(httpClientMock.consumeBytes(Mockito.any(), Mockito.any())).thenReturn(future);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    LogWatchCallback logWatch = new LogWatchCallback(baos, this.context);
+    logWatch.callAndWait(httpClientMock, url);
+
+    logWatch.onClose().thenAccept((Throwable t) -> {
+      reached.countDown();
+    });
+    future.complete(
+        new TestHttpResponse<AsyncBody>().withCode(HttpURLConnection.HTTP_GONE).withBody(new TestAsyncBody()));
+
+    assertThat(reached.await(1, TimeUnit.SECONDS)).isTrue();
+    logWatch.close();
+  }
+
+  @Test
+  public void withOutputStreamCloseEventOnFailureTest() throws MalformedURLException, InterruptedException {
+
+    var future = new CompletableFuture<HttpResponse<AsyncBody>>();
+    var reached = new CountDownLatch(1);
+
+    Mockito.when(httpClientMock.consumeBytes(Mockito.any(), Mockito.any())).thenReturn(future);
+
+    LogWatchCallback logWatch = new LogWatchCallback(new ByteArrayOutputStream(), this.context);
+    logWatch.callAndWait(httpClientMock, url);
+
+    final Throwable tReturned[] = new Throwable[1];
+    logWatch.onClose().thenAccept((Throwable t) -> {
+      tReturned[0] = t;
+      reached.countDown();
+    });
+   
+    var th = new Throwable("any exception");
+    future.completeExceptionally(th);
+
+    assertThat(reached.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(tReturned[0]).isEqualTo(th);
+
+    logWatch.close();
+  }
+}

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallbackTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/LogWatchCallbackTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.fabric8.kubernetes.client.dsl.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## Description

Fixes #6880

This feature implements a listener on the closing event of the LogWatch class. 
Currently, when a LogWatch is instantiated, and when the underlying stream is closed, the log processing stops and the underlying output stream received no more events without been inform that a dead end has been reach. 
With the onClose action I added, when the stream processing ends, (with an error or not), the information can be forwarded and a post processing can be easily started.

Due to some timeouts, I was loosing the log stream and could not reconnect in a smooth way. I did not see any easy way to be informed of this event and thus decided to implement it.

 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
