### PR TITLE
test(kubernetes-client-api): stabilize KubeConfigUtilsMergeTest flake (7691)

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigSourcePrecedenceTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/ConfigSourcePrecedenceTest.java
@@ -34,6 +34,11 @@ class ConfigSourcePrecedenceTest {
           Utils.filePath(ConfigSourcePrecedenceTest.class.getResource("/config-source-precedence/kube-config")));
     }
 
+    @AfterEach
+    void tearDown() {
+      System.clearProperty("kubeconfig");
+    }
+
     @Test
     @DisplayName("then use kubeconfig attributes in Config")
     void whenNoOtherSourceProvided_thenUseKubeConfig() {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/KubeConfigUtilsMergeTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/internal/KubeConfigUtilsMergeTest.java
@@ -293,7 +293,7 @@ class KubeConfigUtilsMergeTest {
 
     @BeforeEach
     void setUp() {
-      result = new ConfigBuilder()
+      result = new ConfigBuilder(Config.empty())
           .addToContexts(new NamedContextBuilder()
               .withName("context-in-original-config")
               .withNewContext()


### PR DESCRIPTION
Fixes #7691.

## Summary

`KubeConfigUtilsMergeTest.userInfoPreservedFromOriginalConfig` was
flaky in CI: when run after a sibling test that left the `kubeconfig`
system property set, the fixture's `new ConfigBuilder()`
(autoConfigure=true) loaded the polluted kubeconfig and copied
`token-from-kubeconfig` into the result before `KubeConfigUtils.merge`
ran. Because the merge skips auth overwrites when the current
context's user (`original-user`) is not present in any of the merged
kubeconfigs, the leaked token survived and the assertion
`autoOAuthToken == null` failed.

## Changes

- `KubeConfigUtilsMergeTest`: switch the original-config fixture to
  `new ConfigBuilder(Config.empty())` so it disables auto-configure,
  matching the pattern used by the rest of the tests in this file.
- `ConfigSourcePrecedenceTest\$KubeConfigSource`: add the missing
  `@AfterEach` clearing the `kubeconfig` system property — the
  upstream root cause of the leak. The other two nested classes in
  the same file already had this cleanup.

## Verification

- Reproduced the original CI failure locally with
  `-Dkubeconfig=…/config-source-precedence/kube-config` against the
  un-fixed test (1 failure, identical assertion).
- With both fixes: full `kubernetes-client-api` module run →
  620 tests, 0 failures, 0 errors, 3 skipped.