### PR TITLE
chore(kubernetes-client-api,kubernetes-client): use forkCount=1C

### DIFF
--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -230,7 +230,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1C</forkCount>
           <reuseForks>true</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>

--- a/kubernetes-client/pom.xml
+++ b/kubernetes-client/pom.xml
@@ -147,7 +147,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1C</forkCount>
           <reuseForks>true</reuseForks>
           <!-- We cleanup system properties an env vars, so that we can test in a predictable env -->
           <environmentVariables>


### PR DESCRIPTION
## Summary

Implements item #2 of #7675.

Both modules pinned `forkCount=1` while state-leakage hazards were open. Those were addressed in #7667 (env-var save/restore in `CertUtilsTest`) and #7673 (`MockedStatic` cleanup in `AbstractWatchManagerTest`). With `reuseForks=true` already in place, single-fork execution is no longer required.

Bumps both modules to `forkCount=1C`, matching the existing `kubernetes-tests` precedent.

## Local verification

| Module | Tests | Failures | Notes |
|---|---:|---:|---|
| `kubernetes-client-api` | full module run | 1 | `KubeConfigUtilsMergeTest#userInfoPreservedFromOriginalConfig` — pre-existing env-leak from host `~/.kube/config`, reproduces on baseline (`git stash` + re-run); not caused by this change. |
| `kubernetes-client` | 260 | 0 | BUILD SUCCESS, 7 skipped, 871% CPU usage confirms multi-fork active. |

## Notes

Item #1 (`-T 1C` in CI workflows) was tried in an earlier push of this PR and reverted: combined with `forkCount=1C`, it triggered timing flakes on 2-core CI runners in unrelated modules (`httpclient-vertx-5`, `httpclient-vertx`) and in this PR's `UploadTest` due to a 100ms hardcoded scheduling delay. Follow-up issues will be filed for the structural test fragilities; `-T 1C` can be revisited after those are fixed.

Refs #7675