### PR TITLE
fix: rolling().restart() doesn't remove preexistent pod template annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.2-SNAPSHOT
 
 #### Bugs
+* Fix #6892: rolling().restart() doesn't remove preexistent pod template annotations
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
@@ -45,10 +45,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -60,7 +59,7 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
 
   private static final Long DEFAULT_SERVER_GC_WAIT_TIMEOUT = 60 * 1000L; // 60 seconds
 
-  private static final transient Logger LOG = LoggerFactory.getLogger(RollingUpdater.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RollingUpdater.class);
 
   protected final Client client;
   protected final String namespace;
@@ -186,33 +185,27 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
   }
 
   public static List<Object> requestPayLoadForRolloutPause() {
-    HashMap<String, Object> patch = new HashMap<>();
-    patch.put("op", "add");
-    patch.put("path", "/spec/paused");
-    patch.put("value", true);
-    return Collections.singletonList(patch);
+    return List.of(Map.of(
+        "op", "add",
+        "path", "/spec/paused",
+        "value", true));
   }
 
   public static List<Object> requestPayLoadForRolloutResume() {
-    HashMap<String, Object> patch = new HashMap<>();
-    patch.put("op", "remove");
-    patch.put("path", "/spec/paused");
-    return Collections.singletonList(patch);
+    return List.of(Map.of(
+        "op", "remove",
+        "path", "/spec/paused"));
   }
 
   public static List<Object> requestPayLoadForRolloutRestart() {
-    HashMap<String, Object> patch = new HashMap<>();
-    HashMap<String, Object> value = new HashMap<>();
-    patch.put("op", "replace");
-    patch.put("path", "/spec/template/metadata/annotations");
-    value.put("kubectl.kubernetes.io/restartedAt",
-        new Date().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-    patch.put("value", value);
-    return Collections.singletonList(patch);
+    return List.of(Map.of(
+        "op", "add",
+        "path", "/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt",
+        "value", new Date().toInstant().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
   }
 
   /**
-   * Lets wait until there are enough Ready pods of the given RC
+   * Let's wait until there are enough Ready pods of the given RC
    */
   private void waitUntilPodsAreReady(final T obj, final String namespace, final int requiredPodCount) {
     final AtomicInteger podCount = new AtomicInteger(0);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
@@ -17,21 +17,20 @@ package io.fabric8.kubernetes.client.mock;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableKubernetesMockClient(crud = true)
 class DeploymentCrudTest {
@@ -39,89 +38,108 @@ class DeploymentCrudTest {
   KubernetesClient client;
 
   @Test
-  void testCrud() {
+  void listInAnyNamespace() {
+    for (var i = 1; i < 4; i++) {
+      var deployment = new DeploymentBuilder().withNewMetadata()
+          .withName("deployment-" + i)
+          .withNamespace("ns-" + i)
+          .addToLabels("testKey", "testValue-" + i)
+          .endMetadata()
+          .withNewSpec()
+          .endSpec()
+          .build();
+      client.apps().deployments().resource(deployment).create();
+    }
+    assertThat(client.apps().deployments().inAnyNamespace().list().getItems())
+        .hasSize(3)
+        .extracting("metadata.name", "metadata.namespace")
+        .containsExactlyInAnyOrder(
+            tuple("deployment-1", "ns-1"),
+            tuple("deployment-2", "ns-2"),
+            tuple("deployment-3", "ns-3"));
+  }
 
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
-        .withName("deployment1")
-        .withNamespace("ns1")
-        .addToLabels("testKey", "testValue")
-        .endMetadata()
-        .withNewSpec()
-        .endSpec()
-        .build();
+  @Test
+  void listInNamespace() {
+    for (var i = 1; i < 4; i++) {
+      var deployment = new DeploymentBuilder().withNewMetadata()
+          .withName("deployment-" + i)
+          .withNamespace("ns-" + i)
+          .addToLabels("testKey", "testValue-" + i)
+          .endMetadata()
+          .withNewSpec()
+          .endSpec()
+          .build();
+      client.apps().deployments().resource(deployment).create();
+    }
+    assertThat(client.apps().deployments().inNamespace("ns-1").list().getItems())
+        .hasSize(1)
+        .extracting("metadata.name", "metadata.namespace")
+        .containsExactlyInAnyOrder(
+            tuple("deployment-1", "ns-1"));
+  }
 
-    Deployment deployment2 = new DeploymentBuilder().withNewMetadata()
-        .withName("deployment2")
-        .withNamespace("ns1")
-        .addToLabels("testKey", "testValue")
-        .endMetadata()
-        .withNewSpec()
-        .endSpec()
-        .build();
+  @Test
+  void listWithLabels() {
+    for (var i = 1; i < 4; i++) {
+      var deployment = new DeploymentBuilder().withNewMetadata()
+          .withName("deployment-" + i)
+          .withNamespace("ns-" + i)
+          .addToLabels("testKey", "testValue-" + i)
+          .endMetadata()
+          .withNewSpec()
+          .endSpec()
+          .build();
+      client.apps().deployments().resource(deployment).create();
+    }
+    assertThat(client.apps().deployments().inAnyNamespace().withLabel("testKey", "testValue-2").list().getItems())
+        .hasSize(1)
+        .extracting("metadata.name", "metadata.namespace")
+        .containsExactlyInAnyOrder(
+            tuple("deployment-2", "ns-2"));
+  }
 
-    Deployment deployment3 = new DeploymentBuilder().withNewMetadata()
-        .withName("deployment3")
-        .addToLabels("testKey", "testValue")
-        .withNamespace("ns2")
-        .endMetadata()
-        .withNewSpec()
-        .endSpec()
-        .build();
+  @Test
+  void delete() {
+    client.apps().deployments()
+        .resource(new DeploymentBuilder().withNewMetadata().withName("deployment-to-delete").endMetadata().build())
+        .create();
+    assertThat(client.apps().deployments().withName("deployment-to-delete").withTimeoutInMillis(100).delete())
+        .singleElement()
+        .extracting("name").isEqualTo("deployment-to-delete");
+  }
 
-    client.apps().deployments().inNamespace("ns1").create(deployment1);
-    client.apps().deployments().inNamespace("ns1").create(deployment2);
-    client.apps().deployments().inNamespace("ns2").create(deployment3);
-
-    DeploymentList aDeploymentList = client.apps().deployments().inAnyNamespace().list();
-    assertNotNull(aDeploymentList);
-    assertEquals(3, aDeploymentList.getItems().size());
-
-    aDeploymentList = client.apps().deployments().inNamespace("ns1").list();
-    assertNotNull(aDeploymentList);
-    assertEquals(2, aDeploymentList.getItems().size());
-
-    FilterWatchListDeletable<Deployment, DeploymentList, RollableScalableResource<Deployment>> withLabels = client.apps()
-        .deployments()
-        .inAnyNamespace()
-        .withLabels(Collections.singletonMap("testKey", "testValue"));
-    aDeploymentList = withLabels.list();
-    assertNotNull(aDeploymentList);
-    assertEquals(3, aDeploymentList.getItems().size());
-
-    assertEquals(3, withLabels.resources().count());
-
-    boolean bDeleted = client.apps().deployments().inNamespace("ns2").withName("deployment3").delete().size() == 1;
-    assertTrue(bDeleted);
-
-    deployment2 = client.apps().deployments()
-        .inNamespace("ns1").withName("deployment2").edit(d -> new DeploymentBuilder(d)
-            .editMetadata().addToLabels("key1", "value1").endMetadata()
-            .build());
-
-    assertNotNull(deployment2);
-    assertEquals("value1", deployment2.getMetadata().getLabels().get("key1"));
+  @Test
+  void edit() {
+    client.apps().deployments()
+        .resource(new DeploymentBuilder().withNewMetadata().withName("deployment-to-edit").endMetadata().build())
+        .create();
+    var edited = client.apps().deployments().withName("deployment-to-edit").edit(d -> new DeploymentBuilder(d)
+        .editMetadata().addToLabels("key1", "value1").endMetadata()
+        .build());
+    assertThat(edited).extracting("metadata.labels").isEqualTo(Map.of("key1", "value1"));
   }
 
   @Test
   @DisplayName("Should replace Deployment in CRUD server")
-  void testReplace() {
+  void testUpdate() {
     // Given
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+    var deployment = client.apps().deployments().inNamespace("ns1").resource(new DeploymentBuilder().withNewMetadata()
         .withName("d1")
         .withNamespace("ns1")
         .addToLabels("testKey", "testValue")
         .endMetadata()
         .withNewSpec()
         .endSpec()
-        .build();
-    deployment1 = client.apps().deployments().inNamespace("ns1").create(deployment1);
+        .build())
+        .create();
 
     // When
-    deployment1.getMetadata().getLabels().put("testKey", "one");
-    client.apps().deployments().inNamespace("ns1").withName("d1").replace(deployment1);
-    Deployment replacedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
+    deployment.getMetadata().getLabels().put("testKey", "one");
+    client.apps().deployments().resource(deployment).update();
 
     // Then
+    Deployment replacedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
     assertNotNull(replacedDeployment);
     assertFalse(replacedDeployment.getMetadata().getLabels().isEmpty());
     assertEquals("one", replacedDeployment.getMetadata().getLabels().get("testKey"));
@@ -131,15 +149,15 @@ class DeploymentCrudTest {
   @DisplayName("Should pause resource")
   void testPause() {
     // Given
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+    client.apps().deployments().inNamespace("ns1").resource(new DeploymentBuilder().withNewMetadata()
         .withName("d1")
         .withNamespace("ns1")
         .addToLabels("testKey", "testValue")
         .endMetadata()
         .withNewSpec()
         .endSpec()
-        .build();
-    client.apps().deployments().inNamespace("ns1").create(deployment1);
+        .build())
+        .create();
 
     // When
     client.apps()
@@ -157,18 +175,17 @@ class DeploymentCrudTest {
 
   @Test
   @DisplayName("Should resume rollout")
-  void testRolloutResume() throws InterruptedException {
+  void testRolloutResume() {
     // Given
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
+    client.apps().deployments().inNamespace("ns1").resource(new DeploymentBuilder().withNewMetadata()
         .withName("d1")
         .withNamespace("ns1")
         .addToLabels("testKey", "testValue")
         .endMetadata()
         .withNewSpec()
-        .withPaused(true)
         .endSpec()
-        .build();
-    client.apps().deployments().inNamespace("ns1").create(deployment1);
+        .build())
+        .create();
 
     // When
     client.apps()
@@ -186,35 +203,37 @@ class DeploymentCrudTest {
 
   @Test
   @DisplayName("Should restart rollout")
-  void testRolloutRestart() throws InterruptedException {
+  void rolloutRestart() {
     // Given
-    Deployment deployment1 = new DeploymentBuilder().withNewMetadata()
-        .withName("d1")
-        .withNamespace("ns1")
-        .addToLabels("testKey", "testValue")
-        .endMetadata()
-        .withNewSpec()
-        .withNewTemplate()
-        .withNewMetadata()
-        .addToAnnotations("", "")
-        .endMetadata()
-        .endTemplate()
-        .endSpec()
-        .build();
-    client.apps().deployments().inNamespace("ns1").create(deployment1);
-
+    client.apps().deployments()
+        .resource(new DeploymentBuilder().withNewMetadata().withName("deployment-to-restart").endMetadata().build())
+        .create();
     // When
-    client.apps()
-        .deployments()
-        .inNamespace("ns1")
-        .withName("d1")
-        .rolling()
-        .restart();
-    Deployment updatedDeployment = client.apps().deployments().inNamespace("ns1").withName("d1").get();
-
+    client.apps().deployments().withName("deployment-to-restart").rolling().restart();
     // Then
-    assertNotNull(updatedDeployment);
-    assertNotNull(
-        updatedDeployment.getSpec().getTemplate().getMetadata().getAnnotations().get("kubectl.kubernetes.io/restartedAt"));
+    assertThat(client.apps().deployments().withName("deployment-to-restart").get())
+        .extracting(d -> d.getSpec().getTemplate().getMetadata().getAnnotations().get("kubectl.kubernetes.io/restartedAt"))
+        .asString().isNotBlank();
+  }
+
+  @Test
+  @DisplayName("Should restart rollout preserving annotations")
+  void rolloutRestartPreservesAnnotations() {
+    // Given
+    client.apps().deployments()
+        .resource(new DeploymentBuilder().withNewMetadata().withName("deployment-to-restart").endMetadata()
+            .withNewSpec().withNewTemplate().withNewMetadata().addToAnnotations("original", "annotation").endMetadata()
+            .endTemplate().endSpec()
+            .build())
+        .create();
+    // When
+    client.apps().deployments().withName("deployment-to-restart").rolling().restart();
+    // Then
+    assertThat(client.apps().deployments().withName("deployment-to-restart").get())
+        .extracting("spec.template.metadata.annotations")
+        .asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
+        .hasFieldOrPropertyWithValue("original", "annotation")
+        .extracting(annotations -> annotations.get("kubectl.kubernetes.io/restartedAt"))
+        .asString().isNotBlank();
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -622,7 +623,8 @@ class DeploymentTest {
     // Then
     RecordedRequest recordedRequest = server.getLastRequest();
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertEquals("[{\"op\":\"add\",\"path\":\"/spec/paused\",\"value\":true}]", recordedRequest.getBody().readUtf8());
+    assertThat(client.getKubernetesSerialization().unmarshal(recordedRequest.getBody().readUtf8(), List.class))
+        .isEqualTo(List.of(Map.of("op", "add", "path", "/spec/paused", "value", true)));
   }
 
   @Test
@@ -652,7 +654,8 @@ class DeploymentTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertNotNull(deployment);
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertEquals("[{\"op\":\"remove\",\"path\":\"/spec/paused\"}]", recordedRequest.getBody().readUtf8());
+    assertThat(client.getKubernetesSerialization().unmarshal(recordedRequest.getBody().readUtf8(), List.class))
+        .isEqualTo(List.of(Map.of("op", "remove", "path", "/spec/paused")));
   }
 
   @Test
@@ -682,7 +685,7 @@ class DeploymentTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertNotNull(deployment);
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io/restartedAt"));
+    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io~1restartedAt"));
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -399,7 +399,7 @@ public class StatefulSetTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertNotNull(deployment);
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io/restartedAt"));
+    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io~1restartedAt"));
   }
 
   @Test


### PR DESCRIPTION
## Description
Fixes #6892

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
