### PR TITLE
fix: correct resuming receiving websocket messages with vert.x client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #7343: Leader election callbacks to be called only once (instead of 2)
+* Fix #7347: Vert.x websocket client doesn't work for messages split into multiple websocket frames
 
 #### Improvements
 * Fix #7345: skip publishing test and example modules to Maven Central

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxWebSocket.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxWebSocket.java
@@ -112,6 +112,6 @@ class VertxWebSocket implements WebSocket {
 
   @Override
   public void request() {
-    ws.fetch(1);
+    ws.resume();
   }
 }

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientNewWebSocketBuilderTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientNewWebSocketBuilderTest.java
@@ -94,9 +94,11 @@ public abstract class AbstractHttpClientNewWebSocketBuilderTest {
         .andEmit("First")
         .waitFor(10L)
         .andEmit("Second")
+        .waitFor(10L)
+        .andEmit("ALongMessageThatCouldBeSplitIntoMultipleWebsocketFrames".repeat(2000))
         .done()
         .always();
-    final CountDownLatch latch = new CountDownLatch(2);
+    final CountDownLatch latch = new CountDownLatch(3);
     final Set<String> messages = ConcurrentHashMap.newKeySet();
     httpClient.newWebSocketBuilder()
         .uri(URI.create(server.url("/websocket-multiple-message")))
@@ -109,7 +111,8 @@ public abstract class AbstractHttpClientNewWebSocketBuilderTest {
           }
         }).get(10L, TimeUnit.SECONDS);
     assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
-    assertThat(messages).containsExactlyInAnyOrder("First", "Second");
+    assertThat(messages).containsExactlyInAnyOrder("First", "Second",
+      "ALongMessageThatCouldBeSplitIntoMultipleWebsocketFrames".repeat(2000));
   }
 
   @Test


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

`ws.fetch(N)` tells the websocket to fetch up to `N` websocket frames. If the message consists of more frames then the remaining frames are queued, and therefore the message never delivered.

Fixes #7347


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
