### PR TITLE
fix(mockserver): KubernetesMockServer.reset resets lastRequest related variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.2-SNAPSHOT
 
 #### Bugs
+* Fix #6750: KubernetesMockServer.reset resets lastRequest related variables
 * Fix #6829: Mixed-case enums are properly supported by the java-generator
 * Fix #6886: Remove invalid JUnit 4 references
 * Fix #6892: rolling().restart() doesn't remove preexistent pod template annotations

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServer.java
@@ -129,7 +129,7 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
   }
 
   /**
-   * Creates a client using the cusotmized {@link KubernetesClientBuilder} provided in the {@link Consumer} parameter.
+   * Creates a client using the customized {@link KubernetesClientBuilder} provided in the {@link Consumer} parameter.
    * <p>
    * The function is invoked using an initial {@link Config} instance that is initialized with the mock server's
    * URL and the {@link TlsVersion} to use.
@@ -228,6 +228,7 @@ public class KubernetesMockServer extends DefaultMockServer implements Resetable
 
   @Override
   public void reset() {
+    super.reset();
     clearExpectations();
     onStart();
     unsupportedPatterns.clear();

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerTest.java
@@ -70,4 +70,42 @@ class KubernetesMockServerTest {
     // Then
     assertThat(client.getKubernetesVersion()).isNull();
   }
+
+  @Test
+  @DisplayName("reset, removes expectation")
+  void resetRemovesExpectation() {
+    // Given
+    server.expect().get().withPath("/test").andReturn(200, "OK").always();
+    assertThat(client.raw("/test")).isEqualTo("OK");
+    // When
+    server.reset();
+    // Then
+    assertThat(client.raw("/test")).isNull();
+  }
+
+  @Test
+  @DisplayName("reset, sets request count to 0")
+  void resetSetsRequestCountToZero() {
+    // Given
+    server.expect().get().withPath("/test").andReturn(200, "OK").always();
+    client.raw("/test");
+    assertThat(server.getRequestCount()).isEqualTo(1);
+    // When
+    server.reset();
+    // Then
+    assertThat(server.getRequestCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("reset, resets last request")
+  void resetResetsLastRequest() throws Exception {
+    // Given
+    server.expect().get().withPath("/test").andReturn(200, "OK").always();
+    client.raw("/test");
+    assertThat(server.getLastRequest()).isNotNull();
+    // When
+    server.reset();
+    // Then
+    assertThat(server.getLastRequest()).isNull();
+  }
 }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/DefaultMockServer.java
@@ -111,6 +111,13 @@ public class DefaultMockServer implements MockServer {
     }
   }
 
+  public void reset() {
+    server.reset();
+    responses.clear();
+    lastRequest.set(null);
+    lastRequestCount.set(0);
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -240,6 +240,18 @@ public class MockWebServer implements Closeable {
     this.protocols = protocols;
   }
 
+  /**
+   * Returns the MockWebServer to its initial state by:
+   * <ul>
+   * <li>Clearing the request count.</li>
+   * <li>Clearing the request queue.</li>
+   * </ul>
+   */
+  public final void reset() {
+    requestCount.set(0);
+    requestQueue.clear();
+  }
+
   private static <T> T await(Future<T> vertxFuture, String errorMessage) {
     final CompletableFuture<T> future = new CompletableFuture<>();
     vertxFuture.onComplete(r -> {


### PR DESCRIPTION
…d variables

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
