### PR TITLE
fix: Kube API Test startup fails on readiness SSL check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix #6930: Add support for Boolean enums in the java-generator
 * Fix #6941: HasMetadata.getApiVersion no slash when empty group
 * Fix #6829: Mixed-case enums are properly supported by the java-generator
+* FIX #6987: Kube API Test startup fails on readiness SSL check
 
 #### Improvements
 * Fix #6863: ensuring SerialExecutor does not throw RejectedExecutionException to prevent unnecessary error logs

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
@@ -41,6 +41,7 @@ import java.util.function.BooleanSupplier;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 
@@ -123,7 +124,10 @@ public class ProcessReadinessChecker {
           response.statusCode(), processName,
           port);
       return response.statusCode() == 200;
-    } catch (ConnectException e) {
+      // It has been reported that in rare circumstances this call might
+      // result in a javax.net.ssl.SSLException: Unrecognized SSL message
+      // in that case we still want to retry, assuming this error goes away.
+    } catch (ConnectException | SSLException e) {
       // still want to retry
       log.debug("Cannot connect to the server", e);
       return false;


### PR DESCRIPTION
In rare curcumstaces this it might occur that the readiness problem communcation
fails on SSL error.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
