### PR TITLE
chore(build): use evergreen 999-SNAPSHOT version

### DIFF
--- a/bom-generator-plugin/pom.xml
+++ b/bom-generator-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/chaos-tests/pom.xml
+++ b/chaos-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>chaos-tests</artifactId>

--- a/crd-generator/api-v2/pom.xml
+++ b/crd-generator/api-v2/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/crd-generator/api/pom.xml
+++ b/crd-generator/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/crd-generator/apt/pom.xml
+++ b/crd-generator/apt/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/crd-generator/cli/pom.xml
+++ b/crd-generator/cli/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/crd-generator/collector/pom.xml
+++ b/crd-generator/collector/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/crd-generator/maven-plugin/pom.xml
+++ b/crd-generator/maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>crd-generator-parent</artifactId>

--- a/crd-generator/test-apt/pom.xml
+++ b/crd-generator/test-apt/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/crd-generator/test/pom.xml
+++ b/crd-generator/test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>crd-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/certmanager/client/pom.xml
+++ b/extensions/certmanager/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>certmanager-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>certmanager-client</artifactId>

--- a/extensions/certmanager/examples/pom.xml
+++ b/extensions/certmanager/examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>certmanager-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>certmanager-examples</artifactId>

--- a/extensions/certmanager/model/pom.xml
+++ b/extensions/certmanager/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>certmanager-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>certmanager-model</artifactId>

--- a/extensions/certmanager/pom.xml
+++ b/extensions/certmanager/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-extensions</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>certmanager-extension-pom</artifactId>

--- a/extensions/certmanager/tests/pom.xml
+++ b/extensions/certmanager/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>certmanager-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>certmanager-tests</artifactId>

--- a/extensions/chaosmesh/client/pom.xml
+++ b/extensions/chaosmesh/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>chaosmesh</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>chaosmesh-client</artifactId>

--- a/extensions/chaosmesh/examples/pom.xml
+++ b/extensions/chaosmesh/examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>chaosmesh</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>chaosmesh-examples</artifactId>

--- a/extensions/chaosmesh/model/pom.xml
+++ b/extensions/chaosmesh/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>chaosmesh</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>chaosmesh-model</artifactId>

--- a/extensions/chaosmesh/pom.xml
+++ b/extensions/chaosmesh/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kubernetes-extensions</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>chaosmesh</artifactId>

--- a/extensions/chaosmesh/tests/pom.xml
+++ b/extensions/chaosmesh/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>chaosmesh</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>chaosmesh-tests</artifactId>

--- a/extensions/istio/client/pom.xml
+++ b/extensions/istio/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>istio-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>istio-client</artifactId>

--- a/extensions/istio/examples/pom.xml
+++ b/extensions/istio/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>istio-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>istio-examples</artifactId>

--- a/extensions/istio/model/pom.xml
+++ b/extensions/istio/model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>istio-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>istio-model</artifactId>

--- a/extensions/istio/pom.xml
+++ b/extensions/istio/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-extensions</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>istio-extension-pom</artifactId>

--- a/extensions/istio/tests/pom.xml
+++ b/extensions/istio/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>istio-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>istio-tests</artifactId>

--- a/extensions/knative/client/pom.xml
+++ b/extensions/knative/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>knative-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>knative-client</artifactId>

--- a/extensions/knative/examples/pom.xml
+++ b/extensions/knative/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>knative-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>knative-examples</artifactId>

--- a/extensions/knative/model/pom.xml
+++ b/extensions/knative/model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>knative-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>knative-model</artifactId>

--- a/extensions/knative/pom.xml
+++ b/extensions/knative/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-extensions</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>knative-extension-pom</artifactId>

--- a/extensions/knative/tests/pom.xml
+++ b/extensions/knative/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>knative-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>knative-tests</artifactId>

--- a/extensions/open-cluster-management/client/pom.xml
+++ b/extensions/open-cluster-management/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>open-cluster-management</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>open-cluster-management-client</artifactId>

--- a/extensions/open-cluster-management/examples/pom.xml
+++ b/extensions/open-cluster-management/examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>open-cluster-management</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openclustermanagement-examples</artifactId>

--- a/extensions/open-cluster-management/model/pom.xml
+++ b/extensions/open-cluster-management/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>open-cluster-management</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>open-cluster-management-model</artifactId>

--- a/extensions/open-cluster-management/pom.xml
+++ b/extensions/open-cluster-management/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kubernetes-extensions</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>open-cluster-management</artifactId>

--- a/extensions/open-cluster-management/tests/pom.xml
+++ b/extensions/open-cluster-management/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>open-cluster-management</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>open-cluster-management-tests</artifactId>

--- a/extensions/open-virtual-network/client/pom.xml
+++ b/extensions/open-virtual-network/client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/extensions/open-virtual-network/model/pom.xml
+++ b/extensions/open-virtual-network/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>ovn</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovn-model</artifactId>

--- a/extensions/open-virtual-network/pom.xml
+++ b/extensions/open-virtual-network/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kubernetes-extensions</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovn</artifactId>

--- a/extensions/open-virtual-network/tests/pom.xml
+++ b/extensions/open-virtual-network/tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <artifactId>ovn-tests</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../kubernetes-model-generator</relativePath>
   </parent>
 

--- a/extensions/tekton/client/pom.xml
+++ b/extensions/tekton/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>tekton-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>tekton-client</artifactId>

--- a/extensions/tekton/examples/pom.xml
+++ b/extensions/tekton/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>tekton-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>tekton-examples</artifactId>

--- a/extensions/tekton/model/pom.xml
+++ b/extensions/tekton/model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>tekton-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>tekton-model</artifactId>

--- a/extensions/tekton/pom.xml
+++ b/extensions/tekton/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-extensions</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>tekton-extension-pom</artifactId>

--- a/extensions/tekton/tests/pom.xml
+++ b/extensions/tekton/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>tekton-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>tekton-tests</artifactId>

--- a/extensions/verticalpodautoscaler/client/pom.xml
+++ b/extensions/verticalpodautoscaler/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>verticalpodautoscaler-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>verticalpodautoscaler-client</artifactId>

--- a/extensions/verticalpodautoscaler/examples/pom.xml
+++ b/extensions/verticalpodautoscaler/examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>verticalpodautoscaler-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>verticalpodautoscaler-examples</artifactId>

--- a/extensions/verticalpodautoscaler/model/pom.xml
+++ b/extensions/verticalpodautoscaler/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>verticalpodautoscaler-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>verticalpodautoscaler-model</artifactId>

--- a/extensions/verticalpodautoscaler/pom.xml
+++ b/extensions/verticalpodautoscaler/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-extensions</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>verticalpodautoscaler-extension-pom</artifactId>

--- a/extensions/verticalpodautoscaler/tests/pom.xml
+++ b/extensions/verticalpodautoscaler/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>verticalpodautoscaler-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>verticalpodautoscaler-tests</artifactId>

--- a/extensions/volcano/client/pom.xml
+++ b/extensions/volcano/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volcano-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volcano-client</artifactId>

--- a/extensions/volcano/examples/pom.xml
+++ b/extensions/volcano/examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volcano-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volcano-examples</artifactId>

--- a/extensions/volcano/model/pom.xml
+++ b/extensions/volcano/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volcano-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volcano-model</artifactId>

--- a/extensions/volcano/pom.xml
+++ b/extensions/volcano/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-extensions</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volcano-extension-pom</artifactId>

--- a/extensions/volcano/tests/pom.xml
+++ b/extensions/volcano/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volcano-extension-pom</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volcano-tests</artifactId>

--- a/extensions/volumesnapshot/client/pom.xml
+++ b/extensions/volumesnapshot/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volumesnapshot</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volumesnapshot-client</artifactId>

--- a/extensions/volumesnapshot/examples/pom.xml
+++ b/extensions/volumesnapshot/examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volumesnapshot</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volumesnapshot-examples</artifactId>

--- a/extensions/volumesnapshot/model/pom.xml
+++ b/extensions/volumesnapshot/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volumesnapshot</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volumesnapshot-model</artifactId>

--- a/extensions/volumesnapshot/pom.xml
+++ b/extensions/volumesnapshot/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kubernetes-extensions</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volumesnapshot</artifactId>

--- a/extensions/volumesnapshot/tests/pom.xml
+++ b/extensions/volumesnapshot/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>volumesnapshot</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>volumesnapshot-tests</artifactId>

--- a/generator-annotations/pom.xml
+++ b/generator-annotations/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>generator-annotations</artifactId>

--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-httpclient-jdk</artifactId>

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-httpclient-jetty</artifactId>

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-httpclient-okhttp</artifactId>

--- a/httpclient-vertx-5/pom.xml
+++ b/httpclient-vertx-5/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-httpclient-vertx-5</artifactId>

--- a/httpclient-vertx/pom.xml
+++ b/httpclient-vertx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-httpclient-vertx</artifactId>

--- a/java-generator/benchmark/pom.xml
+++ b/java-generator/benchmark/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>java-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-generator-benchmark</artifactId>

--- a/java-generator/cli/pom.xml
+++ b/java-generator/cli/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>java-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java-generator/core/pom.xml
+++ b/java-generator/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>java-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java-generator/gradle-plugin/pom.xml
+++ b/java-generator/gradle-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>java-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <!--

--- a/java-generator/it/pom.xml
+++ b/java-generator/it/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>java-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-generator-integration-tests</artifactId>

--- a/java-generator/maven-plugin/pom.xml
+++ b/java-generator/maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>java-generator-parent</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-generator-maven-plugin</artifactId>

--- a/java-generator/pom.xml
+++ b/java-generator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-generator-parent</artifactId>

--- a/junit/kube-api-test/client-inject/pom.xml
+++ b/junit/kube-api-test/client-inject/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>io.fabric8</groupId>
       <artifactId>kube-api-test-parent</artifactId>
-      <version>7.7-SNAPSHOT</version>
+      <version>999-SNAPSHOT</version>
     </parent>
 
     <artifactId>kube-api-test-client-inject</artifactId>

--- a/junit/kube-api-test/core/pom.xml
+++ b/junit/kube-api-test/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.fabric8</groupId>
         <artifactId>kube-api-test-parent</artifactId>
-        <version>7.7-SNAPSHOT</version>
+        <version>999-SNAPSHOT</version>
     </parent>
 
     <artifactId>kube-api-test</artifactId>

--- a/junit/kube-api-test/pom.xml
+++ b/junit/kube-api-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/junit/kubernetes-junit-jupiter-autodetected/pom.xml
+++ b/junit/kubernetes-junit-jupiter-autodetected/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/junit/kubernetes-junit-jupiter/pom.xml
+++ b/junit/kubernetes-junit-jupiter/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/junit/kubernetes-server-mock/pom.xml
+++ b/junit/kubernetes-server-mock/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/junit/mockwebserver/pom.xml
+++ b/junit/mockwebserver/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-client-api</artifactId>

--- a/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/pom.xml
+++ b/kubernetes-client-deps-compatibility-tests/kubernetes-client-httpclient-jpms/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-deps-compatibility-tests</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-client-deps-compatibility-tests/kubernetes-client-init-bc-fips/pom.xml
+++ b/kubernetes-client-deps-compatibility-tests/kubernetes-client-init-bc-fips/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-deps-compatibility-tests</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-client-deps-compatibility-tests/pom.xml
+++ b/kubernetes-client-deps-compatibility-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <name>Fabric8 :: Kubernetes :: Dependency Compatibility :: Tests</name>

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-client</artifactId>

--- a/kubernetes-examples/pom.xml
+++ b/kubernetes-examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-examples</artifactId>

--- a/kubernetes-itests/pom.xml
+++ b/kubernetes-itests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-itests</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-admissionregistration/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-admissionregistration/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-admissionregistration</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-apiextensions/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-apiextensions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-apiextensions</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-apps/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-apps/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-apps</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-autoscaling</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-batch/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-batch/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-batch</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-certificates/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-certificates/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-certificates</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-common/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-common</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-coordination/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-coordination/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-coordination</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-core/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-core</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-discovery/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-discovery/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-discovery</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-events/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-events/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-events</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-extensions/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-extensions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-extensions</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-flowcontrol/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-flowcontrol/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-flowcontrol</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-gatewayapi/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-gatewayapi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-gatewayapi</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-kustomize/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-kustomize/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-kustomize</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-metrics/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-metrics/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-metrics</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-networking/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-networking/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-networking</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-node/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-node/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-node</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-policy/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-policy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-policy</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-rbac/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-rbac/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-rbac</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-resource/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-resource/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-resource</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-scheduling/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-scheduling/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-scheduling</artifactId>

--- a/kubernetes-model-generator/kubernetes-model-storageclass/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-storageclass/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-storageclass</artifactId>

--- a/kubernetes-model-generator/openapi/maven-plugin/pom.xml
+++ b/kubernetes-model-generator/openapi/maven-plugin/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-model-generator/openapi/validator/pom.xml
+++ b/kubernetes-model-generator/openapi/validator/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-model-generator/openshift-model-autoscaling/pom.xml
+++ b/kubernetes-model-generator/openshift-model-autoscaling/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-autoscaling</artifactId>

--- a/kubernetes-model-generator/openshift-model-config/pom.xml
+++ b/kubernetes-model-generator/openshift-model-config/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-config</artifactId>

--- a/kubernetes-model-generator/openshift-model-console/pom.xml
+++ b/kubernetes-model-generator/openshift-model-console/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-console</artifactId>

--- a/kubernetes-model-generator/openshift-model-hive/pom.xml
+++ b/kubernetes-model-generator/openshift-model-hive/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-hive</artifactId>

--- a/kubernetes-model-generator/openshift-model-insights/pom.xml
+++ b/kubernetes-model-generator/openshift-model-insights/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-insights</artifactId>

--- a/kubernetes-model-generator/openshift-model-installer/pom.xml
+++ b/kubernetes-model-generator/openshift-model-installer/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-installer</artifactId>

--- a/kubernetes-model-generator/openshift-model-machine/pom.xml
+++ b/kubernetes-model-generator/openshift-model-machine/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-machine</artifactId>

--- a/kubernetes-model-generator/openshift-model-machineconfiguration/pom.xml
+++ b/kubernetes-model-generator/openshift-model-machineconfiguration/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-machineconfiguration</artifactId>

--- a/kubernetes-model-generator/openshift-model-miscellaneous/pom.xml
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-miscellaneous</artifactId>

--- a/kubernetes-model-generator/openshift-model-monitoring/pom.xml
+++ b/kubernetes-model-generator/openshift-model-monitoring/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-monitoring</artifactId>

--- a/kubernetes-model-generator/openshift-model-operator/pom.xml
+++ b/kubernetes-model-generator/openshift-model-operator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-operator</artifactId>

--- a/kubernetes-model-generator/openshift-model-operatorhub/pom.xml
+++ b/kubernetes-model-generator/openshift-model-operatorhub/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-operatorhub</artifactId>

--- a/kubernetes-model-generator/openshift-model-storageversionmigrator/pom.xml
+++ b/kubernetes-model-generator/openshift-model-storageversionmigrator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-storageversionmigrator</artifactId>

--- a/kubernetes-model-generator/openshift-model-tuned/pom.xml
+++ b/kubernetes-model-generator/openshift-model-tuned/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-tuned</artifactId>

--- a/kubernetes-model-generator/openshift-model-whereabouts/pom.xml
+++ b/kubernetes-model-generator/openshift-model-whereabouts/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model-whereabouts</artifactId>

--- a/kubernetes-model-generator/openshift-model/pom.xml
+++ b/kubernetes-model-generator/openshift-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-model-generator</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-model</artifactId>

--- a/kubernetes-model-generator/pom.xml
+++ b/kubernetes-model-generator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-model-generator</artifactId>

--- a/kubernetes-tests/pom.xml
+++ b/kubernetes-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-test</artifactId>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-log4j</artifactId>

--- a/openshift-client-api/pom.xml
+++ b/openshift-client-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-client-api</artifactId>

--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>openshift-client</artifactId>

--- a/platforms/karaf/features/pom.xml
+++ b/platforms/karaf/features/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>karaf</artifactId>
     <groupId>io.fabric8.kubernetes</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-karaf</artifactId>

--- a/platforms/karaf/itests/pom.xml
+++ b/platforms/karaf/itests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>karaf</artifactId>
     <groupId>io.fabric8.kubernetes</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-karaf-itests</artifactId>

--- a/platforms/karaf/pom.xml
+++ b/platforms/karaf/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.fabric8.kubernetes</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>karaf</artifactId>

--- a/platforms/pom.xml
+++ b/platforms/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <groupId>io.fabric8.kubernetes</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>kubernetes-client-project</artifactId>
-  <version>7.7-SNAPSHOT</version>
+  <version>999-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Fabric8 :: Kubernetes :: Project</name>
@@ -206,7 +206,7 @@
     </osgi.include.resources.default>
     <osgi.include.resources>${osgi.include.resources.default}</osgi.include.resources>
     <karaf.itest.skip>false</karaf.itest.skip>
-    <project.build.outputTimestamp>2026-03-05T11:19:34Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-04-29T07:19:33Z</project.build.outputTimestamp>
     <validation-api.version>2.0.1.Final</validation-api.version>
     <revapi.version>0.15.1</revapi.version>
     <revapi-java.version>0.28.4</revapi-java.version>

--- a/uberjar/pom.xml
+++ b/uberjar/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kubernetes-client-project</artifactId>
     <groupId>io.fabric8</groupId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>kubernetes-openshift-uberjar</artifactId>

--- a/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
+++ b/uberjar/src/test/java/io/fabric8/kubernetes/clnt/UberJarTest.java
@@ -148,11 +148,14 @@ class UberJarTest {
   }
 
   private String getMajorVersion(String projectVersion) {
-    return projectVersion.split("\\.")[0];
+    return projectVersion.split("[.\\-]")[0];
   }
 
   private String getMinorVersion(String projectVersion) {
     String[] versionParts = projectVersion.split("\\.");
+    if (versionParts.length < 2) {
+      return "0";
+    }
     String minorPatchVersion = projectVersion.substring(versionParts[0].length() + 1);
     if (minorPatchVersion.contains("-SNAPSHOT")) { // SNAPSHOT VERSION
       return minorPatchVersion.split("-")[0];

--- a/zjsonpatch/pom.xml
+++ b/zjsonpatch/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>kubernetes-client-project</artifactId>
-    <version>7.7-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
 
   <artifactId>zjsonpatch</artifactId>


### PR DESCRIPTION
## Summary
- Sets the project version to `999-SNAPSHOT` across all 141 pom.xml files using `mvn versions:set`
- Downstream projects can now depend on a stable snapshot version string without updating it each release cycle
- Follows the Quarkus evergreen snapshot pattern

Fixes #7615

## Test plan
- [x] Verify `./mvnw clean install -DskipTests` builds successfully with `999-SNAPSHOT`
- [ ] Verify nightly snapshot workflow publishes `999-SNAPSHOT` artifacts
- [ ] Verify release workflow can override version via `versions:set` before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)