### PR TITLE
test(httpclient): fix flaky multiframeReceive race

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractWebSocketSendReceiveTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractWebSocketSendReceiveTest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,7 +105,9 @@ public abstract class AbstractWebSocketSendReceiveTest {
           .andEmit(multiframe)
           .done()
           .always();
-      final BlockingQueue<String> receivedText = new ArrayBlockingQueue<>(1);
+      // Unbounded: both emits are scheduled at open+5ms by the mock server (see #7665),
+      // so the 2nd message may arrive before the main thread polls the 1st.
+      final BlockingQueue<String> receivedText = new LinkedBlockingQueue<>();
       // TODO: JDK HttpClient implementation doesn't work with ws URIs
       // - Currently we are using an HttpRequest.Builder which is then
       //   mapped to a WebSocket.Builder. We should probably use the WebSocket.Builder
@@ -115,7 +118,7 @@ public abstract class AbstractWebSocketSendReceiveTest {
           .buildAsync(new WebSocket.Listener() {
             @Override
             public void onMessage(WebSocket webSocket, String text) {
-              assertTrue(receivedText.offer(text));
+              receivedText.add(text);
               webSocket.request();
             }
           }).get(10L, TimeUnit.SECONDS);


### PR DESCRIPTION
## Summary
- Fix the ~50% flaky `AbstractWebSocketSendReceiveTest.multiframeReceive` (seen on the JDK client in CI with `expected: "aaa..." but was null`).
- Root cause is a test-side race: the mock server's `WebSocketSession.send` schedules each `waitFor(5).andEmit(...)` independently at `open+5ms` rather than sequentially, so the two messages fire back-to-back. With an `ArrayBlockingQueue<>(1)` receive buffer, if the listener thread wins the race against the main thread's first `poll`, `offer` returns false on the 2nd message, the `assertTrue` throws on the listener thread, the multiframe is dropped, and the second `poll(10s)` times out with `null`.
- Fix: use an unbounded `LinkedBlockingQueue<>()` so the queue acts as a sink, not a synchronizer. No product code change.

## Reproduction
Inserting `Thread.sleep(200L)` in the main thread between `buildAsync(...).get(...)` and the first `poll` reproduces the failure 100% of the time locally, with instrumented diagnostics:

```
[listener] onMessage len=8 offered=true
[listener] onMessage len=66000 offered=false
[main] first poll -> len=8
[main] second poll -> null
[main] listenerError=java.lang.AssertionError: offer returned false for len=66000
```

With the fix in place, the same forced-race scenario passes.

Fixes #7665