### PR TITLE
Make `isReadinessApplicable` static

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/readiness/Readiness.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/readiness/Readiness.java
@@ -84,7 +84,7 @@ public class Readiness {
     }
   }
 
-  public boolean isReadinessApplicable(HasMetadata item) {
+  public static boolean isReadinessApplicable(HasMetadata item) {
     return (item instanceof Deployment ||
         item instanceof io.fabric8.kubernetes.api.model.extensions.Deployment ||
         item instanceof ReplicaSet ||

--- a/openshift-client-api/src/main/java/io/fabric8/openshift/client/readiness/OpenShiftReadiness.java
+++ b/openshift-client-api/src/main/java/io/fabric8/openshift/client/readiness/OpenShiftReadiness.java
@@ -35,9 +35,8 @@ public class OpenShiftReadiness extends Readiness {
     return OpenShiftReadinessHolder.INSTANCE;
   }
 
-  @Override
-  public boolean isReadinessApplicable(HasMetadata item) {
-    return super.isReadinessApplicable(item) ||
+  public static boolean isReadinessApplicable(HasMetadata item) {
+    return Readiness.isReadinessApplicable(item) ||
         item instanceof DeploymentConfig;
   }
 


### PR DESCRIPTION
## Description
Recently, a change was made to make `isReadinessApplicable` public such that it can be used within Quarkus rather than needing to duplicate the method (https://github.com/fabric8io/kubernetes-client/commit/134808e681fb16c4c931550be666408c1bf72727). However, it is a non-static method, so you have to create a Readiness instance before you can use it, which is unnecessary.

This Makes it static so that this method can be used without needing to instantiate an instance of Readiness.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
