### PR TITLE
fix(ci): use lax checksums in MAVEN_ARGS for snapshot workflow

### DIFF
--- a/.github/workflows/release-snapshots.yaml
+++ b/.github/workflows/release-snapshots.yaml
@@ -27,7 +27,12 @@ on:
     - cron: '0 2 * * *' # Every day at 2am
 
 env:
-  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e ${{ github.event.inputs.additional_args }}
+  # Uses -c (lax checksums) instead of -C (strict checksums) used in the release workflow.
+  # Maven's CLI uses if/else-if for -C/-c, so -C always wins when both are present.
+  # Remote SNAPSHOT metadata on the Sonatype server can have persistent checksum
+  # inconsistencies (maven-metadata.xml vs its .sha1 file). Strict checksums make
+  # these fatal during deploy; lax checksums warn and continue.
+  MAVEN_ARGS: -B -c -V -ntp -Dhttp.keepAlive=false -e ${{ github.event.inputs.additional_args }}
   RELEASE_MAVEN_ARGS: -Prelease -Denforcer.skip=true
   MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
   MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -60,9 +65,5 @@ jobs:
         run: ./mvnw ${MAVEN_ARGS} clean install -pl bom-generator-plugin
       - name: Generate BOM
         run: ./mvnw ${MAVEN_ARGS} -Pbom clean validate
-      # Deploy uses -c (lax checksums) to override -C (strict) from MAVEN_ARGS.
-      # Remote SNAPSHOT metadata on the Sonatype server can have persistent or transient
-      # checksum inconsistencies (maven-metadata.xml vs its .sha1 file). Strict checksums
-      # make these fatal; lax checksums warn and continue.
       - name: Build and release Java modules
-        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} -c deploy
+        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} deploy

--- a/bom-generator-plugin/README.md
+++ b/bom-generator-plugin/README.md
@@ -146,8 +146,9 @@ mvn -Prelease deploy
 For SNAPSHOT deployments, the `central-publishing-maven-plugin` deploys each module
 individually (unlike releases, which are bundled). Remote SNAPSHOT metadata on the
 Sonatype server can have checksum inconsistencies (`maven-metadata.xml` vs its `.sha1`
-file), so the deploy step must use lax checksums (`-c`) instead of strict (`-C`).
-See the `release-snapshots.yaml` workflow for the exact commands.
+file), so the snapshot workflow uses `-c` (lax checksums) instead of `-C` (strict).
+Note: Maven's CLI uses `if/else-if` for these flags, so `-C` always wins when both
+are present — they cannot be combined. See `release-snapshots.yaml` for details.
 
 ## Generated BOM Content
 


### PR DESCRIPTION
## Summary
- Replace `-C` (strict checksums) with `-c` (lax checksums) directly in `MAVEN_ARGS` for the snapshot workflow
- Remove the now-unnecessary `-c` flag from the deploy step
- Update `bom-generator-plugin/README.md` with the correct explanation

## Root Cause
Maven's CLI parses `-C` and `-c` with an `if/else-if` pattern ([`MavenCli.java`](https://github.com/apache/maven/blob/maven-3.9.9/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java)):

```java
if (commandLine.hasOption(CLIManager.CHECKSUM_FAILURE_POLICY)) {
    globalChecksumPolicy = MavenExecutionRequest.CHECKSUM_POLICY_FAIL;
} else if (commandLine.hasOption(CLIManager.CHECKSUM_WARNING_POLICY)) {
    globalChecksumPolicy = MavenExecutionRequest.CHECKSUM_POLICY_WARN;
}
```

**`-C` always wins when both flags are present.** The previous fix (#7468) appended `-c` to the deploy command, but it was silently ignored because `-C` was already set in `MAVEN_ARGS`.

The `central-publishing-maven-plugin` creates deployment repositories via `ArtifactRepositoryFactory.createDeploymentArtifactRepository()` with default "warn" checksum policy, but the session-level global policy from `-C` overrides it to "fail".

Fixes https://github.com/fabric8io/kubernetes-client/issues/7467