### PR TITLE
fix(model-core) apiVersion for core k8s resources

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/HasMetadata.java
@@ -76,7 +76,11 @@ public interface HasMetadata extends KubernetesResource {
     final String group = getGroup(clazz);
     final String version = getVersion(clazz);
     if (group != null && version != null) {
-      return group + "/" + version;
+      if (group.isEmpty()) {
+        return version;
+      } else {
+        return group + "/" + version;
+      }
     }
     if (group != null || version != null) {
       throw new IllegalArgumentException(

--- a/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/test/java/io/fabric8/kubernetes/api/model/HasMetadataTest.java
@@ -207,6 +207,11 @@ class HasMetadataTest {
   }
 
   @Test
+  void apiVersionOfConfigMapShouldBeCorrect() {
+    assertEquals("v1", HasMetadata.getApiVersion(ConfigMap.class));
+  }
+
+  @Test
   void addingSameOwnerReferenceMultipleTimesShouldAddItOnlyOnce() {
     HasMetadata hasMetadata = new Default();
     HasMetadata owner = new Owner();


### PR DESCRIPTION
## Description
The HasMetadata#getApiVersion method is returning a string starting with "/" when the group is "". 
This is not consistent with how owner references are specified.

This issues is causing:
https://github.com/operator-framework/java-operator-sdk/issues/2723


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
