### PR TITLE
fix(bom): exclude bom-generator-plugin from generated BOMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1266,6 +1266,7 @@
                       <exclude>io.fabric8*:*-examples</exclude>
                       <exclude>io.fabric8:crd-generator-test*</exclude>
                       <exclude>io.fabric8:kubernetes-test</exclude>
+                      <exclude>io.fabric8:bom-generator-plugin</exclude>
                     </excludes>
                   </modules>
                 </bom>
@@ -1280,6 +1281,7 @@
                       <exclude>io.fabric8*:*-examples</exclude>
                       <exclude>io.fabric8:crd-generator-test*</exclude>
                       <exclude>io.fabric8:kubernetes-test</exclude>
+                      <exclude>io.fabric8:bom-generator-plugin</exclude>
                     </excludes>
                   </modules>
                   <dependencies>


### PR DESCRIPTION
## Summary
- Exclude `bom-generator-plugin` from both `kubernetes-client-bom` and `kubernetes-client-bom-with-deps` generated BOMs

## Problem
The snapshot release workflow has been failing since 2026-02-16 when publishing the `kubernetes-client-bom-with-deps` module with the following error:

```
Checksum validation failed, expected '8914f5d7fff2c1ca91e88185342de9e256814776' (REMOTE_EXTERNAL) 
but is actually 'f5e49553ae6c846e188481994cfcaadc1938c5bc'
```

**Failing run:** https://github.com/fabric8io/kubernetes-client/actions/runs/22084380549

## Root Cause
The `bom-generator-plugin` was being included in the generated BOMs as a `maven-plugin` dependency. When `central-publishing-maven-plugin` publishes `kubernetes-client-bom-with-deps`, it attempts to verify/retrieve metadata for all dependencies in the BOM.

Since `bom-generator-plugin` was published earlier in the same ~50 minute build, there was a checksum mismatch when fetching `maven-metadata.xml` from the Sonatype Central snapshot repository (likely due to metadata replication delays or concurrent access).

## Solution
Add `<exclude>io.fabric8:bom-generator-plugin</exclude>` to the module exclusion list for both BOM configurations. This is the correct fix because:

1. The `bom-generator-plugin` is an internal build tool, not a dependency users need
2. It removes the problematic dependency that was causing the checksum validation failure
3. It aligns with the existing pattern of excluding internal/test modules from the BOM

## Test plan
- [ ] Verify local BOM generation with `./mvnw -Pbom clean validate` excludes `bom-generator-plugin`
- [ ] Re-run snapshot release workflow to confirm the issue is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)