### PR TITLE
test(kubernetes-client): stabilize SerialExecutorTest order-of-insertion flake

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/SerialExecutorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/SerialExecutorTest.java
@@ -61,12 +61,14 @@ class SerialExecutorTest {
     try {
       final StringBuffer sb = new StringBuffer();
       final SerialExecutor se = new SerialExecutor(es);
-      final CountDownLatch latch = new CountDownLatch(1);
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(1);
       se.execute(() -> {
         sb.append("1");
         try {
-          Thread.sleep(100L);
+          start.await();
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       });
@@ -74,8 +76,9 @@ class SerialExecutorTest {
       se.execute(() -> sb.append("3"));
       se.execute(() -> sb.append("4"));
       se.execute(() -> sb.append("5"));
-      se.execute(latch::countDown);
-      assertThat(latch.await(500L, TimeUnit.MILLISECONDS)).isTrue();
+      se.execute(done::countDown);
+      start.countDown();
+      assertThat(done.await(5L, TimeUnit.SECONDS)).isTrue();
       assertThat(sb).hasToString("12345");
     } finally {
       es.shutdownNow();


### PR DESCRIPTION
## Summary

`SerialExecutorTest.taskExecutedInOrderOfInsertion` was flaking on CI: the assertion `latch.await(500L, MILLISECONDS)` occasionally returned `false` because the original test relied on a `Thread.sleep(100L)` inside task 1 plus a tight 500 ms total budget for six tasks to drain — under load, scheduling overhead pushed past the budget.

This change replaces the wall-clock timing with a deterministic `CountDownLatch` gate:

- Task 1 appends `"1"` and blocks on a `start` latch.
- The test thread submits tasks 2–6 (the last counts down `done`) and only then calls `start.countDown()`.
- Since the test thread submits all six tasks before releasing `start` (sequential program order), tasks 2–6 are guaranteed to be in the queue when task 1 returns, so the FIFO drain order is verified deterministically.
- The completion timeout is bumped to a generous 5 s; happy-path runtime drops from ~0.74 s to ~0.20 s.

Refs #7391
Fixes #7697