### PR TITLE
Allow VertxHttpClientBuilder to be seeded with a base WebClientOptions object, allowing more customization of the Vertx HTTP Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Dependency Upgrade
 
 #### New Features
+* Fix #7252: Allow VertxHttpClientBuilder to be seeded with a base WebClientOptions object, allowing more customization of the Vertx HTTP Client
 
 #### _**Note**_: Breaking changes
 

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilderTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientBuilderTest.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.vertx;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxImpl;
+import io.vertx.ext.web.client.WebClientOptions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
@@ -80,5 +81,25 @@ class VertxHttpClientBuilderTest {
     assertThat(builder.vertx)
         .asInstanceOf(InstanceOfAssertFactories.type(VertxImpl.class))
         .returns(true, vi -> vi.closeFuture().isClosed());
+  }
+
+  @Test
+  void buildsSuccessfullyWithCustomWebClientOptions() {
+    WebClientOptions customOptions = new WebClientOptions()
+        .setKeepAlive(false)
+        .setTcpNoDelay(false)
+        .setUserAgent("custom-agent");
+
+    VertxHttpClientFactory factory = new VertxHttpClientFactory();
+    VertxHttpClientBuilder<?> builder = factory.newBuilder();
+
+    try (HttpClient client = builder.withCustomWebClientOptions(customOptions).build()) {
+      assertThat(client)
+          .isInstanceOf(VertxHttpClient.class)
+          .isNotNull();
+
+      assertThat(client.newHttpRequestBuilder().uri("http://localhost").build())
+          .isNotNull();
+    }
   }
 }


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

fixes #7252 

Allows user to seed the Vert.x Http Client Builder with a custom WebOptions object if they want to modify configs of this object. As the issue specs out, this is not the most ideal solution, I think using additionalConfig like the other HttpClient implementations do would be best. But that seems like a breaking change since it would be more invasive.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [X] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
