### PR TITLE
feat(crd-generator): introduce `@JSONSchema` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fix #6880: LogWatch interface provides listeners on close stream event
 * Fix #6971: Exposed Istio v1 models in Istio Client DSL
 * Fix #6998: Removed unneeded dependency on javax.annotation:javax.annotation-api
+* Fix #6999: (crd-generator) introduce JSONSchema annotation for increased control of schema output
 
 #### Dependency Upgrade
 * Fix #6829: Sundrio was upgraded to 0.200.3. In some rare circumstances nested method names will need to be changed.
@@ -54,7 +55,7 @@
 
 #### New Features
 * Fix #5993: Support for Kubernetes v1.31 (elli)
-* Fix #6767: Support for Kubernetes v1.32 (penelope) 
+* Fix #6767: Support for Kubernetes v1.32 (penelope)
 * Fix #6777: Added Javadoc comments to all generated models
 * Fix #6802: (java-generator) Added support for required spec and status
 
@@ -225,7 +226,7 @@
 * Fix #5357: adding additional Quantity methods
 * Fix #5635: refined LeaderElector lifecycle and logging
 * Fix #5787: (crd-generator) add support for deprecated versions for generated CRDs
-* Fix #5788: (crd-generator) add support for Kubernetes validation rules 
+* Fix #5788: (crd-generator) add support for Kubernetes validation rules
 * Fix #5735: Replace usages of `UUID.randomUUID()` with UUID created via AtomicLong
 
 #### New Features
@@ -309,7 +310,7 @@
 * Fix #5220: refinements and clarifications to the validation of names
 
 #### Dependency Upgrade
-* Fix #5286: Update Fabric8 OpenShift Model as per OpenShift 4.13.12 
+* Fix #5286: Update Fabric8 OpenShift Model as per OpenShift 4.13.12
 * Fix #5373: Gradle base API based on v8.2.1
 * Fix #5401: Upgrade Fabric8 Kubernetes Model to Kubernetes v1.28.2
 

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
@@ -167,14 +167,6 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
         resolvingContext.objectMapper.getSerializationConfig().constructType(definition), schema, null);
   }
 
-  private <A extends Annotation> T mapAnnotation(A annotation,
-      Function<A, T> mapper) {
-    if (annotation != null) {
-      return mapper.apply(annotation);
-    }
-    return null;
-  }
-
   /**
    * Walks up the class hierarchy to consume the repeating annotation
    */

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
@@ -435,7 +435,7 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
     collectDependentClasses(rawClass);
 
     JSONSchema schemaAnnotation = resolvingContext.ignoreJSONSchemaAnnotation ? null : rawClass.getDeclaredAnnotation(JSONSchema.class);
-    T classSchema = mapAnnotation(schemaAnnotation, schema -> fromAnnotation(rawClass, schema));
+    T classSchema = mapAnnotation(schemaAnnotation, schema -> fromAnnotation(rawClass, true, schema));
 
     if (classSchema != null) {
       return classSchema;
@@ -461,7 +461,7 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
 
       Class<?> propRawClass = beanProperty.getType().getRawClass();
       JSONSchema propSchemaAnnotation = beanProperty.getAnnotation(JSONSchema.class);
-      T propSchema = mapAnnotation(propSchemaAnnotation, schema -> fromAnnotation(propRawClass, schema));
+      T propSchema = mapAnnotation(propSchemaAnnotation, schema -> fromAnnotation(propRawClass, false, schema));
 
       if (propSchema != null) {
         addProperty(name, objectSchema, propSchema);
@@ -705,14 +705,14 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
     return toIgnore;
   }
 
-  protected T fromAnnotation(Class<?> targetType, JSONSchema schema) {
-      T result = mapImplementation(schema.implementation());
+  protected T fromAnnotation(Class<?> rawClass, boolean isTargetType, JSONSchema schema) {
+      T result = mapImplementation(schema.implementation(), isTargetType);
 
       if (result == null) {
         result = singleProperty(mapDefined(schema.type()));
       }
 
-      setIfDefined(mapDefined(schema.defaultValue(), targetType), result::setDefault);
+      setIfDefined(mapDefined(schema.defaultValue(), rawClass), result::setDefault);
       setIfDefined(mapDefined(schema.description()), result::setDescription);
       setIfDefined(mapBoolean(schema.exclusiveMaximum()), result::setExclusiveMaximum);
       setIfDefined(mapBoolean(schema.exclusiveMinimum()), result::setExclusiveMinimum);
@@ -795,7 +795,7 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
     return Utils.isNullOrEmpty(s) ? null : s;
   }
 
-  protected abstract T mapImplementation(Class<?> value);
+  protected abstract T mapImplementation(Class<?> value, boolean isTargetType);
 
   protected abstract V newKubernetesValidationRule();
 

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/ResolvingContext.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/ResolvingContext.java
@@ -93,6 +93,7 @@ public class ResolvingContext {
   final KubernetesSerialization kubernetesSerialization;
   final Map<String, GeneratorObjectSchema> uriToJacksonSchema;
   final boolean implicitPreserveUnknownFields;
+  final boolean ignoreJSONSchemaAnnotation;
 
   private static ObjectMapper OBJECT_MAPPER;
 
@@ -112,21 +113,27 @@ public class ResolvingContext {
   }
 
   public ResolvingContext forkContext() {
-    return new ResolvingContext(objectMapper, kubernetesSerialization, uriToJacksonSchema, implicitPreserveUnknownFields);
+    return new ResolvingContext(objectMapper, kubernetesSerialization, uriToJacksonSchema, implicitPreserveUnknownFields, ignoreJSONSchemaAnnotation);
+  }
+
+  public ResolvingContext forkContext(boolean ignoreJSONSchemaAnnotation) {
+    return new ResolvingContext(objectMapper, kubernetesSerialization, uriToJacksonSchema, implicitPreserveUnknownFields, ignoreJSONSchemaAnnotation);
   }
 
   public ResolvingContext(ObjectMapper mapper, KubernetesSerialization kubernetesSerialization,
       boolean implicitPreserveUnknownFields) {
-    this(mapper, kubernetesSerialization, new ConcurrentHashMap<>(), implicitPreserveUnknownFields);
+    this(mapper, kubernetesSerialization, new ConcurrentHashMap<>(), implicitPreserveUnknownFields, false);
   }
 
   private ResolvingContext(ObjectMapper mapper, KubernetesSerialization kubernetesSerialization,
       Map<String, GeneratorObjectSchema> uriToJacksonSchema,
-      boolean implicitPreserveUnknownFields) {
+      boolean implicitPreserveUnknownFields,
+      boolean ignoreJSONSchemaAnnotation) {
     this.uriToJacksonSchema = uriToJacksonSchema;
     this.objectMapper = mapper;
     this.kubernetesSerialization = kubernetesSerialization;
     this.implicitPreserveUnknownFields = implicitPreserveUnknownFields;
+    this.ignoreJSONSchemaAnnotation = ignoreJSONSchemaAnnotation;
     generator = new JsonSchemaGenerator(mapper, new WrapperFactory() {
 
       @Override

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/ResolvingContext.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/ResolvingContext.java
@@ -113,11 +113,13 @@ public class ResolvingContext {
   }
 
   public ResolvingContext forkContext() {
-    return new ResolvingContext(objectMapper, kubernetesSerialization, uriToJacksonSchema, implicitPreserveUnknownFields, ignoreJSONSchemaAnnotation);
+    return new ResolvingContext(objectMapper, kubernetesSerialization, uriToJacksonSchema, implicitPreserveUnknownFields,
+        ignoreJSONSchemaAnnotation);
   }
 
   public ResolvingContext forkContext(boolean ignoreJSONSchemaAnnotation) {
-    return new ResolvingContext(objectMapper, kubernetesSerialization, uriToJacksonSchema, implicitPreserveUnknownFields, ignoreJSONSchemaAnnotation);
+    return new ResolvingContext(objectMapper, kubernetesSerialization, uriToJacksonSchema, implicitPreserveUnknownFields,
+        ignoreJSONSchemaAnnotation);
   }
 
   public ResolvingContext(ObjectMapper mapper, KubernetesSerialization kubernetesSerialization,

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/JsonSchema.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/JsonSchema.java
@@ -22,13 +22,21 @@ import io.fabric8.crdv2.generator.KubernetesValidationRule;
 import io.fabric8.crdv2.generator.ResolvingContext;
 import io.fabric8.crdv2.generator.v1.JsonSchema.V1JSONSchemaProps;
 import io.fabric8.crdv2.generator.v1.JsonSchema.V1ValidationRule;
+import io.fabric8.generator.annotation.JSONSchema;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.ExternalDocumentation;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.ExternalDocumentationBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrArray;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrBool;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.ValidationRule;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class JsonSchema extends AbstractJsonSchema<V1JSONSchemaProps, V1ValidationRule> {
 
@@ -107,4 +115,134 @@ public class JsonSchema extends AbstractJsonSchema<V1JSONSchemaProps, V1Validati
     return result;
   }
 
+  @Override
+  protected V1JSONSchemaProps fromAnnotation(Class<?> targetType, JSONSchema schema) {
+      V1JSONSchemaProps result = super.fromAnnotation(targetType, schema);
+      setIfDefined(mapDefined(schema.type()), result::setType);
+      setIfDefined(mapDefined(schema.$ref()), result::set$ref);
+      setIfDefined(mapDefined(schema.$schema()), result::set$schema);
+      setIfDefined(mapSchemaOrBool(schema.additionalItems()), result::setAdditionalItems);
+      setIfDefined(mapSchemaOrBool(schema.additionalProperties()), result::setAdditionalProperties);
+      setIfDefined(mapSchemaList(schema.allOf()), result::setAllOf);
+      setIfDefined(mapSchemaList(schema.anyOf()), result::setAnyOf);
+      setIfDefined(mapSchemaMap(schema.definitions()), result::setDefinitions);
+      setIfDefined(mapDependencies(schema.dependencies()), result::setDependencies);
+      setIfDefined(mapEnumeration(schema.enumeration(), targetType), result::setEnum);
+      setIfDefined(mapDefined(schema.example(), targetType), result::setExample);
+      setIfDefined(mapExternalDocs(schema.externalDocs()), result::setExternalDocs);
+      setIfDefined(mapDefined(schema.id()), result::setId);
+      setIfDefined(mapSchemaOrArray(schema.items()), result::setItems);
+      setIfDefined(mapDefined(schema.multipleOf()), result::setMultipleOf);
+      setIfDefined(mapSchema(schema.not()), result::setNot);
+      setIfDefined(mapSchemaList(schema.oneOf()), result::setOneOf);
+      setIfDefined(mapSchemaMap(schema.patternProperties()), result::setPatternProperties);
+      setIfDefined(mapSchemaMap(schema.properties()), result::setProperties);
+      setIfDefined(mapDefined(schema.title()), result::setTitle);
+      setIfDefined(mapBoolean(schema.uniqueItems()), result::setUniqueItems);
+      setIfDefined(mapBoolean(schema.xKubernetesEmbeddedResource()), result::setXKubernetesEmbeddedResource);
+      setIfDefined(mapBoolean(schema.xKubernetesIntOrString()), result::setXKubernetesIntOrString);
+      setIfDefined(mapDefined(schema.xKubernetesListMapKeys()), result::setXKubernetesListMapKeys);
+      setIfDefined(mapDefined(schema.xKubernetesListType()), result::setXKubernetesListType);
+      setIfDefined(mapDefined(schema.xKubernetesMapType()), result::setXKubernetesMapType);
+      setIfDefined(mapValidationRules(schema.xKubernetesValidations()), result::setXKubernetesValidations);
+      return result;
+  }
+
+  @Override
+  protected V1JSONSchemaProps mapImplementation(Class<?> value) {
+    if (value == JSONSchema.Undefined.class) {
+      return null; // NOSONAR
+    }
+    return new JsonSchema(resolvingContext.forkContext(true), value).getSchema();
+  }
+
+  private JSONSchemaProps mapSchema(Class<?> value) {
+    if (value == JSONSchema.Undefined.class) {
+      return null; // NOSONAR
+    }
+    return new JsonSchema(resolvingContext.forkContext(false), value).getSchema();
+  }
+
+  private JSONSchemaPropsOrBool mapSchemaOrBool(Class<?> value) {
+    if (value == JSONSchema.Undefined.class) {
+      return null; // NOSONAR
+    }
+    JSONSchemaPropsOrBool result = new JSONSchemaPropsOrBool();
+
+    if (JSONSchema.Boolean.class.isAssignableFrom(value)) {
+      @SuppressWarnings("unchecked")
+      Class<JSONSchema.Boolean> booleanType = (Class<JSONSchema.Boolean>) value;
+      result.setAllows(mapBoolean(booleanType));
+    } else {
+      result.setSchema(new JsonSchema(resolvingContext.forkContext(false), value).getSchema());
+    }
+
+    return result;
+  }
+
+  private List<JsonNode> mapEnumeration(String[] examples, Class<?> targetType) {
+    if (examples.length != 0) {
+      return Arrays.stream(examples).map(ex -> mapDefined(ex, targetType)).collect(Collectors.toList());
+    }
+    return null; // NOSONAR
+  }
+
+  private JSONSchemaPropsOrArray mapSchemaOrArray(Class<?>[] values) {
+    return Optional.ofNullable(mapSchemaList(values))
+        .map(schemas -> {
+          JSONSchemaPropsOrArray result = new JSONSchemaPropsOrArray();
+          if (schemas.size() == 1) {
+            result.setSchema(schemas.get(0));
+          } else {
+            result.setJSONSchemas(schemas);
+          }
+          return result;
+        })
+        .orElse(null);
+  }
+
+  private List<JSONSchemaProps> mapSchemaList(Class<?>[] values) {
+    if (values.length == 0) {
+      return null; // NOSONAR
+    }
+
+    return Arrays.stream(values)
+        .map(this::mapSchema)
+        .collect(Collectors.toList());
+  }
+
+  private Map<String, JSONSchemaProps> mapSchemaMap(JSONSchema.Map[] entries) {
+    if (entries.length == 0) {
+      return null; // NOSONAR
+    }
+
+    return Arrays.stream(entries)
+        .map(e -> Map.entry(e.name(), mapSchema(e.value())))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private Map<String, JSONSchemaPropsOrStringArray> mapDependencies(JSONSchema.DependencyMap[] entries) {
+    if (entries.length == 0) {
+      return null; // NOSONAR
+    }
+
+    return Arrays.stream(entries)
+        .map(e -> Map.entry(e.name(), new JSONSchemaPropsOrStringArray(mapDefined(e.value().properties()), mapSchema(e.value().schema()))))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private ExternalDocumentation mapExternalDocs(JSONSchema.ExternalDocumentation externalDocs) {
+    if (Stream.of(externalDocs.description(), externalDocs.url()).allMatch(JSONSchema.Undefined.STRING::equals)) {
+      return null;
+    }
+
+    return new ExternalDocumentationBuilder()
+        .withDescription(mapDefined(externalDocs.description()))
+        .withUrl(mapDefined(externalDocs.url()))
+        .build();
+  }
+
+  private List<ValidationRule> mapValidationRules(io.fabric8.generator.annotation.ValidationRule[] values) {
+    return Arrays.stream(values).map(super::from).collect(Collectors.toList());
+  }
 }

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/JsonSchema.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/JsonSchema.java
@@ -116,8 +116,9 @@ public class JsonSchema extends AbstractJsonSchema<V1JSONSchemaProps, V1Validati
   }
 
   @Override
-  protected V1JSONSchemaProps fromAnnotation(Class<?> targetType, JSONSchema schema) {
-      V1JSONSchemaProps result = super.fromAnnotation(targetType, schema);
+  protected V1JSONSchemaProps fromAnnotation(Class<?> rawClass, boolean isTargetType, JSONSchema schema) {
+      V1JSONSchemaProps result = super.fromAnnotation(rawClass, isTargetType, schema);
+      // maybe override the type if it was determined by reading the optional `implementation`
       setIfDefined(mapDefined(schema.type()), result::setType);
       setIfDefined(mapDefined(schema.$ref()), result::set$ref);
       setIfDefined(mapDefined(schema.$schema()), result::set$schema);
@@ -127,8 +128,8 @@ public class JsonSchema extends AbstractJsonSchema<V1JSONSchemaProps, V1Validati
       setIfDefined(mapSchemaList(schema.anyOf()), result::setAnyOf);
       setIfDefined(mapSchemaMap(schema.definitions()), result::setDefinitions);
       setIfDefined(mapDependencies(schema.dependencies()), result::setDependencies);
-      setIfDefined(mapEnumeration(schema.enumeration(), targetType), result::setEnum);
-      setIfDefined(mapDefined(schema.example(), targetType), result::setExample);
+      setIfDefined(mapEnumeration(schema.enumeration(), rawClass), result::setEnum);
+      setIfDefined(mapDefined(schema.example(), rawClass), result::setExample);
       setIfDefined(mapExternalDocs(schema.externalDocs()), result::setExternalDocs);
       setIfDefined(mapDefined(schema.id()), result::setId);
       setIfDefined(mapSchemaOrArray(schema.items()), result::setItems);
@@ -149,11 +150,11 @@ public class JsonSchema extends AbstractJsonSchema<V1JSONSchemaProps, V1Validati
   }
 
   @Override
-  protected V1JSONSchemaProps mapImplementation(Class<?> value) {
+  protected V1JSONSchemaProps mapImplementation(Class<?> value, boolean isTargetType) {
     if (value == JSONSchema.Undefined.class) {
       return null; // NOSONAR
     }
-    return new JsonSchema(resolvingContext.forkContext(true), value).getSchema();
+    return new JsonSchema(resolvingContext.forkContext(isTargetType), value).getSchema();
   }
 
   private JSONSchemaProps mapSchema(Class<?> value) {

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnno.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnno.java
@@ -1,0 +1,7 @@
+package io.fabric8.crdv2.example.jsonschema;
+
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class JsonSchemaAnno extends CustomResource<JsonSchemaAnnoSpec, JsonSchemaAnnoStatus> {
+  private static final long serialVersionUID = 1L;
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnno.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnno.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.crdv2.example.jsonschema;
 
 import io.fabric8.kubernetes.client.CustomResource;

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoSpec.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoSpec.java
@@ -1,0 +1,102 @@
+package io.fabric8.crdv2.example.jsonschema;
+
+import io.fabric8.generator.annotation.JSONSchema;
+import io.fabric8.generator.annotation.JSONSchema.ExternalDocumentation;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class JsonSchemaAnnoSpec {
+
+  @JSONSchema(type = "string")
+  private Object customizedType;
+
+  /* *********************************************************************** */
+
+  @JSONSchema(externalDocs = @ExternalDocumentation(url = "https://example.com/docs.txt"))
+  private String documentedExternally;
+
+  /* *********************************************************************** */
+
+  @JSONSchema(implementation = StrictItemsSchema.class, additionalProperties = JSONSchema.False.class)
+  @Data
+  static class StrictItemsSchema {
+    String field1;
+    int field2;
+  }
+
+  @JSONSchema(type = "array", additionalItems = JSONSchema.False.class, items = StrictItemsSchema.class)
+  private List<Object> strictItems;
+
+  /* *********************************************************************** */
+
+  @JSONSchema(implementation = LaxItemsSchema1.class, additionalProperties = JSONSchema.True.class)
+  @Data
+  static class LaxItemsSchema1 {
+    String field1;
+    double field2;
+  }
+
+  // besides field1 and field2, allows additional properties if they are objects of type LaxItemsSchema1
+  @JSONSchema(implementation = LaxItemsSchema2.class, additionalProperties = LaxItemsSchema1.class)
+  @Data
+  static class LaxItemsSchema2 {
+    String field1;
+    int field2;
+  }
+
+  @JSONSchema(type = "array", additionalItems = JSONSchema.True.class, items = { LaxItemsSchema1.class,
+      LaxItemsSchema2.class })
+  private List<Object> laxItems;
+
+  /* *********************************************************************** */
+
+  @JSONSchema(implementation = OverriddenPropertiesSchema.class, description = "Has properties that are replaced by referencing type")
+  @Data
+  static class OverriddenPropertiesSchema {
+    String field1;
+    int field2;
+  }
+
+  @JSONSchema(type = "object", properties = {
+      @JSONSchema.Map(name = "field3", value = Long.class),
+      @JSONSchema.Map(name = "field4", value = Double.class),
+  }, implementation = OverriddenPropertiesSchema.class)
+  private OverriddenPropertiesSchema overriddenProperties;
+
+  /* *********************************************************************** */
+
+  @Data
+  static class ObjectEnumerationSchema {
+    String field1;
+    int field2;
+  }
+
+  @JSONSchema(type = "object", implementation = ObjectEnumerationSchema.class, defaultValue = "{ \"field1\": \"allowedValue1\", \"field2\": 1 }", enumeration = {
+      "{ \"field1\": \"allowedValue1\", \"field2\": 1 }",
+      "{ \"field1\": \"allowedValue2\", \"field2\": 2 }",
+  })
+  private OverriddenPropertiesSchema objectEnumeration;
+
+  /* *********************************************************************** */
+
+  @JSONSchema(type = "integer", nullable = JSONSchema.True.class, minimum = 0d, maximum = 100d, exclusiveMaximum = JSONSchema.True.class)
+  static class NullableIntegerWithRange {
+  }
+
+  @Data
+  @JSONSchema(type = "object", implementation = ObjectEnumerationSchema.class, dependencies = {
+      // field1 requires the presence of field2
+      @JSONSchema.DependencyMap(name = "field1", value = @JSONSchema.Dependency(properties = "field2")),
+      // field2 requires that field1 is null or an integer between 0 and 100 (exclusive)
+      @JSONSchema.DependencyMap(name = "field2", value = @JSONSchema.Dependency(schema = NullableIntegerWithRange.class))
+  })
+  static class DependentPropertiesSchema {
+    String field1;
+    Integer field2;
+  }
+
+  private DependentPropertiesSchema dependentProperties;
+
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoSpec.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoSpec.java
@@ -17,6 +17,7 @@ package io.fabric8.crdv2.example.jsonschema;
 
 import io.fabric8.generator.annotation.JSONSchema;
 import io.fabric8.generator.annotation.JSONSchema.ExternalDocumentation;
+import io.fabric8.generator.annotation.ValidationRule;
 import lombok.Data;
 
 import java.util.List;
@@ -91,7 +92,7 @@ public class JsonSchemaAnnoSpec {
   @JSONSchema(type = "object", implementation = ObjectEnumerationSchema.class, defaultValue = "{ \"field1\": \"allowedValue1\", \"field2\": 1 }", enumeration = {
       "{ \"field1\": \"allowedValue1\", \"field2\": 1 }",
       "{ \"field1\": \"allowedValue2\", \"field2\": 2 }",
-  })
+  }, example = "{ \"field1\": \"allowedValue2\", \"field2\": 2 }")
   private OverriddenPropertiesSchema objectEnumeration;
 
   /* *********************************************************************** */
@@ -113,5 +114,76 @@ public class JsonSchemaAnnoSpec {
   }
 
   private DependentPropertiesSchema dependentProperties;
+
+  /* *********************************************************************** */
+
+  @Data
+  @JSONSchema(implementation = SuppressionSchema.class, additionalProperties = String.class, minProperties = 1, maxProperties = 10, example = "{ \"field2\": 42 }", xKubernetesValidations = @ValidationRule("some rule"))
+  static class SuppressionSchema {
+    String field1;
+    Integer field2;
+    @JSONSchema(minItems = 3)
+    List<String> field3;
+  }
+
+  @JSONSchema(implementation = SuppressionSchema.class, additionalProperties = JSONSchema.Suppressed.class, minProperties = JSONSchema.Suppressed.LONG, example = JSONSchema.Suppressed.STRING, xKubernetesValidations = {})
+  private SuppressionSchema suppression;
+
+  /* *********************************************************************** */
+
+  @Data
+  static class StructuralSchema1 {
+    String string1;
+  }
+
+  @Data
+  static class StructuralSchema2 {
+    String string2;
+  }
+
+  @Data
+  static class StructuralSchema3 {
+    String string3;
+    StructuralSchema1 structural3;
+  }
+
+  @Data
+  static class StructuralSchema4 {
+    List<String> string4;
+  }
+
+  @Data
+  static class StructuralSchema5 {
+    String string5;
+  }
+
+  @Data
+  static class StructuralSchema6 {
+    String string6;
+  }
+
+  @Data
+  static class StructuralSchema7 {
+    String string7;
+    StructuralSchema8 intOrString7;
+  }
+
+  @Data
+  @JSONSchema(xKubernetesIntOrString = JSONSchema.True.class, anyOf = { Integer.class, String.class })
+  static class StructuralSchema8 {
+    String string8;
+    Integer integer8;
+  }
+
+  @Data
+  @JSONSchema(structural = true, allOf = { StructuralSchema4.class, StructuralSchema5.class }, anyOf = {
+      StructuralSchema1.class,
+      StructuralSchema3.class }, not = StructuralSchema2.class, oneOf = { StructuralSchema6.class, StructuralSchema7.class })
+  static class StructuralSchema {
+    String string;
+    Integer integer;
+  }
+
+  private StructuralSchema structural;
 
 }

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoSpec.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoSpec.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.crdv2.example.jsonschema;
 
 import io.fabric8.generator.annotation.JSONSchema;

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoStatus.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoStatus.java
@@ -1,0 +1,8 @@
+package io.fabric8.crdv2.example.jsonschema;
+
+import lombok.Data;
+
+@Data
+public class JsonSchemaAnnoStatus {
+
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoStatus.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/jsonschema/JsonSchemaAnnoStatus.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.crdv2.example.jsonschema;
 
 import lombok.Data;

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/JsonSchemaAnnotationTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/JsonSchemaAnnotationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.crdv2.generator.v1;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/JsonSchemaAnnotationTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/JsonSchemaAnnotationTest.java
@@ -1,0 +1,105 @@
+package io.fabric8.crdv2.generator.v1;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.fabric8.crdv2.example.jsonschema.JsonSchemaAnno;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaPropsOrStringArray;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonSchemaAnnotationTest {
+
+  JSONSchemaProps schema;
+
+  @BeforeEach
+  void setup() {
+    schema = JsonSchema.from(JsonSchemaAnno.class);
+    assertNotNull(schema);
+  }
+
+  @Test
+  void testCustomizedType() {
+    JSONSchemaProps target = schema.getProperties().get("spec").getProperties().get("customizedType");
+    assertEquals("string", target.getType());
+  }
+
+  @Test
+  void testExternalDocumentation() {
+    JSONSchemaProps target = schema.getProperties().get("spec").getProperties().get("documentedExternally");
+    assertNull(target.getType()); // type not defined in @JSONSchema
+    assertNotNull(target.getExternalDocs());
+    assertEquals("https://example.com/docs.txt", target.getExternalDocs().getUrl());
+  }
+
+  @Test
+  void testStrictArrayItemSchema() {
+    JSONSchemaProps target = schema.getProperties().get("spec").getProperties().get("strictItems");
+    assertEquals("array", target.getType());
+    assertEquals(Boolean.FALSE, target.getAdditionalItems().getAllows());
+    assertNotNull(target.getItems());
+    JSONSchemaProps items = target.getItems().getSchema();
+    assertEquals("object", items.getType());
+    assertEquals(Boolean.FALSE, items.getAdditionalProperties().getAllows());
+    assertTrue(items.getProperties().keySet().containsAll(List.of("field1", "field2")));
+  }
+
+  @Test
+  void testLaxArrayItemSchema() {
+    JSONSchemaProps target = schema.getProperties().get("spec").getProperties().get("laxItems");
+    assertEquals("array", target.getType());
+    assertEquals(Boolean.TRUE, target.getAdditionalItems().getAllows());
+    assertNotNull(target.getItems());
+    List<JSONSchemaProps> itemsSchemas = target.getItems().getJSONSchemas();
+    assertEquals(2, itemsSchemas.size());
+    assertTrue(itemsSchemas.stream().allMatch(s -> s.getProperties().keySet().containsAll(List.of("field1", "field2"))));
+
+    assertEquals(Boolean.TRUE, itemsSchemas.get(0).getAdditionalProperties().getAllows());
+    assertNull(itemsSchemas.get(0).getAdditionalProperties().getSchema());
+    assertEquals(itemsSchemas.get(0), itemsSchemas.get(1).getAdditionalProperties().getSchema());
+    assertNull(itemsSchemas.get(1).getAdditionalProperties().getAllows());
+  }
+
+  @Test
+  void testOverriddenProperties() {
+    JSONSchemaProps target = schema.getProperties().get("spec").getProperties().get("overriddenProperties");
+    assertEquals("object", target.getType());
+    assertEquals(Set.of("field3", "field4"), target.getProperties().keySet());
+    assertEquals("Has properties that are replaced by referencing type", target.getDescription());
+  }
+
+  @Test
+  void testObjectEnumerationWithDefault() {
+    JSONSchemaProps target = schema.getProperties().get("spec").getProperties().get("objectEnumeration");
+    ObjectNode expected1 = JsonNodeFactory.instance.objectNode().put("field1", "allowedValue1").put("field2", 1);
+    ObjectNode expected2 = JsonNodeFactory.instance.objectNode().put("field1", "allowedValue2").put("field2", 2);
+    assertEquals(expected1, target.getDefault());
+    assertEquals(List.of(expected1, expected2), target.getEnum());
+  }
+
+  @Test
+  void testDependencies() {
+    JSONSchemaProps target = schema.getProperties().get("spec").getProperties().get("dependentProperties");
+    JSONSchemaPropsOrStringArray field1Deps = target.getDependencies().get("field1");
+    assertNull(field1Deps.getSchema());
+    assertEquals(List.of("field2"), field1Deps.getProperty());
+    JSONSchemaPropsOrStringArray field2Deps = target.getDependencies().get("field2");
+    assertNull(field2Deps.getProperty());
+    assertEquals("integer", field2Deps.getSchema().getType());
+    assertEquals(Boolean.TRUE, field2Deps.getSchema().getNullable());
+    assertEquals(Double.valueOf(0), field2Deps.getSchema().getMinimum());
+    assertNull(field2Deps.getSchema().getExclusiveMinimum());
+    assertEquals(Double.valueOf(100), field2Deps.getSchema().getMaximum());
+    assertEquals(Boolean.TRUE, field2Deps.getSchema().getExclusiveMaximum());
+  }
+
+}
+

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
@@ -1,0 +1,200 @@
+package io.fabric8.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JSONSchema {
+
+    /**
+     * Marker interface used to restrict the class types that may be used for
+     * properties of type boolean. This enables readers of the annotation to
+     * distinguish between true, false, and undefined values.
+     */
+    interface Boolean {
+    }
+
+    /**
+     * Marker class used as a default for annotation properties of type
+     * {@code Class}.
+     */
+    public static final class Undefined implements Boolean {
+        /**
+         * Marker value used as a default for annotation properties of type
+         * {@code String}.
+         */
+        public static final String STRING = "io.fabric8.generator.annotation.JSONSchema.UNSET";
+
+        /**
+         * Marker value used as a default for annotation properties of type
+         * {@code double}.
+         */
+        public static final double DOUBLE = Double.POSITIVE_INFINITY;
+
+        /**
+         * Marker value used as a default for annotation properties of type
+         * {@code long}. Same binary value used for Double.POSITIVE_INFINITY.
+         */
+        public static final long LONG = 0x7ff0000000000000L;
+
+        private Undefined() {
+        }
+    }
+
+    /**
+     * Marker class to indicate that a boolean {@code true} schema should be used.
+     * Additionally, this class is used to set a value of {@code true} for
+     * properties that allow true, false, or undefined boolean values.
+     */
+    public static final class True implements Boolean {
+        private True() {
+        }
+    }
+
+    /**
+     * Marker class to indicate that a boolean {@code false} schema should be used.
+     * Additionally, this class is used to set a value of {@code false} for
+     * properties that allow true, false, or undefined boolean values.
+     */
+    public static final class False implements Boolean {
+        private False() {
+        }
+    }
+
+    @Target({})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Map {
+        String name();
+
+        Class<?> value();
+    }
+
+    @Target({})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Dependency {
+        String[] properties() default {};
+
+        Class<?> schema() default Undefined.class;
+    }
+
+    @Target({})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DependencyMap {
+        String name();
+
+        Dependency value();
+    }
+
+    @Target({})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ExternalDocumentation {
+        String description() default Undefined.STRING;
+
+        String url() default Undefined.STRING;
+    }
+
+    /**
+     * The implementation class allows for an additional type to be scanned as the
+     * basis for this schema. After scanning the implementation (if specified), the
+     * remaining properties will be set from this annotation, possibly overriding
+     * those determine by scanning the implementation class.
+     */
+    Class<?> implementation() default Undefined.class;
+
+    String $ref() default Undefined.STRING; // NOSONAR
+
+    String $schema() default Undefined.STRING; // NOSONAR
+
+    Class<?> additionalItems() default Undefined.class;
+
+    Class<?> additionalProperties() default Undefined.class;
+
+    Class<?>[] allOf() default {};
+
+    Class<?>[] anyOf() default {};
+
+    String defaultValue() default Undefined.STRING;
+
+    Map[] definitions() default {};
+
+    DependencyMap[] dependencies() default {};
+
+    String description() default Undefined.STRING;
+
+    /*
+     * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
+     */
+    String[] enumeration() default {};
+
+    /*
+     * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
+     */
+    String example() default Undefined.STRING;
+
+    Class<? extends Boolean> exclusiveMaximum() default Undefined.class;
+
+    Class<? extends Boolean> exclusiveMinimum() default Undefined.class;
+
+    ExternalDocumentation externalDocs() default @ExternalDocumentation;
+
+    String format() default Undefined.STRING;
+
+    String id() default Undefined.STRING;
+
+    Class<?>[] items() default {};
+
+    long maxItems() default Undefined.LONG;
+
+    long maxLength() default Undefined.LONG;
+
+    long maxProperties() default Undefined.LONG;
+
+    double maximum() default Undefined.DOUBLE;
+
+    long minItems() default Undefined.LONG;
+
+    long minLength() default Undefined.LONG;
+
+    long minProperties() default Undefined.LONG;
+
+    double minimum() default Undefined.DOUBLE;
+
+    double multipleOf() default Undefined.DOUBLE;
+
+    Class<?> not() default Undefined.class;
+
+    Class<? extends Boolean> nullable() default Undefined.class;
+
+    Class<?>[] oneOf() default {};
+
+    String pattern() default Undefined.STRING;
+
+    Map[] patternProperties() default {};
+
+    Map[] properties() default {};
+
+    String[] required() default {};
+
+    String title() default Undefined.STRING;
+
+    String type() default Undefined.STRING;
+
+    Class<? extends Boolean> uniqueItems() default Undefined.class;
+
+    Class<? extends Boolean> xKubernetesEmbeddedResource() default Undefined.class;
+
+    Class<? extends Boolean> xKubernetesIntOrString() default Undefined.class;
+
+    String[] xKubernetesListMapKeys() default {};
+
+    String xKubernetesListType() default Undefined.STRING;
+
+    String xKubernetesMapType() default Undefined.STRING;
+
+    Class<? extends Boolean> xKubernetesPreserveUnknownFields() default Undefined.class;
+
+    ValidationRule[] xKubernetesValidations() default {};
+}

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
@@ -246,7 +246,10 @@ public @interface JSONSchema {
    * present in the schemas that are set in the properties in step 1.</li>
    * </ol>
    *
-   * @see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
+   * @see <a href=
+   *      "https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema">Extend
+   *      the Kubernetes API with CustomResourceDefinitions: Specifying a structural schema</a>
+   *
    */
   boolean structural() default false;
 

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
@@ -19,6 +19,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Array;
 
 @Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
@@ -41,7 +42,7 @@ public @interface JSONSchema {
      * Marker value used as a default for annotation properties of type
      * {@code String}.
      */
-    public static final String STRING = "io.fabric8.generator.annotation.JSONSchema.UNSET";
+    public static final String STRING = "io.fabric8.generator.annotation.JSONSchema.Undefined";
 
     /**
      * Marker value used as a default for annotation properties of type
@@ -56,6 +57,105 @@ public @interface JSONSchema {
     public static final long LONG = 0x7ff0000000000000L;
 
     private Undefined() {
+    }
+
+    public static boolean isUndefined(Object value) {
+      if (value == Undefined.class) {
+        return true;
+      }
+      if (STRING.equals(value)) {
+        return true;
+      }
+      if (value instanceof Double && (Double) value == DOUBLE) {
+        return true;
+      }
+      if (value instanceof Long && (Long) value == LONG) {
+        return true;
+      }
+      if (value instanceof Map) {
+        return isUndefined(((Map) value).value());
+      }
+      if (value instanceof DependencyMap) {
+        return isUndefined(((DependencyMap) value).value());
+      }
+      if (value instanceof Dependency) {
+        return isUndefined(((Dependency) value).schema());
+      }
+      if (value instanceof ExternalDocumentation) {
+        return isUndefined(((ExternalDocumentation) value).url());
+      }
+      if (value instanceof ValidationRule) {
+        return isUndefined(((ValidationRule) value).value());
+      }
+      return isUndefinedArray(value);
+    }
+
+    private static boolean isUndefinedArray(Object value) {
+      if (value.getClass().isArray() && Array.getLength(value) == 1) {
+        return isUndefined(Array.get(value, 0));
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Marker class used to suppress annotation properties of type {@code Class} that may have been
+   * set by the use of an `implementation` class.
+   */
+  public static final class Suppressed implements Boolean {
+    /**
+     * Marker value used to suppress annotation properties of type
+     * {@code String} that may have been set by an {@code implementation} class.
+     */
+    public static final String STRING = "io.fabric8.generator.annotation.JSONSchema.Suppressed";
+
+    /**
+     * Marker value used to suppress annotation properties of type
+     * {@code double} that may have been set by an {@code implementation} class.
+     */
+    public static final double DOUBLE = Double.NEGATIVE_INFINITY;
+
+    /**
+     * Marker value used to suppress annotation properties of type
+     * {@code long} that may have been set by an {@code implementation} class.
+     */
+    public static final long LONG = 0xfff0000000000000L;
+
+    private Suppressed() {
+    }
+
+    public static boolean isSuppressed(Object value) {
+      if (value == Suppressed.class) {
+        return true;
+      }
+      if (STRING.equals(value)) {
+        return true;
+      }
+      if (value instanceof Double && (Double) value == DOUBLE) {
+        return true;
+      }
+      if (value instanceof Long && (Long) value == LONG) {
+        return true;
+      }
+      if (value instanceof ExternalDocumentation) {
+        return isSuppressed(((ExternalDocumentation) value).url());
+      }
+      return isSuppressedArray(value);
+    }
+
+    private static boolean isSuppressedArray(Object value) {
+      if (value.getClass().isArray()) {
+        switch (Array.getLength(value)) {
+          case 0:
+            // Any of the annotation arrays can be set to length zero to indicate suppression.
+            return true;
+          case 1:
+            return isSuppressed(Array.get(value, 0));
+          default:
+            break;
+        }
+      }
+      return false;
     }
   }
 
@@ -119,6 +219,37 @@ public @interface JSONSchema {
    */
   Class<?> implementation() default Undefined.class;
 
+  /**
+   * When true, this property indicates that the schema for this element is structural. The CRD
+   * generator will enhance the schema to conform to rules 2 and 3 of a Kubernetes structural schema.
+   * <p>
+   * From the Kubernetes documentation, these rules are as follows (rules 1 and 4 are omitted since they are not relevant to the
+   * processing enabled by {@linkplain #structural}).
+   * <ol start="2">
+   * <li>for each field in an object and each item in an array which is specified within any of {@code allOf}, {@code anyOf},
+   * {@code oneOf} or {@code not}, the schema also specifies the field/item outside of those logical junctors</li>
+   * <li>does not set {@code description}, {@code type}, {@code default}, {@code additionalProperties}, {@code nullable} within
+   * an {@code allOf}, {@code anyOf}, {@code oneOf} or {@code not}, with the exception of the two pattern for
+   * {@code x-kubernetes-int-or-string: true}</li>
+   * </ol>
+   * <p>
+   * This means that if this schema specifies classes within one or more of the logical junctors ({@code allOf}, {@code anyOf},
+   * {@code oneOf} or {@code not}), the CRD generator will
+   * ensure that
+   * <ol>
+   * <li>Each property/item of each entry within the logical junctors is also added to the properties of the structural schema.
+   * If a property name is duplicated, only the first occurrence will be used. If two or more schemas specify array
+   * {@code items}, only the first {@code items} will be used. Finally, if this schema itself specifies {@code items}, any
+   * {@code items} of the schemas within the logical junctors will not be used.</li>
+   * <li>The forbidden attributes of schemas within the logical junctors will be removed. These are {@code description},
+   * {@code type}, {@code default}, {@code additionalProperties}, and {@code nullable}. Note that these attributes will be
+   * present in the schemas that are set in the properties in step 1.</li>
+   * </ol>
+   *
+   * @see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
+   */
+  boolean structural() default false;
+
   String $ref() default Undefined.STRING; // NOSONAR
 
   String $schema() default Undefined.STRING; // NOSONAR
@@ -127,22 +258,22 @@ public @interface JSONSchema {
 
   Class<?> additionalProperties() default Undefined.class;
 
-  Class<?>[] allOf() default {};
+  Class<?>[] allOf() default Undefined.class;
 
-  Class<?>[] anyOf() default {};
+  Class<?>[] anyOf() default Undefined.class;
 
   String defaultValue() default Undefined.STRING;
 
-  Map[] definitions() default {};
+  Map[] definitions() default @Map(name = Undefined.STRING, value = Undefined.class);
 
-  DependencyMap[] dependencies() default {};
+  DependencyMap[] dependencies() default @DependencyMap(name = Undefined.STRING, value = @Dependency());
 
   String description() default Undefined.STRING;
 
   /*
    * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
    */
-  String[] enumeration() default {};
+  String[] enumeration() default Undefined.STRING;
 
   /*
    * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
@@ -159,7 +290,7 @@ public @interface JSONSchema {
 
   String id() default Undefined.STRING;
 
-  Class<?>[] items() default {};
+  Class<?>[] items() default Undefined.class;
 
   long maxItems() default Undefined.LONG;
 
@@ -183,15 +314,15 @@ public @interface JSONSchema {
 
   Class<? extends Boolean> nullable() default Undefined.class;
 
-  Class<?>[] oneOf() default {};
+  Class<?>[] oneOf() default Undefined.class;
 
   String pattern() default Undefined.STRING;
 
-  Map[] patternProperties() default {};
+  Map[] patternProperties() default @Map(name = Undefined.STRING, value = Undefined.class);
 
-  Map[] properties() default {};
+  Map[] properties() default @Map(name = Undefined.STRING, value = Undefined.class);
 
-  String[] required() default {};
+  String[] required() default Undefined.STRING;
 
   String title() default Undefined.STRING;
 
@@ -203,7 +334,7 @@ public @interface JSONSchema {
 
   Class<? extends Boolean> xKubernetesIntOrString() default Undefined.class;
 
-  String[] xKubernetesListMapKeys() default {};
+  String[] xKubernetesListMapKeys() default Undefined.STRING;
 
   String xKubernetesListType() default Undefined.STRING;
 
@@ -211,5 +342,5 @@ public @interface JSONSchema {
 
   Class<? extends Boolean> xKubernetesPreserveUnknownFields() default Undefined.class;
 
-  ValidationRule[] xKubernetesValidations() default {};
+  ValidationRule[] xKubernetesValidations() default @ValidationRule(value = Undefined.STRING);
 }

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/JSONSchema.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.generator.annotation;
 
 import java.lang.annotation.ElementType;
@@ -9,192 +24,192 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JSONSchema {
 
+  /**
+   * Marker interface used to restrict the class types that may be used for
+   * properties of type boolean. This enables readers of the annotation to
+   * distinguish between true, false, and undefined values.
+   */
+  interface Boolean {
+  }
+
+  /**
+   * Marker class used as a default for annotation properties of type
+   * {@code Class}.
+   */
+  public static final class Undefined implements Boolean {
     /**
-     * Marker interface used to restrict the class types that may be used for
-     * properties of type boolean. This enables readers of the annotation to
-     * distinguish between true, false, and undefined values.
+     * Marker value used as a default for annotation properties of type
+     * {@code String}.
      */
-    interface Boolean {
-    }
-
-    /**
-     * Marker class used as a default for annotation properties of type
-     * {@code Class}.
-     */
-    public static final class Undefined implements Boolean {
-        /**
-         * Marker value used as a default for annotation properties of type
-         * {@code String}.
-         */
-        public static final String STRING = "io.fabric8.generator.annotation.JSONSchema.UNSET";
-
-        /**
-         * Marker value used as a default for annotation properties of type
-         * {@code double}.
-         */
-        public static final double DOUBLE = Double.POSITIVE_INFINITY;
-
-        /**
-         * Marker value used as a default for annotation properties of type
-         * {@code long}. Same binary value used for Double.POSITIVE_INFINITY.
-         */
-        public static final long LONG = 0x7ff0000000000000L;
-
-        private Undefined() {
-        }
-    }
+    public static final String STRING = "io.fabric8.generator.annotation.JSONSchema.UNSET";
 
     /**
-     * Marker class to indicate that a boolean {@code true} schema should be used.
-     * Additionally, this class is used to set a value of {@code true} for
-     * properties that allow true, false, or undefined boolean values.
+     * Marker value used as a default for annotation properties of type
+     * {@code double}.
      */
-    public static final class True implements Boolean {
-        private True() {
-        }
-    }
+    public static final double DOUBLE = Double.POSITIVE_INFINITY;
 
     /**
-     * Marker class to indicate that a boolean {@code false} schema should be used.
-     * Additionally, this class is used to set a value of {@code false} for
-     * properties that allow true, false, or undefined boolean values.
+     * Marker value used as a default for annotation properties of type
+     * {@code long}. Same binary value used for Double.POSITIVE_INFINITY.
      */
-    public static final class False implements Boolean {
-        private False() {
-        }
+    public static final long LONG = 0x7ff0000000000000L;
+
+    private Undefined() {
     }
+  }
 
-    @Target({})
-    @Retention(RetentionPolicy.RUNTIME)
-    public @interface Map {
-        String name();
-
-        Class<?> value();
+  /**
+   * Marker class to indicate that a boolean {@code true} schema should be used.
+   * Additionally, this class is used to set a value of {@code true} for
+   * properties that allow true, false, or undefined boolean values.
+   */
+  public static final class True implements Boolean {
+    private True() {
     }
+  }
 
-    @Target({})
-    @Retention(RetentionPolicy.RUNTIME)
-    public @interface Dependency {
-        String[] properties() default {};
-
-        Class<?> schema() default Undefined.class;
+  /**
+   * Marker class to indicate that a boolean {@code false} schema should be used.
+   * Additionally, this class is used to set a value of {@code false} for
+   * properties that allow true, false, or undefined boolean values.
+   */
+  public static final class False implements Boolean {
+    private False() {
     }
+  }
 
-    @Target({})
-    @Retention(RetentionPolicy.RUNTIME)
-    public @interface DependencyMap {
-        String name();
+  @Target({})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Map {
+    String name();
 
-        Dependency value();
-    }
+    Class<?> value();
+  }
 
-    @Target({})
-    @Retention(RetentionPolicy.RUNTIME)
-    public @interface ExternalDocumentation {
-        String description() default Undefined.STRING;
+  @Target({})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Dependency {
+    String[] properties() default {};
 
-        String url() default Undefined.STRING;
-    }
+    Class<?> schema() default Undefined.class;
+  }
 
-    /**
-     * The implementation class allows for an additional type to be scanned as the
-     * basis for this schema. After scanning the implementation (if specified), the
-     * remaining properties will be set from this annotation, possibly overriding
-     * those determine by scanning the implementation class.
-     */
-    Class<?> implementation() default Undefined.class;
+  @Target({})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface DependencyMap {
+    String name();
 
-    String $ref() default Undefined.STRING; // NOSONAR
+    Dependency value();
+  }
 
-    String $schema() default Undefined.STRING; // NOSONAR
-
-    Class<?> additionalItems() default Undefined.class;
-
-    Class<?> additionalProperties() default Undefined.class;
-
-    Class<?>[] allOf() default {};
-
-    Class<?>[] anyOf() default {};
-
-    String defaultValue() default Undefined.STRING;
-
-    Map[] definitions() default {};
-
-    DependencyMap[] dependencies() default {};
-
+  @Target({})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface ExternalDocumentation {
     String description() default Undefined.STRING;
 
-    /*
-     * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
-     */
-    String[] enumeration() default {};
+    String url();
+  }
 
-    /*
-     * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
-     */
-    String example() default Undefined.STRING;
+  /**
+   * The implementation class allows for an additional type to be scanned as the
+   * basis for this schema. After scanning the implementation (if specified), the
+   * remaining properties will be set from this annotation, possibly overriding
+   * those determine by scanning the implementation class.
+   */
+  Class<?> implementation() default Undefined.class;
 
-    Class<? extends Boolean> exclusiveMaximum() default Undefined.class;
+  String $ref() default Undefined.STRING; // NOSONAR
 
-    Class<? extends Boolean> exclusiveMinimum() default Undefined.class;
+  String $schema() default Undefined.STRING; // NOSONAR
 
-    ExternalDocumentation externalDocs() default @ExternalDocumentation;
+  Class<?> additionalItems() default Undefined.class;
 
-    String format() default Undefined.STRING;
+  Class<?> additionalProperties() default Undefined.class;
 
-    String id() default Undefined.STRING;
+  Class<?>[] allOf() default {};
 
-    Class<?>[] items() default {};
+  Class<?>[] anyOf() default {};
 
-    long maxItems() default Undefined.LONG;
+  String defaultValue() default Undefined.STRING;
 
-    long maxLength() default Undefined.LONG;
+  Map[] definitions() default {};
 
-    long maxProperties() default Undefined.LONG;
+  DependencyMap[] dependencies() default {};
 
-    double maximum() default Undefined.DOUBLE;
+  String description() default Undefined.STRING;
 
-    long minItems() default Undefined.LONG;
+  /*
+   * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
+   */
+  String[] enumeration() default {};
 
-    long minLength() default Undefined.LONG;
+  /*
+   * Parsed into com.fasterxml.jackson.databind.JsonNode depending on `type`
+   */
+  String example() default Undefined.STRING;
 
-    long minProperties() default Undefined.LONG;
+  Class<? extends Boolean> exclusiveMaximum() default Undefined.class;
 
-    double minimum() default Undefined.DOUBLE;
+  Class<? extends Boolean> exclusiveMinimum() default Undefined.class;
 
-    double multipleOf() default Undefined.DOUBLE;
+  ExternalDocumentation externalDocs() default @ExternalDocumentation(url = Undefined.STRING);
 
-    Class<?> not() default Undefined.class;
+  String format() default Undefined.STRING;
 
-    Class<? extends Boolean> nullable() default Undefined.class;
+  String id() default Undefined.STRING;
 
-    Class<?>[] oneOf() default {};
+  Class<?>[] items() default {};
 
-    String pattern() default Undefined.STRING;
+  long maxItems() default Undefined.LONG;
 
-    Map[] patternProperties() default {};
+  long maxLength() default Undefined.LONG;
 
-    Map[] properties() default {};
+  long maxProperties() default Undefined.LONG;
 
-    String[] required() default {};
+  double maximum() default Undefined.DOUBLE;
 
-    String title() default Undefined.STRING;
+  long minItems() default Undefined.LONG;
 
-    String type() default Undefined.STRING;
+  long minLength() default Undefined.LONG;
 
-    Class<? extends Boolean> uniqueItems() default Undefined.class;
+  long minProperties() default Undefined.LONG;
 
-    Class<? extends Boolean> xKubernetesEmbeddedResource() default Undefined.class;
+  double minimum() default Undefined.DOUBLE;
 
-    Class<? extends Boolean> xKubernetesIntOrString() default Undefined.class;
+  double multipleOf() default Undefined.DOUBLE;
 
-    String[] xKubernetesListMapKeys() default {};
+  Class<?> not() default Undefined.class;
 
-    String xKubernetesListType() default Undefined.STRING;
+  Class<? extends Boolean> nullable() default Undefined.class;
 
-    String xKubernetesMapType() default Undefined.STRING;
+  Class<?>[] oneOf() default {};
 
-    Class<? extends Boolean> xKubernetesPreserveUnknownFields() default Undefined.class;
+  String pattern() default Undefined.STRING;
 
-    ValidationRule[] xKubernetesValidations() default {};
+  Map[] patternProperties() default {};
+
+  Map[] properties() default {};
+
+  String[] required() default {};
+
+  String title() default Undefined.STRING;
+
+  String type() default Undefined.STRING;
+
+  Class<? extends Boolean> uniqueItems() default Undefined.class;
+
+  Class<? extends Boolean> xKubernetesEmbeddedResource() default Undefined.class;
+
+  Class<? extends Boolean> xKubernetesIntOrString() default Undefined.class;
+
+  String[] xKubernetesListMapKeys() default {};
+
+  String xKubernetesListType() default Undefined.STRING;
+
+  String xKubernetesMapType() default Undefined.STRING;
+
+  Class<? extends Boolean> xKubernetesPreserveUnknownFields() default Undefined.class;
+
+  ValidationRule[] xKubernetesValidations() default {};
 }


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

Closes #6999

This is a POC to demonstrate the idea behind #6999 (it may also close several other issues related to the CRD generator's capabilities). The new `@JSONSchema` annotation may be used on a class or property to short-circuit other schema scanning for the target. The exception is when the annotation's `implementation` is used. In that case, the `implementation` class will be scanned as normal, then the `@JSONSchema` annotation attributes will be used to override those from the scan.

The annotation also includes a `structural` boolean attribute that enables certain handling for [structural schemas](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema). This includes copying properties from `allOf`, `anyOf`, `oneOf`, and `not` to the schema with the annotation, and also removing the restricted attributes without those sub-schemas.

Several of the attributes of the annotation may not actually be valid for a Kube CRD schema. However, the intent here is simply to expose the CRD schema model entirely to give that control to the user.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
