### PR TITLE
test(kubernetes-tests): plain HTTP mocks and explicit delete gracePeriod

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/APIServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/APIServiceTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class APIServiceTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -97,7 +97,7 @@ class APIServiceTest {
         .once();
 
     // When
-    boolean isDeleted = client.apiServices().withName("v1alpha1.demo.fabric8.io").delete().size() == 1;
+    boolean isDeleted = client.apiServices().withName("v1alpha1.demo.fabric8.io").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(isDeleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/BindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/BindingTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class BindingTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIDriverTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIDriverTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CSIDriverTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -85,7 +85,7 @@ class CSIDriverTest {
         .once();
 
     // When
-    boolean isDeleted = client.storage().csiDrivers().withName("c1").delete().size() == 1;
+    boolean isDeleted = client.storage().csiDrivers().withName("c1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSINodeTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSINodeTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CSINodeTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -85,7 +85,7 @@ class CSINodeTest {
         .once();
 
     // When
-    boolean isDeleted = client.storage().csiNodes().withName("c1").delete().size() == 1;
+    boolean isDeleted = client.storage().csiNodes().withName("c1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIStorageCapacityTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CSIStorageCapacityTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CSIStorageCapacityTest {
   KubernetesMockServer server;
   private KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CertificateSigningRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CertificateSigningRequestTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CertificateSigningRequestTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterRoleBindingCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterRoleBindingCrudTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class ClusterRoleBindingCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(ClusterRoleBindingCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterRoleCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterRoleCrudTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class ClusterRoleCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(ClusterRoleCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterRoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterRoleTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterRoleTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterTrustBundleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ClusterTrustBundleTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterTrustBundleTest {
   KubernetesMockServer server;
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ComponentStatusTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ComponentStatusTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ComponentStatusTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapCrudTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class ConfigMapCrudTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ConfigMapTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ConfigMapTest {
 
   KubernetesMockServer server;
@@ -82,7 +82,7 @@ class ConfigMapTest {
         .always();
 
     MixedOperation<ConfigMap, ConfigMapList, Resource<ConfigMap>> configMaps = client.configMaps();
-    assertTrue(configMaps.delete().size() == 1);
+    assertTrue(configMaps.withGracePeriod(0).delete().size() == 1);
 
     server.expect()
         .delete()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ControllerRevisionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ControllerRevisionTest.java
@@ -100,7 +100,8 @@ class ControllerRevisionTest {
         .once();
 
     // When
-    boolean isDeleted = client.apps().controllerRevisions().inNamespace("default").withName("cr1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.apps().controllerRevisions().inNamespace("default").withName("cr1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ControllerRevisionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ControllerRevisionTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ControllerRevisionTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -100,7 +100,7 @@ class ControllerRevisionTest {
         .once();
 
     // When
-    boolean isDeleted = client.apps().controllerRevisions().inNamespace("default").withName("cr1").delete().size() == 1;
+    boolean isDeleted = client.apps().controllerRevisions().inNamespace("default").withName("cr1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrReplaceResourceTest.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CreateOrReplaceResourceTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CreateOrTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CreateOrTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobCrudTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class CronJobCrudTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CronJobTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CronJobTest {
 
   KubernetesMockServer server;
@@ -188,10 +188,10 @@ class CronJobTest {
             .build())
         .once();
 
-    boolean deleted = client.batch().cronjobs().withName("cronJob1").delete().size() == 1;
+    boolean deleted = client.batch().cronjobs().withName("cronJob1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.batch().cronjobs().withName("cronJob2").delete().size() == 1;
+    deleted = client.batch().cronjobs().withName("cronJob2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CrudInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CrudInformerTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class CrudInformerTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrud1109Test.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrud1109Test.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class CustomResourceCrud1109Test {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class CustomResourceCrudTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudWithCRDContextTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceCrudWithCRDContextTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class CustomResourceCrudWithCRDContextTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceDefinitionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceDefinitionTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CustomResourceDefinitionTest {
 
   KubernetesMockServer server;
@@ -125,7 +125,7 @@ class CustomResourceDefinitionTest {
         .andReturn(200, customResourceDefinition).once();
 
     boolean deleted = client.apiextensions().v1beta1().customResourceDefinitions().withName("sparkclusters.radanalytics.io")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/CustomResourceTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CustomResourceTest {
   private static final Long WATCH_EVENT_PERIOD = 5L;
 
@@ -225,7 +225,7 @@ class CustomResourceTest {
 
     // When
     boolean result = client.genericKubernetesResources(customResourceDefinitionContext).inNamespace("ns1")
-        .withName("example-hello").delete().size() == 1;
+        .withName("example-hello").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(result);
@@ -342,7 +342,7 @@ class CustomResourceTest {
   @Test
   void testDeleteWithNonExistentResource() throws IOException {
     assertThat(client.genericKubernetesResources(customResourceDefinitionContext).inNamespace("ns2").withName("example-hello")
-        .delete().size() == 1)
+        .withGracePeriod(0).delete().size() == 1)
         .isFalse();
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -85,7 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class DefaultSharedIndexInformerTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class DeploymentCrudTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class DeploymentTest {
 
   KubernetesMockServer server;
@@ -241,13 +241,13 @@ class DeploymentTest {
         .andReturn(200, new DeploymentBuilder(deployment2).editSpec().withReplicas(0).endSpec().build())
         .times(5);
 
-    boolean deleted = client.apps().deployments().withName("deployment1").delete().size() == 1;
+    boolean deleted = client.apps().deployments().withName("deployment1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.apps().deployments().withName("deployment2").delete().size() == 1;
+    deleted = client.apps().deployments().withName("deployment2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.apps().deployments().inNamespace("ns1").withName("deployment2").delete().size() == 1;
+    deleted = client.apps().deployments().inNamespace("ns1").withName("deployment2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 
@@ -320,7 +320,7 @@ class DeploymentTest {
     Boolean deleted = client.apps().deployments().inAnyNamespace().delete(deployment1, deployment2);
     assertTrue(deleted);
 
-    deleted = client.resource(deployment3).delete().size() == 1;
+    deleted = client.resource(deployment3).withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentV1beta1Test.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentV1beta1Test.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class DeploymentV1beta1Test {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EndpointSliceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EndpointSliceTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class EndpointSliceTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EndpointsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EndpointsTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class EndpointsTest {
 
   KubernetesMockServer server;
@@ -128,13 +128,13 @@ public class EndpointsTest {
     server.expect().withPath("/api/v1/namespaces/ns1/endpoints/endpoint2").andReturn(200, new EndpointsBuilder().build())
         .once();
 
-    boolean deleted = client.endpoints().inNamespace("test").withName("endpoint1").delete().size() == 1;
+    boolean deleted = client.endpoints().inNamespace("test").withName("endpoint1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.endpoints().withName("endpoint2").delete().size() == 1;
+    deleted = client.endpoints().withName("endpoint2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.endpoints().inNamespace("ns1").withName("endpoint2").delete().size() == 1;
+    deleted = client.endpoints().inNamespace("ns1").withName("endpoint2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ErrorMessageTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ErrorMessageTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ErrorMessageTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/EventTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class EventTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/FlowSchemaTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class FlowSchemaTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -106,7 +106,7 @@ class FlowSchemaTest {
         .once();
 
     // When
-    boolean isDeleted = client.flowControl().v1beta1().flowSchema().withName("flowschema1").delete().size() == 1;
+    boolean isDeleted = client.flowControl().v1beta1().flowSchema().withName("flowschema1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/FlowSchemaTest.java
@@ -106,7 +106,8 @@ class FlowSchemaTest {
         .once();
 
     // When
-    boolean isDeleted = client.flowControl().v1beta1().flowSchema().withName("flowschema1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.flowControl().v1beta1().flowSchema().withName("flowschema1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/GenerationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/GenerationTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class GenerationTest {
 
   private final static String NAMESPACE = "test-namespace";

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/HttpServerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/HttpServerTest.java
@@ -24,7 +24,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Test;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class HttpServerTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/IPAddressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/IPAddressTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class IPAddressTest {
   KubernetesMockServer server;
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/IngressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/IngressTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class IngressTest {
 
   KubernetesMockServer server;
@@ -124,13 +124,13 @@ public class IngressTest {
     server.expect().withPath("/apis/extensions/v1beta1/namespaces/ns1/ingresses/ingress2")
         .andReturn(200, new IngressBuilder().build()).once();
 
-    boolean deleted = client.extensions().ingress().withName("ingress1").delete().size() == 1;
+    boolean deleted = client.extensions().ingress().withName("ingress1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.extensions().ingress().withName("ingress2").delete().size() == 1;
+    deleted = client.extensions().ingress().withName("ingress2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.extensions().ingress().inNamespace("ns1").withName("ingress2").delete().size() == 1;
+    deleted = client.extensions().ingress().inNamespace("ns1").withName("ingress2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/JobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/JobTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class JobTest {
 
   KubernetesMockServer server;
@@ -169,10 +169,10 @@ public class JobTest {
         .endStatus()
         .build()).times(5);
 
-    boolean deleted = client.batch().v1().jobs().withName("job1").delete().size() == 1;
+    boolean deleted = client.batch().v1().jobs().withName("job1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.batch().v1().jobs().withName("job2").delete().size() == 1;
+    deleted = client.batch().v1().jobs().withName("job2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesListTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class KubernetesListTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/KubernetesMockServerTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class KubernetesMockServerTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LabelTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LabelTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class LabelTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionCrudTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.fabric8.kubernetes.client.mock.LeaderElectionTest.testAndAssertSingleLeader;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 @DisplayName("LeaderElection runs on Kubernetes Mock Server in CRUD mode")
 class LeaderElectionCrudTest {
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class LeaderElectionTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LimitRangeLoadTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LimitRangeLoadTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class LimitRangeLoadTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LoadTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class LoadTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetadataCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetadataCrudTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class MetadataCrudTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/MetricsTest.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MetricsTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NamespaceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NamespaceTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class NamespaceTest {
 
   KubernetesMockServer server;
@@ -122,7 +122,7 @@ public class NamespaceTest {
   @Test
   public void testDelete() {
     server.expect().withPath("/api/v1/namespaces/namespace1").andReturn(200, new NamespaceBuilder().build()).once();
-    boolean deleted = client.namespaces().withName("namespace1").delete().size() == 1;
+    boolean deleted = client.namespaces().withName("namespace1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkPolicyCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkPolicyCrudTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class NetworkPolicyCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(NetworkPolicyCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkingV1IngressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkingV1IngressTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class NetworkingV1IngressTest {
 
   KubernetesMockServer server;
@@ -143,13 +143,13 @@ class NetworkingV1IngressTest {
     server.expect().withPath("/apis/networking.k8s.io/v1/namespaces/ns1/ingresses/ingress2")
         .andReturn(HttpURLConnection.HTTP_OK, new IngressBuilder().build()).once();
 
-    boolean deleted = client.network().v1().ingresses().withName("ingress1").delete().size() == 1;
+    boolean deleted = client.network().v1().ingresses().withName("ingress1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.network().v1().ingresses().withName("ingress2").delete().size() == 1;
+    deleted = client.network().v1().ingresses().withName("ingress2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.network().v1().ingresses().inNamespace("ns1").withName("ingress2").delete().size() == 1;
+    deleted = client.network().v1().ingresses().inNamespace("ns1").withName("ingress2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkingV1beta1IngressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NetworkingV1beta1IngressTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class NetworkingV1beta1IngressTest {
 
   KubernetesClient client;
@@ -138,13 +138,13 @@ class NetworkingV1beta1IngressTest {
     server.expect().withPath("/apis/networking.k8s.io/v1beta1/namespaces/ns1/ingresses/ingress2")
         .andReturn(200, new IngressBuilder().build()).once();
 
-    boolean deleted = client.network().ingress().withName("ingress1").delete().size() == 1;
+    boolean deleted = client.network().ingress().withName("ingress1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.network().ingress().withName("ingress2").delete().size() == 1;
+    deleted = client.network().ingress().withName("ingress2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.network().ingress().inNamespace("ns1").withName("ingress2").delete().size() == 1;
+    deleted = client.network().ingress().inNamespace("ns1").withName("ingress2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeMetricsTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class NodeMetricsTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/NodeTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class NodeTest {
 
   KubernetesMockServer server;
@@ -69,13 +69,13 @@ public class NodeTest {
     server.expect().withPath("/api/v1/nodes/node1").andReturn(200, new PodBuilder().build()).once();
     server.expect().withPath("/api/v1/nodes/node2").andReturn(200, new PodBuilder().build()).once();
 
-    boolean deleted = client.nodes().withName("node1").delete().size() == 1;
+    boolean deleted = client.nodes().withName("node1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.nodes().withName("node2").delete().size() == 1;
+    deleted = client.nodes().withName("node2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.nodes().withName("node3").delete().size() == 1;
+    deleted = client.nodes().withName("node3").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PersistentVolumeClaimTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PersistentVolumeClaimTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PersistentVolumeClaimTest {
 
   KubernetesMockServer server;
@@ -138,10 +138,10 @@ class PersistentVolumeClaimTest {
         .size() == 1;
     assertTrue(deleted);
 
-    deleted = client.persistentVolumeClaims().withName("persistentvolumeclaim2").delete().size() == 1;
+    deleted = client.persistentVolumeClaims().withName("persistentvolumeclaim2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.persistentVolumeClaims().inNamespace("ns1").withName("persistentvolumeclaim2").delete().size() == 1;
+    deleted = client.persistentVolumeClaims().inNamespace("ns1").withName("persistentvolumeclaim2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PersistentVolumeClaimTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PersistentVolumeClaimTest.java
@@ -141,7 +141,8 @@ class PersistentVolumeClaimTest {
     deleted = client.persistentVolumeClaims().withName("persistentvolumeclaim2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.persistentVolumeClaims().inNamespace("ns1").withName("persistentvolumeclaim2").withGracePeriod(0).delete().size() == 1;
+    deleted = client.persistentVolumeClaims().inNamespace("ns1").withName("persistentvolumeclaim2").withGracePeriod(0).delete()
+        .size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PersistentVolumeTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PersistentVolumeTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class PersistentVolumeTest {
 
   KubernetesMockServer server;
@@ -96,7 +96,7 @@ public class PersistentVolumeTest {
   public void testDelete() {
     server.expect().withPath("/api/v1/persistentvolumes/persistentvolume1")
         .andReturn(200, new PersistentVolumeBuilder().build()).once();
-    boolean deleted = client.persistentVolumes().withName("persistentvolume1").delete().size() == 1;
+    boolean deleted = client.persistentVolumes().withName("persistentvolume1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodCrudTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class PodCrudTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodDisruptionBudgetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodDisruptionBudgetTest.java
@@ -136,7 +136,8 @@ public class PodDisruptionBudgetTest {
             .build())
         .once();
 
-    boolean deleted = client.policy().podDisruptionBudget().withName("poddisruptionbudget1").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.policy().podDisruptionBudget().withName("poddisruptionbudget1").withGracePeriod(0).delete()
+        .size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodDisruptionBudgetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodDisruptionBudgetTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class PodDisruptionBudgetTest {
 
   KubernetesMockServer server;
@@ -136,7 +136,7 @@ public class PodDisruptionBudgetTest {
             .build())
         .once();
 
-    boolean deleted = client.policy().podDisruptionBudget().withName("poddisruptionbudget1").delete().size() == 1;
+    boolean deleted = client.policy().podDisruptionBudget().withName("poddisruptionbudget1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodExecTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("unused")
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class PodExecTest {
 
   private static PodStatus READY = new PodStatusBuilder().addNewCondition().withType("Ready").withStatus("True").endCondition()

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodMetricsTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PodMetricsTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodSchedulingContextTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodSchedulingContextTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PodSchedulingContextTest {
   private KubernetesClient client;
   KubernetesMockServer server;
@@ -81,7 +81,7 @@ class PodSchedulingContextTest {
 
     // When
     boolean isDeleted = client.dynamicResourceAllocation().v1alpha2().podSchedulings().inNamespace("test").withName("cluster")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodSecurityPolicyCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodSecurityPolicyCrudTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 public class PodSecurityPolicyCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(PodSecurityPolicyCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTemplateTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class PodTemplateTest {
 
   KubernetesMockServer server;
@@ -139,7 +139,7 @@ public class PodTemplateTest {
         .once();
 
     // When
-    boolean isDeleted = client.v1().podTemplates().inNamespace("test").withName("pt1").delete().size() == 1;
+    boolean isDeleted = client.v1().podTemplates().inNamespace("test").withName("pt1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(isDeleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -78,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PodTest {
 
   KubernetesMockServer server;
@@ -212,13 +212,13 @@ class PodTest {
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder().build()).once();
     server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, new PodBuilder().build()).once();
 
-    boolean deleted = client.pods().withName("pod1").delete().size() == 1;
+    boolean deleted = client.pods().withName("pod1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.pods().withName("pod2").delete().size() == 1;
+    deleted = client.pods().withName("pod2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.pods().inNamespace("ns1").withName("pod2").cascading(false).delete().size() == 1;
+    deleted = client.pods().inNamespace("ns1").withName("pod2").cascading(false).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityClassTest.java
@@ -106,7 +106,8 @@ public class PriorityClassTest {
             .build())
         .once();
 
-    boolean deleted = client.scheduling().v1beta1().priorityClasses().withName("priorityclass1").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.scheduling().v1beta1().priorityClasses().withName("priorityclass1").withGracePeriod(0).delete()
+        .size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityClassTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class PriorityClassTest {
 
   KubernetesMockServer server;
@@ -106,7 +106,7 @@ public class PriorityClassTest {
             .build())
         .once();
 
-    boolean deleted = client.scheduling().v1beta1().priorityClasses().withName("priorityclass1").delete().size() == 1;
+    boolean deleted = client.scheduling().v1beta1().priorityClasses().withName("priorityclass1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PriorityLevelConfigurationTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PriorityLevelConfigurationTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -111,7 +111,7 @@ class PriorityLevelConfigurationTest {
 
     // When
     boolean isDeleted = client.flowControl().v1beta1().priorityLevelConfigurations().withName("prioritylevelconfiguration1")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PropagationPolicyTest.java
@@ -48,7 +48,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PropagationPolicyTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ReplicaSetTest {
 
   KubernetesMockServer server;
@@ -142,13 +142,13 @@ class ReplicaSetTest {
             .build())
         .times(5);
 
-    boolean deleted = client.apps().replicaSets().withName("repl1").delete().size() == 1;
+    boolean deleted = client.apps().replicaSets().withName("repl1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.apps().replicaSets().withName("repl2").delete().size() == 1;
+    deleted = client.apps().replicaSets().withName("repl2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.apps().replicaSets().inNamespace("ns1").withName("repl2").delete().size() == 1;
+    deleted = client.apps().replicaSets().inNamespace("ns1").withName("repl2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetV1beta1Test.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicaSetV1beta1Test.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ReplicaSetV1beta1Test {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ReplicationControllerTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ReplicationControllerTest {
 
   KubernetesMockServer server;
@@ -143,13 +143,13 @@ class ReplicationControllerTest {
             .build())
         .times(5);
 
-    boolean deleted = client.replicationControllers().withName("repl1").delete().size() == 1;
+    boolean deleted = client.replicationControllers().withName("repl1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.replicationControllers().withName("repl2").delete().size() == 1;
+    deleted = client.replicationControllers().withName("repl2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.replicationControllers().inNamespace("ns1").withName("repl2").delete().size() == 1;
+    deleted = client.replicationControllers().inNamespace("ns1").withName("repl2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RequestConfigTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class RequestConfigTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTemplateTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ResourceClaimTemplateTest {
   private KubernetesClient client;
   KubernetesMockServer server;
@@ -79,7 +79,7 @@ class ResourceClaimTemplateTest {
 
     // When
     boolean isDeleted = client.dynamicResourceAllocation().v1alpha2().resourceClaimTemplates().inNamespace("test")
-        .withName("cluster").delete().size() == 1;
+        .withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClaimTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ResourceClaimTest {
   private KubernetesClient client;
   KubernetesMockServer server;
@@ -79,7 +79,7 @@ class ResourceClaimTest {
 
     // When
     boolean isDeleted = client.dynamicResourceAllocation().v1alpha2().resourceClaims().inNamespace("test").withName("cluster")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceClassTest.java
@@ -30,7 +30,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ResourceClassTest {
   private KubernetesClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceListTest.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ResourceListTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceQuotaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceQuotaTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class ResourceQuotaTest {
 
   KubernetesMockServer server;
@@ -83,13 +83,13 @@ public class ResourceQuotaTest {
     server.expect().withPath("/api/v1/namespaces/ns1/resourcequotas/resourcequota2")
         .andReturn(200, new ResourceQuotaBuilder().build()).once();
 
-    boolean deleted = client.resourceQuotas().withName("resourcequota1").delete().size() == 1;
+    boolean deleted = client.resourceQuotas().withName("resourcequota1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.resourceQuotas().withName("resourcequota2").delete().size() == 1;
+    deleted = client.resourceQuotas().withName("resourcequota2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.resourceQuotas().inNamespace("ns1").withName("resourcequota2").delete().size() == 1;
+    deleted = client.resourceQuotas().inNamespace("ns1").withName("resourcequota2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ResourceTest.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ResourceTest {
 
   KubernetesMockServer server;
@@ -244,12 +244,12 @@ class ResourceTest {
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, pod1).once();
     server.expect().withPath("/api/v1/namespaces/ns1/pods/pod2").andReturn(200, pod2).once();
 
-    Boolean deleted = client.resource(pod1).delete().size() == 1;
+    Boolean deleted = client.resource(pod1).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
-    deleted = client.resource(pod2).delete().size() == 1;
+    deleted = client.resource(pod2).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.resource(pod3).delete().size() == 1;
+    deleted = client.resource(pod3).withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RoleBindingCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RoleBindingCrudTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 public class RoleBindingCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(RoleBindingCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RoleCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RoleCrudTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 public class RoleCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(RoleCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RuntimeClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/RuntimeClassTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class RuntimeClassTest {
 
   KubernetesMockServer server;
@@ -109,7 +109,7 @@ class RuntimeClassTest {
         .once();
 
     // When
-    boolean isDeleted = client.runtimeClasses().withName("test-class").delete().size() == 1;
+    boolean isDeleted = client.runtimeClasses().withName("test-class").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(isDeleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ScaleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ScaleTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ScaleTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SecretCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SecretCrudTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 public class SecretCrudTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/SelfSubjectReviewTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SelfSubjectReviewTest {
   KubernetesClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceAccountTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceAccountTest.java
@@ -31,7 +31,7 @@ import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ServiceAccountTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceCrudTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 public class ServiceCrudTest {
 
   KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/ServiceTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ServiceTest {
 
   KubernetesMockServer server;
@@ -144,7 +144,7 @@ class ServiceTest {
         .andReturn(200, service)
         .once();
 
-    boolean isDeleted = client.services().inNamespace("test").withName("httpbin").delete().size() == 1;
+    boolean isDeleted = client.services().inNamespace("test").withName("httpbin").withGracePeriod(0).delete().size() == 1;
     assertTrue(isDeleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StatefulSetTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class StatefulSetTest {
 
   KubernetesMockServer server;
@@ -166,13 +166,13 @@ public class StatefulSetTest {
             .build())
         .times(5);
 
-    boolean deleted = client.apps().statefulSets().withName("repl1").delete().size() == 1;
+    boolean deleted = client.apps().statefulSets().withName("repl1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.apps().statefulSets().withName("repl2").delete().size() == 1;
+    deleted = client.apps().statefulSets().withName("repl2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.apps().statefulSets().inNamespace("ns1").withName("repl2").delete().size() == 1;
+    deleted = client.apps().statefulSets().inNamespace("ns1").withName("repl2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StorageSpaceCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/StorageSpaceCrudTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 public class StorageSpaceCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(StorageSpaceCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TokenReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TokenReviewTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class TokenReviewTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedClusterScopeCustomResourceApiTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class TypedClusterScopeCustomResourceApiTest {
 
   KubernetesMockServer server;
@@ -91,7 +91,7 @@ class TypedClusterScopeCustomResourceApiTest {
 
     starClient = client.resources(Star.class);
 
-    boolean isDeleted = starClient.inNamespace("test").withName("sun").delete().size() == 1;
+    boolean isDeleted = starClient.inNamespace("test").withName("sun").withGracePeriod(0).delete().size() == 1;
     assertTrue(isDeleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedCustomResourceApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedCustomResourceApiTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class TypedCustomResourceApiTest {
 
   KubernetesMockServer server;
@@ -91,7 +91,7 @@ class TypedCustomResourceApiTest {
 
     podSetClient = client.resources(PodSet.class);
 
-    boolean isDeleted = podSetClient.inNamespace("test").withName("example-podset").delete().size() == 1;
+    boolean isDeleted = podSetClient.inNamespace("test").withName("example-podset").withGracePeriod(0).delete().size() == 1;
     assertTrue(isDeleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedResourcesApiTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/TypedResourcesApiTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class TypedResourcesApiTest {
   KubernetesClient client;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/UpdateResourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/UpdateResourceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class UpdateResourceTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CSIStorageCapacityTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CSIStorageCapacityTest.java
@@ -76,7 +76,8 @@ class V1CSIStorageCapacityTest {
         .once();
 
     // When
-    boolean isDeleted = client.storage().v1().csiStorageCapacities().inNamespace("default").withName("c1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.storage().v1().csiStorageCapacities().inNamespace("default").withName("c1").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CSIStorageCapacityTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CSIStorageCapacityTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1CSIStorageCapacityTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -76,7 +76,7 @@ class V1CSIStorageCapacityTest {
         .once();
 
     // When
-    boolean isDeleted = client.storage().v1().csiStorageCapacities().inNamespace("default").withName("c1").delete().size() == 1;
+    boolean isDeleted = client.storage().v1().csiStorageCapacities().inNamespace("default").withName("c1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CertificateSigningRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CertificateSigningRequestTest.java
@@ -125,7 +125,8 @@ class V1CertificateSigningRequestTest {
         .once();
 
     // When
-    boolean isDeleted = client.certificates().v1().certificateSigningRequests().withName(name).withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.certificates().v1().certificateSigningRequests().withName(name).withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CertificateSigningRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CertificateSigningRequestTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1CertificateSigningRequestTest {
 
   KubernetesMockServer server;
@@ -125,7 +125,7 @@ class V1CertificateSigningRequestTest {
         .once();
 
     // When
-    boolean isDeleted = client.certificates().v1().certificateSigningRequests().withName(name).delete().size() == 1;
+    boolean isDeleted = client.certificates().v1().certificateSigningRequests().withName(name).withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CronJobTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CronJobTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1CronJobTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -188,10 +188,10 @@ class V1CronJobTest {
             .build())
         .once();
 
-    boolean deleted = client.batch().v1().cronjobs().withName("cronJob1").delete().size() == 1;
+    boolean deleted = client.batch().v1().cronjobs().withName("cronJob1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.batch().v1().cronjobs().withName("cronJob2").delete().size() == 1;
+    deleted = client.batch().v1().cronjobs().withName("cronJob2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CustomResourceDefinitionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1CustomResourceDefinitionTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V1CustomResourceDefinitionTest {
 
   KubernetesMockServer server;
@@ -123,7 +123,7 @@ public class V1CustomResourceDefinitionTest {
         .andReturn(HttpURLConnection.HTTP_OK, customResourceDefinition).once();
 
     Boolean deleted = client.apiextensions().v1().customResourceDefinitions().withName("sparkclusters.radanalytics.io")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1DynamicResourceAllocationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1DynamicResourceAllocationTest.java
@@ -40,7 +40,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1DynamicResourceAllocationTest {
   private KubernetesClient client;
   KubernetesMockServer server;
@@ -109,7 +109,7 @@ class V1DynamicResourceAllocationTest {
 
     // When
     boolean isDeleted = client.dynamicResourceAllocation().v1().resourceClaims()
-        .inNamespace("test").withName("claim-to-delete").delete().size() == 1;
+        .inNamespace("test").withName("claim-to-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();
@@ -181,7 +181,7 @@ class V1DynamicResourceAllocationTest {
 
     // When
     boolean isDeleted = client.dynamicResourceAllocation().v1().resourceClaimTemplates()
-        .inNamespace("test").withName("template-to-delete").delete().size() == 1;
+        .inNamespace("test").withName("template-to-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();
@@ -250,7 +250,7 @@ class V1DynamicResourceAllocationTest {
 
     // When
     boolean isDeleted = client.dynamicResourceAllocation().v1().deviceClasses()
-        .withName("device-class-to-delete").delete().size() == 1;
+        .withName("device-class-to-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();
@@ -319,7 +319,7 @@ class V1DynamicResourceAllocationTest {
 
     // When
     boolean isDeleted = client.dynamicResourceAllocation().v1().resourcesSlices()
-        .withName("slice-to-delete").delete().size() == 1;
+        .withName("slice-to-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EndpointSliceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EndpointSliceTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1EndpointSliceTest {
   KubernetesMockServer server;
   private KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1EventsTest {
   private KubernetesClient client;
   KubernetesMockServer server;
@@ -78,7 +78,7 @@ class V1EventsTest {
         .once();
 
     // When
-    boolean isDeleted = client.events().v1().events().inNamespace("default").withName("e1").delete().size() == 1;
+    boolean isDeleted = client.events().v1().events().inNamespace("default").withName("e1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1EventsTest.java
@@ -78,7 +78,8 @@ class V1EventsTest {
         .once();
 
     // When
-    boolean isDeleted = client.events().v1().events().inNamespace("default").withName("e1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.events().v1().events().inNamespace("default").withName("e1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1FlowSchemaTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1FlowSchemaTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -106,7 +106,7 @@ class V1FlowSchemaTest {
         .once();
 
     // When
-    boolean isDeleted = client.flowControl().v1().flowSchema().withName("flowschema1").delete().size() == 1;
+    boolean isDeleted = client.flowControl().v1().flowSchema().withName("flowschema1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1HorizontalPodAutoscalerTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V1HorizontalPodAutoscalerTest {
 
   KubernetesMockServer server;
@@ -145,14 +145,14 @@ public class V1HorizontalPodAutoscalerTest {
         .andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
 
     Boolean deleted = client.autoscaling().v1().horizontalPodAutoscalers().inNamespace("test")
-        .withName("horizontalpodautoscaler1").delete().size() == 1;
+        .withName("horizontalpodautoscaler1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.autoscaling().v1().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").delete().size() == 1;
+    deleted = client.autoscaling().v1().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
     deleted = client.autoscaling().v1().horizontalPodAutoscalers().inNamespace("ns1").withName("horizontalpodautoscaler2")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1HorizontalPodAutoscalerTest.java
@@ -148,7 +148,8 @@ public class V1HorizontalPodAutoscalerTest {
         .withName("horizontalpodautoscaler1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.autoscaling().v1().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").withGracePeriod(0).delete().size() == 1;
+    deleted = client.autoscaling().v1().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").withGracePeriod(0)
+        .delete().size() == 1;
     assertFalse(deleted);
 
     deleted = client.autoscaling().v1().horizontalPodAutoscalers().inNamespace("ns1").withName("horizontalpodautoscaler2")

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1IngressClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1IngressClassTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1IngressClassTest {
 
   KubernetesMockServer server;
@@ -149,8 +149,8 @@ class V1IngressClassTest {
         .andReturn(HttpURLConnection.HTTP_OK, new IngressClassBuilder().build()).once();
 
     // When
-    boolean result1 = client.network().v1().ingressClasses().withName("ingressClass1").delete().size() == 1;
-    boolean result2 = client.network().v1().ingressClasses().withName("ingressClass2").delete().size() == 1;
+    boolean result1 = client.network().v1().ingressClasses().withName("ingressClass1").withGracePeriod(0).delete().size() == 1;
+    boolean result2 = client.network().v1().ingressClasses().withName("ingressClass2").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(result1);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1MutatingWebhookConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1MutatingWebhookConfigurationTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V1MutatingWebhookConfigurationTest {
 
   KubernetesMockServer server;
@@ -103,7 +103,7 @@ public class V1MutatingWebhookConfigurationTest {
 
     // When
     Boolean isDeleted = client.admissionRegistration().v1().mutatingWebhookConfigurations()
-        .withName("mutatingWebhookConfiguration1").delete().size() == 1;
+        .withName("mutatingWebhookConfiguration1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(isDeleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PodDisruptionBudgetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PodDisruptionBudgetTest.java
@@ -136,7 +136,8 @@ class V1PodDisruptionBudgetTest {
             .build())
         .once();
 
-    boolean deleted = client.policy().v1().podDisruptionBudget().withName("poddisruptionbudget1").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.policy().v1().podDisruptionBudget().withName("poddisruptionbudget1").withGracePeriod(0).delete()
+        .size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PodDisruptionBudgetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PodDisruptionBudgetTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1PodDisruptionBudgetTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -136,7 +136,7 @@ class V1PodDisruptionBudgetTest {
             .build())
         .once();
 
-    boolean deleted = client.policy().v1().podDisruptionBudget().withName("poddisruptionbudget1").delete().size() == 1;
+    boolean deleted = client.policy().v1().podDisruptionBudget().withName("poddisruptionbudget1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityClassTest.java
@@ -123,7 +123,8 @@ class V1PriorityClassTest {
         .once();
 
     // When
-    boolean deleted = client.scheduling().v1().priorityClasses().withName("priorityclass1").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.scheduling().v1().priorityClasses().withName("priorityclass1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityClassTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1PriorityClassTest {
 
   KubernetesClient client;
@@ -123,7 +123,7 @@ class V1PriorityClassTest {
         .once();
 
     // When
-    boolean deleted = client.scheduling().v1().priorityClasses().withName("priorityclass1").delete().size() == 1;
+    boolean deleted = client.scheduling().v1().priorityClasses().withName("priorityclass1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1PriorityLevelConfigurationTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1PriorityLevelConfigurationTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -111,7 +111,7 @@ class V1PriorityLevelConfigurationTest {
 
     // When
     boolean isDeleted = client.flowControl().v1().priorityLevelConfigurations().withName("prioritylevelconfiguration1")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1SelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1SelfSubjectReviewTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1SelfSubjectReviewTest {
   private KubernetesClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1SubjectAccessReviewAuthTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1SubjectAccessReviewAuthTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1SubjectAccessReviewAuthTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyBindingTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1ValidatingAdmissionPolicyBindingTest {
 
   KubernetesMockServer server;
@@ -114,7 +114,7 @@ class V1ValidatingAdmissionPolicyBindingTest {
 
     // When
     boolean isDeleted = client.admissionRegistration().v1().validatingAdmissionPolicyBindings()
-        .withName("demo-binding-test.example.com").delete().size() == 1;
+        .withName("demo-binding-test.example.com").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingAdmissionPolicyTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1ValidatingAdmissionPolicyTest {
 
   KubernetesMockServer server;
@@ -113,7 +113,7 @@ class V1ValidatingAdmissionPolicyTest {
 
     // When
     boolean isDeleted = client.admissionRegistration().v1().validatingAdmissionPolicies()
-        .withName("demo-policy.example.com").delete().size() == 1;
+        .withName("demo-policy.example.com").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingWebhookConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1ValidatingWebhookConfigurationTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V1ValidatingWebhookConfigurationTest {
 
   KubernetesMockServer server;
@@ -113,7 +113,7 @@ public class V1ValidatingWebhookConfigurationTest {
 
     // When
     Boolean isDeleted = client.admissionRegistration().v1().validatingWebhookConfigurations()
-        .withName("validatingWebhookConfiguration1").delete().size() == 1;
+        .withName("validatingWebhookConfiguration1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(isDeleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta1EventsTest {
   private KubernetesClient client;
   KubernetesMockServer server;
@@ -78,7 +78,7 @@ class V1beta1EventsTest {
         .once();
 
     // When
-    boolean isDeleted = client.events().v1beta1().events().inNamespace("default").withName("e1").delete().size() == 1;
+    boolean isDeleted = client.events().v1beta1().events().inNamespace("default").withName("e1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1EventsTest.java
@@ -78,7 +78,8 @@ class V1beta1EventsTest {
         .once();
 
     // When
-    boolean isDeleted = client.events().v1beta1().events().inNamespace("default").withName("e1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.events().v1beta1().events().inNamespace("default").withName("e1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1MutatingAdmissionPolicyBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1MutatingAdmissionPolicyBindingTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta1MutatingAdmissionPolicyBindingTest {
 
   KubernetesMockServer server;
@@ -111,7 +111,7 @@ class V1beta1MutatingAdmissionPolicyBindingTest {
 
     // When
     boolean isDeleted = client.admissionRegistration().v1beta1().mutatingAdmissionPolicyBindings()
-        .withName("demo-binding-test.example.com").delete().size() == 1;
+        .withName("demo-binding-test.example.com").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1MutatingAdmissionPolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1MutatingAdmissionPolicyTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta1MutatingAdmissionPolicyTest {
 
   KubernetesMockServer server;
@@ -110,7 +110,7 @@ class V1beta1MutatingAdmissionPolicyTest {
 
     // When
     boolean isDeleted = client.admissionRegistration().v1beta1().mutatingAdmissionPolicies()
-        .withName("sidecar-policy.example.com").delete().size() == 1;
+        .withName("sidecar-policy.example.com").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1MutatingWebhookConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1MutatingWebhookConfigurationTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V1beta1MutatingWebhookConfigurationTest {
 
   KubernetesMockServer server;
@@ -103,7 +103,7 @@ public class V1beta1MutatingWebhookConfigurationTest {
 
     // When
     boolean isDeleted = client.admissionRegistration().v1beta1().mutatingWebhookConfigurations()
-        .withName("mutatingWebhookConfiguration1").delete().size() == 1;
+        .withName("mutatingWebhookConfiguration1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(isDeleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1SubjectAccessReviewAuthTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1SubjectAccessReviewAuthTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta1SubjectAccessReviewAuthTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1ValidatingWebhookConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta1ValidatingWebhookConfigurationTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V1beta1ValidatingWebhookConfigurationTest {
 
   KubernetesMockServer server;
@@ -113,7 +113,7 @@ public class V1beta1ValidatingWebhookConfigurationTest {
 
     // When
     boolean isDeleted = client.admissionRegistration().v1beta1().validatingWebhookConfigurations()
-        .withName("validatingWebhookConfiguration1").delete().size() == 1;
+        .withName("validatingWebhookConfiguration1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(isDeleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2FlowSchemaTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta2FlowSchemaTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -106,7 +106,7 @@ class V1beta2FlowSchemaTest {
         .once();
 
     // When
-    boolean isDeleted = client.flowControl().v1beta2().flowSchema().withName("flowschema1").delete().size() == 1;
+    boolean isDeleted = client.flowControl().v1beta2().flowSchema().withName("flowschema1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2FlowSchemaTest.java
@@ -106,7 +106,8 @@ class V1beta2FlowSchemaTest {
         .once();
 
     // When
-    boolean isDeleted = client.flowControl().v1beta2().flowSchema().withName("flowschema1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.flowControl().v1beta2().flowSchema().withName("flowschema1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta2PriorityLevelConfigurationTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta2PriorityLevelConfigurationTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -111,7 +111,7 @@ class V1beta2PriorityLevelConfigurationTest {
 
     // When
     boolean isDeleted = client.flowControl().v1beta2().priorityLevelConfigurations().withName("prioritylevelconfiguration1")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3FlowSchemaTest.java
@@ -106,7 +106,8 @@ class V1beta3FlowSchemaTest {
         .once();
 
     // When
-    boolean isDeleted = client.flowControl().v1beta3().flowSchema().withName("flowschema1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.flowControl().v1beta3().flowSchema().withName("flowschema1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3FlowSchemaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3FlowSchemaTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta3FlowSchemaTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -106,7 +106,7 @@ class V1beta3FlowSchemaTest {
         .once();
 
     // When
-    boolean isDeleted = client.flowControl().v1beta3().flowSchema().withName("flowschema1").delete().size() == 1;
+    boolean isDeleted = client.flowControl().v1beta3().flowSchema().withName("flowschema1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3PriorityLevelConfigurationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V1beta3PriorityLevelConfigurationTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V1beta3PriorityLevelConfigurationTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -112,7 +112,7 @@ class V1beta3PriorityLevelConfigurationTest {
 
     // When
     boolean isDeleted = client.flowControl().v1beta3().priorityLevelConfigurations().withName("prioritylevelconfiguration1")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
 
     // Then
     AssertionsForClassTypes.assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2HorizontalPodAutoscalerTest.java
@@ -160,7 +160,8 @@ class V2HorizontalPodAutoscalerTest {
         .withName("horizontalpodautoscaler1").withGracePeriod(0).delete().size() == 1;
     assertThat(deleted).isTrue();
 
-    deleted = client.autoscaling().v2().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").withGracePeriod(0).delete().size() == 1;
+    deleted = client.autoscaling().v2().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").withGracePeriod(0)
+        .delete().size() == 1;
     assertThat(deleted).isFalse();
 
     deleted = client.autoscaling().v2().horizontalPodAutoscalers().inNamespace("ns1").withName("horizontalpodautoscaler2")

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2HorizontalPodAutoscalerTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class V2HorizontalPodAutoscalerTest {
 
   KubernetesMockServer server;
@@ -157,14 +157,14 @@ class V2HorizontalPodAutoscalerTest {
         .andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
 
     Boolean deleted = client.autoscaling().v2().horizontalPodAutoscalers().inNamespace("test")
-        .withName("horizontalpodautoscaler1").delete().size() == 1;
+        .withName("horizontalpodautoscaler1").withGracePeriod(0).delete().size() == 1;
     assertThat(deleted).isTrue();
 
-    deleted = client.autoscaling().v2().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").delete().size() == 1;
+    deleted = client.autoscaling().v2().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").withGracePeriod(0).delete().size() == 1;
     assertThat(deleted).isFalse();
 
     deleted = client.autoscaling().v2().horizontalPodAutoscalers().inNamespace("ns1").withName("horizontalpodautoscaler2")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
     assertThat(deleted).isTrue();
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta1HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta1HorizontalPodAutoscalerTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V2beta1HorizontalPodAutoscalerTest {
 
   KubernetesMockServer server;
@@ -132,7 +132,7 @@ public class V2beta1HorizontalPodAutoscalerTest {
         .andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
 
     boolean deleted = client.autoscaling().v2beta1().horizontalPodAutoscalers().inNamespace("test")
-        .withName("horizontalpodautoscaler1").delete().size() == 1;
+        .withName("horizontalpodautoscaler1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
     deleted = client.autoscaling().v2beta1().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").delete()
@@ -140,7 +140,7 @@ public class V2beta1HorizontalPodAutoscalerTest {
     assertFalse(deleted);
 
     deleted = client.autoscaling().v2beta1().horizontalPodAutoscalers().inNamespace("ns1").withName("horizontalpodautoscaler2")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta2HorizontalPodAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/V2beta2HorizontalPodAutoscalerTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 public class V2beta2HorizontalPodAutoscalerTest {
 
   KubernetesMockServer server;
@@ -146,7 +146,7 @@ public class V2beta2HorizontalPodAutoscalerTest {
         .andReturn(200, new HorizontalPodAutoscalerBuilder().build()).once();
 
     boolean deleted = client.autoscaling().v2beta2().horizontalPodAutoscalers().inNamespace("test")
-        .withName("horizontalpodautoscaler1").delete().size() == 1;
+        .withName("horizontalpodautoscaler1").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
     deleted = client.autoscaling().v2beta2().horizontalPodAutoscalers().withName("horizontalpodautoscaler2").delete()
@@ -154,7 +154,7 @@ public class V2beta2HorizontalPodAutoscalerTest {
     assertFalse(deleted);
 
     deleted = client.autoscaling().v2beta2().horizontalPodAutoscalers().inNamespace("ns1").withName("horizontalpodautoscaler2")
-        .delete().size() == 1;
+        .withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VersionInfoTest.java
@@ -28,7 +28,7 @@ import java.text.SimpleDateFormat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class VersionInfoTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VisitResourcesTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VisitResourcesTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class VisitResourcesTest {
   KubernetesMockServer server;
   private KubernetesClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttachmentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttachmentTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class VolumeAttachmentTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -86,7 +86,7 @@ class VolumeAttachmentTest {
         .once();
 
     // When
-    boolean isDeleted = client.storage().volumeAttachments().withName("va1").delete().size() == 1;
+    boolean isDeleted = client.storage().volumeAttachments().withName("va1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttributesClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttributesClassTest.java
@@ -87,7 +87,8 @@ class VolumeAttributesClassTest {
         .once();
 
     // When
-    boolean isDeleted = client.storage().v1().volumeAttributesClasses().withName("gold").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.storage().v1().volumeAttributesClasses().withName("gold").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttributesClassTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/VolumeAttributesClassTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class VolumeAttributesClassTest {
   KubernetesMockServer server;
   private KubernetesClient client;
@@ -87,7 +87,7 @@ class VolumeAttributesClassTest {
         .once();
 
     // When
-    boolean isDeleted = client.storage().v1().volumeAttributesClasses().withName("gold").delete().size() == 1;
+    boolean isDeleted = client.storage().v1().volumeAttributesClasses().withName("gold").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/APIRequestCountTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/APIRequestCountTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class APIRequestCountTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class APIRequestCountTest {
         .once();
 
     // When
-    boolean isDeleted = client.apiRequestCounts().withName("secrets.v1").delete().size() == 1;
+    boolean isDeleted = client.apiRequestCounts().withName("secrets.v1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AdaptTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AdaptTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class AdaptTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AlertmanagerConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AlertmanagerConfigTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class AlertmanagerConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AuthenticationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AuthenticationTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class AuthenticationTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class AuthenticationTest {
         .once();
 
     // When
-    boolean isDeleted = client.config().authentications().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.config().authentications().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BareMetalHostTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BareMetalHostTest.java
@@ -76,7 +76,8 @@ class BareMetalHostTest {
         .once();
 
     // When
-    boolean isDeleted = client.bareMetalHosts().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.bareMetalHosts().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BareMetalHostTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BareMetalHostTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class BareMetalHostTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class BareMetalHostTest {
         .once();
 
     // When
-    boolean isDeleted = client.bareMetalHosts().inNamespace("ns1").withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.bareMetalHosts().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BrokerTemplateInstanceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BrokerTemplateInstanceTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class BrokerTemplateInstanceTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class BrokerTemplateInstanceTest {
         .once();
 
     // When
-    boolean isDeleted = client.brokerTemplateInstances().withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.brokerTemplateInstances().withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigCrudTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class BuildConfigCrudTest {
   OpenShiftClient client;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildConfigTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class BuildConfigTest {
 
   KubernetesMockServer server;
@@ -196,12 +196,12 @@ class BuildConfigTest {
         .withPath("/apis/build.openshift.io/v1/namespaces/ns1/builds?labelSelector=openshift.io%2Fbuild-config.name%3Dbc2")
         .andReturn(200, new BuildListBuilder().build()).once();
 
-    boolean deleted = client.buildConfigs().withName("bc1").delete().size() == 1;
+    boolean deleted = client.buildConfigs().withName("bc1").withGracePeriod(0).delete().size() == 1;
 
-    deleted = client.buildConfigs().withName("bc2").delete().size() == 1;
+    deleted = client.buildConfigs().withName("bc2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.buildConfigs().inNamespace("ns1").withName("bc2").delete().size() == 1;
+    deleted = client.buildConfigs().inNamespace("ns1").withName("bc2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/BuildTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class BuildTest {
   KubernetesMockServer server;
   OpenShiftClient openShiftClient;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CatalogSourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CatalogSourceTest.java
@@ -95,7 +95,8 @@ class CatalogSourceTest {
         .once();
 
     // When
-    boolean deleted = client.operatorHub().catalogSources().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.operatorHub().catalogSources().inNamespace("ns1").withName("foo").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CatalogSourceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CatalogSourceTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CatalogSourceTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class CatalogSourceTest {
         .once();
 
     // When
-    boolean deleted = client.operatorHub().catalogSources().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.operatorHub().catalogSources().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CloudCredentialTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CloudCredentialTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CloudCredentialTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class CloudCredentialTest {
         .once();
 
     // When
-    boolean isDeleted = client.operator().cloudCredentials().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operator().cloudCredentials().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterAutoscalerTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterAutoscalerTest {
   KubernetesMockServer server;
   private OpenShiftClient client;
@@ -76,7 +76,7 @@ class ClusterAutoscalerTest {
         .once();
 
     // When
-    boolean isDeleted = client.openShiftAutoscaling().v1().clusterAutoscalers().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.openShiftAutoscaling().v1().clusterAutoscalers().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterAutoscalerTest.java
@@ -76,7 +76,8 @@ class ClusterAutoscalerTest {
         .once();
 
     // When
-    boolean isDeleted = client.openShiftAutoscaling().v1().clusterAutoscalers().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.openShiftAutoscaling().v1().clusterAutoscalers().withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterCSIDriverTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterCSIDriverTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterCSIDriverTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ClusterCSIDriverTest {
         .once();
 
     // When
-    boolean isDeleted = client.operator().clusterCSIDrivers().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operator().clusterCSIDrivers().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterResourceQuotaTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterResourceQuotaTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterResourceQuotaTest {
 
   KubernetesMockServer server;
@@ -100,7 +100,7 @@ class ClusterResourceQuotaTest {
         .once();
 
     // When
-    boolean deleted = client.quotas().clusterResourceQuotas().withName("foo").delete().size() == 1;
+    boolean deleted = client.quotas().clusterResourceQuotas().withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterRoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterRoleTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterRoleTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ClusterRoleTest {
         .once();
 
     // When
-    boolean isDeleted = client.clusterRoles().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.clusterRoles().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterServiceVersionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ClusterServiceVersionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterServiceVersionTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConfigTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.operator().configs().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operator().configs().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleLinkTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleLinkTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ConsoleLinkTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class ConsoleLinkTest {
         .once();
 
     // When
-    boolean deleted = client.console().consoleLinks().withName("foo").delete().size() == 1;
+    boolean deleted = client.console().consoleLinks().withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsolePluginTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsolePluginTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ConsolePluginTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ConsolePluginTest {
         .once();
 
     // When
-    boolean isDeleted = client.console().consolePlugins().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.console().consolePlugins().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleQuickStartTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleQuickStartTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ConsoleQuickStartTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class ConsoleQuickStartTest {
         .once();
 
     // When
-    boolean isDeleted = client.console().consoleQuickStarts().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.console().consoleQuickStarts().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ConsoleTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ConsoleTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ConsoleTest {
         .once();
 
     // When
-    boolean isDeleted = client.config().consoles().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.config().consoles().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ContainerRuntimeConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ContainerRuntimeConfigTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ContainerRuntimeConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class ContainerRuntimeConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().containerRuntimeConfigs().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().containerRuntimeConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ContainerRuntimeConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ContainerRuntimeConfigTest.java
@@ -77,7 +77,8 @@ class ContainerRuntimeConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().containerRuntimeConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().containerRuntimeConfigs().withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControlPlaneMachineSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControlPlaneMachineSetTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ControlPlaneMachineSetTest {
   KubernetesMockServer server;
   OpenShiftClient client;
@@ -98,7 +98,7 @@ class ControlPlaneMachineSetTest {
         .once();
 
     // When
-    boolean deleted = client.machine().controlPlaneMachineSets().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean deleted = client.machine().controlPlaneMachineSets().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControlPlaneMachineSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControlPlaneMachineSetTest.java
@@ -98,7 +98,8 @@ class ControlPlaneMachineSetTest {
         .once();
 
     // When
-    boolean deleted = client.machine().controlPlaneMachineSets().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.machine().controlPlaneMachineSets().inNamespace("ns1").withName("cluster").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControllerConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControllerConfigTest.java
@@ -77,7 +77,8 @@ class ControllerConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().controllerConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().controllerConfigs().withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControllerConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ControllerConfigTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ControllerConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class ControllerConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().controllerConfigs().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().controllerConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CredentialsRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CredentialsRequestTest.java
@@ -77,7 +77,8 @@ class CredentialsRequestTest {
         .once();
 
     // When
-    boolean isDeleted = client.credentialsRequests().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.credentialsRequests().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CredentialsRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/CredentialsRequestTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class CredentialsRequestTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class CredentialsRequestTest {
         .once();
 
     // When
-    boolean isDeleted = client.credentialsRequests().inNamespace("ns1").withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.credentialsRequests().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSRecordTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSRecordTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class DNSRecordTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class DNSRecordTest {
         .once();
 
     // When
-    boolean deleted = client.operator().dnsRecords().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.operator().dnsRecords().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DNSTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class DNSTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class DNSTest {
         .once();
 
     // When
-    boolean isDeleted = client.config().dnses().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.config().dnses().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigCrudTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class DeploymentConfigCrudTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/DeploymentConfigTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class DeploymentConfigTest {
 
   KubernetesMockServer server;
@@ -166,7 +166,7 @@ class DeploymentConfigTest {
     server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/test/deploymentconfigs/dc1").andReturn(200, dc1).times(2);
     server.expect().withPath("/apis/apps.openshift.io/v1/namespaces/ns1/deploymentconfigs/dc2").andReturn(200, dc2).times(5);
 
-    boolean deleted = client.deploymentConfigs().withName("dc1").delete().size() == 1;
+    boolean deleted = client.deploymentConfigs().withName("dc1").withGracePeriod(0).delete().size() == 1;
     deleted = client.deploymentConfigs().withName("dc2").delete().size() == 1;
     assertFalse(deleted);
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EgressRouterTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EgressRouterTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class EgressRouterTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class EgressRouterTest {
         .once();
 
     // When
-    boolean isDeleted = client.egressRouters().inNamespace("ns1").withName("egressrouter1").delete().size() == 1;
+    boolean isDeleted = client.egressRouters().inNamespace("ns1").withName("egressrouter1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EgressRouterTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EgressRouterTest.java
@@ -76,7 +76,8 @@ class EgressRouterTest {
         .once();
 
     // When
-    boolean isDeleted = client.egressRouters().inNamespace("ns1").withName("egressrouter1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.egressRouters().inNamespace("ns1").withName("egressrouter1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EtcdTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/EtcdTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class EtcdTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class EtcdTest {
         .once();
 
     // When
-    boolean deleted = client.operator().etcds().withName("foo").delete().size() == 1;
+    boolean deleted = client.operator().etcds().withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/FeatureGateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/FeatureGateTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class FeatureGateTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class FeatureGateTest {
         .once();
 
     // When
-    boolean deleted = client.config().featureGates().withName("foo").delete().size() == 1;
+    boolean deleted = client.config().featureGates().withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class GroupTest {
 
   KubernetesMockServer server;
@@ -92,12 +92,12 @@ class GroupTest {
     server.expect().withPath("/apis/user.openshift.io/v1/groups/group1").andReturn(200, new GroupBuilder().build()).once();
     server.expect().withPath("/apis/user.openshift.io/v1/groups/Group2").andReturn(200, new GroupBuilder().build()).once();
 
-    boolean deleted = client.groups().withName("group1").delete().size() == 1;
+    boolean deleted = client.groups().withName("group1").withGracePeriod(0).delete().size() == 1;
 
-    deleted = client.groups().withName("Group2").delete().size() == 1;
+    deleted = client.groups().withName("Group2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.groups().withName("Group3").delete().size() == 1;
+    deleted = client.groups().withName("Group3").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 
@@ -109,10 +109,10 @@ class GroupTest {
     boolean deleted = client.groups().withName("group1").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete()
         .size() == 1;
 
-    deleted = client.groups().withName("Group2").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete().size() == 1;
+    deleted = client.groups().withName("Group2").withPropagationPolicy(DeletionPropagation.FOREGROUND).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.groups().withName("Group3").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete().size() == 1;
+    deleted = client.groups().withName("Group3").withPropagationPolicy(DeletionPropagation.FOREGROUND).withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/GroupTest.java
@@ -109,10 +109,12 @@ class GroupTest {
     boolean deleted = client.groups().withName("group1").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete()
         .size() == 1;
 
-    deleted = client.groups().withName("Group2").withPropagationPolicy(DeletionPropagation.FOREGROUND).withGracePeriod(0).delete().size() == 1;
+    deleted = client.groups().withName("Group2").withPropagationPolicy(DeletionPropagation.FOREGROUND).withGracePeriod(0)
+        .delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.groups().withName("Group3").withPropagationPolicy(DeletionPropagation.FOREGROUND).withGracePeriod(0).delete().size() == 1;
+    deleted = client.groups().withName("Group3").withPropagationPolicy(DeletionPropagation.FOREGROUND).withGracePeriod(0)
+        .delete().size() == 1;
     assertFalse(deleted);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/HelmChartRepositoryTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/HelmChartRepositoryTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class HelmChartRepositoryTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class HelmChartRepositoryTest {
         .once();
 
     // When
-    boolean isDeleted = client.helmChartRepositories().withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.helmChartRepositories().withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IPPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IPPoolTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class IPPoolTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class IPPoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.whereabouts().ippools().inNamespace("ns1").withName("ippool1").delete().size() == 1;
+    boolean isDeleted = client.whereabouts().ippools().inNamespace("ns1").withName("ippool1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IPPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IPPoolTest.java
@@ -77,7 +77,8 @@ class IPPoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.whereabouts().ippools().inNamespace("ns1").withName("ippool1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.whereabouts().ippools().inNamespace("ns1").withName("ippool1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IdentityTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IdentityTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class IdentityTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class IdentityTest {
         .once();
 
     // When
-    boolean isDeleted = client.identities().withName("developer:developer").delete().size() == 1;
+    boolean isDeleted = client.identities().withName("developer:developer").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageContentSourcePolicyTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageContentSourcePolicyTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageContentSourcePolicyTest {
 
   KubernetesMockServer server;
@@ -96,7 +96,7 @@ class ImageContentSourcePolicyTest {
         .once();
 
     // When
-    boolean deleted = client.operator().imageContentSourcePolicies().withName("foo").delete().size() == 1;
+    boolean deleted = client.operator().imageContentSourcePolicies().withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageDigestMirrorSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageDigestMirrorSetTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageDigestMirrorSetTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ImageDigestMirrorSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.config().imageDigestMirrorSets().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.config().imageDigestMirrorSets().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImagePrunerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImagePrunerTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImagePrunerTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class ImagePrunerTest {
         .once();
 
     // When
-    boolean deleted = client.operator().imagePruners().withName("foo").delete().size() == 1;
+    boolean deleted = client.operator().imagePruners().withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageRegistryOperatorConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageRegistryOperatorConfigTest.java
@@ -29,7 +29,7 @@ import java.text.ParseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageRegistryOperatorConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class ImageRegistryOperatorConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.imageRegistryOperatorConfigs().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.imageRegistryOperatorConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageSignatureTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageSignatureTest.java
@@ -27,7 +27,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageSignatureTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImageTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImageTest.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageStreamImageTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImportTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamImportTest.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageStreamImportTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamMappingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamMappingTest.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageStreamMappingTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamTagCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageStreamTagCrudTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class ImageStreamTagCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(ImageStreamTagCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagMirrorSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagMirrorSetTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageTagMirrorSetTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ImageTagMirrorSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.config().imageTagMirrorSets().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.config().imageTagMirrorSets().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ImageTagTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ImageTagTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class ImageTagTest {
         .once();
 
     // When
-    boolean deleted = client.imageTags().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.imageTags().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressControllerTest.java
@@ -113,7 +113,8 @@ class IngressControllerTest {
         .once();
 
     // When
-    boolean deleted = client.operator().ingressControllers().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.operator().ingressControllers().inNamespace("ns1").withName("foo").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressControllerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressControllerTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class IngressControllerTest {
 
   KubernetesMockServer server;
@@ -113,7 +113,7 @@ class IngressControllerTest {
         .once();
 
     // When
-    boolean deleted = client.operator().ingressControllers().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.operator().ingressControllers().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/IngressTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class IngressTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -88,7 +88,7 @@ class IngressTest {
         .once();
 
     // When
-    boolean isDeleted = client.config().ingresses().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.config().ingresses().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubeletConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubeletConfigTest.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class KubeletConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class KubeletConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().kubeletConfigs().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().kubeletConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubeletConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubeletConfigTest.java
@@ -77,7 +77,8 @@ class KubeletConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().kubeletConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().kubeletConfigs().withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubernetesOperationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/KubernetesOperationTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class KubernetesOperationTest {
 
   KubernetesMockServer server;
@@ -38,10 +38,10 @@ class KubernetesOperationTest {
         .andReturn(200, new ReplicationControllerBuilder().build()).once();
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder().build()).once();
 
-    boolean deleted = client.replicationControllers().withName("rc1").cascading(false).delete().size() == 1;
+    boolean deleted = client.replicationControllers().withName("rc1").cascading(false).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.pods().withName("pod1").cascading(false).delete().size() == 1;
+    deleted = client.pods().withName("pod1").cascading(false).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 
@@ -64,18 +64,18 @@ class KubernetesOperationTest {
         .andReturn(200, new BuildConfigBuilder().build()).once();
     server.expect().withPath("/api/v1/namespaces/test/pods/pod1").andReturn(200, new PodBuilder().build()).once();
 
-    boolean deleted = client.replicationControllers().withName("rc1").cascading(false).delete().size() == 1;
+    boolean deleted = client.replicationControllers().withName("rc1").cascading(false).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.pods().withName("pod1").cascading(false).delete().size() == 1;
+    deleted = client.pods().withName("pod1").cascading(false).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
     OpenShiftClient oclient = client.adapt(OpenShiftClient.class);
 
-    deleted = oclient.buildConfigs().withName("bc1").cascading(false).delete().size() == 1;
+    deleted = oclient.buildConfigs().withName("bc1").cascading(false).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = oclient.pods().withName("pod1").cascading(false).delete().size() == 1;
+    deleted = oclient.pods().withName("pod1").cascading(false).withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineAutoscalerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineAutoscalerTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MachineAutoscalerTest {
   KubernetesMockServer server;
   private OpenShiftClient client;
@@ -82,7 +82,7 @@ class MachineAutoscalerTest {
     // When
     Boolean isDeleted = client.openShiftAutoscaling().v1beta1().machineAutoscalers()
         .inNamespace("ns1")
-        .withName("ma").delete().size() == 1;
+        .withName("ma").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigPoolTest.java
@@ -76,7 +76,8 @@ class MachineConfigPoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().machineConfigPools().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().machineConfigPools().withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigPoolTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MachineConfigPoolTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class MachineConfigPoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().machineConfigPools().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().machineConfigPools().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigTest.java
@@ -76,7 +76,8 @@ class MachineConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().machineConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().machineConfigs().withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineConfigTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MachineConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class MachineConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.machineConfigurations().machineConfigs().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machineConfigurations().machineConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineHealthCheckTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineHealthCheckTest.java
@@ -30,7 +30,7 @@ import java.text.ParseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MachineHealthCheckTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -79,7 +79,7 @@ class MachineHealthCheckTest {
         .once();
 
     // When
-    boolean isDeleted = client.machine().machineHealthChecks().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machine().machineHealthChecks().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineHealthCheckTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineHealthCheckTest.java
@@ -79,7 +79,8 @@ class MachineHealthCheckTest {
         .once();
 
     // When
-    boolean isDeleted = client.machine().machineHealthChecks().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machine().machineHealthChecks().inNamespace("ns1").withName("cluster").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineSetTest.java
@@ -76,7 +76,8 @@ class MachineSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.machine().machineSets().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machine().machineSets().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineSetTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MachineSetTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class MachineSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.machine().machineSets().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machine().machineSets().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineTest.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MachineTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -79,7 +79,7 @@ class MachineTest {
         .once();
 
     // When
-    boolean isDeleted = client.machine().machines().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.machine().machines().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/MachineTest.java
@@ -79,7 +79,8 @@ class MachineTest {
         .once();
 
     // When
-    boolean isDeleted = client.machine().machines().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.machine().machines().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/Metal3RemediationTemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/Metal3RemediationTemplateTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class Metal3RemediationTemplateTest {
   KubernetesMockServer server;
   OpenShiftClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/Metal3RemediationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/Metal3RemediationTest.java
@@ -96,7 +96,8 @@ class Metal3RemediationTest {
         .once();
 
     // When
-    boolean deleted = client.metal3Remediations().inNamespace("ns1").withName("test-remediation").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.metal3Remediations().inNamespace("ns1").withName("test-remediation").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/Metal3RemediationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/Metal3RemediationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class Metal3RemediationTest {
   KubernetesMockServer server;
   OpenShiftClient client;
@@ -96,7 +96,7 @@ class Metal3RemediationTest {
         .once();
 
     // When
-    boolean deleted = client.metal3Remediations().inNamespace("ns1").withName("test-remediation").delete().size() == 1;
+    boolean deleted = client.metal3Remediations().inNamespace("ns1").withName("test-remediation").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NamespacedItemTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NamespacedItemTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class NamespacedItemTest {
   private OpenShiftClient client;
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkAttachmentDefinitionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkAttachmentDefinitionTest.java
@@ -78,7 +78,8 @@ class NetworkAttachmentDefinitionTest {
         .once();
 
     // When
-    boolean isDeleted = client.networkAttachmentDefinitions().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.networkAttachmentDefinitions().inNamespace("ns1").withName("test-delete").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkAttachmentDefinitionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkAttachmentDefinitionTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class NetworkAttachmentDefinitionTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -78,7 +78,7 @@ class NetworkAttachmentDefinitionTest {
         .once();
 
     // When
-    boolean isDeleted = client.networkAttachmentDefinitions().inNamespace("ns1").withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.networkAttachmentDefinitions().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/NetworkTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class NetworkTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class NetworkTest {
         .once();
 
     // When
-    boolean isDeleted = client.config().networks().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.config().networks().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientAuthorizationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientAuthorizationTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OAuthClientAuthorizationTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class OAuthClientAuthorizationTest {
         .once();
 
     // When
-    boolean isDeleted = client.oAuthClientAuthorizations().withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.oAuthClientAuthorizations().withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OAuthClientTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OAuthClientTest {
 
   KubernetesMockServer server;
@@ -76,12 +76,12 @@ class OAuthClientTest {
     server.expect().withPath("/apis/oauth.openshift.io/v1/oauthclients/client2")
         .andReturn(200, new OAuthClientBuilder().build()).once();
 
-    boolean deleted = client.oAuthClients().withName("client1").delete().size() == 1;
+    boolean deleted = client.oAuthClients().withName("client1").withGracePeriod(0).delete().size() == 1;
 
-    deleted = client.oAuthClients().withName("client2").delete().size() == 1;
+    deleted = client.oAuthClients().withName("client2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.oAuthClients().withName("client3").delete().size() == 1;
+    deleted = client.oAuthClients().withName("client3").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OLMConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OLMConfigTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OLMConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class OLMConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorHub().olmConfigs().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operatorHub().olmConfigs().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftLoadTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftLoadTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OpenShiftLoadTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftResourcesTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftResourcesTest.java
@@ -112,7 +112,7 @@ import java.util.stream.Stream;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OpenShiftResourcesTest {
   KubernetesMockServer server;
   OpenShiftClient client;
@@ -227,7 +227,7 @@ class OpenShiftResourcesTest {
         .once();
 
     // When
-    boolean resourceDeleted = client.resources(resourceClass).withName("foo").delete().size() == 1;
+    boolean resourceDeleted = client.resources(resourceClass).withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(resourceDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftVersionInfoTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenShiftVersionInfoTest.java
@@ -30,7 +30,7 @@ import java.text.SimpleDateFormat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OpenShiftVersionInfoTest {
   KubernetesMockServer server;
   OpenShiftClient client;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleBindingTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OpenshiftRoleBindingTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OpenshiftRoleTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OpenshiftRoleTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorConditionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorConditionTest.java
@@ -78,7 +78,8 @@ class OperatorConditionTest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorHub().operatorConditions().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.operatorHub().operatorConditions().inNamespace("ns1").withName("cluster").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorConditionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorConditionTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OperatorConditionTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -78,7 +78,7 @@ class OperatorConditionTest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorHub().operatorConditions().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operatorHub().operatorConditions().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorPKITest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorPKITest.java
@@ -76,7 +76,8 @@ class OperatorPKITest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorPKIs().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.operatorPKIs().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorPKITest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorPKITest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OperatorPKITest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class OperatorPKITest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorPKIs().inNamespace("ns1").withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.operatorPKIs().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OperatorTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OperatorTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class OperatorTest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorHub().operators().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operatorHub().operators().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OverlappingRangeIPReservationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/OverlappingRangeIPReservationTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class OverlappingRangeIPReservationTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PackageManifestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PackageManifestTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PackageManifestTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class PackageManifestTest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorHub().packageManifests().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operatorHub().packageManifests().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PackageManifestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PackageManifestTest.java
@@ -76,7 +76,8 @@ class PackageManifestTest {
         .once();
 
     // When
-    boolean isDeleted = client.operatorHub().packageManifests().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.operatorHub().packageManifests().inNamespace("ns1").withName("cluster").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodNetworkConnectivityCheckTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodNetworkConnectivityCheckTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PodNetworkConnectivityCheckTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicyReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicyReviewTest.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PodSecurityPolicyReviewTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySelfSubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySelfSubjectReviewTest.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PodSecurityPolicySelfSubjectReviewTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySubjectReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PodSecurityPolicySubjectReviewTest.java
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PodSecurityPolicySubjectReviewTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProbeTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProbeTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ProbeTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ProbeTest {
         .once();
 
     // When
-    boolean isDeleted = client.monitoring().probes().inNamespace("ns1").withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.monitoring().probes().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProbeTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProbeTest.java
@@ -76,7 +76,8 @@ class ProbeTest {
         .once();
 
     // When
-    boolean isDeleted = client.monitoring().probes().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.monitoring().probes().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProfileTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProfileTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ProfileTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ProfileTest {
         .once();
 
     // When
-    boolean isDeleted = client.tuned().profiles().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.tuned().profiles().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProfileTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProfileTest.java
@@ -76,7 +76,8 @@ class ProfileTest {
         .once();
 
     // When
-    boolean isDeleted = client.tuned().profiles().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.tuned().profiles().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectHelmChartRepositoryTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectHelmChartRepositoryTest.java
@@ -98,7 +98,8 @@ class ProjectHelmChartRepositoryTest {
         .once();
 
     // When
-    boolean deleted = client.projectHelmChartRepositories().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.projectHelmChartRepositories().inNamespace("ns1").withName("foo").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectHelmChartRepositoryTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectHelmChartRepositoryTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ProjectHelmChartRepositoryTest {
   KubernetesMockServer server;
   OpenShiftClient client;
@@ -98,7 +98,7 @@ class ProjectHelmChartRepositoryTest {
         .once();
 
     // When
-    boolean deleted = client.projectHelmChartRepositories().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.projectHelmChartRepositories().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectRequestTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectRequestTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ProjectRequestTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ProjectTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ProjectTest {
 
   KubernetesMockServer server;
@@ -81,12 +81,12 @@ class ProjectTest {
     server.expect().withPath("/apis/project.openshift.io/v1/projects/project2").andReturn(200, new ProjectBuilder().build())
         .once();
 
-    boolean deleted = client.projects().withName("project1").delete().size() == 1;
+    boolean deleted = client.projects().withName("project1").withGracePeriod(0).delete().size() == 1;
 
-    deleted = client.projects().withName("project2").delete().size() == 1;
+    deleted = client.projects().withName("project2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.projects().withName("project3").delete().size() == 1;
+    deleted = client.projects().withName("project3").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusRuleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusRuleTest.java
@@ -108,7 +108,8 @@ class PrometheusRuleTest {
         .once();
 
     // When
-    boolean deleted = client.monitoring().prometheusRules().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.monitoring().prometheusRules().inNamespace("ns1").withName("foo").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusRuleTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusRuleTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PrometheusRuleTest {
 
   KubernetesMockServer server;
@@ -108,7 +108,7 @@ class PrometheusRuleTest {
         .once();
 
     // When
-    boolean deleted = client.monitoring().prometheusRules().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.monitoring().prometheusRules().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class PrometheusTest {
 
   KubernetesMockServer server;
@@ -112,7 +112,7 @@ class PrometheusTest {
         .once();
 
     // When
-    boolean deleted = client.monitoring().prometheuses().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.monitoring().prometheuses().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/PrometheusTest.java
@@ -112,7 +112,8 @@ class PrometheusTest {
         .once();
 
     // When
-    boolean deleted = client.monitoring().prometheuses().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.monitoring().prometheuses().inNamespace("ns1").withName("foo").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RangeAllocationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RangeAllocationTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class RangeAllocationTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class RangeAllocationTest {
         .once();
 
     // When
-    boolean deleted = client.rangeAllocations().withName("foo").delete().size() == 1;
+    boolean deleted = client.rangeAllocations().withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingRestrictionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingRestrictionTest.java
@@ -77,7 +77,8 @@ class RoleBindingRestrictionTest {
         .once();
 
     // When
-    boolean isDeleted = client.roleBindingRestrictions().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.roleBindingRestrictions().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingRestrictionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RoleBindingRestrictionTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class RoleBindingRestrictionTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class RoleBindingRestrictionTest {
         .once();
 
     // When
-    boolean isDeleted = client.roleBindingRestrictions().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.roleBindingRestrictions().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/RouteCrudTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class RouteCrudTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsCrudTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(crud = true, https = false)
 class SecurityContextConstraintsCrudTest {
 
   private static final Logger logger = LoggerFactory.getLogger(SecurityContextConstraintsCrudTest.class);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SecurityContextConstraintsTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SecurityContextConstraintsTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ServiceMonitorTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ServiceMonitorTest.java
@@ -107,7 +107,8 @@ class ServiceMonitorTest {
         .once();
 
     // When
-    boolean deleted = client.monitoring().serviceMonitors().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.monitoring().serviceMonitors().inNamespace("ns1").withName("foo").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ServiceMonitorTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ServiceMonitorTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ServiceMonitorTest {
 
   KubernetesMockServer server;
@@ -107,7 +107,7 @@ class ServiceMonitorTest {
         .once();
 
     // When
-    boolean deleted = client.monitoring().serviceMonitors().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.monitoring().serviceMonitors().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageStateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageStateTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class StorageStateTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class StorageStateTest {
         .once();
 
     // When
-    boolean isDeleted = client.kubeStorageVersionMigrator().storageStates().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.kubeStorageVersionMigrator().storageStates().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageStateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageStateTest.java
@@ -76,7 +76,8 @@ class StorageStateTest {
         .once();
 
     // When
-    boolean isDeleted = client.kubeStorageVersionMigrator().storageStates().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.kubeStorageVersionMigrator().storageStates().withName("cluster").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class StorageTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class StorageTest {
         .once();
 
     // When
-    boolean isDeleted = client.operator().storages().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.operator().storages().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageVersionMigrationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageVersionMigrationTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class StorageVersionMigrationTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -78,7 +78,7 @@ class StorageVersionMigrationTest {
         .once();
 
     // When
-    boolean isDeleted = client.kubeStorageVersionMigrator().storageVersionMigrations().withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.kubeStorageVersionMigrator().storageVersionMigrations().withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageVersionMigrationTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/StorageVersionMigrationTest.java
@@ -78,7 +78,8 @@ class StorageVersionMigrationTest {
         .once();
 
     // When
-    boolean isDeleted = client.kubeStorageVersionMigrator().storageVersionMigrations().withName("cluster").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.kubeStorageVersionMigrator().storageVersionMigrations().withName("cluster").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubjectAccessReviewTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SubjectAccessReviewTest {
 
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubscriptionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubscriptionTest.java
@@ -95,7 +95,8 @@ class SubscriptionTest {
         .once();
 
     // When
-    boolean deleted = client.operatorHub().subscriptions().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
+    boolean deleted = client.operatorHub().subscriptions().inNamespace("ns1").withName("foo").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubscriptionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/SubscriptionTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SubscriptionTest {
 
   KubernetesMockServer server;
@@ -95,7 +95,7 @@ class SubscriptionTest {
         .once();
 
     // When
-    boolean deleted = client.operatorHub().subscriptions().inNamespace("ns1").withName("foo").delete().size() == 1;
+    boolean deleted = client.operatorHub().subscriptions().inNamespace("ns1").withName("foo").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertTrue(deleted);

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateInstanceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateInstanceTest.java
@@ -77,7 +77,8 @@ class TemplateInstanceTest {
         .once();
 
     // When
-    boolean isDeleted = client.templateInstances().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.templateInstances().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateInstanceTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateInstanceTest.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class TemplateInstanceTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class TemplateInstanceTest {
         .once();
 
     // When
-    boolean isDeleted = client.templateInstances().inNamespace("ns1").withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.templateInstances().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TemplateTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class TemplateTest {
 
   KubernetesMockServer server;
@@ -172,12 +172,12 @@ class TemplateTest {
         .andReturn(200, new TemplateBuilder().build())
         .once();
 
-    boolean deleted = client.templates().withName("tmpl1").delete().size() == 1;
+    boolean deleted = client.templates().withName("tmpl1").withGracePeriod(0).delete().size() == 1;
 
-    deleted = client.templates().withName("tmpl2").delete().size() == 1;
+    deleted = client.templates().withName("tmpl2").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
 
-    deleted = client.templates().inNamespace("ns1").withName("tmpl2").delete().size() == 1;
+    deleted = client.templates().inNamespace("ns1").withName("tmpl2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
   }
 

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ThanosRulerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ThanosRulerTest.java
@@ -77,7 +77,8 @@ class ThanosRulerTest {
         .once();
 
     // When
-    boolean isDeleted = client.monitoring().thanosRulers().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.monitoring().thanosRulers().inNamespace("ns1").withName("test-delete").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ThanosRulerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/ThanosRulerTest.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ThanosRulerTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class ThanosRulerTest {
         .once();
 
     // When
-    boolean isDeleted = client.monitoring().thanosRulers().inNamespace("ns1").withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.monitoring().thanosRulers().inNamespace("ns1").withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TunedTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/TunedTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class TunedTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class TunedTest {
         .once();
 
     // When
-    boolean isDeleted = client.tuned().tuneds().inNamespace("ns1").withName("cluster").delete().size() == 1;
+    boolean isDeleted = client.tuned().tuneds().inNamespace("ns1").withName("cluster").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserIdentityMappingTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserIdentityMappingTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class UserIdentityMappingTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserOAuthAccessTokenTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserOAuthAccessTokenTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class UserOAuthAccessTokenTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -79,7 +79,7 @@ class UserOAuthAccessTokenTest {
         .once();
 
     // When
-    boolean isDeleted = client.userOAuthAccessTokens().withName("test-delete").delete().size() == 1;
+    boolean isDeleted = client.userOAuthAccessTokens().withName("test-delete").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/UserTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class UserTest {
 
   KubernetesMockServer server;
@@ -79,12 +79,12 @@ class UserTest {
     server.expect().withPath("/apis/user.openshift.io/v1/users/user1").andReturn(200, new UserBuilder().build()).once();
     server.expect().withPath("/apis/user.openshift.io/v1/users/User2").andReturn(200, new UserBuilder().build()).once();
 
-    boolean deleted = client.users().withName("user1").delete().size() == 1;
+    boolean deleted = client.users().withName("user1").withGracePeriod(0).delete().size() == 1;
 
-    deleted = client.users().withName("User2").delete().size() == 1;
+    deleted = client.users().withName("User2").withGracePeriod(0).delete().size() == 1;
     assertTrue(deleted);
 
-    deleted = client.users().withName("User3").delete().size() == 1;
+    deleted = client.users().withName("User3").withGracePeriod(0).delete().size() == 1;
     assertFalse(deleted);
   }
 }

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterClaimTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterClaimTest.java
@@ -29,7 +29,7 @@ import java.text.ParseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterClaimTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -77,7 +77,7 @@ class ClusterClaimTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().clusterClaims().inNamespace("ns1").withName("clusterclaim1").delete().size() == 1;
+    boolean isDeleted = client.hive().clusterClaims().inNamespace("ns1").withName("clusterclaim1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterClaimTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterClaimTest.java
@@ -77,7 +77,8 @@ class ClusterClaimTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().clusterClaims().inNamespace("ns1").withName("clusterclaim1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.hive().clusterClaims().inNamespace("ns1").withName("clusterclaim1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeploymentTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeploymentTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterDeploymentTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeprovisionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterDeprovisionTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterDeprovisionTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterImageSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterImageSetTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterImageSetTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ClusterImageSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().clusterImageSets().withName("clusterimageset1").delete().size() == 1;
+    boolean isDeleted = client.hive().clusterImageSets().withName("clusterimageset1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterPoolTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterPoolTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ClusterPoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().clusterPools().inNamespace("ns1").withName("clusterpool1").delete().size() == 1;
+    boolean isDeleted = client.hive().clusterPools().inNamespace("ns1").withName("clusterpool1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterPoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterPoolTest.java
@@ -76,7 +76,8 @@ class ClusterPoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().clusterPools().inNamespace("ns1").withName("clusterpool1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.hive().clusterPools().inNamespace("ns1").withName("clusterpool1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterRelocateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterRelocateTest.java
@@ -76,7 +76,8 @@ class ClusterRelocateTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().clusterRelocates().inNamespace("ns1").withName("clusterrelocate1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.hive().clusterRelocates().inNamespace("ns1").withName("clusterrelocate1").withGracePeriod(0)
+        .delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterRelocateTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/ClusterRelocateTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class ClusterRelocateTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class ClusterRelocateTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().clusterRelocates().inNamespace("ns1").withName("clusterrelocate1").delete().size() == 1;
+    boolean isDeleted = client.hive().clusterRelocates().inNamespace("ns1").withName("clusterrelocate1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/DNSZoneTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/DNSZoneTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class DNSZoneTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class DNSZoneTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().dnsZones().inNamespace("ns1").withName("dnszone1").delete().size() == 1;
+    boolean isDeleted = client.hive().dnsZones().inNamespace("ns1").withName("dnszone1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/DNSZoneTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/DNSZoneTest.java
@@ -76,7 +76,8 @@ class DNSZoneTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().dnsZones().inNamespace("ns1").withName("dnszone1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.hive().dnsZones().inNamespace("ns1").withName("dnszone1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/HiveConfigTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/HiveConfigTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class HiveConfigTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class HiveConfigTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().hiveConfigs().withName("hiveconfig1").delete().size() == 1;
+    boolean isDeleted = client.hive().hiveConfigs().withName("hiveconfig1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/MachinePoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/MachinePoolTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class MachinePoolTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class MachinePoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().machinePools().inNamespace("ns1").withName("machinepool1").delete().size() == 1;
+    boolean isDeleted = client.hive().machinePools().inNamespace("ns1").withName("machinepool1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/MachinePoolTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/MachinePoolTest.java
@@ -76,7 +76,8 @@ class MachinePoolTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().machinePools().inNamespace("ns1").withName("machinepool1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.hive().machinePools().inNamespace("ns1").withName("machinepool1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncIdentityProviderTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncIdentityProviderTest.java
@@ -30,7 +30,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SelectorSyncIdentityProviderTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SelectorSyncSetTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SelectorSyncSetTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class SelectorSyncSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().selectorSyncSets().withName("selectorsyncset1").delete().size() == 1;
+    boolean isDeleted = client.hive().selectorSyncSets().withName("selectorsyncset1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncIdentityProviderTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncIdentityProviderTest.java
@@ -30,7 +30,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SyncIdentityProviderTest {
   private OpenShiftClient client;
   KubernetesMockServer server;

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncSetTest.java
@@ -28,7 +28,7 @@ import java.net.HttpURLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(https = false)
 class SyncSetTest {
   private OpenShiftClient client;
   KubernetesMockServer server;
@@ -76,7 +76,7 @@ class SyncSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().syncSets().inNamespace("ns1").withName("syncset1").delete().size() == 1;
+    boolean isDeleted = client.hive().syncSets().inNamespace("ns1").withName("syncset1").withGracePeriod(0).delete().size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncSetTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/hive/SyncSetTest.java
@@ -76,7 +76,8 @@ class SyncSetTest {
         .once();
 
     // When
-    boolean isDeleted = client.hive().syncSets().inNamespace("ns1").withName("syncset1").withGracePeriod(0).delete().size() == 1;
+    boolean isDeleted = client.hive().syncSets().inNamespace("ns1").withName("syncset1").withGracePeriod(0).delete()
+        .size() == 1;
 
     // Then
     assertThat(isDeleted).isTrue();


### PR DESCRIPTION
## Description

Two related test-side changes from the speed audit in #7675.

### 1. Switch mock servers to plain HTTP

`@EnableKubernetesMockClient` defaults to `https=true`. Under `forkCount=1C` the TLS handshake on the first HTTP call in each fork dominated wall time on the slowest classes (e.g. `MachineConfigPoolTest#delete` 18.08s, `OpenShiftResourcesTest` 114.2s). Switched 245 mock-mode tests to `https=false`; TLS is not under test in any of them.

**Skipped:** `UntrustedCertTest` and `KeyLoadTests`, which exercise cert trust and key loading explicitly.

### 2. Make `withGracePeriod(0)` explicit on `delete()` calls

The original §3 of #7675 claimed the OpenShift `delete` tests were eating ~16s each in a polling/retry loop. Empirical verification shows no such loop runs: `BaseOperation.waitForDelete` is gated on `context.getTimeout() > 0`, which these tests never set. Adding `.withGracePeriod(0)` is therefore a **no-op behavior change** kept for intent clarity (it documents that the test does not exercise the post-delete polling path) and matches the pattern other tests already use.

Applied to 212 `.delete().size() == 1` lines. Skipped per-line where the test asserts on the DELETE request body:
- `PropagationPolicyTest` (wholesale)
- `DeploymentConfigTest`, `CustomResourceTest`, `CreateOrReplaceResourceTest`, `TypedClusterScopeCustomResourceApiTest`, `TypedCustomResourceApiTest` (specific methods)

`ImageSignatureTest` and `StatefulSetTest#testDeleteLoadedResource` were left at plain `.delete()` because the DSL there (`CreateOrDeleteable` / `Deletable`) doesn't expose `withGracePeriod`.

## Verification

- Local `mvn -pl kubernetes-tests test`: **1:41 min** (was **2:30 min**, -33%).
- 1276 tests pass, 0 failures, 4 skipped.
- Per-method examples (full-suite run): `MachineConfigPoolTest#delete` 18.08s → **7.39s**; `AlertmanagerConfigTest#delete` 17.07s → **8.54s**; `OpenShiftResourcesTest` 114.2s → **54.97s**.

## Notes

The remaining ~7-8s "first HTTP call in fork" cost is Vert.x/Netty cold-start, deferred to follow-up item 10 of #7675. The full re-diagnosis (why the original §3 hypothesis was wrong) is documented in the updated issue body.

Refs #7675