### PR TITLE
fix bugs in DefaultMockServerTest due to DefaultMockServerTest JSON-order

### DIFF
--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerTest.groovy
@@ -15,6 +15,7 @@
  */
 package io.fabric8.mockwebserver
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.fabric8.mockwebserver.http.Headers
 import io.fabric8.mockwebserver.http.RecordedRequest
 import io.fabric8.mockwebserver.internal.WebSocketMessage
@@ -328,7 +329,9 @@ class DefaultMockServerTest extends Specification {
 
 		then: "Expect the response to contain the serialized json"
 		req1.result().statusCode() == 200
-		req1.result().body().toString() == "{\"id\":0,\"username\":\"root\",\"enabled\":true}"
+		def responseBody = req1.result().body().toString()
+		def responseJson = new ObjectMapper().readValue(responseBody, Map)
+		responseJson == [id: 0, username: "root", enabled: true]
 	}
 
 	def "when setting a timed websocket String message it should be fired at the specified time"() {


### PR DESCRIPTION
## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->
### Problem
`DefaultMockServerTest` used raw‐string comparisons such as `req1.result().body().toString() == '{"id":0,"username":"root","enabled":true}'`
We used NonDex to shuffle object-field order in random seeds at runtime, so the same JSON might arrive as
{"username":"root","enabled":true,"id":0} and the assertion fails even though the payload is semantically identical.
```
io.fabric8.mockwebserver.DefaultMockServerTest.when setting an expectation as an object it should be serialized to json -- Time elapsed: 0.507 s <<< FAILURE!
Condition not satisfied:

req1.result().body().toString() == "{\"id\":0,\"username\":\"root\",\"enabled\":true}"
|    |        |      |          |
|    |        |      |          false
|    |        |      |          30 differences (26% similarity)
|    |        |      |          {"(enabled":true,")id":0,"username":"root"(---------------)}
|    |        |      |          {"(---------------)id":0,"username":"root"(,"enabled":true)}
|    |        |      {"enabled":true,"id":0,"username":"root"}
|    |        {"enabled":true,"id":0,"username":"root"}
|    <io.vertx.ext.web.client.impl.HttpResponseImpl@30893e08 headers=Content-Length=41
|     statusMessage=OK version=HTTP_1_1 body={"enabled":true,"id":0,"username":"root"} trailers= redirects=[] statusCode=200 cookies=[]>
Future{result=io.vertx.ext.web.client.impl.HttpResponseImpl@30893e08}

	at io.fabric8.mockwebserver.DefaultMockServerTest.when setting an expectation as an object it should be serialized to json(DefaultMockServerTest.groovy:331)
```
### Solution
Replace brittle string equality checks with structural JSON assertions.
### Reproduce
```
mvn -pl junit/mockwebserver edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=io.fabric8.mockwebserver.DefaultMockServerTest
```

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
