### PR TITLE
Fix `KubernetesMockServerExtension` Javadoc

### DIFF
--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -39,8 +39,8 @@ import java.util.Queue;
 
 /**
  * The class that implements JUnit5 extension mechanism. You can use it directly in your JUnit test
- * by annotating it with <code>@ExtendWith(KubernetesMockExtension.class)</code> or through
- * <code>@EnableKubernetesMock</code> annotation
+ * by annotating it with <code>@ExtendWith(KubernetesMockServerExtension.class)</code> or through
+ * <code>@EnableKubernetesMockClient</code> annotation
  */
 public class KubernetesMockServerExtension
     implements AfterEachCallback, AfterAllCallback, BeforeEachCallback, BeforeAllCallback {


### PR DESCRIPTION
In https://github.com/fabric8io/kubernetes-client/commit/850044a2f727edc362a6fa119d3ba8f6f4b7e55d the Javadoc was updated but it refers to classes that don't exist and aren't what's used elsewhere in the rests.

## Type of change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
