### PR TITLE
fix(httpclient): add explicit Automatic-Module-Name to all httpclient modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
-* Fix #7460: Add explicit Automatic-Module-Name to httpclient modules to fix invalid JPMS module name for kubernetes-httpclient-vertx-5
+* Fix #7460: Add explicit Automatic-Module-Name to all httpclient modules to fix invalid auto-derived JPMS module names and vertx/vertx-5 collision
 
 #### Improvements
 

--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -29,6 +29,7 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: JDK</name>
 
   <properties>
+    <jpms.module.name>io.fabric8.kubernetes.client.jdkhttp</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -29,6 +29,7 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: Jetty</name>
 
   <properties>
+    <jpms.module.name>io.fabric8.kubernetes.client.jetty</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -29,6 +29,7 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: OkHttp</name>
 
   <properties>
+    <jpms.module.name>io.fabric8.kubernetes.client.okhttp</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",

--- a/httpclient-vertx-5/pom.xml
+++ b/httpclient-vertx-5/pom.xml
@@ -29,6 +29,7 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: Vert.x 5</name>
 
   <properties>
+    <jpms.module.name>io.fabric8.kubernetes.client.vertx5</jpms.module.name>
     <vertx.version>${vertx5.version}</vertx.version>
     <osgi.require-capability>
       osgi.extender;
@@ -162,17 +163,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>io.fabric8.kubernetes.httpclient.vertx5</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/httpclient-vertx/pom.xml
+++ b/httpclient-vertx/pom.xml
@@ -29,6 +29,7 @@
   <name>Fabric8 :: Kubernetes :: HttpClient :: Vert.x</name>
 
   <properties>
+    <jpms.module.name>io.fabric8.kubernetes.client.vertx</jpms.module.name>
     <osgi.require-capability>
       osgi.extender;
       filter:="(osgi.extender=osgi.serviceloader.registrar)",

--- a/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/pom.xml
+++ b/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.fabric8</groupId>
+    <artifactId>kubernetes-client-deps-compatibility-tests</artifactId>
+    <version>7.7-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <name>Fabric8 :: Kubernetes :: HttpClient JPMS Module Name :: Test</name>
+  <artifactId>kubernetes-client-httpclient-jpms</artifactId>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-httpclient-jars</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>kubernetes-httpclient-jdk</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/httpclient-jars</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>kubernetes-httpclient-jetty</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/httpclient-jars</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/httpclient-jars</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>kubernetes-httpclient-vertx</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/httpclient-jars</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>kubernetes-httpclient-vertx-5</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/httpclient-jars</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <httpclient.jars.dir>${project.build.directory}/httpclient-jars</httpclient.jars.dir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/src/test/java/io/fabric8/deps/compatibility/tests/HttpClientAutomaticModuleNameTest.java
+++ b/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/src/test/java/io/fabric8/deps/compatibility/tests/HttpClientAutomaticModuleNameTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.deps.compatibility.tests;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpClientAutomaticModuleNameTest {
+
+  private static final Map<String, String> EXPECTED_MODULE_NAMES = new LinkedHashMap<>();
+
+  static {
+    EXPECTED_MODULE_NAMES.put("kubernetes-httpclient-jdk", "io.fabric8.kubernetes.client.jdkhttp");
+    EXPECTED_MODULE_NAMES.put("kubernetes-httpclient-jetty", "io.fabric8.kubernetes.client.jetty");
+    EXPECTED_MODULE_NAMES.put("kubernetes-httpclient-okhttp", "io.fabric8.kubernetes.client.okhttp");
+    EXPECTED_MODULE_NAMES.put("kubernetes-httpclient-vertx-5", "io.fabric8.kubernetes.client.vertx5");
+    EXPECTED_MODULE_NAMES.put("kubernetes-httpclient-vertx", "io.fabric8.kubernetes.client.vertx");
+  }
+
+  private static Path jarsDir;
+
+  @BeforeAll
+  static void setUp() {
+    String jarsDirProperty = System.getProperty("httpclient.jars.dir");
+    assertThat(jarsDirProperty)
+        .as("System property 'httpclient.jars.dir' must be set")
+        .isNotNull();
+    jarsDir = Paths.get(jarsDirProperty);
+    assertThat(jarsDir).isDirectory();
+  }
+
+  @Test
+  void httpClientModulesHaveCorrectAutomaticModuleName() throws IOException {
+    try (Stream<Path> jarFiles = Files.list(jarsDir)) {
+      Map<String, String> actualModuleNames = new LinkedHashMap<>();
+      jarFiles.filter(p -> p.toString().endsWith(".jar")).forEach(jarPath -> {
+        String fileName = jarPath.getFileName().toString();
+        Map.Entry<String, String> match = findMatchingArtifact(fileName);
+        if (match != null) {
+          try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+            Manifest manifest = jarFile.getManifest();
+            assertThat(manifest)
+                .as("Manifest for %s", fileName)
+                .isNotNull();
+            String actualModuleName = manifest.getMainAttributes().getValue("Automatic-Module-Name");
+            assertThat(actualModuleName)
+                .as("Automatic-Module-Name in %s", fileName)
+                .isEqualTo(match.getValue());
+            actualModuleNames.put(match.getKey(), actualModuleName);
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to read JAR: " + jarPath, e);
+          }
+        }
+      });
+      assertThat(actualModuleNames)
+          .as("All httpclient modules should have been verified")
+          .hasSize(EXPECTED_MODULE_NAMES.size());
+    }
+  }
+
+  @Test
+  void httpClientModulesHaveValidJpmsModuleNames() throws IOException {
+    try (Stream<Path> jarFiles = Files.list(jarsDir)) {
+      Map<String, String> resolvedModuleNames = new LinkedHashMap<>();
+      jarFiles.filter(p -> p.toString().endsWith(".jar")).forEach(jarPath -> {
+        String fileName = jarPath.getFileName().toString();
+        Map.Entry<String, String> match = findMatchingArtifact(fileName);
+        if (match != null) {
+          ModuleFinder finder = ModuleFinder.of(jarPath);
+          assertThat(finder.findAll())
+              .as("ModuleFinder should resolve module from %s", fileName)
+              .hasSize(1);
+          ModuleReference moduleRef = finder.findAll().iterator().next();
+          String resolvedName = moduleRef.descriptor().name();
+          assertThat(resolvedName)
+              .as("JPMS module name resolved from %s", fileName)
+              .isEqualTo(match.getValue());
+          resolvedModuleNames.put(match.getKey(), resolvedName);
+        }
+      });
+      assertThat(resolvedModuleNames)
+          .as("All httpclient modules should have been verified via ModuleFinder")
+          .hasSize(EXPECTED_MODULE_NAMES.size());
+    }
+  }
+
+  /**
+   * Finds the best matching artifact prefix for the given filename.
+   * Uses longest-prefix matching to distinguish e.g. "kubernetes-httpclient-vertx-5" from "kubernetes-httpclient-vertx".
+   */
+  private static Map.Entry<String, String> findMatchingArtifact(String fileName) {
+    return EXPECTED_MODULE_NAMES.entrySet().stream()
+        .filter(entry -> fileName.startsWith(entry.getKey() + "-"))
+        .max(Comparator.comparingInt(entry -> entry.getKey().length()))
+        .orElse(null);
+  }
+}

--- a/kubernetes-client-deps-compatibility-tests/pom.xml
+++ b/kubernetes-client-deps-compatibility-tests/pom.xml
@@ -36,6 +36,7 @@
 
   <modules>
     <module>kubernetes-client-init-bc-fips</module>
+    <module>kubernetes-client-httpclient-jpms</module>
   </modules>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1664,6 +1664,29 @@
       </build>
     </profile>
     <profile>
+      <id>jpms-module-name</id>
+      <activation>
+        <file>
+          <exists>${basedir}/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Automatic-Module-Name>${jpms.module.name}</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>revapi-compare-jars</id>
       <activation>
         <property>


### PR DESCRIPTION
## Summary

- Add explicit `Automatic-Module-Name` manifest entries to all 5 httpclient modules using package-based names, fixing invalid auto-derived JPMS module names and the `vertx`/`vertx-5` collision (both derived `kubernetes.httpclient.vertx`)
- Centralize the configuration via a file-activated `jpms-module-name` profile in the parent POM that reads from a `jpms.module.name` property in each module
- Add a `kubernetes-client-httpclient-jpms` test module that verifies both the manifest entries and JPMS `ModuleFinder` resolution for all httpclient JARs

### Module name mapping

| Module | Auto-derived (wrong) | Package-based (fixed) |
|---|---|---|
| httpclient-jdk | `kubernetes.httpclient.jdk` | `io.fabric8.kubernetes.client.jdkhttp` |
| httpclient-jetty | `kubernetes.httpclient.jetty` | `io.fabric8.kubernetes.client.jetty` |
| httpclient-okhttp | `kubernetes.httpclient.okhttp` | `io.fabric8.kubernetes.client.okhttp` |
| httpclient-vertx | `kubernetes.httpclient.vertx` | `io.fabric8.kubernetes.client.vertx` |
| httpclient-vertx-5 | `kubernetes.httpclient.vertx` (collision!) | `io.fabric8.kubernetes.client.vertx5` |

Fixes #7460