### PR TITLE
enhance: add support for streaming lists

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/impl/cache/Reflector.java
@@ -63,7 +63,15 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   private CompletableFuture<Void> timeoutFuture;
 
   private boolean cachedListing = true;
-
+ 
+  private static class StreamingListState {
+    Set<String> nextKeys = new ConcurrentSkipListSet<>();
+    private CompletableFuture<Void> listDone = new CompletableFuture<>();
+  }
+ 
+  private boolean streamingList;
+  private volatile StreamingListState streamingListState;
+  
   public Reflector(ListerWatcher<T, L> listerWatcher, ProcessorStore<T> store) {
     this(listerWatcher, store, Runnable::run);
   }
@@ -122,22 +130,45 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
     if (isStopped()) {
       return CompletableFuture.completedFuture(null);
     }
-    Set<String> nextKeys = new ConcurrentSkipListSet<>();
-    CompletableFuture<Void> theFuture = processList(nextKeys, null).thenCompose(result -> {
-      final String latestResourceVersion = result.getMetadata().getResourceVersion();
-      log.debug("Listing items ({}) for {} at v{}", nextKeys.size(), this, latestResourceVersion);
-      CompletableFuture<?> cf = new CompletableFuture<>();
-      store.retainAll(nextKeys, executor -> {
-        boolean startWatchImmediately = cachedListing && lastSyncResourceVersion == null;
-        lastSyncResourceVersion = latestResourceVersion;
-        if (startWatchImmediately) {
-          cf.complete(null);
-        } else {
-          executor.execute(() -> cf.complete(null));
-        }
+    
+    CompletableFuture<Void> theFuture = null;
+    if (streamingList) {
+      streamingListState = new StreamingListState(); 
+      CompletableFuture<Void> cf = streamingListState.listDone;
+      theFuture = establishWatch(startWatcher(lastSyncResourceVersion)).thenCompose(ignored -> cf);
+    } else {
+      Set<String> nextKeys = new ConcurrentSkipListSet<>();
+      CompletableFuture<? extends Watch> startWatcher = processList(nextKeys, null).thenCompose(result -> {
+        final String latestResourceVersion = result.getMetadata().getResourceVersion();
+        log.debug("Listing items ({}) for {} at v{}", nextKeys.size(), this, latestResourceVersion);
+        CompletableFuture<?> cf = new CompletableFuture<>();
+        store.retainAll(nextKeys, executor -> {
+          boolean startWatchImmediately = cachedListing && lastSyncResourceVersion == null;
+          lastSyncResourceVersion = latestResourceVersion;
+          if (startWatchImmediately) {
+            cf.complete(null);
+          } else {
+            executor.execute(() -> cf.complete(null));
+          }
+        });
+        return cf.thenCompose(ignored -> startWatcher(latestResourceVersion));
       });
-      return cf.thenCompose(ignored -> startWatcher(latestResourceVersion));
-    }).thenAccept(w -> {
+      theFuture = establishWatch(startWatcher);
+    }
+    
+    theFuture.whenComplete((v, t) -> {
+      if (t != null) {
+        onException("listSyncAndWatch", t);
+      } else {
+        startFuture.complete(null);
+        retryIntervalCalculator.resetReconnectAttempts();
+      }
+    });
+    return theFuture;
+  }
+
+  private CompletableFuture<Void> establishWatch(CompletableFuture<? extends Watch> future) {
+    return future.thenAccept(w -> {
       if (w != null) {
         if (!isStopped()) {
           if (log.isDebugEnabled()) {
@@ -149,15 +180,6 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
         }
       }
     });
-    theFuture.whenComplete((v, t) -> {
-      if (t != null) {
-        onException("listSyncAndWatch", t);
-      } else {
-        startFuture.complete(null);
-        retryIntervalCalculator.resetReconnectAttempts();
-      }
-    });
-    return theFuture;
   }
 
   private void onException(String operation, Throwable t) {
@@ -225,6 +247,9 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
             // so instead we'll terminate below and set a fail-safe here
             // .withTimeoutSeconds((long) ((Math.random() + 1) * minTimeout))
             .withTimeoutSeconds(minTimeout * 2)
+            .withAllowWatchBookmarks(true)
+            .withSendInitialEvents(streamingListState != null)
+            .withResourceVersionMatch(streamingListState != null ? "NotOlderThan" : null)
             .build(),
         watcher);
 
@@ -278,6 +303,26 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
             resource.getKind(),
             resource.getMetadata().getResourceVersion(), Reflector.this);
       }
+      
+      if (streamingListState != null) {
+        switch (action) {
+        case ADDED:
+          String key = store.getKey(resource);
+          streamingListState.nextKeys.add(key);
+          break;
+        case BOOKMARK:
+          // done with the initial events, trigger that we are ready and switch to regular
+          // watching
+          log.debug("Listing items ({}) for {} at v{}", streamingListState.nextKeys.size(), this, resource.getMetadata().getResourceVersion());
+          store.retainAll(streamingListState.nextKeys, ignored -> streamingListState.listDone.complete(null));
+          streamingListState = null;
+          break;
+        case MODIFIED:
+        case DELETED:
+          throw new KubernetesClientException("Unexpected event");
+        }
+      }
+      
       switch (action) {
         case ERROR:
           throw new KubernetesClientException("ERROR event");
@@ -342,5 +387,9 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
   public void usingInitialState() {
     this.cachedListing = false;
   }
+  
+  public void setStreamingList(boolean streamingList) {
+    this.streamingList = streamingList;
+  }  
 
 }


### PR DESCRIPTION
Adds support for informers to use watch / streaming lists. This is currently enabled via Reflector.setStreamingList

TODO:

- how to allow wiring of streamingList=true 
  - to do this automatically we'd need to check both the server version and feature gates
  - could be a setting on the Config (like the existing watch settings)
  - could also be exposed per informer

I'm leaning toward doing the latter two and not doing this automatically for now.

- additional validation
  - If you set a Limit it will simply be ignored

- other api methods, see https://github.com/fabric8io/kubernetes-client/issues/5081#issuecomment-3124763623

closes: #5081

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
