### PR TITLE
ci: cache Maven dependencies for build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           java-version: ${{ matrix.environment.java  }}
           distribution: 'temurin'
+          cache: 'maven'
       - name: Build Project
         #run: make install MAVEN_ARGS="${MAVEN_ARGS}"
         run: mvn ${MAVEN_ARGS} install
@@ -70,3 +71,8 @@ jobs:
         run: |
           chmod a+x java-generator/cli/target/java-gen
           java-generator/cli/target/java-gen --source=java-generator/core/src/test/resources/crontab-crd.yml --target=./tmp
+      - name: Drop in-repo artifacts before cache save
+        # Don't let io.fabric8:* jars installed by this run leak into the cache that future
+        # runs restore. Only third-party dependencies should be cached.
+        if: always()
+        run: rm -rf ~/.m2/repository/io/fabric8

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: 'maven'
       - name: Build Project
         run: ./mvnw clean install
+      - name: Drop in-repo artifacts before cache save
+        # Don't let io.fabric8:* jars installed by this run leak into the cache that future
+        # runs restore. Only third-party dependencies should be cached.
+        if: always()
+        shell: pwsh
+        run: Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "$env:USERPROFILE\.m2\repository\io\fabric8"
 


### PR DESCRIPTION
## Summary

Adds `cache: 'maven'` to `setup-java` in `build.yml` and `windows-build.yml`. Currently each of the four matrix cells (Java 11/17/21 on Linux, Java 17 on Windows) re-downloads every Maven dependency on every PR.

Expected saving: 30–60s per cell, ~2–4 minutes per PR run.

## Cache hygiene

`setup-java@v5` saves `~/.m2/repository` wholesale, which includes the `io.fabric8:*` artifacts that `mvn install` places there during the build. Those would be restored on subsequent runs and could — in edge cases like partial builds — be resolved in place of freshly-built artifacts from the current commit.

To keep the cache limited to external dependencies only, a post-build step removes `~/.m2/repository/io/fabric8` before the cache is saved. The current run is unaffected because it rebuilds everything itself; the cleanup just ensures only third-party jars persist for future runs.

The cache key is based on `**/pom.xml`, so any dependency change invalidates the cache automatically.

Refs #7648