### PR TITLE
add a back door to modify the schema

### DIFF
--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/SchemaCustomizer.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/SchemaCustomizer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.generator.v1;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
+import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SchemaCustomizer {
+
+  public interface Customizer {
+
+    /**
+     * Customizes the given {@link JSONSchemaProps}
+     * 
+     * @param props the {@link JSONSchemaProps} to customize
+     * @param input the input String from the {@link SchemaCustomizer} annotation
+     * @param kubernetesSerialization
+     * @return the customized {@link JSONSchemaProps}
+     */
+    JSONSchemaProps apply(JSONSchemaProps props, String input, KubernetesSerialization kubernetesSerialization);
+
+  }
+
+  /**
+   * Replace the incoming schema with the given the input of JSONSchemaProps in yaml or json,
+   */
+  public static class RawCustomizer implements Customizer {
+
+    @Override
+    public JSONSchemaProps apply(JSONSchemaProps props, String input, KubernetesSerialization kubernetesSerialization) {
+      return kubernetesSerialization.unmarshal(input, JSONSchemaProps.class);
+    }
+
+  }
+
+  /**
+   * Patch the incoming schema with the given JSON merge patch input.
+   */
+  public static class MergePatchCustomizer implements Customizer {
+
+    @Override
+    public JSONSchemaProps apply(JSONSchemaProps props, String input, KubernetesSerialization kubernetesSerialization) {
+      kubernetesSerialization.mergePatch(props, input);
+      return props;
+    }
+
+  }
+
+  Class<? extends Customizer> value();
+
+  String input() default "";
+
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/Customized.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/Customized.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.example.customized;
+
+import io.fabric8.crdv2.generator.v1.SchemaCustomizer;
+
+@SchemaCustomizer(input = "my description", value = DescriptionCustomizer.class)
+public class Customized {
+
+  public int field;
+
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/DescriptionCustomizer.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/DescriptionCustomizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.example.customized;
+
+import io.fabric8.crdv2.generator.v1.SchemaCustomizer;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
+import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
+
+public class DescriptionCustomizer implements SchemaCustomizer.Customizer {
+
+  @Override
+  public JSONSchemaProps apply(JSONSchemaProps props, String input, KubernetesSerialization kubernetesSerialization) {
+    props.setDescription(input);
+    return props;
+  }
+
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/RawCustomized.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/RawCustomized.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.example.customized;
+
+import io.fabric8.crdv2.generator.v1.SchemaCustomizer;
+
+@SchemaCustomizer(input = "properties:\n"
+    + "  prop:\n"
+    + "    type: \"integer\"", value = SchemaCustomizer.RawCustomizer.class)
+public class RawCustomized {
+
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/SchemaCustomizerTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/SchemaCustomizerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.generator.v1;
+
+import io.fabric8.crdv2.example.customized.Customized;
+import io.fabric8.crdv2.example.customized.RawCustomized;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SchemaCustomizerTest {
+
+  @Test
+  void applyCustomizer() {
+    JSONSchemaProps schema = JsonSchema.from(Customized.class);
+    assertEquals("my description", schema.getDescription());
+  }
+
+  @Test
+  void applyRawCustomizer() {
+    JSONSchemaProps schema = JsonSchema.from(RawCustomized.class);
+    assertEquals(1, schema.getProperties().size());
+    assertEquals("integer", schema.getProperties().get("prop").getType());
+  }
+
+}

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -873,6 +873,11 @@ spec:
         # [...]
 ```
 
+### Schema Customization
+
+In some instances the built-in set of annotations and logic may not produce the desired CRD output. There is a mechanism
+included in the crd-generator-api-v2 module for this. See the `io.fabric8.crdv2.generator.v1.SchemaCustomizer` annotation
+for directly manipulating the JSONSchemaProps of the annotated resource. This annotation is applied last, after all of the other annotations are processed.
 
 ## Features cheatsheet
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesSerialization.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
@@ -426,6 +427,15 @@ public class KubernetesSerialization {
       return input; // valid json
     } catch (JsonProcessingException e) {
       return asJson(unmarshal(input, JsonNode.class));
+    }
+  }
+
+  public void mergePatch(Object updatable, String patch) {
+    ObjectReader reader = mapper.readerForUpdating(updatable);
+    try {
+      reader.readValue(patch);
+    } catch (JsonProcessingException e) {
+      throw KubernetesClientException.launderThrowable(e);
     }
   }
 


### PR DESCRIPTION
There is a lot of complexity / trepidation with broadening and documenting our annotation support for advanced cases including structural schema. Just wanted to make a quick proposal of a way to give users lower level control over schema generation. Shown here as an object level annotation, but it would probably be applicable in other places as well.

This would be understood / documented as something for advanced usage and would require devs to add a provided scope dependency to crd-generator-api-v2.

We could offer at least 1 built-in customizer - that simply deserializes the input as the replacement. You could also entertain one that applies a patch.

The order in which the annotations are applied needs to be well defined - or if only the highest one found should be applied. This would also be defined as being applied in some predictable largely independent way of schemaswap / from.

closes: #7355

cc @matteriben @MikeEdgar 

