### PR TITLE
fix: cannot call close if body is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix #7116: (java-generator) Use timezone format compatible with Kubernetes
 
 #### Bugs
+* Fix #7087: Avoid possible NPE in OkHttp websocket handlinger
 * Fix #7080: Avoid NPE in CRDGenerator if post-processor is set to null
 
 #### Improvements

--- a/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
+++ b/httpclient-okhttp/src/main/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketImpl.java
@@ -75,13 +75,10 @@ class OkHttpWebSocketImpl implements WebSocket {
 
       @Override
       public void onFailure(okhttp3.WebSocket webSocket, Throwable t, Response response) {
-        if (response != null) {
-          response.close();
-        }
+        // Ensure response body is always closed (leak)
+        Optional.ofNullable(response).map(Response::body).ifPresent(ResponseBody::close);
         if (!opened) {
           if (response != null) {
-            // Ensure response body is always closed (leak)
-            Optional.ofNullable(response.body()).ifPresent(ResponseBody::close);
             final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(
                 fabric8Request, response.code(), response.headers().toMultimap());
             future.complete(new WebSocketResponse(upgradeResponse, t));


### PR DESCRIPTION

## Description

Follow-up to a potential okhttp issue - while we don't have a reproducer it's clear we are checking if the body can be null further down in the method so it should be done at the top instead of just calling response close (which is documented as just a body close).

close: #7087

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
