### PR TITLE
fix(openapi-generator): pin Go version to 1.25 in CI workflow

### DIFF
--- a/.github/workflows/generate-model.yml
+++ b/.github/workflows/generate-model.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          go-version: '1.25'
       - name: Setup Java 17
         uses: actions/setup-java@v5
         with:

--- a/kubernetes-model-generator/openapi/generator/go.mod
+++ b/kubernetes-model-generator/openapi/generator/go.mod
@@ -1,8 +1,6 @@
 module github.com/fabric8io/kubernetes-client/kubernetes-model-generator/openapi/generator
 
-go 1.24.4
-
-toolchain go1.24.5
+go 1.25.6
 
 require (
 	github.com/cert-manager/cert-manager v1.18.2


### PR DESCRIPTION
## Description

The generate-model CI pipeline started failing after Go 1.26 was released. The workflow used go-version: 'stable' which automatically picked up Go 1.26, causing schema generation differences compared to the committed schemas generated with Go 1.25.x.

Changes:
- Pin CI Go version to 1.25 instead of 'stable'
- Update go.mod toolchain from 1.24.x to 1.25.6

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
