### PR TITLE
chore(ci): group Dependabot updates and document grouped PR flow

### DIFF
--- a/.claude/skills/bump-go-dep/SKILL.md
+++ b/.claude/skills/bump-go-dep/SKILL.md
@@ -22,9 +22,21 @@ ultrathink
 ## Step 1: Analyze the Dependabot PR
 
 From the context above, extract:
-- **Go module path** (e.g., `sigs.k8s.io/kustomize/api`)
-- **Old version** and **new version**
+- **Single-dep or grouped PR?** — see below.
+- **Go module path(s)** (e.g., `sigs.k8s.io/kustomize/api`)
+- **Old version** and **new version** for each dep
 - **CI failure details** — understand what failed and why
+
+### Single-dep vs grouped PR
+
+Dependabot groups are configured in `.github/dependabot.yml` (e.g., `kubernetes`, `openshift`, `knative`, `opentelemetry`, `golang-x`, `operator-framework`, etc.). When a group has multiple eligible updates, Dependabot opens a single PR for the whole group.
+
+Signals of a grouped PR:
+- Title like `chore(deps): bump the <group-name> group in /... with N updates`
+- Branch like `dependabot/go_modules/.../<group-name>-<hash>`
+- PR body lists multiple `Updates ...` blocks
+
+Extract the **group name** and the **full list of (module, old, new)** tuples from the PR body. All subsequent steps (branch, CHANGELOG, commit, PR) must reflect every dep in the group.
 
 Classify the failure:
 1. **Model drift** — `make generate-model` produces different output than what's committed (most common, the "Check No Schema file modified" step fails)
@@ -52,6 +64,8 @@ git checkout -b chore/bump-<short-dep-name>-<new-version>
 
 Use a short, readable name for the dependency (e.g., `kustomize-api-0.21.1`, `gateway-api-1.5.0`, `cert-manager-1.20.0`).
 
+**For grouped PRs**, name the branch after the group and the shared target version when there is one (e.g., `chore/bump-kubernetes-0.36.0`, `chore/bump-opentelemetry-1.43.0`). If there is no single shared version, just use the group name (e.g., `chore/bump-knative-group`).
+
 ## Step 3: Bump the Dependency
 
 ### 3a. Update go.mod
@@ -60,6 +74,8 @@ Use a short, readable name for the dependency (e.g., `kustomize-api-0.21.1`, `ga
 cd kubernetes-model-generator/openapi/generator
 go get <module-path>@v<new-version>
 ```
+
+**For grouped PRs**, run `go get` for **every** module in the group, each at its target version. Do this in one invocation when possible (`go get foo@v1 bar@v2 baz@v3`) so the solver resolves them together.
 
 ### 3b. Check for related dependencies that may need bumping
 
@@ -181,6 +197,8 @@ Under `#### Dependency Upgrade`, insert in alphabetical order by the readable de
 
 For example, "bump cert-manager..." goes before "bump gateway-api..." which goes before "bump tekton...".
 
+**For grouped PRs**, emit **one entry per dep in the group**, each in its own alphabetical position. Use the same `#PLACEHOLDER` for all of them — they all resolve to the single fix PR number in Step 10.
+
 ### Bug fix entry (if generator code was fixed)
 
 Under `#### Bugs`, insert in alphabetical order by topic:
@@ -230,6 +248,18 @@ Closes #<dependabot-pr-number>
 
 **IMPORTANT**: Include `Closes #<dependabot-pr-number>` to auto-close the Dependabot PR.
 
+**For grouped PRs**, use a group-level subject and list each dep in the body:
+
+```
+chore(deps): bump the <group-name> group
+
+- <module-path> from <old> to <new>
+- <module-path> from <old> to <new>
+- ...
+
+Closes #<dependabot-pr-number>
+```
+
 ## Step 9: Push and Create PR
 
 Push the branch and create the PR:
@@ -249,6 +279,8 @@ Closes #<dependabot-pr-number>
 EOF
 )"
 ```
+
+**For grouped PRs**, mirror the commit style — title `chore(deps): bump the <group-name> group`, body `## Summary` lists each `<module-path> from <old> to <new>` as bullets, and closes the single Dependabot group PR.
 
 **IMPORTANT**: Do NOT include a "Test plan" section or "Generated with Claude Code" footer in the PR body.
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,12 @@ updates:
   - oscerd
   - rohanKanojia
   - manusa
+  # We maintain two Vert.x-based HTTP clients: httpclient-vertx (Vert.x 4.x)
+  # and httpclient-vertx-5 (Vert.x 5.x). Each must stay on its own major, and
+  # the two are updated independently — so no group and no major bumps.
+  ignore:
+  - dependency-name: "io.vertx:*"
+    update-types: ["version-update:semver-major"]
   groups:
     bouncycastle:
       patterns:
@@ -35,9 +41,6 @@ updates:
     jackson:
       patterns:
       - "com.fasterxml.jackson*:*"
-    vertx:
-      patterns:
-      - "io.vertx:*"
     jetty:
       patterns:
       - "org.eclipse.jetty:*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,13 +28,107 @@ updates:
   - oscerd
   - rohanKanojia
   - manusa
+  groups:
+    bouncycastle:
+      patterns:
+      - "org.bouncycastle:*"
+    jackson:
+      patterns:
+      - "com.fasterxml.jackson*:*"
+    vertx:
+      patterns:
+      - "io.vertx:*"
+    jetty:
+      patterns:
+      - "org.eclipse.jetty:*"
+      - "org.eclipse.jetty.*:*"
+    keycloak:
+      patterns:
+      - "org.keycloak:*"
+    okhttp:
+      patterns:
+      - "com.squareup.okhttp3:*"
+    maven-plugins:
+      patterns:
+      - "org.apache.maven.plugins:*"
+      - "org.apache.maven:*"
+      - "org.codehaus.mojo:*"
+    testing:
+      patterns:
+      - "org.junit*:*"
+      - "org.mockito:*"
+      - "org.assertj:*"
+      - "org.awaitility:*"
+      - "com.approvaltests:*"
+      - "org.spockframework:*"
+    logging:
+      patterns:
+      - "org.apache.logging.log4j:*"
+      - "org.slf4j:*"
+      - "ch.qos.logback*:*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: daily
     time: "11:00"
+  groups:
+    github-actions:
+      patterns:
+      - "*"
 - package-ecosystem: "gomod"
   directory: "/kubernetes-model-generator/openapi/generator"
   schedule:
     interval: "daily"
     time: "11:00"
+  groups:
+    kubernetes:
+      patterns:
+      - "k8s.io/*"
+      - "sigs.k8s.io/*"
+    openshift:
+      patterns:
+      - "github.com/openshift/*"
+    knative:
+      patterns:
+      - "knative.dev/*"
+    opentelemetry:
+      patterns:
+      - "go.opentelemetry.io/*"
+    golang-x:
+      patterns:
+      - "golang.org/x/*"
+    google-apis:
+      patterns:
+      - "google.golang.org/*"
+      - "github.com/google/*"
+    go-openapi:
+      patterns:
+      - "github.com/go-openapi/*"
+    operator-framework:
+      patterns:
+      - "github.com/operator-framework/*"
+    tektoncd:
+      patterns:
+      - "github.com/tektoncd/*"
+    metal3-io:
+      patterns:
+      - "github.com/metal3-io/*"
+    stolostron:
+      patterns:
+      - "github.com/stolostron/*"
+    open-cluster-management:
+      patterns:
+      - "open-cluster-management.io/*"
+    prometheus:
+      patterns:
+      - "github.com/prometheus/*"
+      - "github.com/prometheus-operator/*"
+    cloudevents:
+      patterns:
+      - "github.com/cloudevents/*"
+    azure:
+      patterns:
+      - "github.com/Azure/*"
+    go-uber:
+      patterns:
+      - "go.uber.org/*"


### PR DESCRIPTION
## Summary

Dependabot was opening one PR per coupled dependency (e.g. three separate
`k8s.io/*` bumps for the 0.36.0 release), wasting CI resources on redundant
model regeneration runs. This change mirrors the kubernetes-mcp-server setup
and extends it to cover this repo's larger dependency surface.

### Grouping added

- **gomod**: `kubernetes`, `openshift`, `knative`, `opentelemetry`, `golang-x`,
  `google-apis`, `go-openapi`, `operator-framework`, `tektoncd`, `metal3-io`,
  `stolostron`, `open-cluster-management`, `prometheus`, `cloudevents`,
  `azure`, `go-uber`
- **maven**: `bouncycastle`, `jackson`, `vertx`, `jetty`, `keycloak`,
  `okhttp`, `maven-plugins`, `testing`, `logging`
- **github-actions**: single catch-all group

### Skill update

The `bump-go-dep` skill now detects grouped Dependabot PRs and handles
multi-dep branch naming, CHANGELOG entries (one per dep, shared fix PR
number), commit messages, and PR bodies.