### PR TITLE
fix(ci): inline cancel-on-failure to fix workflow status shown as skipped

### DIFF
--- a/.github/workflows/generate-model.yml
+++ b/.github/workflows/generate-model.yml
@@ -66,12 +66,6 @@ jobs:
             echo "Schema files modified. Build Failure";
             exit 1;
           fi;
-
-  cancel-on-failure:
-    name: Cancel PR workflows on failure
-    runs-on: ubuntu-latest
-    if: ${{ failure() && github.event_name == 'pull_request' }}
-    needs: [generate-model]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/cancel-pr-workflows
+      - name: Cancel PR workflows on failure
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        uses: ./.github/actions/cancel-pr-workflows

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -52,12 +52,6 @@ jobs:
         run: ./mvnw ${MAVEN_ARGS} -Pitests -N license:check
       - name: Check Format (only on touched files)
         run: ./mvnw ${MAVEN_ARGS} -Pitests spotless:check
-
-  cancel-on-failure:
-    name: Cancel PR workflows on failure
-    runs-on: ubuntu-latest
-    if: ${{ failure() && github.event_name == 'pull_request' }}
-    needs: [style-check]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/cancel-pr-workflows
+      - name: Cancel PR workflows on failure
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        uses: ./.github/actions/cancel-pr-workflows


### PR DESCRIPTION
## Summary

- Fixes the workflow status showing as "skipped" in the GitHub UI when prerequisite checks (style-checks, generate-model) succeed
- The separate `cancel-on-failure` job introduced in #7475 gets skipped on success, which causes GitHub to mark the entire workflow as "skipped"
- Inlines the cancellation as a step within the main job — `if: failure()` steps are silently skipped without affecting the overall workflow conclusion