### PR TITLE
rationalizing Config constructors / building

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigBuilder.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigBuilder.java
@@ -22,10 +22,18 @@ import java.util.Optional;
 import static io.fabric8.kubernetes.client.Config.disableAutoConfig;
 
 public class ConfigBuilder extends ConfigFluent<ConfigBuilder> implements VisitableBuilder<Config, ConfigBuilder> {
+  /**
+   * Note: differs from the typical generated builder - the fluent state is
+   * preserved whole
+   */
   public ConfigBuilder() {
     this.fluent = this;
   }
 
+  /**
+   * Note: differs from the typical generated builder - the fluent state is
+   * preserved whole
+   */
   public ConfigBuilder(ConfigFluent<?> fluent) {
     this.fluent = fluent;
   }
@@ -42,23 +50,19 @@ public class ConfigBuilder extends ConfigFluent<ConfigBuilder> implements Visita
 
   ConfigFluent<?> fluent;
 
+  @Override
   public Config build() {
-    Config buildable = new Config(fluent.getMasterUrl(), fluent.getApiVersion(), fluent.getNamespace(), fluent.getTrustCerts(),
-        fluent.getDisableHostnameVerification(), fluent.getCaCertFile(), fluent.getCaCertData(), fluent.getClientCertFile(),
-        fluent.getClientCertData(), fluent.getClientKeyFile(), fluent.getClientKeyData(), fluent.getClientKeyAlgo(),
-        fluent.getClientKeyPassphrase(), fluent.getUsername(), fluent.getPassword(), fluent.getOauthToken(),
-        fluent.getAutoOAuthToken(), fluent.getWatchReconnectInterval(), fluent.getWatchReconnectLimit(),
-        fluent.getConnectionTimeout(), fluent.getRequestTimeout(), fluent.getScaleTimeout(), fluent.getLoggingInterval(),
-        fluent.getMaxConcurrentRequests(), fluent.getMaxConcurrentRequestsPerHost(), fluent.getHttp2Disable(),
-        fluent.getHttpProxy(), fluent.getHttpsProxy(), fluent.getNoProxy(), fluent.getUserAgent(), fluent.getTlsVersions(),
-        fluent.getWebsocketPingInterval(), fluent.getProxyUsername(), fluent.getProxyPassword(), fluent.getTrustStoreFile(),
-        fluent.getTrustStorePassphrase(), fluent.getKeyStoreFile(), fluent.getKeyStorePassphrase(),
-        fluent.getImpersonateUsername(), fluent.getImpersonateGroups(), fluent.getImpersonateExtras(),
-        fluent.getOauthTokenProvider(), fluent.getCustomHeaders(), fluent.getRequestRetryBackoffLimit(),
-        fluent.getRequestRetryBackoffInterval(), fluent.getUploadRequestTimeout(), fluent.getOnlyHttpWatches(),
-        fluent.getCurrentContext(), fluent.getContexts(),
-        Optional.ofNullable(fluent.getAutoConfigure()).orElse(!disableAutoConfig()), true);
-    buildable.setAuthProvider(fluent.getAuthProvider());
-    return buildable;
+    // build the config state from the generated builder, then use that
+    // to construct the full state
+    SundrioConfig config = toSundrioConfig(fluent);
+    return new Config(config, true);
+  }
+
+  public static SundrioConfig toSundrioConfig(SundrioConfigFluent<?> fluent) {
+    SundrioConfigBuilder builder = new SundrioConfigBuilder();
+    builder.fluent = fluent;
+    SundrioConfig config = builder.build();
+    config.setAutoConfigure(Optional.ofNullable(config.getAutoConfigure()).orElse(!disableAutoConfig()));
+    return config;
   }
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/ConfigFluent.java
@@ -25,60 +25,9 @@ public class ConfigFluent<A extends ConfigFluent<A>> extends SundrioConfigFluent
     this.copyInstance(instance);
   }
 
+  // no need to override the base logic
   public void copyInstance(Config instance) {
-    if (instance != null) {
-      this.withMasterUrl(instance.getMasterUrl());
-      this.withApiVersion(instance.getApiVersion());
-      this.withNamespace(instance.getNamespace());
-      this.withTrustCerts(instance.isTrustCerts());
-      this.withDisableHostnameVerification(instance.isDisableHostnameVerification());
-      this.withCaCertFile(instance.getCaCertFile());
-      this.withCaCertData(instance.getCaCertData());
-      this.withClientCertFile(instance.getClientCertFile());
-      this.withClientCertData(instance.getClientCertData());
-      this.withClientKeyFile(instance.getClientKeyFile());
-      this.withClientKeyData(instance.getClientKeyData());
-      this.withClientKeyAlgo(instance.getClientKeyAlgo());
-      this.withClientKeyPassphrase(instance.getClientKeyPassphrase());
-      this.withUsername(instance.getUsername());
-      this.withPassword(instance.getPassword());
-      this.withOauthToken(instance.getOauthToken());
-      this.withAutoOAuthToken(instance.getAutoOAuthToken());
-      this.withWatchReconnectInterval(instance.getWatchReconnectInterval());
-      this.withWatchReconnectLimit(instance.getWatchReconnectLimit());
-      this.withConnectionTimeout(instance.getConnectionTimeout());
-      this.withRequestTimeout(instance.getRequestTimeout());
-      this.withScaleTimeout(instance.getScaleTimeout());
-      this.withLoggingInterval(instance.getLoggingInterval());
-      this.withMaxConcurrentRequests(instance.getMaxConcurrentRequests());
-      this.withMaxConcurrentRequestsPerHost(instance.getMaxConcurrentRequestsPerHost());
-      this.withHttp2Disable(instance.isHttp2Disable());
-      this.withHttpProxy(instance.getHttpProxy());
-      this.withHttpsProxy(instance.getHttpsProxy());
-      this.withNoProxy(instance.getNoProxy());
-      this.withUserAgent(instance.getUserAgent());
-      this.withTlsVersions(instance.getTlsVersions());
-      this.withWebsocketPingInterval(instance.getWebsocketPingInterval());
-      this.withProxyUsername(instance.getProxyUsername());
-      this.withProxyPassword(instance.getProxyPassword());
-      this.withTrustStoreFile(instance.getTrustStoreFile());
-      this.withTrustStorePassphrase(instance.getTrustStorePassphrase());
-      this.withKeyStoreFile(instance.getKeyStoreFile());
-      this.withKeyStorePassphrase(instance.getKeyStorePassphrase());
-      this.withImpersonateUsername(instance.getImpersonateUsername());
-      this.withImpersonateGroups(instance.getImpersonateGroups());
-      this.withImpersonateExtras(instance.getImpersonateExtras());
-      this.withOauthTokenProvider(instance.getOauthTokenProvider());
-      this.withCustomHeaders(instance.getCustomHeaders());
-      this.withRequestRetryBackoffLimit(instance.getRequestRetryBackoffLimit());
-      this.withRequestRetryBackoffInterval(instance.getRequestRetryBackoffInterval());
-      this.withUploadRequestTimeout(instance.getUploadRequestTimeout());
-      this.withOnlyHttpWatches(instance.isOnlyHttpWatches());
-      this.withCurrentContext(instance.getCurrentContext());
-      this.withContexts(instance.getContexts());
-      this.withAutoConfigure(instance.getAutoConfigure());
-      this.withAuthProvider(instance.getAuthProvider());
-    }
+    super.copyInstance(instance);
   }
 
   // Fix #https://github.com/fabric8io/kubernetes-client/issues/6249

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/SundrioConfig.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/SundrioConfig.java
@@ -15,15 +15,31 @@
  */
 package io.fabric8.kubernetes.client;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.fabric8.kubernetes.api.model.AuthProviderConfig;
 import io.fabric8.kubernetes.api.model.NamedContext;
 import io.fabric8.kubernetes.client.http.TlsVersion;
 import io.sundr.builder.annotations.Buildable;
+import lombok.Data;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * This class is necessary to be able to autogenerate a builder for the Config class using Sundrio while providing
+ *
+ * To add a new config option:
+ * <ol>
+ * <li>add a field in this class. Adding getters / setters is optional
+ * <li>add logic in the {@link Config} constructor to copy the field. Optionally add auto configuration logic.
+ * <li>no other changes are typically necessary
+ * </ol>
+ * 
+ * This class is necessary to be able to cleanly deserialize the config.
+ * It is also used to autogenerate a builder for the Config class using Sundrio while providing
  * specific behavior for the build() method.
  *
  * This way we can extend the default SundrioConfigBuilder, overriding the build method and enabling autoconfiguration only in
@@ -34,30 +50,119 @@ import java.util.Map;
  * The end purpose is for users to actually use the builder to override the default values or autoconfigured ones
  * by providing their values through the builder withXxx accessors
  */
-class SundrioConfig extends Config {
-  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false)
-  public SundrioConfig(String masterUrl, String apiVersion, String namespace, Boolean trustCerts,
-      Boolean disableHostnameVerification,
-      String caCertFile, String caCertData, String clientCertFile, String clientCertData, String clientKeyFile,
-      String clientKeyData, String clientKeyAlgo, String clientKeyPassphrase, String username, String password,
-      String oauthToken, String autoOAuthToken, Integer watchReconnectInterval, Integer watchReconnectLimit,
-      Integer connectionTimeout,
-      Integer requestTimeout,
-      Long scaleTimeout, Integer loggingInterval, Integer maxConcurrentRequests, Integer maxConcurrentRequestsPerHost,
-      Boolean http2Disable, String httpProxy, String httpsProxy, String[] noProxy,
-      String userAgent, TlsVersion[] tlsVersions, Long websocketPingInterval, String proxyUsername,
-      String proxyPassword, String trustStoreFile, String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase,
-      String impersonateUsername, String[] impersonateGroups, Map<String, List<String>> impersonateExtras,
-      OAuthTokenProvider oauthTokenProvider, Map<String, String> customHeaders, Integer requestRetryBackoffLimit,
-      Integer requestRetryBackoffInterval, Integer uploadRequestTimeout, Boolean onlyHttpWatches, NamedContext currentContext,
-      List<NamedContext> contexts, Boolean autoConfigure) {
-    super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData,
-        clientCertFile, clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username,
-        password, oauthToken, autoOAuthToken, watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout,
-        scaleTimeout, loggingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, http2Disable,
-        httpProxy, httpsProxy, noProxy, userAgent, tlsVersions, websocketPingInterval, proxyUsername, proxyPassword,
-        trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups,
-        impersonateExtras, oauthTokenProvider, customHeaders, requestRetryBackoffLimit, requestRetryBackoffInterval,
-        uploadRequestTimeout, onlyHttpWatches, currentContext, contexts, autoConfigure, true);
+@Buildable(lazyCollectionInitEnabled = false, lazyMapInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false
+/* , ignore = "additionalProperties" */)
+@SuppressWarnings({ "LombokGetterMayBeUsed", "LombokSetterMayBeUsed" })
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class SundrioConfig {
+
+  protected Boolean trustCerts;
+  protected Boolean disableHostnameVerification;
+  protected String masterUrl;
+  protected String apiVersion;
+  protected String namespace;
+  protected Boolean defaultNamespace;
+  protected String caCertFile;
+  protected String caCertData;
+  protected String clientCertFile;
+  protected String clientCertData;
+  protected String clientKeyFile;
+  protected String clientKeyData;
+  protected String clientKeyAlgo;
+  protected String clientKeyPassphrase;
+  protected String trustStoreFile;
+  protected String trustStorePassphrase;
+  protected String keyStoreFile;
+  protected String keyStorePassphrase;
+  protected AuthProviderConfig authProvider;
+  protected String username;
+  protected String password;
+  protected volatile String oauthToken;
+  @JsonIgnore
+  protected volatile String autoOAuthToken;
+  @JsonIgnore
+  protected OAuthTokenProvider oauthTokenProvider;
+  protected Long websocketPingInterval;
+  protected Integer connectionTimeout;
+  protected Integer maxConcurrentRequests;
+  protected Integer maxConcurrentRequestsPerHost;
+
+  protected List<NamedContext> contexts;
+  protected NamedContext currentContext;
+
+  protected Integer watchReconnectInterval;
+  protected Integer watchReconnectLimit;
+  protected Integer uploadRequestTimeout;
+  protected Integer requestRetryBackoffLimit;
+  protected Integer requestRetryBackoffInterval;
+  protected Integer requestTimeout;
+  protected Long scaleTimeout;
+  protected Integer loggingInterval;
+  protected String impersonateUsername;
+  protected String[] impersonateGroups;
+  protected Map<String, List<String>> impersonateExtras;
+
+  protected Boolean http2Disable;
+  protected String httpProxy;
+  protected String httpsProxy;
+  protected String proxyUsername;
+  protected String proxyPassword;
+  protected String[] noProxy;
+  protected String userAgent;
+  protected TlsVersion[] tlsVersions;
+
+  protected Boolean onlyHttpWatches;
+
+  /**
+   * custom headers
+   */
+  protected Map<String, String> customHeaders;
+
+  protected Boolean autoConfigure;
+
+  @JsonIgnore
+  protected Map<String, Object> additionalProperties = new HashMap<>();
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
   }
+
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
+
+  /*
+   * Begin specific overrides for getters / setters
+   * Only needed if changing the default signature, adding javadocs, etc.
+   */
+
+  public void setImpersonateGroups(String... impersonateGroup) {
+    this.impersonateGroups = impersonateGroup;
+  }
+
+  /**
+   * Returns all the {@link NamedContext}s that exist in the kube config
+   *
+   * @return all the contexts
+   *
+   * @see NamedContext
+   */
+  public List<NamedContext> getContexts() {
+    return contexts;
+  }
+
+  /**
+   * Returns the current context that's defined in the kube config. Returns {@code null} if there's none
+   *
+   * @return the current context
+   *
+   * @see NamedContext
+   */
+  public NamedContext getCurrentContext() {
+    return currentContext;
+  }
+
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigConstructorTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigConstructorTest.java
@@ -82,20 +82,7 @@ class ConfigConstructorTest {
 
   static Stream<Arguments> blankConfigurationProviders() {
     return Stream.of(
-        Arguments.of(new Config(null, null, null, null, null,
-            null, null, null, null, null,
-            null, null, null, null, null,
-            null, null, null, null, null,
-            null, null, null, null,
-            null,
-            null, null, null, null,
-            null, null, null,
-            null,
-            null, null, null, null, null,
-            null, null, null,
-            null, null, null,
-            null, null, null, null,
-            null, null, false)));
+        Arguments.of(new Config()));
   }
 
   @Nested
@@ -186,20 +173,7 @@ class ConfigConstructorTest {
     void whenAutoConfigureEnabled_thenUseBothDefaultAndAutoConfiguredValues() {
       // Given
       // When
-      Config config = new Config(null, null, null, null, null,
-          null, null, null, null, null,
-          null, null, null, null, null,
-          null, null, null, null, null,
-          null, null, null, null,
-          null,
-          null, null, null, null,
-          null, null, null,
-          null,
-          null, null, null, null, null,
-          null, null, null,
-          null, null, null,
-          null, null, null, null,
-          null, true, true);
+      Config config = new Config(new SundrioConfigBuilder().withAutoConfigure().build(), true);
 
       // Then
       assertThat(config)
@@ -253,20 +227,7 @@ class ConfigConstructorTest {
     @Test
     @DisplayName("when autoConfigure disabled, then auto configured values are ignored")
     void whenAutoConfigureDisabled_thenOnlyUseDefaultValues() {
-      Config config = new Config(null, null, null, null, null,
-          null, null, null, null, null,
-          null, null, null, null, null,
-          null, null, null, null, null,
-          null, null, null, null,
-          null,
-          null, null, null, null,
-          null, null, null,
-          null,
-          null, null, null, null, null,
-          null, null, null,
-          null, null, null,
-          null, null, null, null,
-          null, false, true);
+      Config config = new Config(new SundrioConfigBuilder().withAutoConfigure(false).build(), true);
 
       assertThat(config)
           .isNotNull()
@@ -362,20 +323,7 @@ class ConfigConstructorTest {
           System.setProperty("proxy.password", "autoconfigured-proxyPassword");
 
           // When
-          Config config = new Config(null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null,
-              null,
-              null, null, null, null,
-              null, null, null,
-              null,
-              null, null, null, null, null,
-              null, null, null,
-              null, null, null,
-              null, null, null, null,
-              null, true, true);
+          Config config = new Config(new SundrioConfigBuilder().withAutoConfigure().build(), true);
 
           // Then
           assertThat(config)
@@ -470,20 +418,7 @@ class ConfigConstructorTest {
           String kubeConfigFilePath = Utils.filePath(ConfigConstructorTest.class.getResource("/test-kubeconfig"));
           System.setProperty("kubeconfig", kubeConfigFilePath);
           // When
-          Config config = new Config(null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null,
-              null,
-              null, null, null, null,
-              null, null, null,
-              null,
-              null, null, null, null, null,
-              null, null, null,
-              null, null, null,
-              null, null, null, null,
-              null, true, true);
+          Config config = new Config(new SundrioConfigBuilder().withAutoConfigure().build(), true);
 
           // Then
           assertThat(config)
@@ -511,20 +446,7 @@ class ConfigConstructorTest {
           System.setProperty("kubenamespace",
               Utils.filePath(ConfigConstructorTest.class.getResource("/config-source-precedence/serviceaccount/namespace")));
           // When
-          Config config = new Config(null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null, null,
-              null, null, null, null,
-              null,
-              null, null, null, null,
-              null, null, null,
-              null,
-              null, null, null, null, null,
-              null, null, null,
-              null, null, null,
-              null, null, null, null,
-              null, true, true);
+          Config config = new Config(new SundrioConfigBuilder().withAutoConfigure().build(), true);
 
           // Then
           assertThat(config)
@@ -561,20 +483,7 @@ class ConfigConstructorTest {
           // When
           // Then
           assertThatExceptionOfType(NullPointerException.class)
-              .isThrownBy(() -> new Config(null, null, null, null, null,
-                  null, null, null, null, null,
-                  null, null, null, null, null,
-                  null, null, null, null, null,
-                  null, null, null, null,
-                  null,
-                  null, null, null, null,
-                  null, null, null,
-                  null,
-                  null, null, null, null, null,
-                  null, null, null,
-                  null, null, null,
-                  null, null, null, null,
-                  null, true, false));
+              .isThrownBy(() -> new Config(new SundrioConfigBuilder().withAutoConfigure().build(), false));
         } finally {
           System.clearProperty("kubeconfig");
         }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigTest.java
@@ -398,6 +398,15 @@ class ConfigTest {
         .isEqualTo(30000L);
   }
 
+  @Test
+  void testBuilderAdditionalProperties() {
+    // Given + When
+    Config config = new ConfigBuilder().withAdditionalProperties(Map.of("a", "b")).build();
+    // Then
+    assertThat(config.getAdditionalProperties())
+        .isEqualTo(Map.of("a", "b"));
+  }
+
   @Nested
   @DisplayName("Inside Kubernetes cluster")
   class InCluster {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/SundrioConfigBuilderTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/SundrioConfigBuilderTest.java
@@ -29,8 +29,7 @@ class SundrioConfigBuilderTest {
     assertThat(Arrays.stream(SundrioConfigFluent.class.getDeclaredFields())
         .filter(f -> !Modifier.isStatic(f.getModifiers()))
         .collect(Collectors.toList()))
-        .withFailMessage("You've probably modified Config and SundrioConfig constructor annotated with @Buildable," +
-            "please update the ConfigFluent.copyInstance method too")
-        .hasSize(51);
+        .withFailMessage("You've probably modified SundrioConfig, please update the Config copy constructor as well")
+        .hasSize(53);
   }
 }

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -47,7 +47,7 @@ public class OpenShiftConfig extends Config {
 
   //This is not meant to be used. This constructor is used only by the generated builder.
   OpenShiftConfig() {
-    super();
+    super(!disableAutoConfig());
   }
 
   @JsonCreator(mode = Mode.DELEGATING)

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfig.java
@@ -15,24 +15,20 @@
  */
 package io.fabric8.openshift.client;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.fabric8.kubernetes.api.model.NamedContext;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.OAuthTokenProvider;
-import io.fabric8.kubernetes.client.http.TlsVersion;
+import io.fabric8.kubernetes.client.SundrioConfig;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.client.readiness.OpenShiftReadiness;
-import io.sundr.builder.annotations.Buildable;
-import io.sundr.builder.annotations.BuildableReference;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
-import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true, allowGetters = true, allowSetters = true)
@@ -49,63 +45,34 @@ public class OpenShiftConfig extends Config {
 
   public static final Long DEFAULT_BUILD_TIMEOUT = 5 * 60 * 1000L;
 
-  // dummy fields so that Builder is created correctly
-  private String oapiVersion;
-  private String openShiftUrl;
-  private Long buildTimeout;
-  private Boolean disableApiGroupCheck; //If group hasn't been explicitly set.
-
   //This is not meant to be used. This constructor is used only by the generated builder.
   OpenShiftConfig() {
-    super(!disableAutoConfig());
+    super();
+  }
+
+  @JsonCreator(mode = Mode.DELEGATING)
+  public OpenShiftConfig(SundrioConfig config) {
+    this(config, null, null, null, null);
   }
 
   public OpenShiftConfig(Config kubernetesConfig) {
-    this(kubernetesConfig,
-        getDefaultOpenShiftUrl(kubernetesConfig), getDefaultOapiVersion(kubernetesConfig), DEFAULT_BUILD_TIMEOUT);
+    this(kubernetesConfig, null, null, null, null);
   }
 
-  public OpenShiftConfig(Config kubernetesConfig, String openShiftUrl) {
-    this(kubernetesConfig,
-        getDefaultOpenShiftUrl(kubernetesConfig), getDefaultOapiVersion(kubernetesConfig), DEFAULT_BUILD_TIMEOUT);
-    this.setOpenShiftUrl(openShiftUrl);
-  }
+  OpenShiftConfig(SundrioConfig kubernetesConfig, String openShiftUrl, String oapiVersion, Long buildTimeout,
+      Boolean disableApiGroupCheck) {
+    super(kubernetesConfig); // initi the base state - including setting defaults
+    if (oapiVersion == null) {
+      oapiVersion = getDefaultOapiVersion(apiVersion);
+    }
 
-  @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false, refs = {
-      @BuildableReference(Config.class) })
-  public OpenShiftConfig(String openShiftUrl, String oapiVersion, String masterUrl, String apiVersion, String namespace,
-      Boolean trustCerts, Boolean disableHostnameVerification, String caCertFile, String caCertData,
-      String clientCertFile,
-      String clientCertData, String clientKeyFile, String clientKeyData, String clientKeyAlgo,
-      String clientKeyPassphrase,
-      String username, String password, String oauthToken, String autoOAuthToken, Integer watchReconnectInterval,
-      Integer watchReconnectLimit,
-      Integer connectionTimeout, Integer requestTimeout, Long scaleTimeout, Integer loggingInterval,
-      Integer maxConcurrentRequests, Integer maxConcurrentRequestsPerHost, Boolean http2Disable, String httpProxy,
-      String httpsProxy,
-      String[] noProxy, String userAgent, TlsVersion[] tlsVersions,
-      Long websocketPingInterval, String proxyUsername, String proxyPassword, String trustStoreFile,
-      String trustStorePassphrase, String keyStoreFile, String keyStorePassphrase, String impersonateUsername,
-      String[] impersonateGroups, Map<String, List<String>> impersonateExtras, OAuthTokenProvider oauthTokenProvider,
-      Map<String, String> customHeaders, Integer requestRetryBackoffLimit, Integer requestRetryBackoffInterval,
-      Integer uploadRequestTimeout, Boolean onlyHttpWatches, Long buildTimeout,
-      Boolean disableApiGroupCheck, NamedContext currentContext, List<NamedContext> contexts,
-      Boolean autoConfigure) {
-    super(masterUrl, apiVersion, namespace, trustCerts, disableHostnameVerification, caCertFile, caCertData,
-        clientCertFile,
-        clientCertData, clientKeyFile, clientKeyData, clientKeyAlgo, clientKeyPassphrase, username, password,
-        oauthToken, autoOAuthToken,
-        watchReconnectInterval, watchReconnectLimit, connectionTimeout, requestTimeout, scaleTimeout,
-        loggingInterval, maxConcurrentRequests, maxConcurrentRequestsPerHost, http2Disable, httpProxy, httpsProxy,
-        noProxy, userAgent, tlsVersions, websocketPingInterval, proxyUsername, proxyPassword,
-        trustStoreFile, trustStorePassphrase, keyStoreFile, keyStorePassphrase, impersonateUsername, impersonateGroups,
-        impersonateExtras, oauthTokenProvider, customHeaders,
-        requestRetryBackoffLimit,
-        requestRetryBackoffInterval,
-        uploadRequestTimeout, onlyHttpWatches, currentContext, contexts, autoConfigure);
     this.setOapiVersion(oapiVersion);
     this.setBuildTimeout(buildTimeout);
     this.setDisableApiGroupCheck(disableApiGroupCheck);
+
+    if (openShiftUrl == null) {
+      openShiftUrl = getDefaultOpenShiftUrl(getMasterUrl(), oapiVersion);
+    }
 
     if (openShiftUrl == null || openShiftUrl.isEmpty()) {
       openShiftUrl = URLUtils.join(getMasterUrl(), "oapi", oapiVersion);
@@ -116,58 +83,24 @@ public class OpenShiftConfig extends Config {
     this.setOpenShiftUrl(openShiftUrl);
   }
 
-  public OpenShiftConfig(Config kubernetesConfig, String openShiftUrl, String oapiVersion, long buildTimeout) {
-    this(openShiftUrl, oapiVersion,
-        kubernetesConfig.getMasterUrl(), kubernetesConfig.getApiVersion(),
-        kubernetesConfig.getNamespace(), kubernetesConfig.isTrustCerts(),
-        kubernetesConfig.isDisableHostnameVerification(), kubernetesConfig.getCaCertFile(),
-        kubernetesConfig.getCaCertData(), kubernetesConfig.getClientCertFile(),
-        kubernetesConfig.getClientCertData(), kubernetesConfig.getClientKeyFile(),
-        kubernetesConfig.getClientKeyData(), kubernetesConfig.getClientKeyAlgo(),
-        kubernetesConfig.getClientKeyPassphrase(),
-        kubernetesConfig.getUsername(), kubernetesConfig.getPassword(), kubernetesConfig.getOauthToken(),
-        kubernetesConfig.getAutoOAuthToken(), kubernetesConfig.getWatchReconnectInterval(),
-        kubernetesConfig.getWatchReconnectLimit(),
-        kubernetesConfig.getConnectionTimeout(), kubernetesConfig.getRequestTimeout(),
-        kubernetesConfig.getScaleTimeout(),
-        kubernetesConfig.getLoggingInterval(), kubernetesConfig.getMaxConcurrentRequests(),
-        kubernetesConfig.getMaxConcurrentRequestsPerHost(), kubernetesConfig.isHttp2Disable(),
-        kubernetesConfig.getHttpProxy(), kubernetesConfig.getHttpsProxy(), kubernetesConfig.getNoProxy(),
-        kubernetesConfig.getUserAgent(), kubernetesConfig.getTlsVersions(),
-        kubernetesConfig.getWebsocketPingInterval(), kubernetesConfig.getProxyUsername(),
-        kubernetesConfig.getProxyPassword(), kubernetesConfig.getTrustStoreFile(),
-        kubernetesConfig.getTrustStorePassphrase(), kubernetesConfig.getKeyStoreFile(),
-        kubernetesConfig.getKeyStorePassphrase(), kubernetesConfig.getImpersonateUsername(),
-        kubernetesConfig.getImpersonateGroups(), kubernetesConfig.getImpersonateExtras(),
-        kubernetesConfig.getOauthTokenProvider(), kubernetesConfig.getCustomHeaders(),
-        kubernetesConfig.getRequestRetryBackoffLimit(), kubernetesConfig.getRequestRetryBackoffInterval(),
-        kubernetesConfig.getUploadRequestTimeout(),
-        kubernetesConfig.isOnlyHttpWatches(),
-        buildTimeout,
-        false,
-        kubernetesConfig.getCurrentContext(),
-        kubernetesConfig.getContexts(),
-        kubernetesConfig.getAutoConfigure());
-  }
-
   public static OpenShiftConfig wrap(Config config) {
     return config instanceof OpenShiftConfig ? (OpenShiftConfig) config : new OpenShiftConfig(config);
   }
 
-  private static String getDefaultOapiVersion(Config config) {
-    return Utils.getSystemPropertyOrEnvVar(KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY, config.getApiVersion());
+  private static String getDefaultOapiVersion(String apiVersion) {
+    return Utils.getSystemPropertyOrEnvVar(KUBERNETES_OAPI_VERSION_SYSTEM_PROPERTY, apiVersion);
   }
 
-  private static String getDefaultOpenShiftUrl(Config config) {
+  private static String getDefaultOpenShiftUrl(String masterUrl, String oapiVersion) {
     String openshiftUrl = Utils.getSystemPropertyOrEnvVar(OPENSHIFT_URL_SYSTEM_PROPERTY);
     if (openshiftUrl != null) {
       // The OPENSHIFT_URL environment variable may be set to the root url (i.e. without the '/oapi/version' path) in some configurations
       if (isRootURL(openshiftUrl)) {
-        openshiftUrl = URLUtils.join(openshiftUrl, "oapi", getDefaultOapiVersion(config));
+        openshiftUrl = URLUtils.join(openshiftUrl, "oapi", oapiVersion);
       }
       return openshiftUrl;
     } else {
-      return URLUtils.join(config.getMasterUrl(), "oapi", getDefaultOapiVersion(config));
+      return URLUtils.join(masterUrl, "oapi", oapiVersion);
     }
   }
 
@@ -198,12 +131,20 @@ public class OpenShiftConfig extends Config {
     this.additionalProperties.put(OPENSHIFT_URL, openShiftUrl);
   }
 
-  public long getBuildTimeout() {
-    return (long) this.additionalProperties.getOrDefault(BUILD_TIMEOUT, DEFAULT_BUILD_TIMEOUT);
+  public Long getBuildTimeout() {
+    return (Long) this.additionalProperties.getOrDefault(BUILD_TIMEOUT, DEFAULT_BUILD_TIMEOUT);
   }
 
   public void setBuildTimeout(long buildTimeout) {
-    this.additionalProperties.put(BUILD_TIMEOUT, buildTimeout);
+    setBuildTimeout(Long.valueOf(buildTimeout));
+  }
+
+  public void setBuildTimeout(Long buildTimeout) {
+    if (buildTimeout == null) {
+      this.additionalProperties.remove(BUILD_TIMEOUT);
+    } else {
+      this.additionalProperties.put(BUILD_TIMEOUT, buildTimeout);
+    }
   }
 
   @JsonIgnore
@@ -212,7 +153,15 @@ public class OpenShiftConfig extends Config {
   }
 
   public void setDisableApiGroupCheck(boolean disableApiGroupCheck) {
-    this.additionalProperties.put(DISABLE_API_GROUP_CHECK, disableApiGroupCheck);
+    setDisableApiGroupCheck(Boolean.valueOf(disableApiGroupCheck));
+  }
+
+  public void setDisableApiGroupCheck(Boolean disableApiGroupCheck) {
+    if (disableApiGroupCheck == null) {
+      this.additionalProperties.remove(DISABLE_API_GROUP_CHECK);
+    } else {
+      this.additionalProperties.put(DISABLE_API_GROUP_CHECK, disableApiGroupCheck);
+    }
   }
 
   @Override

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfigBuilder.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfigBuilder.java
@@ -23,19 +23,19 @@ import io.fabric8.kubernetes.client.SundrioConfig;
 public class OpenShiftConfigBuilder extends OpenShiftConfigFluent<OpenShiftConfigBuilder>
     implements VisitableBuilder<OpenShiftConfig, OpenShiftConfigBuilder> {
   public OpenShiftConfigBuilder() {
-    this(new OpenShiftConfig());
+    this(new SundrioOpenShiftConfig());
   }
 
   public OpenShiftConfigBuilder(OpenShiftConfigFluent<?> fluent) {
-    this(fluent, new OpenShiftConfig());
+    this(fluent, new SundrioOpenShiftConfig());
   }
 
-  public OpenShiftConfigBuilder(OpenShiftConfigFluent<?> fluent, OpenShiftConfig instance) {
+  public OpenShiftConfigBuilder(OpenShiftConfigFluent<?> fluent, SundrioOpenShiftConfig instance) {
     this.fluent = fluent;
     fluent.copyInstance(instance);
   }
 
-  public OpenShiftConfigBuilder(OpenShiftConfig instance) {
+  public OpenShiftConfigBuilder(SundrioOpenShiftConfig instance) {
     this.fluent = this;
     this.copyInstance(instance);
   }

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfigBuilder.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfigBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.openshift.client;
+
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.SundrioConfig;
+
+public class OpenShiftConfigBuilder extends OpenShiftConfigFluent<OpenShiftConfigBuilder>
+    implements VisitableBuilder<OpenShiftConfig, OpenShiftConfigBuilder> {
+  public OpenShiftConfigBuilder() {
+    this(new OpenShiftConfig());
+  }
+
+  public OpenShiftConfigBuilder(OpenShiftConfigFluent<?> fluent) {
+    this(fluent, new OpenShiftConfig());
+  }
+
+  public OpenShiftConfigBuilder(OpenShiftConfigFluent<?> fluent, OpenShiftConfig instance) {
+    this.fluent = fluent;
+    fluent.copyInstance(instance);
+  }
+
+  public OpenShiftConfigBuilder(OpenShiftConfig instance) {
+    this.fluent = this;
+    this.copyInstance(instance);
+  }
+
+  OpenShiftConfigFluent<?> fluent;
+
+  @Override
+  public OpenShiftConfig build() {
+    // build the config state from the generated builder, then use that
+    // to construct the full state
+    SundrioConfig config = ConfigBuilder.toSundrioConfig(fluent);
+    OpenShiftConfig buildable = new OpenShiftConfig(config, fluent.getOpenShiftUrl(),
+        fluent.getOapiVersion(), fluent.getBuildTimeout(), fluent.getDisableApiGroupCheck());
+    return buildable;
+  }
+
+}

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfigFluent.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/OpenShiftConfigFluent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.openshift.client;
+
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@SuppressWarnings("unchecked")
+public class OpenShiftConfigFluent<A extends OpenShiftConfigFluent<A>> extends SundrioOpenShiftConfigFluent<A> {
+
+  public OpenShiftConfigFluent() {
+    super();
+  }
+
+  public OpenShiftConfigFluent(OpenShiftConfig instance) {
+    super();
+    this.copyInstance(instance);
+  }
+
+  // no need to override the base logic
+  public void copyInstance(OpenShiftConfig instance) {
+    super.copyInstance(instance);
+  }
+
+}

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/SundrioOpenShiftConfig.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/SundrioOpenShiftConfig.java
@@ -18,8 +18,6 @@ package io.fabric8.openshift.client;
 import io.fabric8.kubernetes.client.Config;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * Add new Openshift options here instead of {@link OpenShiftConfig}, then add the mapping logic
@@ -27,8 +25,6 @@ import lombok.Setter;
  */
 @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false, refs = {
     @BuildableReference(Config.class) })
-@Getter
-@Setter
 class SundrioOpenShiftConfig extends OpenShiftConfig {
 
   // for the fluent generation - mapped to additional properties

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/SundrioOpenShiftConfig.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/SundrioOpenShiftConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift.client;
+
+import io.fabric8.kubernetes.client.Config;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Add new Openshift options here instead of {@link OpenShiftConfig}, then add the mapping logic
+ * to additional properties in {@link OpenShiftConfig} and a new parameter to the {@link OpenShiftConfig} constructor
+ */
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false, refs = {
+    @BuildableReference(Config.class) })
+@Getter
+@Setter
+class SundrioOpenShiftConfig extends OpenShiftConfig {
+
+  // for the fluent generation - mapped to additional properties
+  private String oapiVersion;
+  private String openShiftUrl;
+  private Long buildTimeout;
+  private Boolean disableApiGroupCheck; //If group hasn't been explicitly set.
+
+}


### PR DESCRIPTION
## Description

@manusa @rohanKanojia separated this from the pr dealing with watchLists. I realize that using just the swicth to use a static constructor is pretty narrow change. If possible I'd like to shoot for something bigger. The changes here get rid of all of our messiest constructors and hopely make adding new options more straight-forward.

- SundrioConfig -> goes from extending the Config to being a base class (could be renamed BaseConfig or something).  
  - There are two reasons to do this:
    - Creates a clean pojo from which to do sundrio generation.
    - Creates a clean pojo from which to do delegated Json deserialization - see the Config(SundrioConfig config) constructor.
  - Downsides:
    - Probably needs to be public (https://github.com/fabric8io/kubernetes-client/issues/4724) - or maybe just the class and not the constructor. Since all the apis expect Config, not SundrioConfig, there's not much that can be done with it. If we didn't have the need for overriding ConfigFluent methods, we could probably do away with SundrioConfig (see below for similar reasoning with OpenshiftConfigFluent)
  - Latent issues:
    -  additionalProperties and defaultNamespace do not seem to be handled properly (missing) in the current SundrioConfigFluent.
- ConfigFluent can just reuse the base logic, no need to mess with updating fluents when a new option is added
- You do still have to update the Config copy constructor to copy the value from the SundrioConfig.

- For Openshift the paradigm flips. There's now an SundrioOpenShiftConfig extending OpenshiftConfig with the dummy fields moved there.
  - I believe we could get rid of this class and the hardcoded OpenshiftConfigFluent/Builder if the logic in the copy constructor (if x is not null or empty, set x) were moved to the setter methods as that can all be done in the default sundrio logic post construction.

Other latent issues:
- We're subtlely changing the meaning of several of the ConfigBuilder consturctor methods, not sure if we should address that now that the change is already in.
- autoConfigure behavior seems inconsistent. If you do new ConfigBuilder().build() we'll use autoConfigure unless disabled, but if you parse we will only use autoConfigure if the field is true.
- OpenShiftConfig wrapping can rerun autoConfigure.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
