### PR TITLE
docs(cheatsheet): fix Secret creation example to use addToStringData

### DIFF
--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -683,12 +683,10 @@ Secret secret = client.secrets().inNamespace("default").withName("secret1").get(
 ```
 - Create a `Secret`:
 ```java
-Function<String, String> encodeBase64 = val -> Base64.getEncoder().encodeToString(val.getBytes(StandardCharsets.UTF_8));
-
 Secret secret1 = new SecretBuilder()
       .withNewMetadata().withName("secret1").endMetadata()
-      .addToData("username",  encodeBase64.apply("guccifer"))
-      .addToData("password",  encodeBase64.apply("shadowgovernment"))
+      .addToStringData("username", "guccifer")
+      .addToStringData("password", "shadowgovernment")
       .build();
 Secret secretCreated = client.secrets().inNamespace("default").resource(secret1).create();
 ```

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -683,10 +683,12 @@ Secret secret = client.secrets().inNamespace("default").withName("secret1").get(
 ```
 - Create a `Secret`:
 ```java
+Function<String, String> encodeBase64 = val -> Base64.getEncoder().encodeToString(val.getBytes(StandardCharsets.UTF_8));
+
 Secret secret1 = new SecretBuilder()
       .withNewMetadata().withName("secret1").endMetadata()
-      .addToData("username", "guccifer")
-      .addToData("password", "shadowgovernment")
+      .addToData("username",  encodeBase64.apply("guccifer"))
+      .addToData("password",  encodeBase64.apply("shadowgovernment"))
       .build();
 Secret secretCreated = client.secrets().inNamespace("default").resource(secret1).create();
 ```


### PR DESCRIPTION
Updated the creation of a Secret to encode username and password in Base64 format.

Otherwise would result in error
```
Secret in version "v1" cannot be handled as a Secret: illegal base64 data at input byte 9
```

## Description
<!--
Thank a lot for taking time to contribute to Fabric8 <3!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes. It is
really helpful for people who would review your code.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/main/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
