### PR TITLE
fix(okhttp): remove internal API usage and fix deprecated OkHttp 5 calls

### DIFF
--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -59,6 +59,10 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-jvm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
       <version>${okhttp.version}</version>
     </dependency>


### PR DESCRIPTION
## Summary

Follow-up to #7422 (OkHttp 4.12.0 → 5.3.2 bump) addressing compatibility issues identified during review:

- **Remove `okhttp3.internal.http.HttpMethod` usage**: Replace the internal API call `HttpMethod.requiresRequestBody()` with a local constant set. OkHttp 5.2+ enforces Java 9 module boundaries (`module-info.java`), which will cause `package okhttp3.internal.http is not visible` errors for users on the module path. This internal API has been fragile since the 3.x → 4.x upgrade (9fa6296fea #6441).
- **Reorder `RequestBody.create()` parameters**: The `create(MediaType, content)` overloads were deprecated in OkHttp 4.x in favor of `create(content, MediaType)`. Updated all three call sites to use the non-deprecated signature.
- **Add explicit `okhttp-jvm` dependency**: In OkHttp 5.x, the `okhttp` artifact is a Kotlin Multiplatform root that may resolve to an empty JAR for Maven users. The `httpclient-okhttp` module was relying on `logging-interceptor` to transitively pull in `okhttp-jvm`. Added the explicit dependency to prevent breakage if transitive resolution changes.

## Test plan

- [x] `mvn clean install -pl httpclient-okhttp -am -DskipTests` passes
- [x] `mvn test -pl httpclient-okhttp` — all 84 tests pass
- [x] `mvn spotless:check -pl httpclient-okhttp` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)