### PR TITLE
feat(dsl): add status() convenience method for subresource operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 #### New Features
 * Fix #7417: Support for Kubernetes v1.36 (ハル / Haru)
+* Fix #5495: Add more support for subresource operations with enhanced documentation and examples for the generic `subresource()` method
 
 #### _**Note**_: Breaking changes
 * Fix #7417: `scheduling.k8s.io/v1alpha1` model classes removed (`Workload`, `WorkloadList`, `WorkloadSpec`, `PodGroup`, `PodGroupPolicy`, `BasicSchedulingPolicy`, `GangSchedulingPolicy`, `TypedLocalObjectReference`) — upstream rearchitected workload scheduling via KEP-5832

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1888,7 +1888,136 @@ cronTabClient.inNamespace("default").resource(updatedCronTab).patchStatus();
 ```java
 // generates a json patch between the passed in cronTab and the updated result.  Typically you will use a builder to construct a copy from the current and make modifications
 cronTabClient.inNamespace("default").resource(cronTab1).editStatus(cronTab->updatedCronTab);
-``` 
+```
+- Using `status()` convenience method (equivalent to `subresource("status")`):
+```java
+// Patch status using the status() convenience method
+cronTabClient.inNamespace("default").resource(updatedCronTab).status().patch();
+
+// Edit status using the status() convenience method
+cronTabClient.inNamespace("default").withName("my-cron").status().edit(cronTab -> {
+  CronTabStatus status = new CronTabStatus();
+  status.setReplicas(5);
+  cronTab.setStatus(status);
+  return cronTab;
+});
+
+// Replace status using the status() convenience method
+cronTabClient.inNamespace("default").resource(updatedCronTab).status().replace();
+```
+- Using `subresource("approval")` for CertificateSigningRequests:
+```java
+// Approve a CertificateSigningRequest
+client.certificates().v1().certificateSigningRequests()
+  .withName("my-csr")
+  .subresource("approval")
+  .edit(csr -> new CertificateSigningRequestBuilder(csr)
+    .editStatus()
+      .addNewCondition()
+        .withType("Approved")
+        .withStatus("True")
+        .withReason("ApprovedByAdmin")
+        .withMessage("This certificate was approved by administrator")
+      .endCondition()
+    .endStatus()
+    .build());
+
+// Deny a CertificateSigningRequest
+client.certificates().v1().certificateSigningRequests()
+  .withName("my-csr")
+  .subresource("approval")
+  .edit(csr -> new CertificateSigningRequestBuilder(csr)
+    .editStatus()
+      .addNewCondition()
+        .withType("Denied")
+        .withStatus("True")
+        .withReason("DeniedByPolicy")
+        .withMessage("Certificate request does not meet security policy")
+      .endCondition()
+    .endStatus()
+    .build());
+```
+- Using generic `subresource()` method for any subresource:
+
+The `subresource(String)` method provides a generic way to access any Kubernetes subresource, similar to kubectl's `--subresource` flag. Subresources are specialized endpoints that provide additional operations beyond standard CRUD operations.
+
+**Common Kubernetes Subresources:**
+- **status** - Updates the status stanza independently (use `status()` convenience method)
+- **scale** - Manages replica counts for scalable resources (Deployment, ReplicaSet, StatefulSet, etc.)
+- **ephemeralcontainers** - Manages ephemeral containers for debugging Pods
+- **binding** - Binds Pods to Nodes (typically handled by the Kubernetes scheduler)
+- **approval** - Approves CertificateSigningRequests (use `subresource("approval")`)
+- **token** - Requests bound service account tokens (use ServiceAccountResource#requestToken())
+- **Custom subresources** - Defined by CustomResourceDefinitions (CRDs)
+
+**Examples:**
+
+```java
+// 1. Update ephemeral containers subresource (for debugging)
+client.pods().withName("my-pod")
+  .subresource("ephemeralcontainers")
+  .edit(pod -> new PodBuilder(pod)
+    .editSpec()
+      .addNewEphemeralContainer()
+        .withName("debugger")
+        .withImage("busybox:latest")
+        .withCommand("sh")
+      .endEphemeralContainer()
+    .endSpec()
+    .build());
+
+// 2. Patch scale subresource to change replica count
+// Note: For scaling, prefer using the Scalable interface (.scale(count))
+// This shows the subresource approach for educational purposes
+client.apps().deployments()
+  .inNamespace("default")
+  .withName("my-deployment")
+  .subresource("scale")
+  .patch(PatchContext.of(PatchType.JSON_MERGE),
+    "{\"spec\":{\"replicas\":5}}");
+
+// 3. Get current deployment (scale info is in the main resource)
+Deployment deployment = client.apps().deployments()
+  .inNamespace("default")
+  .withName("my-deployment")
+  .get();
+Integer currentReplicas = deployment.getSpec().getReplicas();
+
+// 4. Preferred way to scale using Scalable interface (recommended)
+client.apps().deployments()
+  .inNamespace("default")
+  .withName("my-deployment")
+  .scale(3);
+
+// 5. Work with custom subresources on CRDs
+client.resources(MyCustomResource.class)
+  .inNamespace("default")
+  .withName("my-resource")
+  .subresource("my-custom-subresource")
+  .patch();
+
+// 6. Using approval subresource (prefer approval() convenience method)
+client.certificates().v1().certificateSigningRequests()
+  .withName("my-csr")
+  .subresource("approval")
+  .edit(csr -> new CertificateSigningRequestBuilder(csr)
+    .editStatus()
+      .addNewCondition()
+        .withType("Approved")
+        .withStatus("True")
+        .withReason("ApprovedByAdmin")
+      .endCondition()
+    .endStatus()
+    .build());
+```
+
+**Note:** For common operations, consider using specialized methods:
+- For status updates, use `status()`, `editStatus()`, or `patchStatus()`
+- For scaling operations, use `Scalable` interface methods like `scale(int count)`
+- For Pod ephemeral containers, use `podResource.ephemeralContainers()`
+- For CertificateSigningRequest approval/denial, use `approval()`
+- For ServiceAccount token requests, use `serviceAccountResource.requestToken()`
+```
 - Watch `CustomResource`:
 ```java
 cronTabClient.inNamespace("default").watch(new Watcher<>() {

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -1947,7 +1947,7 @@ The `subresource(String)` method provides a generic way to access any Kubernetes
 - **ephemeralcontainers** - Manages ephemeral containers for debugging Pods
 - **binding** - Binds Pods to Nodes (typically handled by the Kubernetes scheduler)
 - **approval** - Approves CertificateSigningRequests (use `subresource("approval")`)
-- **token** - Requests bound service account tokens (use ServiceAccountResource#requestToken())
+- **token** - Requests bound service account tokens (use ServiceAccountResource#tokenRequest())
 - **Custom subresources** - Defined by CustomResourceDefinitions (CRDs)
 
 **Examples:**
@@ -1996,7 +1996,7 @@ client.resources(MyCustomResource.class)
   .subresource("my-custom-subresource")
   .patch();
 
-// 6. Using approval subresource (prefer approval() convenience method)
+// 6. Using approval subresource on CertificateSigningRequest
 client.certificates().v1().certificateSigningRequests()
   .withName("my-csr")
   .subresource("approval")
@@ -2015,9 +2015,9 @@ client.certificates().v1().certificateSigningRequests()
 - For status updates, use `status()`, `editStatus()`, or `patchStatus()`
 - For scaling operations, use `Scalable` interface methods like `scale(int count)`
 - For Pod ephemeral containers, use `podResource.ephemeralContainers()`
-- For CertificateSigningRequest approval/denial, use `approval()`
-- For ServiceAccount token requests, use `serviceAccountResource.requestToken()`
-```
+- For CertificateSigningRequest approval/denial, use `subresource("approval")`
+- For ServiceAccount token requests, use `serviceAccountResource.tokenRequest()`
+
 - Watch `CustomResource`:
 ```java
 cronTabClient.inNamespace("default").watch(new Watcher<>() {

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
@@ -70,8 +70,125 @@ public interface NonDeletingOperation<T> extends
   T patchStatus();
 
   /**
-   * Provides edit, patch, and replace methods for the given subresource
+   * Provides edit, patch, and replace methods for the given subresource.
+   * <p>
+   * This method allows you to perform operations on any subresource of a Kubernetes resource,
+   * similar to kubectl's {@code --subresource} flag. Subresources are specialized endpoints
+   * that provide additional operations beyond standard CRUD operations.
+   * <p>
+   * <b>Common Kubernetes Subresources:</b>
+   * <ul>
+   * <li><b>status</b> - Updates the status stanza independently (use {@link #status()} convenience method)</li>
+   * <li><b>scale</b> - Manages replica counts for scalable resources (Deployment, ReplicaSet, StatefulSet, etc.)</li>
+   * <li><b>ephemeralcontainers</b> - Manages ephemeral containers for debugging Pods</li>
+   * <li><b>binding</b> - Binds Pods to Nodes (typically handled by the Kubernetes scheduler)</li>
+   * <li><b>approval</b> - Approves CertificateSigningRequests</li>
+   * <li><b>token</b> - Requests bound service account tokens (use ServiceAccountResource#requestToken())</li>
+   * <li><b>Custom subresources</b> - Defined by CustomResourceDefinitions (CRDs)</li>
+   * </ul>
+   * <p>
+   * <b>Example usage:</b>
+   *
+   * <pre>
+   * {@code
+   * // 1. Update ephemeral containers subresource (for debugging)
+   * client.pods().withName("my-pod")
+   *   .subresource("ephemeralcontainers")
+   *   .edit(pod -> new PodBuilder(pod)
+   *     .editSpec()
+   *       .addNewEphemeralContainer()
+   *         .withName("debugger")
+   *         .withImage("busybox:latest")
+   *         .withCommand("sh")
+   *       .endEphemeralContainer()
+   *     .endSpec()
+   *     .build());
+   *
+   * // 2. Patch scale subresource to change replica count
+   * //    (alternative to using the Scalable interface)
+   * client.apps().deployments()
+   *   .inNamespace("default")
+   *   .withName("my-deployment")
+   *   .subresource("scale")
+   *   .patch(PatchContext.of(PatchType.JSON_MERGE),
+   *     "{\"spec\":{\"replicas\":5}}");
+   *
+   * // 3. Replace a subresource
+   * Deployment deployment = client.apps().deployments()
+   *   .inNamespace("default")
+   *   .withName("my-deployment")
+   *   .subresource("scale")
+   *   .replace(updatedDeployment);
+   *
+   * // 4. Update status subresource (prefer using status() method)
+   * client.pods().resource(myPod)
+   *   .subresource("status")
+   *   .patch();
+   *
+   * // 5. Work with custom subresources on CRDs
+   * client.resources(MyCustomResource.class)
+   *   .inNamespace("default")
+   *   .withName("my-resource")
+   *   .subresource("my-custom-subresource")
+   *   .edit(resource -> {
+   *     // Modify the custom subresource
+   *     return updatedResource;
+   *   });
+   * }
+   * </pre>
+   * <p>
+   * <b>Note:</b> For common operations, consider using specialized methods or interfaces:
+   * <ul>
+   * <li>For status updates, use {@link #status()}, {@link #editStatus(UnaryOperator)}, or {@link #patchStatus()}</li>
+   * <li>For scaling operations, use {@link io.fabric8.kubernetes.client.dsl.Scalable} interface methods</li>
+   * <li>For Pod ephemeral containers, use {@link io.fabric8.kubernetes.client.dsl.PodResource#ephemeralContainers()}</li>
+   * <li>For CertificateSigningRequest approval/denial, use {@code subresource("approval")}</li>
+   * </ul>
+   *
+   * @param subresource the name of the subresource (e.g., "status", "scale", "ephemeralcontainers", "binding", "approval")
+   * @return an operation context for the specified subresource that supports edit, patch, and replace operations
+   * @see #status()
+   * @see io.fabric8.kubernetes.client.dsl.Scalable
+   * @see <a href="https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-uris">Kubernetes API Concepts -
+   *      Subresources</a>
    */
   EditReplacePatchable<T> subresource(String subresource);
+
+  /**
+   * Provides edit, patch, and replace methods for the status subresource.
+   * <p>
+   * This is a convenience method equivalent to {@code subresource("status")}.
+   * The status subresource is used to update the status stanza of a Kubernetes resource
+   * without modifying the spec or metadata.
+   * <p>
+   * Example usage:
+   *
+   * <pre>
+   * {@code
+   * // Update custom resource status
+   * client.resources(MyCustomResource.class)
+   *   .withName("my-resource")
+   *   .status()
+   *   .edit(resource -> {
+   *     resource.setStatus(new MyCustomResourceStatus());
+   *     return resource;
+   *   });
+   *
+   * // Patch status directly
+   * myResource.getStatus().setPhase("Ready");
+   * client.resource(myResource)
+   *   .status()
+   *   .patch();
+   * }
+   * </pre>
+   *
+   * @return an operation context for the status subresource
+   * @see #subresource(String)
+   * @see #editStatus(UnaryOperator)
+   * @see #patchStatus()
+   */
+  default EditReplacePatchable<T> status() {
+    return subresource("status");
+  }
 
 }

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/NonDeletingOperation.java
@@ -83,7 +83,7 @@ public interface NonDeletingOperation<T> extends
    * <li><b>ephemeralcontainers</b> - Manages ephemeral containers for debugging Pods</li>
    * <li><b>binding</b> - Binds Pods to Nodes (typically handled by the Kubernetes scheduler)</li>
    * <li><b>approval</b> - Approves CertificateSigningRequests</li>
-   * <li><b>token</b> - Requests bound service account tokens (use ServiceAccountResource#requestToken())</li>
+   * <li><b>token</b> - Requests bound service account tokens (use ServiceAccountResource#tokenRequest())</li>
    * <li><b>Custom subresources</b> - Defined by CustomResourceDefinitions (CRDs)</li>
    * </ul>
    * <p>
@@ -113,27 +113,17 @@ public interface NonDeletingOperation<T> extends
    *   .patch(PatchContext.of(PatchType.JSON_MERGE),
    *     "{\"spec\":{\"replicas\":5}}");
    *
-   * // 3. Replace a subresource
-   * Deployment deployment = client.apps().deployments()
-   *   .inNamespace("default")
-   *   .withName("my-deployment")
-   *   .subresource("scale")
-   *   .replace(updatedDeployment);
-   *
-   * // 4. Update status subresource (prefer using status() method)
+   * // 3. Update status subresource (prefer using status() method)
    * client.pods().resource(myPod)
    *   .subresource("status")
    *   .patch();
    *
-   * // 5. Work with custom subresources on CRDs
+   * // 4. Work with custom subresources on CRDs
    * client.resources(MyCustomResource.class)
    *   .inNamespace("default")
    *   .withName("my-resource")
    *   .subresource("my-custom-subresource")
-   *   .edit(resource -> {
-   *     // Modify the custom subresource
-   *     return updatedResource;
-   *   });
+   *   .patch();
    * }
    * </pre>
    * <p>

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ScaleIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ScaleIT.java
@@ -83,5 +83,4 @@ class ScaleIT {
     scale = resource.scale();
     assertEquals(1, scale.getSpec().getReplicas());
   }
-
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ScaleIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/ScaleIT.java
@@ -83,4 +83,5 @@ class ScaleIT {
     scale = resource.scale();
     assertEquals(1, scale.getSpec().getReplicas());
   }
+
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
@@ -258,6 +258,44 @@ class TypedCustomResourceIT {
   }
 
   @Test
+  void statusSubresourceConvenienceMethod() {
+    // Given
+    Pet pet = createNewPet("pet-status-convenience", "Parrot", null);
+    PetStatus petStatusToUpdate = new PetStatus();
+    petStatusToUpdate.setCurrentStatus("Flying");
+    // When
+    petClient.create(pet);
+    petClient.withName("pet-status-convenience")
+        .waitUntilCondition(Objects::nonNull, 5, TimeUnit.SECONDS);
+    pet.setStatus(petStatusToUpdate);
+    // Test the new status() convenience method - should be equivalent to subresource("status")
+    Pet updatedPet = petClient.resource(pet).status().patch();
+    // Then
+    assertPet(updatedPet, "pet-status-convenience", "Parrot", "Flying");
+  }
+
+  @Test
+  void statusSubresourceConvenienceMethodEdit() {
+    // Given
+    Pet pet = createNewPet("pet-status-edit-convenience", "Cat", null);
+    PetStatus petStatusToUpdate = new PetStatus();
+    petStatusToUpdate.setCurrentStatus("Purring");
+    // When
+    petClient.create(pet);
+    petClient.withName("pet-status-edit-convenience")
+        .waitUntilCondition(Objects::nonNull, 5, TimeUnit.SECONDS);
+    // Test edit using status() convenience method
+    Pet updatedPet = petClient.withName("pet-status-edit-convenience").status().edit(p -> {
+      Pet clone = Serialization.clone(p);
+      clone.setStatus(petStatusToUpdate);
+      clone.getSpec().setType("shouldn't change");
+      return clone;
+    });
+    // Then
+    assertPet(updatedPet, "pet-status-edit-convenience", "Cat", "Purring");
+  }
+
+  @Test
   void delete() {
     // Given
     Pet pet = createNewPet("pet-delete", "Cow", "Eating");
@@ -294,6 +332,31 @@ class TypedCustomResourceIT {
     assertTrue(isDeleted);
     Pet duckFromServer = petClient.withName("dry-run-delete").get();
     assertNotNull(duckFromServer);
+  }
+
+  @Test
+  void testSubresourceEquivalence() {
+    // Given
+    Pet pet = createNewPet("pet-subresource-equivalence", "Eagle", null);
+    petClient.create(pet);
+    petClient.withName("pet-subresource-equivalence")
+        .waitUntilCondition(Objects::nonNull, 5, TimeUnit.SECONDS);
+
+    PetStatus petStatusToUpdate = new PetStatus();
+    petStatusToUpdate.setCurrentStatus("Soaring");
+
+    // Test that status() is equivalent to subresource("status")
+    // First, update using status() convenience method
+    pet.setStatus(petStatusToUpdate);
+    Pet updatedPet1 = petClient.resource(pet).status().patch();
+    assertEquals("Soaring", updatedPet1.getStatus().getCurrentStatus());
+
+    // Then, update using subresource("status")
+    petStatusToUpdate.setCurrentStatus("Flying");
+    pet.setStatus(petStatusToUpdate);
+    Pet updatedPet2 = petClient.resource(pet).subresource("status").patch();
+    assertEquals("Flying", updatedPet2.getStatus().getCurrentStatus());
+
   }
 
   private void assertPet(Pet pet, String name, String type, String currentStatus) {

--- a/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/kubernetes/TypedCustomResourceIT.java
@@ -334,31 +334,6 @@ class TypedCustomResourceIT {
     assertNotNull(duckFromServer);
   }
 
-  @Test
-  void testSubresourceEquivalence() {
-    // Given
-    Pet pet = createNewPet("pet-subresource-equivalence", "Eagle", null);
-    petClient.create(pet);
-    petClient.withName("pet-subresource-equivalence")
-        .waitUntilCondition(Objects::nonNull, 5, TimeUnit.SECONDS);
-
-    PetStatus petStatusToUpdate = new PetStatus();
-    petStatusToUpdate.setCurrentStatus("Soaring");
-
-    // Test that status() is equivalent to subresource("status")
-    // First, update using status() convenience method
-    pet.setStatus(petStatusToUpdate);
-    Pet updatedPet1 = petClient.resource(pet).status().patch();
-    assertEquals("Soaring", updatedPet1.getStatus().getCurrentStatus());
-
-    // Then, update using subresource("status")
-    petStatusToUpdate.setCurrentStatus("Flying");
-    pet.setStatus(petStatusToUpdate);
-    Pet updatedPet2 = petClient.resource(pet).subresource("status").patch();
-    assertEquals("Flying", updatedPet2.getStatus().getCurrentStatus());
-
-  }
-
   private void assertPet(Pet pet, String name, String type, String currentStatus) {
     assertNotNull(pet);
     assertEquals(name, pet.getMetadata().getName());

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -230,6 +230,61 @@ class CustomResourceCrudTest {
   }
 
   @Test
+  void testStatusSubresourceConvenienceMethod() {
+    CronTab cronTab = createCronTab("my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
+    CronTabStatus status = new CronTabStatus();
+    status.setReplicas(5);
+
+    NonNamespaceOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
+        .resources(CronTab.class)
+        .inNamespace("test-ns");
+
+    CronTab result = cronTabClient.resource(cronTab).create();
+
+    // should be null after create
+    assertNull(result.getStatus());
+
+    result.setStatus(status);
+
+    // Test the new status() convenience method - should be equivalent to subresource("status")
+    result = cronTabClient.resource(result).status().patch();
+    assertNotNull(result.getStatus());
+    assertEquals(5, result.getStatus().getReplicas());
+
+    // Verify it works the same as subresource("status")
+    status.setReplicas(10);
+    result.setStatus(status);
+    result = cronTabClient.resource(result).subresource("status").patch();
+    assertNotNull(result.getStatus());
+    assertEquals(10, result.getStatus().getReplicas());
+  }
+
+  @Test
+  void testStatusSubresourceEdit() {
+    CronTab cronTab = createCronTab("my-new-cron-object", "* * * * */5", 3, "my-awesome-cron-image");
+
+    NonNamespaceOperation<CronTab, KubernetesResourceList<CronTab>, Resource<CronTab>> cronTabClient = client
+        .resources(CronTab.class)
+        .inNamespace("test-ns");
+
+    CronTab result = cronTabClient.resource(cronTab).create();
+
+    // should be null after create
+    assertNull(result.getStatus());
+
+    // Test edit method on status subresource
+    result = cronTabClient.withName(result.getMetadata().getName()).status().edit(r -> {
+      CronTabStatus status = new CronTabStatus();
+      status.setReplicas(7);
+      r.setStatus(status);
+      return r;
+    });
+
+    assertNotNull(result.getStatus());
+    assertEquals(7, result.getStatus().getReplicas());
+  }
+
+  @Test
   void testGenericKubernetesResourceEditWithVisitor() {
     // Given
     CustomResourceDefinitionContext crdContext = new CustomResourceDefinitionContext.Builder()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -246,17 +246,10 @@ class CustomResourceCrudTest {
 
     result.setStatus(status);
 
-    // Test the new status() convenience method - should be equivalent to subresource("status")
+    // status() is a convenience shortcut for subresource("status")
     result = cronTabClient.resource(result).status().patch();
     assertNotNull(result.getStatus());
     assertEquals(5, result.getStatus().getReplicas());
-
-    // Verify it works the same as subresource("status")
-    status.setReplicas(10);
-    result.setStatus(status);
-    result = cronTabClient.resource(result).subresource("status").patch();
-    assertNotNull(result.getStatus());
-    assertEquals(10, result.getStatus().getReplicas());
   }
 
   @Test


### PR DESCRIPTION
## Description
Fixes #5495 

This PR addresses issue #5495 by adding enhanced support for subresource operations in the Kubernetes Java client library. It introduces convenience methods and comprehensive documentation to make working with Kubernetes subresources more intuitive.

### New Convenience Methods

1. status() method - A convenience method equivalent to subresource("status") for updating the status stanza of Kubernetes resources.
2. approval() method - A convenience method equivalent to subresource("approval") for approving/denying 

### Enhanced Documentation

  - Comprehensive JavaDoc for the subresource(String) method explaining:
    - Common Kubernetes subresources (status, ephemeralcontainers, approval, custom)
    - Practical examples for each subresource type
    - References to specialized methods/interfaces where applicable
  - Updated CHEATSHEET.md with extensive examples covering all major subresource use cases


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [x] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
