### PR TITLE
fix(kubernetes-client): defer ExecWebSocketListener.onError handling through SerialExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
+* Fix #7700: ExecWebSocketListener.onError now defers failure handling through the SerialExecutor so a pending channel-3 exit-status task runs first and the parsed exit code is preserved instead of being overwritten by a peer-close exception
 * Fix #7696: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation
 * Fix #7695: ExecWebSocketListener now defers exitCode completion through the SerialExecutor so pending stdout/stderr async writes are flushed before exit signals
 * Fix #7632: java-generator now HTML-escapes `<`, `>`, and `&` in CRD descriptions to produce valid Javadoc

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -260,35 +260,44 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
     closed.set(true);
     HttpResponse<?> response = null;
 
-    try {
-      if (t instanceof WebSocketHandshakeException) {
-        response = ((WebSocketHandshakeException) t).getResponse();
-        if (response != null) {
-          Status status = OperationSupport.createStatus(response, serialization);
-          status.setMessage(t.getMessage());
-          t = new KubernetesClientException(status).initCause(t);
-        }
-      }
-      cleanUpOnce();
-    } finally {
-      if (exitCode.isDone()) {
-        LOGGER.debug("Exec failure after done", t);
-      } else {
-        try {
-          if (listener != null) {
-            ExecListener.Response execResponse = null;
-            if (response != null) {
-              execResponse = new SimpleResponse(response);
-            }
-            listener.onFailure(t, execResponse);
-          } else {
-            LOGGER.error("Exec Failure", t);
-          }
-        } finally {
-          exitCode.completeExceptionally(t);
-        }
+    if (t instanceof WebSocketHandshakeException) {
+      response = ((WebSocketHandshakeException) t).getResponse();
+      if (response != null) {
+        Status status = OperationSupport.createStatus(response, serialization);
+        status.setMessage(t.getMessage());
+        t = new KubernetesClientException(status).initCause(t);
       }
     }
+    executorService.shutdownNow();
+    // Defer failure handling through serialExecutor so any in-flight async writes and a
+    // queued channel-3 exit-status task complete first; otherwise a peer-close arriving
+    // immediately after the exit-status frame would cancel the still-pending
+    // handleExitStatus and overwrite the parsed exit code with the close exception.
+    final Throwable finalT = t;
+    final HttpResponse<?> finalResponse = response;
+    serialExecutor.execute(() -> {
+      try {
+        if (exitCode.isDone()) {
+          LOGGER.debug("Exec failure after done", finalT);
+        } else {
+          try {
+            if (listener != null) {
+              ExecListener.Response execResponse = null;
+              if (finalResponse != null) {
+                execResponse = new SimpleResponse(finalResponse);
+              }
+              listener.onFailure(finalT, execResponse);
+            } else {
+              LOGGER.error("Exec Failure", finalT);
+            }
+          } finally {
+            exitCode.completeExceptionally(finalT);
+          }
+        }
+      } finally {
+        serialExecutor.shutdownNow();
+      }
+    });
   }
 
   @Override

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -18,6 +18,7 @@ package io.fabric8.kubernetes.client.dsl.internal;
 import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.api.model.StatusCause;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext.StreamContext;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
@@ -28,8 +29,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -187,6 +191,104 @@ class ExecWebSocketListenerTest {
     } finally {
       asyncExecutor.shutdownNow();
     }
+  }
+
+  @Test
+  void onErrorAfterChannel3StatusPrefersParsedExitCodeOverConnectionClose() throws Exception {
+    // Reproduces the race in PodTest.testExecWithExitCode: channel-3 status frame is
+    // received and queues handleExitStatus through the SerialExecutor; the peer then
+    // closes the connection and onError fires before the deferred task runs.
+    final Queue<Runnable> manualQueue = new ArrayDeque<>();
+    final Executor manualExecutor = manualQueue::offer;
+
+    final ExecWebSocketListener listener = new ExecWebSocketListener(new PodOperationContext(), manualExecutor,
+        new KubernetesSerialization());
+    final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
+    listener.onOpen(mockedWebSocket);
+
+    // Channel 3: NonZeroExitCode=1 status frame
+    final byte[] failureJson = new KubernetesSerialization().asJson(new StatusBuilder()
+        .withStatus("Failure")
+        .withReason("NonZeroExitCode")
+        .withNewDetails().withCauses(new StatusCause("ExitCode", "1", "ExitCode")).endDetails()
+        .build()).getBytes(StandardCharsets.UTF_8);
+    final ByteBuffer channel3 = ByteBuffer.allocate(failureJson.length + 1)
+        .put((byte) 3).put(failureJson);
+    channel3.flip();
+    listener.onMessage(mockedWebSocket, channel3);
+    assertFalse(listener.exitCode().isDone(),
+        "exitCode must remain pending while handleExitStatus is queued in the executor");
+
+    // The connection closes before the deferred handleExitStatus has a chance to run
+    listener.onError(mockedWebSocket, new IOException("Connection was closed"));
+    assertFalse(listener.exitCode().isDone(),
+        "exitCode must not be completed exceptionally while the queued handleExitStatus is still pending");
+
+    // Drain: handleExitStatus must run first (parsed exit code), then the failure task
+    // observes exitCode is already done and only logs.
+    Runnable next;
+    while ((next = manualQueue.poll()) != null) {
+      next.run();
+    }
+
+    assertEquals(1, listener.exitCode().get(2, TimeUnit.SECONDS),
+        "exitCode must resolve to the parsed value, not the connection-close exception");
+  }
+
+  @Test
+  void onErrorWithExecListenerInvokesOnFailureWithThrowable() {
+    final Queue<Runnable> manualQueue = new ArrayDeque<>();
+    final Executor manualExecutor = manualQueue::offer;
+    final java.util.concurrent.atomic.AtomicReference<Throwable> capturedThrowable = new java.util.concurrent.atomic.AtomicReference<>();
+    final java.util.concurrent.atomic.AtomicReference<ExecListener.Response> capturedResponse = new java.util.concurrent.atomic.AtomicReference<>();
+    final ExecListener execListener = new ExecListener() {
+      @Override
+      public void onFailure(Throwable t, Response failureResponse) {
+        capturedThrowable.set(t);
+        capturedResponse.set(failureResponse);
+      }
+
+      @Override
+      public void onClose(int code, String reason) {
+      }
+    };
+    final PodOperationContext context = new PodOperationContext().toBuilder()
+        .execListener(execListener)
+        .build();
+    final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
+    listener.onOpen(Mockito.mock(WebSocket.class));
+
+    final IOException boom = new IOException("boom");
+    listener.onError(null, boom);
+
+    Runnable next;
+    while ((next = manualQueue.poll()) != null) {
+      next.run();
+    }
+
+    assertThat(capturedThrowable.get()).isSameAs(boom);
+    assertNull(capturedResponse.get(), "non-handshake errors must not provide a SimpleResponse");
+    assertThrows(KubernetesClientException.class, listener::checkError);
+  }
+
+  @Test
+  void onErrorWithoutPendingExitStatusCompletesExitExceptionally() {
+    final Queue<Runnable> manualQueue = new ArrayDeque<>();
+    final Executor manualExecutor = manualQueue::offer;
+    final ExecWebSocketListener listener = new ExecWebSocketListener(new PodOperationContext(), manualExecutor,
+        new KubernetesSerialization());
+    listener.onOpen(Mockito.mock(WebSocket.class));
+
+    listener.onError(null, new IOException("boom"));
+    assertFalse(listener.exitCode().isDone(),
+        "exitCode completion is deferred through the SerialExecutor on error");
+
+    Runnable next;
+    while ((next = manualQueue.poll()) != null) {
+      next.run();
+    }
+
+    assertThrows(KubernetesClientException.class, listener::checkError);
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -239,8 +240,8 @@ class ExecWebSocketListenerTest {
   void onErrorWithExecListenerInvokesOnFailureWithThrowable() {
     final Queue<Runnable> manualQueue = new ArrayDeque<>();
     final Executor manualExecutor = manualQueue::offer;
-    final java.util.concurrent.atomic.AtomicReference<Throwable> capturedThrowable = new java.util.concurrent.atomic.AtomicReference<>();
-    final java.util.concurrent.atomic.AtomicReference<ExecListener.Response> capturedResponse = new java.util.concurrent.atomic.AtomicReference<>();
+    final AtomicReference<Throwable> capturedThrowable = new AtomicReference<>();
+    final AtomicReference<ExecListener.Response> capturedResponse = new AtomicReference<>();
     final ExecListener execListener = new ExecListener() {
       @Override
       public void onFailure(Throwable t, Response failureResponse) {


### PR DESCRIPTION
## Description

`PodTest.testExecWithExitCode` is intermittently flaky. The mock server sends the
channel-3 exit-status frame and immediately closes the websocket via `done()`.
Since #7695, the channel-3 path queues `handleExitStatus` through the
`SerialExecutor` so any pending stdout/stderr async writes are flushed before the
exit signal is propagated. When the peer-close arrives before the deferred task
runs, Vert.x fires `onError`, which synchronously called `cleanUpOnce()` →
`serialExecutor.shutdownNow()`. The pending `handleExitStatus` wrapper then sees
`shutdown=true`, returns without running, and `onError` completes `exitCode`
exceptionally with the `HttpClosedException` — losing the parsed exit code.

`onError` no longer calls `cleanUpOnce()` synchronously. It still shuts down the
input-pump `executorService` synchronously, but defers the failure handling and
the `serialExecutor.shutdownNow()` through the `SerialExecutor` itself. Any
pending writes and the queued `handleExitStatus` run first; when the deferred
failure task finally executes it observes `exitCode.isDone()` and only logs.

`listener.onFailure(...)` and `exitCode.completeExceptionally(...)` are now
invoked on the `SerialExecutor`'s executor thread instead of synchronously on
the websocket callback thread, symmetric with the existing `onClose` deferred
path.

Three new unit tests in `ExecWebSocketListenerTest` cover the changed
`onError` branches:

- `onErrorAfterChannel3StatusPrefersParsedExitCodeOverConnectionClose` —
  reproduces the race deterministically and verifies the parsed exit code wins.
- `onErrorWithExecListenerInvokesOnFailureWithThrowable` — covers the
  `listener != null` arm.
- `onErrorWithoutPendingExitStatusCompletesExitExceptionally` — covers the
  `listener == null` LOGGER.error fallback.

Hammered `PodTest#testExecWithExitCode` 68× (sequential + parallel under CPU
contention) — all green.

Fixes #7700
Refs #7702