### PR TITLE
test(kubernetes-tests): stabilize WatchTest tryWithResources flake (#7679)

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/WatchTest.java
@@ -77,14 +77,18 @@ class WatchTest {
   @DisplayName("TryWithResources, connects and receives event then receives GONE, should receive first event and then close")
   void testTryWithResourcesConnectsThenReceivesEvent() throws InterruptedException {
     // Given
+    // Use a longer emit window than the file-wide EVENT_WAIT_PERIOD_MS (10 ms): the test
+    // depends on the DELETED event being delivered and processed before the 410 GONE
+    // arrives so that onClose fires with isHttpGone()==true.
+    final long emitWindowMs = 50L;
     server.expect()
         .withPath(
             "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .waitFor(emitWindowMs)
         .andEmit(new WatchEvent(pod1, "DELETED"))
-        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .waitFor(emitWindowMs)
         .andEmit(outdatedEvent())
         .done()
         .once();
@@ -334,14 +338,18 @@ class WatchTest {
   @DisplayName("TryWithResources, connects and receives event then receives GONE, should receive first event and then close")
   void testTryWithResourcesConnectsThenReceivesEventBookmark() throws InterruptedException {
     // Given
+    // Use a longer emit window than the file-wide EVENT_WAIT_PERIOD_MS (10 ms): the test
+    // depends on the BOOKMARK event being delivered and processed before the 410 GONE
+    // arrives so that onClose fires with isHttpGone()==true.
+    final long emitWindowMs = 50L;
     server.expect()
         .withPath(
             "/api/v1/namespaces/test/pods?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dpod1&resourceVersion=1&watch=true")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .waitFor(emitWindowMs)
         .andEmit(new WatchEvent(pod1, "BOOKMARK"))
-        .waitFor(EVENT_WAIT_PERIOD_MS)
+        .waitFor(emitWindowMs)
         .andEmit(outdatedEvent())
         .done()
         .once();


### PR DESCRIPTION
## Summary

Fixes the flaky `WatchTest.testTryWithResourcesConnectsThenReceivesEvent`
test reported in #7679 (and the structurally identical
`testTryWithResourcesConnectsThenReceivesEventBookmark`).

## Background

After surefire fork reuse was enabled in kubernetes-tests (#7657), the
test failed in CI on 2026-04-28:

```
Tests run: 13, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 14.43 s
testTryWithResourcesConnectsThenReceivesEvent -- Time elapsed: 10.16 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
  at WatchTest.java:113
```

Line 113 is `assertTrue(closeLatch.await(10, TimeUnit.SECONDS))`. The
preceding `deleteLatch` await had succeeded, so the WebSocket opened
and the DELETED event was received, but `Watcher.onClose(cause)` either
did not fire with `isHttpGone()==true` or the 410 GONE event never
reached the watcher within 10 s.

## Root cause

The mock setup uses two `waitFor(EVENT_WAIT_PERIOD_MS).andEmit(...)`
calls with `EVENT_WAIT_PERIOD_MS = 10L`, which schedules the DELETED
event and the 410 GONE event in tight succession through the mock's
single-threaded scheduler. On slow CI runners with a cold Vert.x
eventloop (a `BlockedThreadChecker - Thread vert.x-eventloop-thread-1
has been blocked for 2236 ms` warning is observable even on local
runs), this 10 ms window is too tight: the DELETED event delivery /
processing can overlap with the 410 GONE arrival enough that the
watcher's `onClose` is invoked with a non-`HttpGone` cause, which then
fails the assertion silently inside the `SerialExecutor` callback —
swallowed by `SerialExecutor.java:62-77`'s `catch (Throwable)` and
delegated to `uncaughtExceptionHandler`, so `closeLatch.countDown()` is
never reached and the test times out.

This is the same family of fork-reuse-induced flakes that #7676
addressed for `AbstractWatchManagerTest.testWebSocketExceptionHandling`
and `DefaultSharedIndexInformerTest.shouldDeleteIfMissingOnResync`.

## Investigation

A read-only investigation of `AbstractWatchManager`,
`WatcherWebSocketListener`, `VertxWebSocket`, `VertxMockWebSocket`, and
`WebSocketSession` did not surface a deliverable production-code
defect:

- The watch manager correctly produces an `HttpGone` cause from
  `onStatus(410)` (`AbstractWatchManager.java:400-403`).
- `WatcherException.isHttpGone()` correctly returns true for both
  `cause.getCode()==410` and `cause.getStatus().getCode()==410`.
- `VertxWebSocket.init()` deliberately uses `endHandler` (not
  `closeHandler`) to ensure the close is processed in frame order
  after all messages.
- The mock server schedules text frames and the close frame on the
  same Vert.x channel pipeline, so wire-level ordering is preserved.

The remaining race is at the test-harness level: the 10 ms window is
an implicit assumption about delivery latency, not a product
guarantee.

## Fix

Mirror the precedent in #7676's second commit (`987d83396d`): inline
a local `emitWindowMs = 50L` for *only* the affected tests, leaving
the file-wide `EVENT_WAIT_PERIOD_MS = 10L` untouched so the other ~11
tests in the class are not widened.

Both `testTryWithResourcesConnectsThenReceivesEvent` and the
structurally identical
`testTryWithResourcesConnectsThenReceivesEventBookmark` (BOOKMARK +
410 GONE pattern, same race exposure) are widened to 50 ms.

## Verification

- 30 / 30 single-test loop runs PASS after the fix
- Full `WatchTest` class (13 tests) PASS in 18.6 s
- `mvn spotless:check` clean
- Runtime impact (mean of 5 runs each):
  - Before: 6.746 s
  - After:  6.830 s
  - **Δ ≈ +84 ms**, within the noise floor

## Notes

- The original flake could not be reproduced locally on a multi-core
  dev box even under CPU pressure (130 pre-fix runs all PASS); the
  flake is CI-specific. The fix's effectiveness in CI is inferred
  from the #7676 precedent rather than directly demonstrated locally.
- No production-code change was made — this is a pure test-side
  widening, consistent with the #7676 precedent.

Refs #7679