### PR TITLE
chore(kubernetes-client): enable surefire fork reuse

### DIFF
--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -148,7 +148,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
+          <reuseForks>true</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>
             <KUBERNETES_MASTER />

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -139,18 +139,19 @@ class AbstractWatchManagerTest {
     // Given
     final CompletableFuture<?> cf = mock(CompletableFuture.class);
     ExecutorService executor = CommonThreadPool.get();
-    final MockedStatic<Utils> utils = mockStatic(Utils.class);
-    utils.when(() -> Utils.schedule(any(), any(), anyLong(), any())).thenReturn(cf);
-    final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
-    final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
-    awm.baseOperation.context = Mockito.mock(OperationContext.class);
-    Mockito.when(awm.baseOperation.context.getExecutor()).thenReturn(executor);
+    try (MockedStatic<Utils> utils = mockStatic(Utils.class)) {
+      utils.when(() -> Utils.schedule(any(), any(), anyLong(), any())).thenReturn(cf);
+      final WatcherAdapter<HasMetadata> watcher = new WatcherAdapter<>();
+      final WatchManager<HasMetadata> awm = withDefaultWatchManager(watcher);
+      awm.baseOperation.context = Mockito.mock(OperationContext.class);
+      Mockito.when(awm.baseOperation.context.getExecutor()).thenReturn(executor);
 
-    awm.scheduleReconnect(new WatchRequestState());
-    // When
-    awm.cancelReconnect();
-    // Then
-    verify(cf, times(1)).cancel(true);
+      awm.scheduleReconnect(new WatchRequestState());
+      // When
+      awm.cancelReconnect();
+      // Then
+      verify(cf, times(1)).cancel(true);
+    }
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
@@ -114,7 +114,7 @@ class PortForwarderWebsocketListenerTest {
         .singleElement()
         .asInstanceOf(InstanceOfAssertFactories.throwable(RuntimeException.class))
         .hasMessage("Server error");
-    assertThat(in.isOpen()).isFalse();
+    Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> !in.isOpen());
     assertThat(out.isOpen()).isFalse();
   }
 
@@ -164,7 +164,7 @@ class PortForwarderWebsocketListenerTest {
     assertThat(outputContent.toString()).isEmpty();
     assertThat(listener.errorOccurred()).isTrue();
     assertThat(listener.getServerThrowables()).isNotEmpty();
-    assertThat(in.isOpen()).isFalse();
+    await().atMost(1, TimeUnit.SECONDS).until(() -> !in.isOpen());
     assertThat(out.isOpen()).isFalse();
   }
 


### PR DESCRIPTION
## Summary

Item 5 of #7648 — unblock `reuseForks=true` for the `kubernetes-client`
Surefire configuration. Local measurement matches the issue body:
~153s → ~29s for the module test suite, no new failures vs. baseline.
Verified under both default and reverse-alphabetical run orders.

Closes #7648

## Root cause

`AbstractWatchManagerTest.cancelReconnectNonNullAttempt` opened a
`MockedStatic<Utils>` without closing it. With `reuseForks=false` the
JVM died after each test class so the leak was harmless; with
`reuseForks=true` the static mock survived into later test classes
and intercepted `Utils.daemonThreadFactory(...)` calls, returning
Mockito's default (`null`). The null reached
`Executors.newCachedThreadPool(threadFactory)` inside
`BaseClient.DEFAULT_EXECUTOR_SUPPLIER` and tripped the explicit
null-check in `ThreadPoolExecutor.<init>`, surfacing as
`KubernetesClientException` from `KubernetesClientBuilder.build()`
in unrelated \`setUp()\` methods (`ServiceOperationsImplTest`,
`ServiceAccountOperationsImplTest`, `WatchConnectionManagerTest`,
`PodOperationsImpl_CVE2021_20218_Test`).

## Changes

- Wrap the `MockedStatic<Utils>` in try-with-resources so the static
  mocking is deregistered as soon as the test method returns.
- Flip \`<reuseForks>\` from \`false\` to \`true\` in
  \`kubernetes-client/pom.xml\`.