### PR TITLE
test(java-generator): verify Javadoc HTML rendering of escaped CRD description

### DIFF
--- a/java-generator/core/src/test/java/io/fabric8/java/generator/JavadocRenderingTest.java
+++ b/java-generator/core/src/test/java/io/fabric8/java/generator/JavadocRenderingTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.java.generator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.spi.ToolProvider;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class JavadocRenderingTest {
+
+  @TempDir
+  private File tempDir;
+
+  private Config config;
+  private File javadocOutputDir;
+
+  @BeforeEach
+  void setUp() {
+    config = Config.builder()
+        .generatedAnnotations(false)
+        .build();
+    javadocOutputDir = new File(tempDir, "javadoc-output");
+    javadocOutputDir.mkdirs();
+  }
+
+  @Test
+  void javadocRendersHtmlEscapedDescriptionsWithoutErrors() throws Exception {
+    ToolProvider javadocTool = ToolProvider.findFirst("javadoc").orElse(null);
+    assumeTrue(javadocTool != null, "javadoc tool not available in this JDK");
+
+    File crd = CompilationTest.getCRD("html-description-crd.yml");
+    new FileJavaGenerator(config, crd).run(tempDir);
+
+    List<String> sourceFiles = collectJavaFiles(tempDir.toPath());
+    assertThat(sourceFiles).isNotEmpty();
+
+    int exitCode = runJavadoc(javadocTool, sourceFiles);
+
+    assertThat(exitCode)
+        .as("javadoc should complete without errors")
+        .isZero();
+  }
+
+  @Test
+  void javadocRenderedHtmlContainsCorrectDescriptions() throws Exception {
+    ToolProvider javadocTool = ToolProvider.findFirst("javadoc").orElse(null);
+    assumeTrue(javadocTool != null, "javadoc tool not available in this JDK");
+
+    File crd = CompilationTest.getCRD("html-description-crd.yml");
+    new FileJavaGenerator(config, crd).run(tempDir);
+
+    List<String> sourceFiles = collectJavaFiles(tempDir.toPath());
+    int exitCode = runJavadoc(javadocTool, sourceFiles);
+    assertThat(exitCode).as("javadoc exit code").isZero();
+
+    File specHtml = findFile(javadocOutputDir.toPath(), "WidgetSpec.html");
+    assertThat(specHtml).isNotNull().exists();
+    String html = Files.readString(specHtml.toPath());
+
+    assertThat(html)
+        .contains("&lt;DatabaseName&gt;")
+        .contains("A &amp; B")
+        .contains("&lt;min&gt;")
+        .contains("&lt;max&gt;")
+        .contains("&lt;protocol&gt;")
+        .contains("&lt;host&gt;")
+        .contains("&amp;key2=val2")
+        .contains("A simple name with no special characters.");
+
+    File statusHtml = findFile(javadocOutputDir.toPath(), "WidgetStatus.html");
+    assertThat(statusHtml).isNotNull().exists();
+    String statusContent = Files.readString(statusHtml.toPath());
+
+    assertThat(statusContent)
+        .contains("&lt;Pending&gt;")
+        .contains("&lt;Running&gt;")
+        .contains("&lt;Failed&gt;");
+  }
+
+  private int runJavadoc(ToolProvider javadocTool, List<String> sourceFiles) {
+    String classpath = System.getProperty("java.class.path");
+    List<String> args = new ArrayList<>();
+    args.add("-d");
+    args.add(javadocOutputDir.getAbsolutePath());
+    args.add("-classpath");
+    args.add(classpath);
+    args.add("-quiet");
+    args.add("--show-members=private");
+    args.add("-Xdoclint:all");
+    args.addAll(sourceFiles);
+
+    StringWriter outWriter = new StringWriter();
+    StringWriter errWriter = new StringWriter();
+    return javadocTool.run(
+        new PrintWriter(outWriter),
+        new PrintWriter(errWriter),
+        args.toArray(new String[0]));
+  }
+
+  private static List<String> collectJavaFiles(Path dir) throws Exception {
+    try (Stream<Path> walk = Files.walk(dir)) {
+      return walk
+          .map(Path::toString)
+          .filter(string -> string.endsWith(".java"))
+          .collect(Collectors.toList());
+    }
+  }
+
+  private static File findFile(Path dir, String fileName) throws Exception {
+    try (Stream<Path> walk = Files.walk(dir)) {
+      return walk
+          .filter(p -> p.getFileName().toString().equals(fileName))
+          .map(Path::toFile)
+          .findFirst()
+          .orElse(null);
+    }
+  }
+}

--- a/java-generator/core/src/test/resources/html-description-crd.yml
+++ b/java-generator/core/src/test/resources/html-description-crd.yml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/java-generator/core/src/test/resources/html-description-crd.yml
+++ b/java-generator/core/src/test/resources/html-description-crd.yml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: "Widget is a test resource for verifying Javadoc HTML escaping."
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              description: "WidgetSpec defines the desired state of Widget."
+              properties:
+                simpleName:
+                  type: string
+                  description: "A simple name with no special characters."
+                angleBracketField:
+                  type: string
+                  description: "The format is <DatabaseName> where <DatabaseName> is the name of the database."
+                ampersandField:
+                  type: string
+                  description: "This field supports A & B operations."
+                mixedHtmlChars:
+                  type: string
+                  description: "Threshold must be <100 & >0, expressed as <min> & <max>."
+                commentTerminator:
+                  type: string
+                  description: "Pattern must not contain */ or similar sequences."
+                urlFormat:
+                  type: string
+                  description: "Format: <protocol>://<host>:<port>/<path>?key1=val1&key2=val2"
+            status:
+              type: object
+              description: "WidgetStatus defines the observed state of Widget."
+              properties:
+                phase:
+                  type: string
+                  description: "Current phase - one of: <Pending>, <Running>, <Failed>."


### PR DESCRIPTION
## Description
Fixes: #7643 

Chore: Add Integration tests to verify the html rendered output.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
