### PR TITLE
Fix typo in warning log messages

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -570,9 +570,9 @@ public class OperationSupport {
     List<String> warnings = response.headers("Warning");
     if (warnings != null && !warnings.isEmpty()) {
       if (context.fieldValidation == Validation.WARN) {
-        LOG.warn("Recieved warning(s) from request {}: {}", request.uri(), warnings);
+        LOG.warn("Received warning(s) from request {}: {}", request.uri(), warnings);
       } else {
-        LOG.debug("Recieved warning(s) from request {}: {}", request.uri(), warnings);
+        LOG.debug("Received warning(s) from request {}: {}", request.uri(), warnings);
       }
     }
     if (response.isSuccessful()) {


### PR DESCRIPTION
This trivial PR just fixes a typo within a warning message.