### PR TITLE
fix: change rolling update logic to a json merge patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 #### Bugs
 * Fix #7148: corrected octal format detection
-* Fix #7167: Allow Informer.isWatching to see underlying Watch state
-* Fix #7087: Avoid possible NPE in OkHttp websocket handlinger
+- Fix #7167: Allow Informer.isWatching to see underlying Watch state
+* Fix #7087: Avoid possible NPE in OkHttp websocket handling
+* Fix #7072: Changed rolling update handling to json merge patch to avoid 422 errors
 * Fix #7080: Avoid NPE in CRDGenerator if post-processor is set to null
 * Fix #7116: (java-generator) Use timezone format compatible with Kubernetes
 * Fix #7163: Ensure that streams are notified of errors

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -623,8 +623,8 @@ class DeploymentTest {
     // Then
     RecordedRequest recordedRequest = server.getLastRequest();
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertThat(client.getKubernetesSerialization().unmarshal(recordedRequest.getBody().readUtf8(), List.class))
-        .isEqualTo(List.of(Map.of("op", "add", "path", "/spec/paused", "value", true)));
+    assertThat(recordedRequest.getBody().readUtf8())
+        .isEqualTo("{\"spec\":{\"paused\":true}}");
   }
 
   @Test
@@ -654,8 +654,8 @@ class DeploymentTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertNotNull(deployment);
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertThat(client.getKubernetesSerialization().unmarshal(recordedRequest.getBody().readUtf8(), List.class))
-        .isEqualTo(List.of(Map.of("op", "remove", "path", "/spec/paused")));
+    assertThat(recordedRequest.getBody().readUtf8())
+        .isEqualTo("{\"spec\":{\"paused\":null}}");
   }
 
   @Test
@@ -685,7 +685,7 @@ class DeploymentTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertNotNull(deployment);
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io~1restartedAt"));
+    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io/restartedAt"));
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -399,7 +399,7 @@ public class StatefulSetTest {
     RecordedRequest recordedRequest = server.getLastRequest();
     assertNotNull(deployment);
     assertEquals("PATCH", recordedRequest.getMethod());
-    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io~1restartedAt"));
+    assertTrue(recordedRequest.getBody().readUtf8().contains("kubectl.kubernetes.io/restartedAt"));
   }
 
   @Test


### PR DESCRIPTION
## Description

Reverts to the older style for rolling update, with a simplification of map creation.

Replaces and closes #7118 - @dkaukov I'd advocate for this approach to cut down on additional complexity / multiple requests

closes: #7072

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
