### PR TITLE
chore(ci): decouple Vert.x 5 module versions from vertx.version for Dependabot

### DIFF
--- a/httpclient-vertx-5/pom.xml
+++ b/httpclient-vertx-5/pom.xml
@@ -56,42 +56,42 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-client</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-common</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-common</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core-logging</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-bridge-common</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-uri-template</artifactId>
-        <version>${vertx.version}</version>
+        <version>${vertx5.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -104,12 +104,12 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
+      <version>${vertx5.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <version>${vertx.version}</version>
+      <version>${vertx5.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/kubernetes-itests/pom.xml
+++ b/kubernetes-itests/pom.xml
@@ -174,42 +174,42 @@
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-common</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-common</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core-logging</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-bridge-common</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
           <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-uri-template</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vertx5.version}</version>
           </dependency>
         </dependencies>
       </dependencyManagement>


### PR DESCRIPTION
## Summary
- Reference `${vertx5.version}` directly at dep-sites inside `httpclient-vertx-5/pom.xml` and the `httpclient-vertx-5` profile in `kubernetes-itests/pom.xml`, instead of routing through the module-local `${vertx.version}` override.
- Keep the local `<vertx.version>${vertx5.version}</vertx.version>` declarations untouched — they mirror the public contract documented in the v7.5.0 migration notes (`CHANGELOG.md`) and the `Vertx5HttpClientFactory` runtime hint.

## Why
The module-local override pattern was introduced in #7184 and centralized via `vertx5.version` in the parent pom in #7441. Both of those goals are preserved here.

What broke is Dependabot's behaviour: when bumping `vertx.version`, it walks the POMs from each `io.vertx:*` dep declaration, traces back to the managing property, and rewrites every `<vertx.version>…</vertx.version>` declaration it finds — including the child-module overrides. In #7659 that silently replaced `<vertx.version>${vertx5.version}</vertx.version>` with the literal `4.5.26` in the Vert.x 5 modules.

`chaos-tests/pom.xml` uses the same override pattern and was **not** touched by Dependabot, because it declares no `io.vertx:*` dependencies and therefore never gets walked. This PR applies the same trick to the other two modules: after the edit, no dep inside them references `${vertx.version}`, so Dependabot has no reason to walk in and rewrite the local property declaration. The public contract — downstream users setting `<vertx.version>${vertx5.version}</vertx.version>` in their own poms to flip the inherited BOM — still works unchanged via the root pom's `dependencyManagement`.