### PR TITLE
fix(junit): EnableKubernetesMockClient annotation works with Nested tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### 7.4-SNAPSHOT
 
 #### Bugs
+* Fix #3032: EnableKubernetesMockClient annotation works with Nested tests
 * Fix #7148: corrected octal format detection
-- Fix #7167: Allow Informer.isWatching to see underlying Watch state
+* Fix #7167: Allow Informer.isWatching to see underlying Watch state
 * Fix #7087: Avoid possible NPE in OkHttp websocket handling
 * Fix #7072: Changed rolling update handling to json merge patch to avoid 422 errors
 * Fix #7080: Avoid NPE in CRDGenerator if post-processor is set to null

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/KubernetesTest.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/KubernetesTest.java
@@ -20,6 +20,7 @@ import io.fabric8.junit.jupiter.NamespaceExtension;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -51,6 +52,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @ExtendWith(NamespaceExtension.class)
 @ExtendWith(KubernetesExtension.class)
+@Inherited
 public @interface KubernetesTest {
   /**
    * Create an ephemeral Namespace for the test.

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/LoadKubernetesManifests.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/LoadKubernetesManifests.java
@@ -20,6 +20,7 @@ import io.fabric8.junit.jupiter.LoadKubernetesManifestsExtension;
 import io.fabric8.junit.jupiter.NamespaceExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -40,6 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @ExtendWith(NamespaceExtension.class)
 @ExtendWith(KubernetesExtension.class)
 @ExtendWith(LoadKubernetesManifestsExtension.class)
+@Inherited
 public @interface LoadKubernetesManifests {
 
   String[] value();

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/RequireK8sSupport.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/RequireK8sSupport.java
@@ -19,6 +19,7 @@ import io.fabric8.junit.jupiter.RequireK8sSupportCondition;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -27,6 +28,7 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(RequireK8sSupportCondition.class)
+@Inherited
 public @interface RequireK8sSupport {
   Class<? extends HasMetadata> value();
 }

--- a/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/RequireK8sVersionAtLeast.java
+++ b/junit/kubernetes-junit-jupiter/src/main/java/io/fabric8/junit/jupiter/api/RequireK8sVersionAtLeast.java
@@ -18,6 +18,7 @@ package io.fabric8.junit.jupiter.api;
 import io.fabric8.junit.jupiter.RequireK8sVersionAtLeastCondition;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -26,6 +27,7 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(RequireK8sVersionAtLeastCondition.class)
+@Inherited
 public @interface RequireK8sVersionAtLeast {
   int majorVersion();
 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/EnableKubernetesMockClient.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/EnableKubernetesMockClient.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.server.mock;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.function.Consumer;
@@ -35,6 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({ TYPE, METHOD, ANNOTATION_TYPE })
 @Retention(RUNTIME)
 @ExtendWith(KubernetesMockServerExtension.class)
+@Inherited
 public @interface EnableKubernetesMockClient {
 
   boolean https() default true;

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/EnableKubernetesMockClientInheritanceTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/EnableKubernetesMockClientInheritanceTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnableKubernetesMockClientInheritanceTest {
+
+  @EnableKubernetesMockClient
+  public static class BaseTest {
+
+  }
+
+  @Nested
+  class NestedTest extends BaseTest {
+
+    KubernetesMockServer mockServer;
+    KubernetesClient kubernetesClient;
+
+    @Test
+    void shouldInjectMockServer() {
+      assertThat(mockServer).isNotNull();
+    }
+
+    @Test
+    void shouldInjectKubernetesClient() {
+      assertThat(kubernetesClient).isNotNull();
+    }
+
+  }
+}

--- a/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTestWithNestedTest.java
+++ b/junit/kubernetes-server-mock/src/test/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtensionTestWithNestedTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client.server.mock;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient(crud = true)
+public class KubernetesMockServerExtensionTestWithNestedTest {
+
+  KubernetesMockServer mockServer;
+  KubernetesClient kubernetesClient;
+
+  @Nested
+  class TheNestedClass {
+
+    KubernetesMockServer nestedMockServer;
+    KubernetesClient nestedKubernetesClient;
+
+    @Test
+    void shouldInjectMockServer() {
+      assertThat(mockServer).isNotNull();
+    }
+
+    @Test
+    void shouldInjectKubernetesClient() {
+      assertThat(kubernetesClient).isNotNull();
+    }
+
+    @Test
+    void shouldInjectNestedMockServer() {
+      assertThat(nestedMockServer).isNotNull();
+    }
+
+    @Test
+    void shouldInjectNestedKubernetesClient() {
+      assertThat(nestedKubernetesClient).isNotNull();
+    }
+  }
+
+}


### PR DESCRIPTION
## Description

Fixes #3032

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
