### PR TITLE
Add fallback for rollout restart when annotations are missing (HTTP 422)

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/apps/v1/RollingUpdater.java
@@ -184,9 +184,10 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
     try {
       return applyPatch(resource, RollingUpdater.requestPayLoadForRolloutRestart(), resource.getKubernetesSerialization());
     } catch (KubernetesClientException e) {
-      if (e.getCode() == 422 /*HTTP_UNPROCESSABLE_ENTITY*/) {
+      if (e.getCode() == 422 /* HTTP_UNPROCESSABLE_ENTITY */) {
         LOG.debug("Annotations path missing, retrying with full annotations patch.");
-        return applyPatch(resource, RollingUpdater.requestPayLoadForRolloutRestartAndCreateAnnotations(), resource.getKubernetesSerialization());
+        return applyPatch(resource, RollingUpdater.requestPayLoadForRolloutRestartAndCreateAnnotations(),
+            resource.getKubernetesSerialization());
       } else {
         throw e;
       }
@@ -219,9 +220,9 @@ public abstract class RollingUpdater<T extends HasMetadata, L> {
 
   public static List<Object> requestPayLoadForRolloutRestartAndCreateAnnotations() {
     return List.of(Map.of(
-      "op", "add",
-      "path", "/spec/template/metadata/annotations",
-      "value", Map.of("kubectl.kubernetes.io/restartedAt", nowAsRestartTimestamp())));
+        "op", "add",
+        "path", "/spec/template/metadata/annotations",
+        "value", Map.of("kubectl.kubernetes.io/restartedAt", nowAsRestartTimestamp())));
   }
 
   /**


### PR DESCRIPTION
## Description
This PR adds a fallback for rollout restart when patching fails with HTTP 422 (`Unprocessable Entity`).
If adding the `kubectl.kubernetes.io/restartedAt` annotation fails (e.g., because the `annotations` field doesn't exist), we retry the patch with one that creates the `annotations` map.

Fixes: https://github.com/fabric8io/kubernetes-client/issues/7072

---

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

