### PR TITLE
fix(ci): use lax checksums for snapshot deploy step

### DIFF
--- a/.github/workflows/release-snapshots.yaml
+++ b/.github/workflows/release-snapshots.yaml
@@ -60,12 +60,9 @@ jobs:
         run: ./mvnw ${MAVEN_ARGS} clean install -pl bom-generator-plugin
       - name: Generate BOM
         run: ./mvnw ${MAVEN_ARGS} -Pbom clean validate
-      # BOMs are deployed separately to avoid SNAPSHOT metadata checksum errors.
-      # The central-publishing-maven-plugin deploys each module individually for SNAPSHOTs.
-      # If BOMs deploy in the same reactor, they may fetch metadata for artifacts that were
-      # just deployed, hitting a brief server-side inconsistency window between the
-      # maven-metadata.xml and its checksum file.
+      # Deploy uses -c (lax checksums) to override -C (strict) from MAVEN_ARGS.
+      # Remote SNAPSHOT metadata on the Sonatype server can have persistent or transient
+      # checksum inconsistencies (maven-metadata.xml vs its .sha1 file). Strict checksums
+      # make these fatal; lax checksums warn and continue.
       - name: Build and release Java modules
-        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} deploy -pl '!target/classes/kubernetes-client-bom,!target/classes/kubernetes-client-bom-with-deps'
-      - name: Deploy BOMs
-        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} deploy -pl target/classes/kubernetes-client-bom,target/classes/kubernetes-client-bom-with-deps
+        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} -c deploy

--- a/bom-generator-plugin/README.md
+++ b/bom-generator-plugin/README.md
@@ -144,10 +144,10 @@ mvn -Prelease deploy
 ### SNAPSHOT deployment
 
 For SNAPSHOT deployments, the `central-publishing-maven-plugin` deploys each module
-individually (unlike releases, which are bundled). BOMs must be deployed in a separate
-Maven invocation to avoid checksum validation errors caused by the server-side metadata
-inconsistency window for recently deployed SNAPSHOT artifacts. See the
-`release-snapshots.yaml` workflow for the exact commands.
+individually (unlike releases, which are bundled). Remote SNAPSHOT metadata on the
+Sonatype server can have checksum inconsistencies (`maven-metadata.xml` vs its `.sha1`
+file), so the deploy step must use lax checksums (`-c`) instead of strict (`-C`).
+See the `release-snapshots.yaml` workflow for the exact commands.
 
 ## Generated BOM Content
 


### PR DESCRIPTION
## Summary

The snapshot deploy step fails with checksum validation errors like:

```
Checksum validation failed, expected '...' (REMOTE_EXTERNAL) but is actually '...'
```

Remote SNAPSHOT metadata (`maven-metadata.xml`) on the Sonatype server can have persistent
checksum inconsistencies (`.xml` vs `.sha1` file mismatch). The `-C` (`--strict-checksums`)
flag in `MAVEN_ARGS` makes these fatal. Adding `-c` (`--lax-checksums`) to the deploy step
overrides this, allowing the build to warn and continue instead of failing.

Also reverts the split deploy from #7465 (separate BOM invocation) since lax checksums
makes it unnecessary.

Fixes #7467