### PR TITLE
chore: drop redundant mockito-inline boilerplate and document https=false convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,13 @@ mvn spotless:check
 
 Two modes available via `@EnableKubernetesMockClient`:
 
+**Default to plain HTTP** (`https = false`) for new mock-mode tests. The first HTTPS call in each surefire fork pays a ~7–8 s TLS/Vert.x cold-start cost, which compounds under `forkCount=1C`. Only enable HTTPS when TLS itself is the unit under test (current exceptions: `UntrustedCertTest` and `KeyLoadTests`).
+
+```java
+@EnableKubernetesMockClient(https = false, crud = true)
+class MyTest { /* ... */ }
+```
+
 **CRUD Mode** (recommended for most tests):
 ```java
 @EnableKubernetesMockClient(crud = true)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Do all your development or fixing work here.
 
 After all your development/fixing work is done, do not forget to add `Unit Test` and `Regression Test` around that. It will be nice if you can add an example of the new feature you have added.
 
+For new mock-mode tests, prefer `@EnableKubernetesMockClient(https = false)` unless TLS itself is under test — see the "Mock Server Testing" section of [AGENTS.md](AGENTS.md) for the rationale and exceptions.
+
 #### Check your work after running all Unit and Regression Tests
 
 You should run all the unit tests by hitting the following command

--- a/extensions/chaosmesh/client/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/chaosmesh/client/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/httpclient-vertx-5/pom.xml
+++ b/httpclient-vertx-5/pom.xml
@@ -135,7 +135,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/httpclient-vertx/pom.xml
+++ b/httpclient-vertx/pom.xml
@@ -80,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/kubernetes-client-api/pom.xml
+++ b/kubernetes-client-api/pom.xml
@@ -205,7 +205,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kubernetes-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/kubernetes-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/kubernetes-model-generator/kubernetes-model-common/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-common/pom.xml
@@ -46,10 +46,6 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
     <bcpkix-fips.version>2.1.11</bcpkix-fips.version>
     <keycloak.version>26.6.1</keycloak.version><!-- Used by CRD Generator integration tests for verifications -->
     <mockito.version>5.23.0</mockito.version>
-    <mockito-inline.version>5.2.0</mockito-inline.version>
     <spock.version>2.4-M6-groovy-4.0</spock.version>
 
     <conscrypt-openjdk-uber.bundle.version>1.4.2_1</conscrypt-openjdk-uber.bundle.version>
@@ -888,12 +887,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
-        <version>${mockito-inline.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.core.version}</version>
@@ -1224,7 +1217,6 @@
                 <exclude>**/go.mod</exclude>
                 <exclude>**/go.sum</exclude>
                 <exclude>kubernetes-client/src/test/resources/**/*</exclude>
-                <exclude>kubernetes-client/src/test/resources/mockito-extensions/*</exclude>
                 <exclude>**/src/test/resources/ssl/*</exclude>
                 <exclude>**/src/test/resources/io/fabric8/java/generator/approvals/*.*.approved.txt</exclude>
                 <exclude>crd-generator/**/src/test/resources/**/*.approved.yml</exclude>


### PR DESCRIPTION
## Description

Items 5, 6, and 11 of the round-2 CI cleanup umbrella (#7675).

### Item 5 — chaosmesh-client `MockMaker` leak

Deleted `extensions/chaosmesh/client/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker`. The file lived in `src/main/resources/`, so it was packaged into the `bundle` JAR and silently switched downstream consumers' MockMaker to `mock-maker-inline`. Verified `extensions/chaosmesh/tests` still passes after the removal.

### Item 6 — drop redundant `mockito-inline:5.2.0` deps

Mockito 5+ ships `mock-maker-inline` as the default in `mockito-core`; the separate `mockito-inline` artifact is a deprecated 4.x leftover. The project uses `mockito.version=5.23.0` (5.11.0 on the Java 17 profile), so the explicit dep and the matching test-resource override in `kubernetes-client` are no-ops.

- Removed `<mockito-inline.version>` property and dependencyManagement entry from the root `pom.xml`.
- Replaced `mockito-inline` with `mockito-core` in 6 modules that had no other Mockito dep: `kubernetes-client-api`, `httpclient-jdk`, `httpclient-jetty`, `httpclient-okhttp`, `httpclient-vertx`, `httpclient-vertx-5`.
- Removed `mockito-inline` from `kubernetes-model-common` (already had `mockito-core`).
- Deleted `kubernetes-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker` and the matching license-plugin `<exclude>`.

### Item 11 — `https = false` convention docs

Added a "Default to plain HTTP" callout in `AGENTS.md` (Mock Server Testing section) explaining the rationale (per-fork TLS/Vert.x cold-start cost, see #7683) and naming the two exceptions (`UntrustedCertTest`, `KeyLoadTests`). Added a one-liner pointer in `CONTRIBUTING.md`. `CLAUDE.md` is a symlink to `AGENTS.md`, so it's covered.

## Verification

| Module | Tests | Result |
|---|---|---|
| `kubernetes-client-api` | 620 | 619 pass; 1 pre-existing `KubeConfigUtilsMergeTest#userInfoPreservedFromOriginalConfig` env-leak flake documented in #7675, unrelated |
| `kubernetes-model-common` | 60 | All pass |
| `httpclient-jdk/jetty/okhttp/vertx/vertx-5` | 180 | All pass |
| `kubernetes-client` (`PortForwarderWebsocketListenerTest` + `AbstractWatchManagerTest`) | 20 | All pass — confirms `MockedStatic` still works without the deleted resource |
| `extensions/chaosmesh/tests` | 2 | All pass — confirms removing the leaked resource doesn't regress consumers |

Refs #7675