### PR TITLE
feat(crd-generator): add support for @Annotations and @Labels in CRD generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fix #7080: Avoid NPE in CRDGenerator if post-processor is set to null
 * Fix #7116: (java-generator) Use timezone format compatible with Kubernetes
 * Fix #7163: Ensure that streams are notified of errors
-* Fix #7092: Add support for @Annotations and @Labels in CRD generation - CRD generator now includes annotations and labels specified via these annotations in the generated CRD metadata
+* Fix #7092: (crd-generator) Add support for @Annotations and @Labels in CRD generation - CRD generator now includes annotations and labels specified via these annotations in the generated CRD metadata
 
 #### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Feat #7092: Add support for @Annotations and @Labels in CRD generation - CRD generator now includes annotations and labels specified via these annotations in the generated CRD metadata
 
 #### _**Note**_: Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@
 * Fix #7080: Avoid NPE in CRDGenerator if post-processor is set to null
 * Fix #7116: (java-generator) Use timezone format compatible with Kubernetes
 * Fix #7163: Ensure that streams are notified of errors
+* Fix #7092: Add support for @Annotations and @Labels in CRD generation - CRD generator now includes annotations and labels specified via these annotations in the generated CRD metadata
 
 #### Improvements
 
 #### Dependency Upgrade
 
 #### New Features
-* Feat #7092: Add support for @Annotations and @Labels in CRD generation - CRD generator now includes annotations and labels specified via these annotations in the generated CRD metadata
 
 #### _**Note**_: Breaking changes
 

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CRDUtils.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CRDUtils.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import io.fabric8.crd.generator.annotation.Annotations;
+import io.fabric8.crd.generator.annotation.Labels;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -92,4 +94,31 @@ public class CRDUtils {
     return res;
   }
 
+  /**
+   * Retrieves the annotations associated with this class or an empty array if none was provided
+   *
+   * @param clazz the class for which the annotations are to be retrieved
+   * @return the annotations associated with this class or an empty array if none was provided
+   */
+  public static String[] getAnnotations(Class<?> clazz) {
+    Annotations annotations = clazz.getAnnotation(Annotations.class);
+    if (annotations != null) {
+      return annotations.value();
+    }
+    return new String[] {};
+  }
+
+  /**
+   * Retrieves the labels associated with this class or an empty array if none was provided
+   *
+   * @param clazz the class for which the labels are to be retrieved
+   * @return the labels associated with this class or an empty array if none was provided
+   */
+  public static String[] getLabels(Class<?> clazz) {
+    Labels labels = clazz.getAnnotation(Labels.class);
+    if (labels != null) {
+      return labels.value();
+    }
+    return new String[] {};
+  }
 }

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CustomResourceInfo.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CustomResourceInfo.java
@@ -199,13 +199,15 @@ public class CustomResourceInfo {
         served = cr.isServed();
       }
 
+      final String[] annotations = CRDUtils.getAnnotations(customResource);
+      final String[] labels = CRDUtils.getLabels(customResource);
+
       return new CustomResourceInfo(rdc.getGroup(), rdc.getVersion(), rdc.getKind(),
           singular, rdc.getPlural(), shortNames, categories, storage, served,
           deprecated, deprecationWarning,
           scope, customResource,
           customResource.getCanonicalName(), specAndStatus.getSpecClassName(),
-          specAndStatus.getStatusClassName(), toStringArray(instance.getMetadata().getAnnotations()),
-          toStringArray(instance.getMetadata().getLabels()));
+          specAndStatus.getStatusClassName(), annotations, labels);
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
       throw KubernetesClientException.launderThrowable(e);
     }
@@ -238,17 +240,6 @@ public class CustomResourceInfo {
           "Modified constructor for CustomResource class {} to make it accessible.", customResource.getCanonicalName());
     }
     return (HasMetadata) defaultConstructor.newInstance();
-  }
-
-  public static String[] toStringArray(Map<String, String> map) {
-    String[] res = new String[map.size()];
-    Set<Map.Entry<String, String>> entrySet = map.entrySet();
-    int i = 0;
-    for (Map.Entry<String, String> e : entrySet) {
-      res[i] = e.getKey() + "=" + e.getValue();
-      i++;
-    }
-    return res;
   }
 
   @Override

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CustomResourceInfo.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/CustomResourceInfo.java
@@ -29,10 +29,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 public class CustomResourceInfo {
 

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/annotated/AnnotationsAndLabels.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/annotated/AnnotationsAndLabels.java
@@ -23,8 +23,8 @@ import io.fabric8.kubernetes.model.annotation.Version;
 
 @Group("samples.fabric8.io")
 @Version("v1alpha1")
-@Annotations({"example.io/processed-by=fabric8", "example.io/version=v1.0.0"})
-@Labels({"app.kubernetes.io/managed-by=fabric8", "app.kubernetes.io/component=crd"})
+@Annotations({ "example.io/processed-by=fabric8", "example.io/version=v1.0.0" })
+@Labels({ "app.kubernetes.io/managed-by=fabric8", "app.kubernetes.io/component=crd" })
 public class AnnotationsAndLabels extends CustomResource<AnnotatedSpec, Void> {
 
-} 
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/annotated/AnnotationsAndLabels.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/annotated/AnnotationsAndLabels.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.example.annotated;
+
+import io.fabric8.crd.generator.annotation.Annotations;
+import io.fabric8.crd.generator.annotation.Labels;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("samples.fabric8.io")
+@Version("v1alpha1")
+@Annotations({"example.io/processed-by=fabric8", "example.io/version=v1.0.0"})
+@Labels({"app.kubernetes.io/managed-by=fabric8", "app.kubernetes.io/component=crd"})
+public class AnnotationsAndLabels extends CustomResource<AnnotatedSpec, Void> {
+
+} 

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CRDGeneratorTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CRDGeneratorTest.java
@@ -625,14 +625,14 @@ class CRDGeneratorTest {
     final String crdName = CustomResourceInfo.fromClass(AnnotationsAndLabels.class).crdName();
 
     final CRDGenerationInfo crdInfo = newCRDGenerator()
-      .inOutputDir(tempDir)
-      .customResourceClasses(AnnotationsAndLabels.class)
-      .forCRDVersions("v1")
-      .detailedGenerate();
+        .inOutputDir(tempDir)
+        .customResourceClasses(AnnotationsAndLabels.class)
+        .forCRDVersions("v1")
+        .detailedGenerate();
 
     CustomResourceDefinition definition = new KubernetesSerialization().unmarshal(
-      Files.newInputStream(Path.of(crdInfo.getCRDInfos(crdName).get("v1").getFilePath())),
-      CustomResourceDefinition.class);
+        Files.newInputStream(Path.of(crdInfo.getCRDInfos(crdName).get("v1").getFilePath())),
+        CustomResourceDefinition.class);
 
     assertNotNull(definition.getMetadata().getAnnotations());
     assertNotNull(definition.getMetadata().getLabels());

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CRDGeneratorTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CRDGeneratorTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crdv2.generator;
 
+import io.fabric8.crdv2.example.annotated.AnnotationsAndLabels;
 import io.fabric8.crdv2.example.basic.Basic;
 import io.fabric8.crdv2.example.complex.Complex;
 import io.fabric8.crdv2.example.cyclic.Cyclic;
@@ -617,6 +618,30 @@ class CRDGeneratorTest {
     assertThat(new KubernetesSerialization().unmarshal(
         Files.newInputStream(Path.of(crdInfo.getCRDInfos(crdName).get("v1").getFilePath())), HasMetadata.class))
         .isNotNull();
+  }
+
+  @Test
+  void shouldIncludeClassAnnotationsAndLabelsInGeneratedCRD() throws Exception {
+    final String crdName = CustomResourceInfo.fromClass(AnnotationsAndLabels.class).crdName();
+
+    final CRDGenerationInfo crdInfo = newCRDGenerator()
+      .inOutputDir(tempDir)
+      .customResourceClasses(AnnotationsAndLabels.class)
+      .forCRDVersions("v1")
+      .detailedGenerate();
+
+    CustomResourceDefinition definition = new KubernetesSerialization().unmarshal(
+      Files.newInputStream(Path.of(crdInfo.getCRDInfos(crdName).get("v1").getFilePath())),
+      CustomResourceDefinition.class);
+
+    assertNotNull(definition.getMetadata().getAnnotations());
+    assertNotNull(definition.getMetadata().getLabels());
+
+    assertEquals("fabric8", definition.getMetadata().getAnnotations().get("example.io/processed-by"));
+    assertEquals("v1.0.0", definition.getMetadata().getAnnotations().get("example.io/version"));
+
+    assertEquals("fabric8", definition.getMetadata().getLabels().get("app.kubernetes.io/managed-by"));
+    assertEquals("crd", definition.getMetadata().getLabels().get("app.kubernetes.io/component"));
   }
 
   private CustomResourceDefinitionVersion checkCRD(Class<? extends CustomResource<?, ?>> customResource, String kind,

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CustomResourceInfoTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CustomResourceInfoTest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.crdv2.generator;
 
+import io.fabric8.crd.generator.annotation.Annotations;
+import io.fabric8.crd.generator.annotation.Labels;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -75,6 +77,13 @@ public class CustomResourceInfoTest {
     }
   }
 
+  @Group(GROUP)
+  @Version(VERSION)
+  @Annotations({"test-annotation=test-value", "another-annotation=another-value"})
+  @Labels({"test-label=test-value", "another-label=another-value"})
+  public static class AnnotatedCR extends io.fabric8.kubernetes.client.CustomResource<Spec, Status> {
+  }
+
   @Test
   void shouldBeProperlyScoped() {
     CustomResourceInfo info = CustomResourceInfo.fromClass(ClusteredCR.class);
@@ -132,5 +141,16 @@ public class CustomResourceInfoTest {
   void shouldFailForMissingDefaultConstructor() {
     assertThrows(IllegalStateException.class,
         () -> CustomResourceInfo.fromClass(NoDefaultConstructorCustomResource.class));
+  }
+
+  @Test
+  void shouldIncludeAnnotationsAndLabelsInCustomResourceInfo() {
+    CustomResourceInfo info = CustomResourceInfo.fromClass(AnnotatedCR.class);
+
+    String[] expectedAnnotations = {"test-annotation=test-value", "another-annotation=another-value"};
+    String[] expectedLabels = {"test-label=test-value", "another-label=another-value"};
+
+    assertArrayEquals(expectedAnnotations, info.annotations());
+    assertArrayEquals(expectedLabels, info.labels());
   }
 }

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CustomResourceInfoTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/CustomResourceInfoTest.java
@@ -79,8 +79,8 @@ public class CustomResourceInfoTest {
 
   @Group(GROUP)
   @Version(VERSION)
-  @Annotations({"test-annotation=test-value", "another-annotation=another-value"})
-  @Labels({"test-label=test-value", "another-label=another-value"})
+  @Annotations({ "test-annotation=test-value", "another-annotation=another-value" })
+  @Labels({ "test-label=test-value", "another-label=another-value" })
   public static class AnnotatedCR extends io.fabric8.kubernetes.client.CustomResource<Spec, Status> {
   }
 
@@ -147,8 +147,8 @@ public class CustomResourceInfoTest {
   void shouldIncludeAnnotationsAndLabelsInCustomResourceInfo() {
     CustomResourceInfo info = CustomResourceInfo.fromClass(AnnotatedCR.class);
 
-    String[] expectedAnnotations = {"test-annotation=test-value", "another-annotation=another-value"};
-    String[] expectedLabels = {"test-label=test-value", "another-label=another-value"};
+    String[] expectedAnnotations = { "test-annotation=test-value", "another-annotation=another-value" };
+    String[] expectedLabels = { "test-label=test-value", "another-label=another-value" };
 
     assertArrayEquals(expectedAnnotations, info.annotations());
     assertArrayEquals(expectedLabels, info.labels());


### PR DESCRIPTION
## Description

This PR implements support for `@Annotations` and `@Labels` annotations in the CRD generator, addressing issue #7092.

Previously, when using `@Annotations` and `@Labels` annotations on CustomResource classes, these metadata were not included in the generated CRD files. This implementation ensures that annotations and labels specified via these annotations are properly included in the CRD metadata.

## Related docs
- https://github.com/fabric8io/kubernetes-client/blob/main/doc/CRD-generator.md#iofabric8crdgeneratorannotationannotations
- https://github.com/fabric8io/kubernetes-client/blob/main/doc/CRD-generator.md#iofabric8crdgeneratorannotationlabels

## Testing

All tests pass successfully:
- `CustomResourceInfoTest#shouldIncludeAnnotationsAndLabelsInCustomResourceInfo` ✅
- `CRDGeneratorTest#shouldIncludeClassAnnotationsAndLabelsInGeneratedCRD` ✅

## Fixes

Fixes #7092

## Type of change
 - [x] Feature (non-breaking change which adds functionality)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
