### PR TITLE
fix(ci): exclude target directory from Dependabot Maven scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 99
+  exclude-paths:
+  - "target/**"
   reviewers:
   - oscerd
   - rohanKanojia


### PR DESCRIPTION
## Summary

- Add `exclude-paths: ["target/**"]` to the Maven ecosystem config in `dependabot.yml`
- Fixes Dependabot failure: `Dependabot couldn't find a pom.xml` at `target/classes/kubernetes-client-bom/pom.xml`
- The `release` profile declares BOM modules under `target/classes/` which are generated during the build by the `bom-generator-plugin`. Dependabot scans all Maven profiles (including inactive ones) and fails when it can't find these generated pom.xml files in the repository.