### PR TITLE
Make vertx request header case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fix #6906: Knative VolatileTime should be serialized as String
 * Fix #6930: Add support for Boolean enums in the java-generator
 * Fix #6886: Remove invalid JUnit 4 references
-* Fix #6917: Fabric 8 client does not authenticate correctly on openshift if the returned Location header is lower case
+* Fix #6917: Client does not authenticate correctly on OpenShift if the returned Location header is lower-case
 
 #### Improvements
 * Fix #6863: ensuring SerialExecutor does not throw RejectedExecutionException to prevent unnecessary error logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix #6906: Knative VolatileTime should be serialized as String
 * Fix #6930: Add support for Boolean enums in the java-generator
 * Fix #6886: Remove invalid JUnit 4 references
+* Fix #6917: Fabric 8 client does not authenticate correctly on openshift if the returned Location header is lower case
 
 #### Improvements
 * Fix #6863: ensuring SerialExecutor does not throw RejectedExecutionException to prevent unnecessary error logs

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
@@ -18,7 +18,6 @@ package io.fabric8.kubernetes.client.vertx;
 import io.fabric8.kubernetes.client.http.AsyncBody;
 import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
-import io.fabric8.kubernetes.client.http.StandardHttpHeaders;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest.BodyContent;
 import io.vertx.core.Future;
@@ -41,13 +40,12 @@ import java.util.function.Function;
 
 class VertxHttpRequest {
 
-  private static final class VertxHttpResponse extends StandardHttpHeaders implements HttpResponse<AsyncBody> {
+  private static final class VertxHttpResponse implements HttpResponse<AsyncBody> {
     private final AsyncBody result;
     private final HttpClientResponse resp;
     private final HttpRequest request;
 
     private VertxHttpResponse(AsyncBody result, HttpClientResponse resp, HttpRequest request) {
-      super(toHeadersMap(resp.headers()));
       this.result = result;
       this.resp = resp;
       this.request = request;
@@ -71,6 +69,16 @@ class VertxHttpRequest {
     @Override
     public Optional<HttpResponse<?>> previousResponse() {
       return Optional.empty();
+    }
+
+    @Override
+    public List<String> headers(String key) {
+      return resp.headers().getAll(key);
+    }
+
+    @Override
+    public Map<String, List<String>> headers() {
+      return toHeadersMap(resp.headers());
     }
   }
 

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
@@ -16,7 +16,6 @@
 package io.fabric8.kubernetes.client.vertx;
 
 import io.fabric8.kubernetes.client.http.AsyncBody;
-import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest.BodyContent;
@@ -34,53 +33,10 @@ import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 class VertxHttpRequest {
-
-  private static final class VertxHttpResponse implements HttpResponse<AsyncBody> {
-    private final AsyncBody result;
-    private final HttpClientResponse resp;
-    private final HttpRequest request;
-
-    private VertxHttpResponse(AsyncBody result, HttpClientResponse resp, HttpRequest request) {
-      this.result = result;
-      this.resp = resp;
-      this.request = request;
-    }
-
-    @Override
-    public int code() {
-      return resp.statusCode();
-    }
-
-    @Override
-    public AsyncBody body() {
-      return result;
-    }
-
-    @Override
-    public HttpRequest request() {
-      return request;
-    }
-
-    @Override
-    public Optional<HttpResponse<?>> previousResponse() {
-      return Optional.empty();
-    }
-
-    @Override
-    public List<String> headers(String key) {
-      return resp.headers().getAll(key);
-    }
-
-    @Override
-    public Map<String, List<String>> headers() {
-      return toHeadersMap(resp.headers());
-    }
-  }
 
   final Vertx vertx;
   private final RequestOptions options;

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpResponse.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.vertx;
+
+import io.fabric8.kubernetes.client.http.AsyncBody;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.kubernetes.client.http.StandardHttpHeaders;
+import io.vertx.core.http.HttpClientResponse;
+
+import java.util.Optional;
+
+public class VertxHttpResponse extends StandardHttpHeaders implements HttpResponse<AsyncBody> {
+  private final AsyncBody result;
+  private final HttpClientResponse resp;
+  private final HttpRequest request;
+
+  VertxHttpResponse(AsyncBody result, HttpClientResponse resp, HttpRequest request) {
+    super(VertxHttpRequest.toHeadersMap(resp.headers()));
+    this.result = result;
+    this.resp = resp;
+    this.request = request;
+  }
+
+  @Override
+  public int code() {
+    return resp.statusCode();
+  }
+
+  @Override
+  public AsyncBody body() {
+    return result;
+  }
+
+  @Override
+  public HttpRequest request() {
+    return request;
+  }
+
+  @Override
+  public Optional<HttpResponse<?>> previousResponse() {
+    return Optional.empty();
+  }
+
+}

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpHeaders.java
@@ -23,9 +23,12 @@ public interface HttpHeaders {
 
   /**
    * Returns a List of all the Header String values for the provided key/name.
+   * <p>
+   * key is case-insensitive as defined in RFC 2616.
    *
    * @param key The header key/name for which to provide the values.
    * @return the List of header values for the provided key.
+   * @see <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-4.2">RFC 2616 Section 4.2</a>
    */
   List<String> headers(String key);
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpHeaders.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.kubernetes.client.http;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,7 +42,13 @@ public class StandardHttpHeaders implements HttpHeaders {
 
   @Override
   public List<String> headers(String key) {
-    return Collections.unmodifiableList(headers.getOrDefault(key, Collections.emptyList()));
+    final List<String> values = new ArrayList<>();
+    for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+      if (entry.getKey().equalsIgnoreCase(key)) {
+        values.addAll(entry.getValue());
+      }
+    }
+    return Collections.unmodifiableList(values);
   }
 
   @Override

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpGetTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpGetTest.java
@@ -79,6 +79,23 @@ public abstract class AbstractHttpGetTest {
     }
   }
 
+  @Test
+  @DisplayName("Test that headers are case insensitive")
+  public void caseInsensitiveHeaders() throws Exception {
+    final var value = "values";
+    server.expect().withPath("/header").andReturn(200, value)
+        .withHeader("fakeheader", "firstvalue")
+        .withHeader("FAKEHEADER", "secondvalue")
+        .always();
+    // When
+    try (HttpClient client = getHttpClientFactory().newBuilder().build()) {
+      final var request = client.newHttpRequestBuilder().uri(server.url("/header")).build();
+      final var result = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
+      assertThat(result)
+          .satisfies(r -> assertThat(r.headers("FakeHeader")).isNotEmpty().containsExactly("firstvalue", "secondvalue"));
+    }
+  }
+
   @DisplayName("Supported response body types")
   @ParameterizedTest(name = "{index}: {0}")
   @ValueSource(classes = { String.class, byte[].class, Reader.class, InputStream.class })


### PR DESCRIPTION
## Description
Make vertx http request's header case insensitive to fix case related issues.

Fixes #6917
## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

