### PR TITLE
fix(httpclient): add reactor dependencies to JPMS test module

### DIFF
--- a/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/pom.xml
+++ b/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/pom.xml
@@ -35,6 +35,34 @@
   </properties>
 
   <dependencies>
+    <!-- Declared as provided dependencies to ensure reactor build order.
+         The maven-dependency-plugin:copy goal resolves from repositories, not the reactor,
+         so without these dependencies, parallel builds (-T) may fail when snapshots aren't published. -->
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-jdk</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-jetty</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-okhttp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-vertx</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-vertx-5</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>


### PR DESCRIPTION
## Summary

The `kubernetes-client-httpclient-jpms` test module uses `maven-dependency-plugin:copy` to fetch httpclient JARs for JPMS module name validation. However, the `copy` goal resolves artifacts from repositories (local/remote), not the Maven reactor.

Without explicit dependencies on the httpclient modules, parallel builds (`-T 1C`) may process the JPMS test module before the httpclient modules are installed to the local repository. This causes the build to look for snapshots in the remote repository, failing when they aren't published.

**Fix:** Declare the 5 httpclient modules as `provided` scope dependencies so the reactor knows the correct build order.

Fixes failures in `javadocs.yml` and `e2e-tests.yml` CI pipelines:
- https://github.com/fabric8io/kubernetes-client/actions/runs/22665032189/job/65698564716
- https://github.com/fabric8io/kubernetes-client/actions/runs/22665032153/job/65698585331