### PR TITLE
fix: ensure that vertx streams notify when there is an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## CHANGELOG
 
 ### 7.4-SNAPSHOT
-* Fix #7116: (java-generator) Use timezone format compatible with Kubernetes
 
 #### Bugs
 * Fix #7087: Avoid possible NPE in OkHttp websocket handlinger
 * Fix #7080: Avoid NPE in CRDGenerator if post-processor is set to null
+* Fix #7116: (java-generator) Use timezone format compatible with Kubernetes
+* Fix #7163: Ensure that streams are notified of errors
 
 #### Improvements
 

--- a/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
+++ b/httpclient-jetty/src/main/java/io/fabric8/kubernetes/client/jetty/JettyAsyncResponseListener.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.util.Callback;
 
 import java.nio.ByteBuffer;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.LongConsumer;
@@ -75,7 +76,8 @@ public abstract class JettyAsyncResponseListener extends Response.Listener.Adapt
     if (result.isSucceeded()) {
       asyncBodyDone.complete(null);
     } else {
-      asyncBodyDone.completeExceptionally(result.getRequestFailure());
+      asyncBodyDone.completeExceptionally(
+          Optional.ofNullable(result.getFailure()).orElse(new RuntimeException("Request failed, but no failure was given")));
     }
   }
 

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
@@ -81,7 +81,8 @@ class VertxHttpRequest {
           resp.request().reset();
           result.done().completeExceptionally(e);
         }
-      }).endHandler(end -> result.done().complete(null));
+      }).endHandler(end -> result.done().complete(null))
+          .exceptionHandler(ex -> result.done().completeExceptionally(ex));
       return new VertxHttpResponse(result, resp, request);
     };
     return client.request(options).compose(request -> {


### PR DESCRIPTION
## Description

closes: #7163

Checked each of the client's behavior when reading a stream with a proxy that is shutdown in the middle. Vertx did not notify correctly, and Jetty produced the wrong error.

@manusa at first glance I didn't see a way to induce this with the mockserver

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
