### PR TITLE
chore(ci): update actions-setup-minikube to v2.15.0

### DIFF
--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@v2.15.0
         with:
           minikube version: v1.37.0
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@v2.15.0
         with:
           minikube version: v1.37.0
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,12 +68,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.34.2,v1.33.0,v1.32.4,v1.31.8,v1.30.12,v1.29.14,v1.20.15,v1.19.16]
+        kubernetes: [v1.34.2,v1.33.0,v1.32.4,v1.31.8,v1.30.12,v1.29.14,v1.28.15,v1.27.16]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@v2.15.0
         with:
           minikube version: v1.37.0
           kubernetes version: ${{ matrix.kubernetes }}


### PR DESCRIPTION
## Summary
- Update `actions-setup-minikube` from v2.14.0 to v2.15.0 in all E2E workflow files
- Fixes Docker compatibility issue with GitHub runners (https://github.blog/changelog/2026-01-30-docker-and-docker-compose-version-upgrades-on-hosted-runners/)
- Replace legacy Kubernetes versions (v1.19.16, v1.20.15) with v1.27.16 and v1.28.15

## Test plan
- [ ] Verify E2E tests pass with the updated minikube action
- [ ] Confirm Kubernetes version matrix covers expected range (v1.27 - v1.34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)