### PR TITLE
fix(ci): deploy BOMs separately in snapshot workflow

### DIFF
--- a/.github/workflows/release-snapshots.yaml
+++ b/.github/workflows/release-snapshots.yaml
@@ -60,5 +60,12 @@ jobs:
         run: ./mvnw ${MAVEN_ARGS} clean install -pl bom-generator-plugin
       - name: Generate BOM
         run: ./mvnw ${MAVEN_ARGS} -Pbom clean validate
+      # BOMs are deployed separately to avoid SNAPSHOT metadata checksum errors.
+      # The central-publishing-maven-plugin deploys each module individually for SNAPSHOTs.
+      # If BOMs deploy in the same reactor, they may fetch metadata for artifacts that were
+      # just deployed, hitting a brief server-side inconsistency window between the
+      # maven-metadata.xml and its checksum file.
       - name: Build and release Java modules
-        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} deploy
+        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} deploy -pl '!target/classes/kubernetes-client-bom,!target/classes/kubernetes-client-bom-with-deps'
+      - name: Deploy BOMs
+        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} deploy -pl target/classes/kubernetes-client-bom,target/classes/kubernetes-client-bom-with-deps

--- a/bom-generator-plugin/README.md
+++ b/bom-generator-plugin/README.md
@@ -127,16 +127,27 @@ Examples:
 ## Example Workflow
 
 ```bash
-# Generate BOMs (single command, no separate plugin invocation needed)
-mvn clean install -Pbom
+# 1. Install the plugin first (it's not published to any repository)
+mvn clean install -pl bom-generator-plugin
+
+# 2. Generate BOMs (runs at the validate phase)
+mvn -Pbom clean validate
 
 # The BOMs are generated in:
 # - target/classes/kubernetes-client-bom/pom.xml
 # - target/classes/kubernetes-client-bom-with-deps/pom.xml
 
-# Release with updated BOMs
-mvn clean install -Prelease
+# 3. Release with generated BOMs (the -Prelease profile adds them as reactor modules)
+mvn -Prelease deploy
 ```
+
+### SNAPSHOT deployment
+
+For SNAPSHOT deployments, the `central-publishing-maven-plugin` deploys each module
+individually (unlike releases, which are bundled). BOMs must be deployed in a separate
+Maven invocation to avoid checksum validation errors caused by the server-side metadata
+inconsistency window for recently deployed SNAPSHOT artifacts. See the
+`release-snapshots.yaml` workflow for the exact commands.
 
 ## Generated BOM Content
 


### PR DESCRIPTION
## Summary

The `central-publishing-maven-plugin` deploys each module individually for SNAPSHOTs (unlike releases, which are bundled into a single ZIP upload). When BOMs deploy in the same reactor invocation as the modules they reference, they may fetch `maven-metadata.xml` for recently deployed artifacts and hit a brief server-side inconsistency window between the metadata file and its checksum, causing checksum validation failures like:

```
Checksum validation failed, expected '...' (REMOTE_EXTERNAL) but is actually '...'
```

This PR splits the snapshot deploy step into two separate Maven invocations:
1. Deploy all modules except BOMs
2. Deploy BOMs (after metadata has settled on the server)

Also updates the `bom-generator-plugin` README with the correct workflow steps and documents the SNAPSHOT deployment caveat.