### PR TITLE
test(kubernetes-tests): stabilize ResourceTest waitUntilCondition flake (7677)

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -734,7 +734,7 @@ class ResourceTest {
         .open()
         .immediately()
         .andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
-        .waitFor(10)
+        .waitFor(50)
         .andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
         .done()
         .once();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -732,9 +732,7 @@ class ResourceTest {
             "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod&resourceVersion=1&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
-        .immediately()
-        .andEmit(new WatchEvent(conditionNotMetPod, "MODIFIED"))
-        .waitFor(50)
+        .waitFor(500)
         .andEmit(new WatchEvent(conditionMetPod, "MODIFIED"))
         .done()
         .once();


### PR DESCRIPTION
## Description

Fixes the flaky `ResourceTest.testFromServerWaitUntilConditionAlwaysGetsResourceFromServer` reported in #7677.

In CI, the test surfaces as:

```
io.fabric8.kubernetes.client.KubernetesClientTimeoutException:
  Timed out waiting for [10000] milliseconds for [Pod] with name:[pod] in namespace [test].
```

This PR contains two commits:

### 1. Bump `waitFor(10)` → `waitFor(50)` (insufficient)

First attempt — mirrored the narrow fix from #7676. **It did not stabilize the test**; the flake recurred in CI.

### 2. Drop redundant emit, align with `ResourceListTest` pattern

The two-event watch sequence was racy and partly redundant: the list response already populates the cache with the NOT_MET pod (`resourceVersion=1`), so emitting `MODIFIED NOT_MET` (also rv=1) on the watch immediately after upgrade adds no state change while introducing a tight `.immediately()` → `.waitFor(50)` → close window.

Replaced with the proven pattern used in `ResourceListTest.java:211` (single `MODIFIED` event, `waitFor(500)`, `done()`, `once()`).

The test still asserts the same intent:
- list returns NOT_MET
- watch flips cache to MET
- `response` equals the server's MET pod (`assertEquals(conditionMetPod, response)`)
- total request count is 2 (`assertEquals(2, server.getRequestCount())`)

## Note on PodTest.java

`PodTest.java` contains four similar `waitFor(10)` calls in port-forward byte-streaming tests (lines 797-803, 845-851). They drive a different mechanism — a `SocketChannel` read-loop until EOF, with no timeout race against the emit cadence — and are not implicated in #7677, so they are intentionally left untouched. Flagged here as a potential follow-up since past flakes in the Pod test surface area have been observed.

## Verification

- 10x consecutive runs of the targeted test (post-restructure): 10/10 green.
- Full `ResourceTest` class (24 tests): all green.
- The flake itself is not reproducible locally, so CI is the final check.

Refs #7677, #7676