### PR TITLE
fix: Ensure vert.x websockets handle multiple frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #7343: Leader election callbacks to be called only once (instead of 2)
+* Fix #7347: Ensure vert.x websockets handle multiple frames
 
 #### Improvements
 * Fix #7345: skip publishing test and example modules to Maven Central

--- a/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientWebSocketSendReceiveTest.java
+++ b/httpclient-jdk/src/test/java/io/fabric8/kubernetes/client/jdkhttp/JdkHttpClientWebSocketSendReceiveTest.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client.okhttp;
+package io.fabric8.kubernetes.client.jdkhttp;
 
-import io.fabric8.kubernetes.client.http.AbstractWebSocketSendTest;
+import io.fabric8.kubernetes.client.http.AbstractWebSocketSendReceiveTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("java:S2187")
-public class OkHttpWebSocketSendTest extends AbstractWebSocketSendTest {
+public class JdkHttpClientWebSocketSendReceiveTest extends AbstractWebSocketSendReceiveTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
-    return new OkHttpClientFactory();
+    return new JdkHttpClientFactory();
   }
 }

--- a/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketSendReceiveTest.java
+++ b/httpclient-jetty/src/test/java/io/fabric8/kubernetes/client/jetty/JettyWebSocketSendReceiveTest.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client.jdkhttp;
+package io.fabric8.kubernetes.client.jetty;
 
-import io.fabric8.kubernetes.client.http.AbstractWebSocketSendTest;
+import io.fabric8.kubernetes.client.http.AbstractWebSocketSendReceiveTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("java:S2187")
-public class JdkHttpClientWebSocketSendTest extends AbstractWebSocketSendTest {
+public class JettyWebSocketSendReceiveTest extends AbstractWebSocketSendReceiveTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
-    return new JdkHttpClientFactory();
+    return new JettyHttpClientFactory();
   }
 }

--- a/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketSendReceiveTest.java
+++ b/httpclient-okhttp/src/test/java/io/fabric8/kubernetes/client/okhttp/OkHttpWebSocketSendReceiveTest.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client.vertx;
+package io.fabric8.kubernetes.client.okhttp;
 
-import io.fabric8.kubernetes.client.http.AbstractWebSocketSendTest;
+import io.fabric8.kubernetes.client.http.AbstractWebSocketSendReceiveTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("java:S2187")
-public class VertxHttpClientWebSocketSendTest extends AbstractWebSocketSendTest {
+public class OkHttpWebSocketSendReceiveTest extends AbstractWebSocketSendReceiveTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
-    return new VertxHttpClientFactory();
+    return new OkHttpClientFactory();
   }
 }

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxWebSocket.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxWebSocket.java
@@ -43,6 +43,11 @@ class VertxWebSocket implements WebSocket {
   }
 
   void init() {
+    ws.frameHandler(frame -> {
+      if (!frame.isFinal()) {
+        ws.fetch(1);
+      }
+    });
     ws.binaryMessageHandler(msg -> {
       ws.pause();
       listener.onMessage(this, msg.getByteBuf().nioBuffer());

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientWebSocketSendReceiveTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/VertxHttpClientWebSocketSendReceiveTest.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.kubernetes.client.jetty;
+package io.fabric8.kubernetes.client.vertx;
 
-import io.fabric8.kubernetes.client.http.AbstractWebSocketSendTest;
+import io.fabric8.kubernetes.client.http.AbstractWebSocketSendReceiveTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("java:S2187")
-public class JettyWebSocketSendTest extends AbstractWebSocketSendTest {
+public class VertxHttpClientWebSocketSendReceiveTest extends AbstractWebSocketSendReceiveTest {
   @Override
   protected HttpClient.Factory getHttpClientFactory() {
-    return new JettyHttpClientFactory();
+    return new VertxHttpClientFactory();
   }
 }


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

Fixes #7347
Supersedes closes #7348

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
