### PR TITLE
fix(bom): skip deployment of bom-generator-plugin

### DIFF
--- a/bom-generator-plugin/pom.xml
+++ b/bom-generator-plugin/pom.xml
@@ -32,6 +32,10 @@
 
   <packaging>maven-plugin</packaging>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
## Summary
- Add `maven.deploy.skip=true` to `bom-generator-plugin` to prevent it from being deployed to Maven Central

## Problem
The snapshot release workflow continues to fail with checksum validation errors when publishing:

```
Failed to retrieve remote metadata io.fabric8:bom-generator-plugin:7.6-SNAPSHOT/maven-metadata.xml: 
Checksum validation failed, expected '8914f5d7fff2c1ca91e88185342de9e256814776' (REMOTE_EXTERNAL) 
but is actually 'f5e49553ae6c846e188481994cfcaadc1938c5bc'
```

**Failing run:** https://github.com/fabric8io/kubernetes-client/actions/runs/22090965078

## Root Cause
PR #7439 excluded `bom-generator-plugin` from the generated BOMs, but the plugin itself was still being deployed. During the ~50 minute build:

1. `bom-generator-plugin` gets deployed early in the build
2. Later, when `kubernetes-client-bom-with-deps` is published, the `central-publishing-maven-plugin` tries to verify metadata for all artifacts
3. Due to Sonatype Central replication delays or concurrent access, the checksum for `bom-generator-plugin`'s `maven-metadata.xml` doesn't match

## Solution
Add `<maven.deploy.skip>true</maven.deploy.skip>` to `bom-generator-plugin/pom.xml`. This is the standard pattern used by other internal modules:
- `extensions/tekton/examples`
- `platforms/karaf/itests`
- `chaos-tests`

The `bom-generator-plugin` is an internal build tool and doesn't need to be published to Maven Central.

## Test plan
- [ ] Re-run snapshot release workflow to confirm the issue is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)