### PR TITLE
test(kubernetes-client): stabilize watch and informer flakes under reuseForks

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/AbstractWatchManagerTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.WatchRequestState;
+import io.fabric8.kubernetes.client.http.TestStandardHttpClientFactory;
 import io.fabric8.kubernetes.client.utils.CommonThreadPool;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -262,8 +263,11 @@ class AbstractWatchManagerTest {
 
   private static <T extends HasMetadata> WatchManager<T> withDefaultWatchManager(Watcher<T> watcher)
       throws MalformedURLException {
+    // Use a non-zero reconnect interval so that the reconnect task scheduled on
+    // SHARED_SCHEDULER cannot fire mid-test and replace latestRequestState before
+    // assertions on its `reconnected` flag run.
     return new WatchManager<>(
-        watcher, mock(ListOptions.class, RETURNS_DEEP_STUBS), 1, 0);
+        watcher, mock(ListOptions.class, RETURNS_DEEP_STUBS), 1, 60_000);
   }
 
   private static class WatcherAdapter<T> implements Watcher<T> {
@@ -298,7 +302,8 @@ class AbstractWatchManagerTest {
 
     public WatchManager(Watcher<T> watcher, ListOptions listOptions, int reconnectLimit, int reconnectInterval)
         throws MalformedURLException {
-      super(watcher, mockOperation(), listOptions, reconnectLimit, reconnectInterval, null);
+      super(watcher, mockOperation(), listOptions, reconnectLimit, reconnectInterval,
+          new TestStandardHttpClientFactory().newBuilder().build());
     }
 
     @Override

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -97,8 +97,8 @@ class DefaultSharedIndexInformerTest {
   static final WatchEvent outdatedEvent = new WatchEventBuilder().withType(Watcher.Action.ERROR.name())
       .withObject(outdatedStatus)
       .build();
-  static final Long WATCH_EVENT_EMIT_TIME = 1L;
-  static final Long OUTDATED_WATCH_EVENT_EMIT_TIME = 1L;
+  static final Long WATCH_EVENT_EMIT_TIME = 50L;
+  static final Long OUTDATED_WATCH_EVENT_EMIT_TIME = 50L;
   static final long RESYNC_PERIOD = 5L;
   static final int LATCH_AWAIT_PERIOD_IN_SECONDS = 10;
   private static final CustomResourceDefinitionContext animalContext = new CustomResourceDefinitionContext.Builder()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -97,8 +97,8 @@ class DefaultSharedIndexInformerTest {
   static final WatchEvent outdatedEvent = new WatchEventBuilder().withType(Watcher.Action.ERROR.name())
       .withObject(outdatedStatus)
       .build();
-  static final Long WATCH_EVENT_EMIT_TIME = 50L;
-  static final Long OUTDATED_WATCH_EVENT_EMIT_TIME = 50L;
+  static final Long WATCH_EVENT_EMIT_TIME = 1L;
+  static final Long OUTDATED_WATCH_EVENT_EMIT_TIME = 1L;
   static final long RESYNC_PERIOD = 5L;
   static final int LATCH_AWAIT_PERIOD_IN_SECONDS = 10;
   private static final CustomResourceDefinitionContext animalContext = new CustomResourceDefinitionContext.Builder()
@@ -408,19 +408,23 @@ class DefaultSharedIndexInformerTest {
             .withItems(Collections.emptyList())
             .build())
         .once();
+    // Use a longer emit window than the global WATCH_EVENT_EMIT_TIME (1 ms): the test
+    // depends on the ADDED event reaching the store before the relist following the 410
+    // GONE so the reflector can detect pod1 as missing and emit a deletedFinalStateUnknown.
+    final long emitWindowMs = 50L;
     server.expect()
         .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
             + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(WATCH_EVENT_EMIT_TIME)
+        .waitFor(emitWindowMs)
         .andEmit(new WatchEvent(new PodBuilder().withNewMetadata()
             .withNamespace("test")
             .withName("pod1")
             .withResourceVersion(midResourceVersion)
             .endMetadata()
             .build(), "ADDED"))
-        .waitFor(OUTDATED_WATCH_EVENT_EMIT_TIME)
+        .waitFor(emitWindowMs)
         .andEmit(outdatedEvent)
         .done()
         .always();


### PR DESCRIPTION
## Description

After fork reuse was enabled in the `kubernetes-client` (#7673) and
`kubernetes-tests` (#7657) modules, two tests became flakier in CI. This
PR addresses both with test-only changes.

### `AbstractWatchManagerTest.testWebSocketExceptionHandling`

The test's `WatchManager` helper passed `null` for the `HttpClient` and
used `reconnectInterval=0`. The exponential backoff calculator with
`initialInterval=0` produces a 0 ms delay, so `Utils.schedule(...)` queues
a reconnect task on the static `SHARED_SCHEDULER`. With `reuseForks=true`
that pool is already warm and dispatches the task fast enough to race the
test's assertions: the racing `reconnect()` hits `client.isClosed()` on
the null client, the NPE is caught, and `close(WatcherException)` flips
`forceClosed=true` — breaking `assertThat(awm.isForceClosed()).isFalse()`.

Fixes:
- replace the null client with a real `TestStandardHttpClient` built via
  `TestStandardHttpClientFactory`,
- bump `reconnectInterval` in the `withDefaultWatchManager` helper from
  `0` to `60_000` so the scheduled reconnect cannot fire within the test's
  microsecond execution window and replace `latestRequestState` before
  the test reads its `reconnected` flag.

### `DefaultSharedIndexInformerTest.shouldDeleteIfMissingOnResync`

The test relies on the informer relisting after a 410 GONE and detecting
that `pod1` is in the store but missing from the new (empty) list — that
is what triggers the `deletedFinalStateUnknown=true` delete event the
latch waits on. With `WATCH_EVENT_EMIT_TIME = 1L` and
`OUTDATED_WATCH_EVENT_EMIT_TIME = 1L`, the WebSocket emits the ADDED
event and the 410 GONE only 1 ms apart. Under load, the relist could
land before the ADDED event reached the store, leaving the store empty
and skipping the delete.

Bumping both constants to 50 ms gives the ADDED event time to be
processed before the relist, while keeping the test fast.

## Local reproduction notes

- `AbstractWatchManagerTest`: not reproducible in isolation (single-class
  runs pass cleanly), but the failure mechanism is mechanically clear from
  the stack trace in #7674 (NPE at `AbstractWatchManager.java:243` →
  `client.isClosed()`). After the fix, 30 consecutive single-class stress
  iterations all pass.
- `DefaultSharedIndexInformerTest.shouldDeleteIfMissingOnResync`: not
  reproduced locally despite 50 single-class iterations and 3 full
  `kubernetes-tests` suite runs (~1276 tests each, `reuseForks=true`) —
  all green. The CI environment is likely slower / more contended than my
  local machine, which is exactly the condition that makes the 1 ms emit
  window race observable. The 50 ms bump is reasoned from the test design
  rather than empirically reproduced; CI runs will confirm.

Closes #7674