### PR TITLE
chore(kubernetes-client-api): enable surefire fork reuse

### DIFF
--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -231,7 +231,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
+          <reuseForks>true</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>
             <KUBERNETES_MASTER />

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigDisableAutoConfigurationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigDisableAutoConfigurationTest.java
@@ -255,6 +255,7 @@ class ConfigDisableAutoConfigurationTest {
       @AfterEach
       void tearDown() {
         System.clearProperty("kubernetes.master");
+        System.clearProperty("kubernetes.namespace");
       }
     }
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/CertUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/CertUtilsTest.java
@@ -35,8 +35,9 @@ import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -49,28 +50,33 @@ class CertUtilsTest {
 
   private static final String FABRIC8_STORE_PATH = Utils.filePath(CertUtilsTest.class.getResource("/ssl-test/fabric8-store"));
   private static final String FABRIC8_STORE_PASSPHRASE = "fabric8";
-  private Properties systemProperties;
+  private static final String[] MANAGED_SSL_PROPERTIES = {
+      "javax.net.ssl.trustStore",
+      "javax.net.ssl.trustStorePassword",
+      "javax.net.ssl.trustStoreType",
+      "javax.net.ssl.keyStore",
+      "javax.net.ssl.keyStorePassword"
+  };
+  private Map<String, String> originalSslProperties;
 
   @BeforeEach
   public void storeSystemProperties() {
-    systemProperties = new Properties();
-    storeSystemProperty("javax.net.ssl.trustStore");
-    storeSystemProperty("javax.net.ssl.trustStorePassword");
-    storeSystemProperty("javax.net.ssl.trustStoreType");
-    storeSystemProperty("javax.net.ssl.keyStore");
-    storeSystemProperty("javax.net.ssl.keyStorePassword");
-  }
-
-  private void storeSystemProperty(String systemProperty) {
-    String value = System.getProperty(systemProperty);
-    if (Utils.isNotNullOrEmpty(value)) {
-      systemProperties.put(systemProperty, value);
+    originalSslProperties = new HashMap<>();
+    for (String property : MANAGED_SSL_PROPERTIES) {
+      originalSslProperties.put(property, System.getProperty(property));
     }
   }
 
   @AfterEach
   public void resetSystemPropertiesBack() {
-    System.setProperties(systemProperties);
+    for (String property : MANAGED_SSL_PROPERTIES) {
+      String original = originalSslProperties.get(property);
+      if (original == null) {
+        System.clearProperty(property);
+      } else {
+        System.setProperty(property, original);
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Flip `<reuseForks>` from `false` to `true` in `kubernetes-client-api/pom.xml`. Locally measured: ~84s → ~37s (-55%) for the module's test suite, no new failures vs. baseline.
- Fix `CertUtilsTest`'s `@AfterEach` which called `System.setProperties(snapshot)` where `snapshot` only held 5 SSL keys. Under `reuseForks=false` this was benign (fresh JVM per class); under `reuseForks=true` it wiped `os.name`, `user.home`, etc. and broke `UtilsTest` with NPE in `Utils.isWindowsOperatingSystem`. Replace the bulk swap with selective save/restore of only the SSL keys the test actually mutates.

Refs #7648 (item 2 of the umbrella issue).