### PR TITLE
feat(mockwebserver): add opt-out for HTTP/2 cleartext (h2c) upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix #7350: Improper callback timing in leaderelection leads to the dual-leader
 
 #### Improvements
+* Fix #7662: (mockwebserver) new `MockWebServer#setHttp2ClearTextEnabled(boolean)` setter to opt out of HTTP/2 cleartext (h2c) upgrade
 * Fix #7522: improve dependency management for kubernetes-httpclient-okhttp
 * Fix #7550: add a ResourceEventHandler onList method and deprecated onNothing
 * Fix #3396: (mockwebserver) Enhance self-signed certificate generation to include Subject Alternative Names (SANs) for proper TLS verification by modern clients

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -98,6 +98,7 @@ public class MockWebServer implements Closeable {
   private InetAddress inetAddress;
   private String hostName;
   private List<Protocol> protocols;
+  private boolean http2ClearTextEnabled;
   private boolean started;
 
   public MockWebServer() {
@@ -110,6 +111,7 @@ public class MockWebServer implements Closeable {
     enabledSecuredTransportProtocols = new ArrayList<>();
     enabledSecuredTransportProtocols.addAll(DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS);
     protocols = Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1);
+    http2ClearTextEnabled = true;
   }
 
   private void before() {
@@ -148,6 +150,8 @@ public class MockWebServer implements Closeable {
       options
           .setTrustOptions(selfSignedCertificate.trustOptions())
           .setKeyCertOptions(selfSignedCertificate.keyCertOptions());
+    } else {
+      options.setHttp2ClearTextEnabled(http2ClearTextEnabled);
     }
     httpServer = vertx.createHttpServer(options);
     httpServer.connectionHandler(event -> {
@@ -260,6 +264,16 @@ public class MockWebServer implements Closeable {
 
   public void setProtocols(List<Protocol> protocols) {
     this.protocols = protocols;
+  }
+
+  /**
+   * Enables or disables HTTP/2 over cleartext (h2c). Enabled by default, matching Vert.x's
+   * own default. Set to {@code false} for tests that use HTTP clients (such as the JDK
+   * HttpClient) which probe for {@code Upgrade: h2c} — accepting the upgrade can lead to
+   * non-deterministic HTTP/2 framing behaviour on large responses.
+   */
+  public void setHttp2ClearTextEnabled(boolean http2ClearTextEnabled) {
+    this.http2ClearTextEnabled = http2ClearTextEnabled;
   }
 
   /**

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractAsyncBodyTest.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.http;
 
 import io.fabric8.mockwebserver.DefaultMockServer;
+import io.fabric8.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +39,16 @@ public abstract class AbstractAsyncBodyTest {
 
   @BeforeAll
   static void beforeAll() {
-    server = new DefaultMockServer(false);
+    // Disable h2c on the mock server. The JDK HttpClient defaults to HTTP/2 and, on some
+    // Java 11 updates, sends an Upgrade: h2c header on plain-HTTP requests. With h2c
+    // accepted by the mock server, the upgraded HTTP/2 framing has intermittently failed
+    // on the 1 MiB response in consumeBytesProcessesLargeBodies with:
+    //   java.net.ProtocolException: protocol error: zero streamId for DataFrame
+    // These tests cover async body consumption, not HTTP/2 negotiation, so pinning the
+    // transport to HTTP/1.1 is the right scope.
+    final MockWebServer mockWebServer = new MockWebServer();
+    mockWebServer.setHttp2ClearTextEnabled(false);
+    server = new DefaultMockServer(mockWebServer, new HashMap<>(), false);
     server.start();
   }
 


### PR DESCRIPTION
## Summary

Adds a `MockWebServer#setHttp2ClearTextEnabled(boolean)` opt-out setter. Default stays at `true` (matching Vert.x's own default) to preserve behaviour for external consumers of `kubernetes-server-mock`. The Kubernetes-client `AbstractAsyncBodyTest` opts out to fix a long-standing CI flake.

## Flake

`JdkHttpClientAsyncBodyTest.consumeBytesProcessesLargeBodies` on Java 11:

```
[ERROR] io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientAsyncBodyTest.consumeBytesProcessesLargeBodies
java.util.concurrent.ExecutionException: java.net.ProtocolException: protocol error: zero streamId for DataFrame
	at jdk.internal.net.http.Http2Connection.protocolError(Http2Connection.java:1184)
	at jdk.internal.net.http.Http2Connection.processFrame(Http2Connection.java:826)
	at jdk.internal.net.http.frame.FramesDecoder.decode(FramesDecoder.java:155)
```

## Root cause

The JDK HttpClient defaults to HTTP/2 and, on some Java 11 updates, sends `Upgrade: h2c` on plain-HTTP requests. Vert.x's `HttpServerOptions.setHttp2ClearTextEnabled` defaults to `true`, so the mock server accepts the upgrade and switches mid-connection to HTTP/2 framing. On 1 MiB bodies this intermittently produces a DATA frame the JDK's H2 decoder rejects as malformed — a framing race in the upgrade path, either on the Netty/Vert.x send side or the JDK decoder.

Small bodies fit in one/few frames and don't expose it. Older Java 11 updates never send the `Upgrade: h2c` header at all, which is why this only bites on CI.

## Why opt-out, not change-the-default

`kubernetes-server-mock` is published externally and may be used by third-party projects that rely on h2c being accepted over cleartext. Flipping the default would be a behaviour change for those consumers. Adding an opt-out lets callers who know h2c doesn't apply to their scenario (e.g. tests that mock the real Kubernetes API, which is HTTPS-only) disable it surgically.

`AbstractAsyncBodyTest` now opts out with an inline comment describing the symptom and the reasoning.