### PR TITLE
chore(build): make JaCoCo opt-in and restore Sonar coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ generate-model: openapi-generate-schema openapi-generate-java-classes
 .PHONY: sonar
 sonar: clean
 	# $(MAVEN_ARGS) ---> -T 1C won't work with sonar analysis (yet)
-	mvn -Psonar install sonar:sonar
+	mvn -Pcoverage,sonar install sonar:sonar
 
 .PHONY: javadoc
 javadoc: clean

--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -231,7 +231,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
+          <reuseForks>true</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>
             <KUBERNETES_MASTER />

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigDisableAutoConfigurationTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigDisableAutoConfigurationTest.java
@@ -255,6 +255,7 @@ class ConfigDisableAutoConfigurationTest {
       @AfterEach
       void tearDown() {
         System.clearProperty("kubernetes.master");
+        System.clearProperty("kubernetes.namespace");
       }
     }
 

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/CertUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/CertUtilsTest.java
@@ -35,8 +35,9 @@ import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -49,28 +50,33 @@ class CertUtilsTest {
 
   private static final String FABRIC8_STORE_PATH = Utils.filePath(CertUtilsTest.class.getResource("/ssl-test/fabric8-store"));
   private static final String FABRIC8_STORE_PASSPHRASE = "fabric8";
-  private Properties systemProperties;
+  private static final String[] MANAGED_SSL_PROPERTIES = {
+      "javax.net.ssl.trustStore",
+      "javax.net.ssl.trustStorePassword",
+      "javax.net.ssl.trustStoreType",
+      "javax.net.ssl.keyStore",
+      "javax.net.ssl.keyStorePassword"
+  };
+  private Map<String, String> originalSslProperties;
 
   @BeforeEach
   public void storeSystemProperties() {
-    systemProperties = new Properties();
-    storeSystemProperty("javax.net.ssl.trustStore");
-    storeSystemProperty("javax.net.ssl.trustStorePassword");
-    storeSystemProperty("javax.net.ssl.trustStoreType");
-    storeSystemProperty("javax.net.ssl.keyStore");
-    storeSystemProperty("javax.net.ssl.keyStorePassword");
-  }
-
-  private void storeSystemProperty(String systemProperty) {
-    String value = System.getProperty(systemProperty);
-    if (Utils.isNotNullOrEmpty(value)) {
-      systemProperties.put(systemProperty, value);
+    originalSslProperties = new HashMap<>();
+    for (String property : MANAGED_SSL_PROPERTIES) {
+      originalSslProperties.put(property, System.getProperty(property));
     }
   }
 
   @AfterEach
   public void resetSystemPropertiesBack() {
-    System.setProperties(systemProperties);
+    for (String property : MANAGED_SSL_PROPERTIES) {
+      String original = originalSslProperties.get(property);
+      if (original == null) {
+        System.clearProperty(property);
+      } else {
+        System.setProperty(property, original);
+      }
+    }
   }
 
   @Test

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/UntrustedCertTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/UntrustedCertTest.java
@@ -41,6 +41,8 @@ public class UntrustedCertTest {
       //We override the config to create a client that doesn't trust all certs.
       Config override = new ConfigBuilder(client.getConfiguration())
           .withTrustCerts(false)
+          .withConnectionTimeout(1000)
+          .withRequestRetryBackoffLimit(0)
           .build();
 
       KubernetesClient client = new DefaultKubernetesClient(override);
@@ -56,6 +58,8 @@ public class UntrustedCertTest {
       Config override = new ConfigBuilder(client.getConfiguration())
           .withTrustCerts(false)
           .withCaCertData(CA_CERT_DATA)
+          .withConnectionTimeout(1000)
+          .withRequestRetryBackoffLimit(0)
           .build();
 
       KubernetesClient client = new DefaultKubernetesClient(override);

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
     <useIncrementalCompilation>false</useIncrementalCompilation>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.deploy.skip>false</maven.deploy.skip>
+    <!-- Default empty argLine; JaCoCo's prepare-agent (coverage profile) sets this property -->
+    <argLine/>
 
     <!-- Core versions -->
     <sundrio.version>0.230.2</sundrio.version>
@@ -1149,29 +1151,11 @@
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-report</id>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <argLine>-Xmx2048m</argLine>
+          <argLine>@{argLine} -Xmx2048m</argLine>
           <environmentVariables>
             <ENV_VAR_EXISTS>value</ENV_VAR_EXISTS>
             <ENV_VAR_EXISTS_BOOLEAN>true</ENV_VAR_EXISTS_BOOLEAN>
@@ -1304,6 +1288,31 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>bom</id>
       <build>


### PR DESCRIPTION
## Summary

Four commits addressing items #2 and #4-#6 of #7648, plus a Sonar
coverage regression spotted along the way:

### `kubernetes-client-api` fork reuse (issue item 2)

`kubernetes-client-api/pom.xml`: flip `<reuseForks>` from `false` to
`true`. Local measurement matches the issue body: ~84s -> ~37s (-55%)
for the kubernetes-client-api test suite.

To make fork reuse safe, `CertUtilsTest`'s `@AfterEach` was calling
`System.setProperties(snapshot)` where `snapshot` only contained 5 SSL
keys — with a fresh JVM per test class (`reuseForks=false`) that was
benign, but with `reuseForks=true` it wiped `os.name`, `user.home`,
etc. and broke `UtilsTest` with NPE in
`Utils.isWindowsOperatingSystem`. Replaced the bulk swap with
selective save/restore of only the SSL keys the test actually mutates.

`ConfigDisableAutoConfigurationTest`'s first `@BeforeEach` set
`kubernetes.namespace=testns` but its `@AfterEach` only cleared
`kubernetes.master`. Harmless with one-shot JVMs; with reused forks it
leaked into `ConfigConstructorTest.configLoadedViaServiceAccount`
which expects the namespace from the mounted serviceaccount file.
Reproduced locally with `-Dsurefire.runOrder=reversealphabetical`,
matching the failure observed on Java 11/17/21 in #7667.

### JaCoCo opt-in via `coverage` profile (issue item 4)

Moved `prepare-agent` and `report` out of the default plugins block
into a new `coverage` profile. Normal PR builds no longer pay the
instrumentation overhead; Sonar opts in via `make sonar` which now
passes `-Pcoverage,sonar`.

### Restore JaCoCo agent attachment (regression fix)

While moving the executions, I noticed the agent never actually
attached: surefire's literal `<argLine>-Xmx2048m</argLine>` (added in
bb954e56ef on 2025-07-16) clobbers the `argLine` Maven property that
JaCoCo writes. Switched to `@{argLine} -Xmx2048m` (late evaluation)
and added an empty default `<argLine/>` property so non-coverage
builds don't pass a literal token to the JVM. Explains the incomplete
Sonar coverage observed since mid-2025.

### `UntrustedCertTest` speedup (issue item 6)

42s -> 3s by setting a short connection timeout and disabling the
default 10x retry backoff on the failing-path tests. Assertions
unchanged. Dominant cost was the retry loop, not the connect timeout.

## Verification

- `mvn test -pl kubernetes-client-api` -> baseline failures only,
  none new from `reuseForks=true`.
- `mvn test -pl kubernetes-client-api -Dsurefire.runOrder=reversealphabetical`
  -> `ConfigConstructorTest.configLoadedViaServiceAccount` passes
  (regression repro before fix; passes after).
- `mvn test -pl kubernetes-tests -Dtest=UntrustedCertTest`
  -> 3 tests, 0 failures, 2.6s.
- Default `mvn test -pl kubernetes-client-api` -> no JaCoCo
  executions, no `*.exec` produced, BUILD SUCCESS.
- `mvn verify -pl kubernetes-client-api -Pcoverage` -> agent attaches,
  `target/jacoco.exec` produced, `target/site/jacoco/index.html`
  generated with package coverage.
- `mvn verify -pl kubernetes-tests` -> `report-aggregate` no-ops
  cleanly without the agent, BUILD SUCCESS.
- `mvn spotless:check` (Java 17) -> BUILD SUCCESS.

Refs #7648