### PR TITLE
chore: speed up kubernetes-tests with surefire fork reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 * Fix #7350: Improper callback timing in leaderelection leads to the dual-leader
 
 #### Improvements
-* Fix #7648: speed up `kubernetes-tests` by enabling surefire fork reuse and per-core forks
 * Fix #7522: improve dependency management for kubernetes-httpclient-okhttp
 * Fix #7550: add a ResourceEventHandler onList method and deprecated onNothing
 * Fix #3396: (mockwebserver) Enhance self-signed certificate generation to include Subject Alternative Names (SANs) for proper TLS verification by modern clients

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #7350: Improper callback timing in leaderelection leads to the dual-leader
 
 #### Improvements
+* Fix #7648: speed up `kubernetes-tests` by enabling surefire fork reuse and per-core forks
 * Fix #7522: improve dependency management for kubernetes-httpclient-okhttp
 * Fix #7550: add a ResourceEventHandler onList method and deprecated onNothing
 * Fix #3396: (mockwebserver) Enhance self-signed certificate generation to include Subject Alternative Names (SANs) for proper TLS verification by modern clients

--- a/kubernetes-tests/pom.xml
+++ b/kubernetes-tests/pom.xml
@@ -95,6 +95,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <forkCount>1C</forkCount>
+          <reuseForks>true</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>
             <KUBERNETES_MASTER />

--- a/pom.xml
+++ b/pom.xml
@@ -1176,7 +1176,6 @@
             <ENV_VAR_EXISTS>value</ENV_VAR_EXISTS>
             <ENV_VAR_EXISTS_BOOLEAN>true</ENV_VAR_EXISTS_BOOLEAN>
           </environmentVariables>
-          <parallel>suitesAndClasses</parallel>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Summary

Enable `reuseForks=true` and `forkCount=1C` on the `kubernetes-tests` surefire configuration.

Previously the module inherited `forkCount=1` from the root pom together with a `<parallel>suitesAndClasses</parallel>` setting that is JUnit 4 syntax and has no effect on JUnit 5, so the ~1256 tests in this module were effectively running single-threaded in a single JVM.

## Measurements

Locally on this module (1256 tests, 253 classes):

| Config | Wall time | Failures |
|---|---|---|
| Baseline (`forkCount=1`, `reuseForks=true` inherited, `<parallel>` no-op) | 266s | 0 |
| `forkCount=1C`, `reuseForks=true` (this PR) | **109s (-59%)** | **0** |

On a 2-core GitHub runner, expected ~266s → ~150s (-45%).

Refs #7648