### PR TITLE
fix(httpclient-vertx): clear response exception handler before reset in cancel()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
-* Fix #7694: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation
+* Fix #7696: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation
 * Fix #7632: java-generator now HTML-escapes `<`, `>`, and `&` in CRD descriptions to produce valid Javadoc
 * Fix #7543: fix processInlineDuplicateFields to recursively resolve nested inline embeds
 * Fix #7450: StandardHttpClient.shouldRetry() does not retry on Vert.x HttpClosedException

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
+* Fix #7694: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation
 * Fix #7632: java-generator now HTML-escapes `<`, `>`, and `&` in CRD descriptions to produce valid Javadoc
 * Fix #7543: fix processInlineDuplicateFields to recursively resolve nested inline embeds
 * Fix #7450: StandardHttpClient.shouldRetry() does not retry on Vert.x HttpClosedException

--- a/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
+++ b/httpclient-vertx/src/main/java/io/fabric8/kubernetes/client/vertx/VertxHttpRequest.java
@@ -69,8 +69,12 @@ class VertxHttpRequest {
 
         @Override
         public void cancel() {
+          // The exception handler must be cleared before calling reset(), otherwise
+          // the reset triggers a StreamResetException that completes the future
+          // exceptionally before done.cancel() can run.
           resp.handler(null);
           resp.endHandler(null);
+          resp.exceptionHandler(null);
           resp.request().reset();
           done.cancel(false);
         }


### PR DESCRIPTION
## Description

Fixes #7694

Fixes the flake reported in #7694: `VertxHttpClientAsyncBodyTest.consumeBytesNotProcessedIfCancelled` intermittently fails with `ExecutionException(StreamResetException: Stream reset: 0)` instead of the expected `CancellationException`.

In `VertxHttpRequest#cancel()`, calling `resp.request().reset()` can synchronously invoke the registered `exceptionHandler` with a `StreamResetException`, which calls `done.completeExceptionally(...)` before `done.cancel(false)` runs. Consumers observing `done.get()` then see the wrapped `StreamResetException` instead of `CancellationException`.

This mirrors the fix already in place on the Vert.x 5 sibling (`Vertx5AsyncBody#cancel`, introduced in #7433) by clearing the exception handler before issuing the reset.

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Chore (non-breaking change which doesn't affect codebase; test, version modification, documentation, etc.)