### PR TITLE
fix(kubernetes-client): order exec exit code after pending writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #7696: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation
+* Fix #XXXX: ExecWebSocketListener now defers exitCode completion through the SerialExecutor so pending stdout/stderr async writes are flushed before exit signals (ref #7685)
 * Fix #7632: java-generator now HTML-escapes `<`, `>`, and `&` in CRD descriptions to produce valid Javadoc
 * Fix #7543: fix processInlineDuplicateFields to recursively resolve nested inline embeds
 * Fix #7450: StandardHttpClient.shouldRetry() does not retry on Vert.x HttpClosedException

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Bugs
 * Fix #7696: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation
-* Fix #XXXX: ExecWebSocketListener now defers exitCode completion through the SerialExecutor so pending stdout/stderr async writes are flushed before exit signals (ref #7685)
+* Fix #7695: ExecWebSocketListener now defers exitCode completion through the SerialExecutor so pending stdout/stderr async writes are flushed before exit signals
 * Fix #7632: java-generator now HTML-escapes `<`, `>`, and `&` in CRD descriptions to produce valid Javadoc
 * Fix #7543: fix processInlineDuplicateFields to recursively resolve nested inline embeds
 * Fix #7450: StandardHttpClient.shouldRetry() does not retry on Vert.x HttpClosedException

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -315,7 +315,9 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
         case 2:
           if (terminateOnError) {
             String stringValue = toString(bytes);
-            exitCode.completeExceptionally(new KubernetesClientException(stringValue));
+            // Defer through serialExecutor so any pending channel 1 async writes
+            // are flushed before the exitCode future completes exceptionally.
+            serialExecutor.execute(() -> exitCode.completeExceptionally(new KubernetesClientException(stringValue)));
             close = true;
           } else {
             error.handle(byteString, webSocket);
@@ -326,7 +328,9 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
           try {
             errorChannel.handle(bytes, webSocket);
           } finally {
-            handleExitStatus(byteString);
+            // Defer through serialExecutor so any pending async writes (channel 1/2/errorChannel)
+            // are flushed before the exitCode future completes.
+            serialExecutor.execute(() -> handleExitStatus(byteString));
           }
           break;
         default:

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/UploadTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/behavior/UploadTest.java
@@ -32,7 +32,6 @@ import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketResponse;
 import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,9 +52,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -144,14 +140,11 @@ class UploadTest {
   @DisplayName("Successful")
   class Success {
 
-    private ScheduledExecutorService executorService;
-
     private WebSocket webSocket;
     private Path toUpload;
 
     @BeforeEach
     void setUp() {
-      executorService = Executors.newSingleThreadScheduledExecutor();
       final AtomicInteger tarByteCount = new AtomicInteger(0);
       webSocket = mock(WebSocket.class);
       when(webSocket.send(any())).thenAnswer(i -> {
@@ -163,8 +156,7 @@ class UploadTest {
         if (s.asHttpRequest().uri().getQuery().contains("command=wc -c")) {
           l.onMessage(webSocket, ByteBuffer.wrap(("\u0001" + tarByteCount.get() + "\n").getBytes(StandardCharsets.UTF_8)));
         }
-        // Needs a short delay to be able to process the previous message (TODO: this should be fixed in the production code)
-        executorService.schedule(() -> l.onMessage(webSocket, exitZeroEvent()), 100, TimeUnit.MILLISECONDS);
+        l.onMessage(webSocket, exitZeroEvent());
         return CompletableFuture.completedFuture(new WebSocketResponse(new WebSocketUpgradeResponse(null), webSocket));
       };
       // 3 Operations:
@@ -175,11 +167,6 @@ class UploadTest {
         informPodReady("success-pod");
         httpClient.wsExpect("/api/v1/namespaces/.+/pods/success-pod/exec", future);
       });
-    }
-
-    @AfterEach
-    void tearDown() {
-      executorService.shutdownNow();
     }
 
     @Nested

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -18,18 +18,29 @@ package io.fabric8.kubernetes.client.dsl.internal;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.StatusCause;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext.StreamContext;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -122,6 +133,111 @@ class ExecWebSocketListenerTest {
     listener.onClose(mock, 1000, "testing");
 
     assertNull(listener.exitCode().join());
+  }
+
+  @Test
+  void onMessageChannel3CompletesExitAfterPendingChannel1Writes() throws Exception {
+    final CountDownLatch writeStarted = new CountDownLatch(1);
+    final CountDownLatch releaseWrite = new CountDownLatch(1);
+    final OutputStream blockingOut = new OutputStream() {
+      @Override
+      public void write(int b) {
+      }
+
+      @Override
+      public void write(byte[] b, int off, int len) throws IOException {
+        writeStarted.countDown();
+        try {
+          if (!releaseWrite.await(5, TimeUnit.SECONDS)) {
+            throw new IOException("write was not released");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException(e);
+        }
+      }
+    };
+    final PodOperationContext context = new PodOperationContext().toBuilder()
+        .output(new StreamContext(blockingOut))
+        .build();
+    final ExecutorService asyncExecutor = Executors.newSingleThreadExecutor();
+    try {
+      final ExecWebSocketListener listener = new ExecWebSocketListener(context, asyncExecutor, new KubernetesSerialization());
+      final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
+      listener.onOpen(mockedWebSocket);
+
+      // Channel 1 (stdout) message: queues an async write that will block until released
+      listener.onMessage(mockedWebSocket, ByteBuffer.wrap(new byte[] { (byte) 1, (byte) 'p', (byte) 'a', (byte) 'y' }));
+      assertTrue(writeStarted.await(2, TimeUnit.SECONDS), "expected the channel 1 async write to start");
+
+      // Channel 3 (exit-success) message fires while the previous write is still in flight
+      final String successJson = new KubernetesSerialization().asJson(new StatusBuilder().withStatus("Success").build());
+      final byte[] channel3 = ("" + successJson).getBytes(StandardCharsets.UTF_8);
+      listener.onMessage(mockedWebSocket, ByteBuffer.wrap(channel3));
+
+      // The exitCode must NOT complete before the pending channel 1 write has been processed.
+      // Without the fix, exitCode is completed synchronously inside onMessage and this assertion fails.
+      assertThrows(TimeoutException.class, () -> listener.exitCode().get(200, TimeUnit.MILLISECONDS),
+          "exitCode must not complete before pending channel 1 async writes finish");
+
+      releaseWrite.countDown();
+      assertEquals(0, listener.exitCode().get(2, TimeUnit.SECONDS));
+    } finally {
+      asyncExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  void onMessageChannel2TerminateOnErrorCompletesExitAfterPendingChannel1Writes() throws Exception {
+    final CountDownLatch writeStarted = new CountDownLatch(1);
+    final CountDownLatch releaseWrite = new CountDownLatch(1);
+    final OutputStream blockingOut = new OutputStream() {
+      @Override
+      public void write(int b) {
+      }
+
+      @Override
+      public void write(byte[] b, int off, int len) throws IOException {
+        writeStarted.countDown();
+        try {
+          if (!releaseWrite.await(5, TimeUnit.SECONDS)) {
+            throw new IOException("write was not released");
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException(e);
+        }
+      }
+    };
+    final PodOperationContext context = new PodOperationContext().toBuilder()
+        .output(new StreamContext(blockingOut))
+        .terminateOnError(true)
+        .build();
+    final ExecutorService asyncExecutor = Executors.newSingleThreadExecutor();
+    try {
+      final ExecWebSocketListener listener = new ExecWebSocketListener(context, asyncExecutor, new KubernetesSerialization());
+      final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
+      listener.onOpen(mockedWebSocket);
+
+      // Channel 1 (stdout) message: queues an async write that will block until released
+      listener.onMessage(mockedWebSocket, ByteBuffer.wrap(new byte[] { (byte) 1, (byte) 'p', (byte) 'a', (byte) 'y' }));
+      assertTrue(writeStarted.await(2, TimeUnit.SECONDS), "expected the channel 1 async write to start");
+
+      // Channel 2 (stderr) with terminateOnError=true: completes exitCode exceptionally
+      listener.onMessage(mockedWebSocket,
+          ByteBuffer.wrap(new byte[] { (byte) 2, (byte) 'b', (byte) 'o', (byte) 'o', (byte) 'm' }));
+
+      // The exitCode must NOT complete (exceptionally) before the pending channel 1 write has been processed.
+      assertThrows(TimeoutException.class, () -> listener.exitCode().get(200, TimeUnit.MILLISECONDS),
+          "exitCode must not complete before pending channel 1 async writes finish");
+
+      releaseWrite.countDown();
+      final ExecutionException ex = assertThrows(ExecutionException.class,
+          () -> listener.exitCode().get(2, TimeUnit.SECONDS));
+      assertThat(ex.getCause()).isInstanceOf(KubernetesClientException.class);
+    } finally {
+      asyncExecutor.shutdownNow();
+    }
   }
 
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -171,9 +171,11 @@ class ExecWebSocketListenerTest {
       assertTrue(writeStarted.await(2, TimeUnit.SECONDS), "expected the channel 1 async write to start");
 
       // Channel 3 (exit-success) message fires while the previous write is still in flight
-      final String successJson = new KubernetesSerialization().asJson(new StatusBuilder().withStatus("Success").build());
-      final byte[] channel3 = ("" + successJson).getBytes(StandardCharsets.UTF_8);
-      listener.onMessage(mockedWebSocket, ByteBuffer.wrap(channel3));
+      final byte[] successJson = new KubernetesSerialization().asJson(new StatusBuilder().withStatus("Success").build())
+          .getBytes(StandardCharsets.UTF_8);
+      final ByteBuffer channel3 = ByteBuffer.allocate(successJson.length + 1).put((byte) 3).put(successJson);
+      channel3.flip();
+      listener.onMessage(mockedWebSocket, channel3);
 
       // The exitCode must NOT complete before the pending channel 1 write has been processed.
       // Without the fix, exitCode is completed synchronously inside onMessage and this assertion fails.


### PR DESCRIPTION
## Summary

`ExecWebSocketListener.onMessage` completed the `exitCode` future synchronously on channel 3 (exit status) and on channel 2 with `terminateOnError`, while channel 1/2 messages bound to a user-supplied `OutputStream` queue their write on the `SerialExecutor`. Waiters on `exitCode` could therefore unblock and read the `OutputStream` before the queued write had run — surfacing as a flake in `UploadTest#uploadReturnsTrue` under fork-concurrency CPU contention (`forkCount=1C` on a 2-core runner).

## Changes

- `ExecWebSocketListener`: defer both exit completions (`case 2` `terminateOnError` and `case 3` exit status) through `serialExecutor`, so they are ordered after any pending channel-1/2 async writes. `SerialExecutor` is FIFO, so writes queued before exit completion are flushed first; existing tests using `Runnable::run` still execute synchronously through this path, preserving prior semantics.
- `UploadTest`: the 100ms hardcoded `ScheduledExecutorService.schedule(...)` workaround in `Success#setUp` (and the corresponding `tearDown`/imports) is removed — the production fix makes the timing-based gate unnecessary; the exit message is now fired synchronously after the byte-count message.
- `ExecWebSocketListenerTest`: two new deterministic tests (`onMessageChannel3CompletesExitAfterPendingChannel1Writes`, `onMessageChannel2TerminateOnErrorCompletesExitAfterPendingChannel1Writes`) using a latch-blocked `OutputStream` plus an async backing executor — they fail without the fix and pass with it without relying on `Thread.sleep`.

Closes #7685