### PR TITLE
fix(crd-generator): improve SchemaCustomizer with tests and @Repeatable support

### DIFF
--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/AbstractJsonSchema.java
@@ -518,11 +518,10 @@ public abstract class AbstractJsonSchema<T extends KubernetesJSONSchemaProps, V 
         try {
           props[0] = sc.value().getConstructor().newInstance().apply(props[0], sc.input(),
               this.resolvingContext.kubernetesSerialization);
-        } catch (Exception e) {
-          if (!(e instanceof RuntimeException)) {
-            e = new RuntimeException(e);
-          }
-          throw (RuntimeException) e;
+        } catch (ReflectiveOperationException e) {
+          throw new RuntimeException("Failed to instantiate or apply SchemaCustomizer: " + sc.value().getName(), e);
+        } catch (RuntimeException e) {
+          throw new RuntimeException("Failed to apply SchemaCustomizer: " + sc.value().getName(), e);
         }
       });
       if (props[0] != objectSchema) {

--- a/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/SchemaCustomizer.java
+++ b/crd-generator/api-v2/src/main/java/io/fabric8/crdv2/generator/v1/SchemaCustomizer.java
@@ -19,12 +19,14 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(SchemaCustomizer.List.class)
 public @interface SchemaCustomizer {
 
   public interface Customizer {
@@ -69,5 +71,11 @@ public @interface SchemaCustomizer {
   Class<? extends Customizer> value();
 
   String input() default "";
+
+  @Target({ ElementType.TYPE })
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface List {
+    SchemaCustomizer[] value();
+  }
 
 }

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/MergePatchCustomized.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/example/customized/MergePatchCustomized.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crdv2.example.customized;
+
+import io.fabric8.crdv2.generator.v1.SchemaCustomizer;
+
+@SchemaCustomizer(input = "{\"description\": \"patched description\", \"minProperties\": 1}", value = SchemaCustomizer.MergePatchCustomizer.class)
+public class MergePatchCustomized {
+
+  public String existingField;
+
+}

--- a/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/SchemaCustomizerTest.java
+++ b/crd-generator/api-v2/src/test/java/io/fabric8/crdv2/generator/v1/SchemaCustomizerTest.java
@@ -16,11 +16,13 @@
 package io.fabric8.crdv2.generator.v1;
 
 import io.fabric8.crdv2.example.customized.Customized;
+import io.fabric8.crdv2.example.customized.MergePatchCustomized;
 import io.fabric8.crdv2.example.customized.RawCustomized;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class SchemaCustomizerTest {
 
@@ -35,6 +37,17 @@ class SchemaCustomizerTest {
     JSONSchemaProps schema = JsonSchema.from(RawCustomized.class);
     assertEquals(1, schema.getProperties().size());
     assertEquals("integer", schema.getProperties().get("prop").getType());
+  }
+
+  @Test
+  void applyMergePatchCustomizer() {
+    JSONSchemaProps schema = JsonSchema.from(MergePatchCustomized.class);
+    // Verify the patch was applied
+    assertEquals("patched description", schema.getDescription());
+    assertEquals(1L, schema.getMinProperties());
+    // Verify existing properties are preserved
+    assertNotNull(schema.getProperties().get("existingField"));
+    assertEquals("string", schema.getProperties().get("existingField").getType());
   }
 
 }

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -907,6 +907,7 @@ for directly manipulating the JSONSchemaProps of the annotated resource. This an
 | `io.fabric8.kubernetes.model.annotation.SpecReplicas`           | The field is used in scale subresource as `specReplicaPath`                                         |
 | `io.fabric8.kubernetes.model.annotation.StatusReplicas`         | The field is used in scale subresource as `statusReplicaPath`                                       |
 | `io.fabric8.kubernetes.model.annotation.LabelSelector`          | The field is used in scale subresource as `labelSelectorPath`                                       |
+| `io.fabric8.crdv2.generator.v1.SchemaCustomizer`                | Advanced: Allows direct manipulation of the `JSONSchemaProps` via a custom `Customizer` class       |
 
 
 A field of type `com.fasterxml.jackson.databind.JsonNode` is encoded as an empty object with `x-kubernetes-preserve-unknown-fields: true` defined.


### PR DESCRIPTION
## Summary

Follows up on #7220 
Relates to #7355

- Add test for `MergePatchCustomizer` to ensure merge patch functionality works correctly
- Make `@SchemaCustomizer` annotation `@Repeatable` for applying multiple customizers on the same class
- Improve exception messages to include the customizer class name for easier debugging
- Add `SchemaCustomizer` to the Features cheatsheet table in documentation

## Test plan
- [x] Run `mvn test -pl crd-generator/api-v2 -Dtest=SchemaCustomizerTest` - all 3 tests pass
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)