### PR TITLE
fix(openapi): enhance embedded field processing to respect swaggerignore tag

### DIFF
--- a/kubernetes-model-generator/openapi/generator/pkg/openapi/openapi-gen-processors.go
+++ b/kubernetes-model-generator/openapi/generator/pkg/openapi/openapi-gen-processors.go
@@ -58,9 +58,9 @@ func processInlineDuplicateFields(_ *generator.Context, _ *types.Package, t *typ
 	// Gather the embedded type field names
 	embeddedFieldNames := make(map[string]bool)
 	for _, embeddedMember := range m.Type.Members {
+		embeddedSwaggerIgnore := reflect.StructTag(embeddedMember.Tags).Get("swaggerignore")
 		embeddedJSON := reflect.StructTag(embeddedMember.Tags).Get("json")
-
-		if embeddedJSON == "" || embeddedJSON == "-" || strings.Contains(embeddedJSON, ",omitted") {
+		if embeddedSwaggerIgnore != "" || embeddedJSON == "" || embeddedJSON == "-" || strings.Contains(embeddedJSON, ",omitted") {
 			continue
 		}
 

--- a/kubernetes-model-generator/openapi/generator/pkg/openapi/openapi-gen.go
+++ b/kubernetes-model-generator/openapi/generator/pkg/openapi/openapi-gen.go
@@ -42,7 +42,6 @@ type GoGenerator struct {
 func (g *GoGenerator) Generate() error {
 	g.ReportFilename = g.OutputFile + ".report.txt"
 	g.memberProcessors = []func(context *generator.Context, pkg *types.Package, t *types.Type, member *types.Member, memberIndex int){
-		processSwaggerIgnore,
 		processInlineDuplicateFields,
 		processMapKeyTypes,
 		processOmitPrivateFields,
@@ -50,6 +49,7 @@ func (g *GoGenerator) Generate() error {
 		processProtobufEnumsForIstio,
 		processProtobufOneof,
 		processProtobufTags,
+		processSwaggerIgnore,
 	}
 	g.packageProcessors = []func(context *generator.Context, pkg *types.Package){
 		processProtobufPackageOneOf,
@@ -97,9 +97,9 @@ func (g *GoGenerator) processUniverse(context *generator.Context) {
 
 	for _, pkg := range context.Universe {
 		for _, t := range pkg.Types {
-			for memberIndex, member := range t.Members {
+			for memberIndex := range t.Members {
 				for _, memberProcessor := range g.memberProcessors {
-					memberProcessor(context, pkg, t, &member, memberIndex)
+					memberProcessor(context, pkg, t, &t.Members[memberIndex], memberIndex)
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Related to #7371 #7386 #7376

The root-cause of the issue is the fact that the type processing in

https://github.com/fabric8io/kubernetes-client/blob/eb8eee4cb28e17ab048cc14512716841e4895e44/kubernetes-model-generator/openapi/generator/pkg/openapi/openapi-gen.go#L98-L109

doesn't follow a deterministic order.

Since the `processInlineDuplicateFields` processes the child embedded type members, it might be the case that one of these members hasn't been processed by the `processSwaggerIgnore` processor yet.

After multiple iterations trying to find a simpler+**granular** solution, I couldn't come up with the granular one that preserved simplicity.
Keeping things granular and focused (i.e. not considering the swaggerignore tags in the inlineduplicatefields processor) requires adding too much complexity to the code which in the ends defeats the simplicity purpose.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
