### PR TITLE
fix(httpclient-vertx-5): fire endHandler when registered after stream end (7698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Bugs
 * Fix #7700: ExecWebSocketListener.onError now defers failure handling through the SerialExecutor so a pending channel-3 exit-status task runs first and the parsed exit code is preserved instead of being overwritten by a peer-close exception
+* Fix #7698: (httpclient-vertx-5) InputStreamReadStream now fires endHandler when registered after the end signal has already been delivered, fixing a race for empty/fast streams
 * Fix #7696: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation
 * Fix #7695: ExecWebSocketListener now defers exitCode completion through the SerialExecutor so pending stdout/stderr async writes are flushed before exit signals
 * Fix #7632: java-generator now HTML-escapes `<`, `>`, and `&` in CRD descriptions to produce valid Javadoc

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/StreamFlowController.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/StreamFlowController.java
@@ -23,8 +23,11 @@ import io.vertx.core.streams.impl.InboundBuffer;
 class StreamFlowController {
 
   private final Buffer endSentinel;
+  private final Object endLock = new Object();
   private InboundBuffer<Buffer> inboundBuffer;
   private Handler<Void> endHandler;
+  private boolean ended;
+  private boolean endDelivered;
 
   StreamFlowController() {
     this.endSentinel = Buffer.buffer();
@@ -43,9 +46,7 @@ class StreamFlowController {
     if (dataHandler != null) {
       inboundBuffer.handler(buffer -> {
         if (buffer == endSentinel) {
-          if (endHandler != null) {
-            endHandler.handle(null);
-          }
+          dispatchEnd();
         } else {
           dataHandler.handle(buffer);
         }
@@ -55,8 +56,35 @@ class StreamFlowController {
     }
   }
 
+  private void dispatchEnd() {
+    final Handler<Void> toFire;
+    synchronized (endLock) {
+      ended = true;
+      if (endDelivered) {
+        return;
+      }
+      toFire = endHandler;
+      if (toFire != null) {
+        endDelivered = true;
+      }
+    }
+    if (toFire != null) {
+      toFire.handle(null);
+    }
+  }
+
   void setEndHandler(final Handler<Void> handler) {
-    this.endHandler = handler;
+    final boolean fireNow;
+    synchronized (endLock) {
+      this.endHandler = handler;
+      fireNow = ended && !endDelivered && handler != null;
+      if (fireNow) {
+        endDelivered = true;
+      }
+    }
+    if (fireNow) {
+      handler.handle(null);
+    }
   }
 
   boolean writeChunk(final Buffer chunk) {

--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/StreamFlowControllerTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/StreamFlowControllerTest.java
@@ -191,6 +191,52 @@ class StreamFlowControllerTest {
   }
 
   @Test
+  @DisplayName("Should fire endHandler registered after end sentinel was delivered")
+  void shouldFireEndHandlerRegisteredAfterEndSentinel() throws Exception {
+    AtomicBoolean endHandlerCalled = new AtomicBoolean(false);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    vertx.runOnContext(v -> {
+      controller.initialize(context, () -> {
+      });
+      controller.configureDataHandler(buffer -> {
+      });
+
+      // End sentinel arrives BEFORE endHandler is registered (the race this fixes).
+      controller.writeEndSentinel();
+
+      controller.setEndHandler(h -> {
+        endHandlerCalled.set(true);
+        latch.countDown();
+      });
+    });
+
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(endHandlerCalled.get()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should not fail when endHandler is set to null after end was delivered")
+  void shouldHandleNullEndHandlerAfterEndDelivered() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    vertx.runOnContext(v -> {
+      controller.initialize(context, () -> {
+      });
+      controller.configureDataHandler(buffer -> {
+      });
+
+      controller.writeEndSentinel();
+      // Setting null after end must not throw nor fire anything.
+      controller.setEndHandler(null);
+
+      latch.countDown();
+    });
+
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
   @DisplayName("Should properly separate end sentinel from data")
   void shouldProperlySeparateEndSentinelFromData() throws Exception {
     List<Buffer> receivedBuffers = new ArrayList<>();


### PR DESCRIPTION
## Summary

Fixes a race in `InputStreamReadStream` where the `endHandler` could be silently dropped for empty or very fast streams.

`InputStreamReadStream.handler(...)` starts reading immediately. For an empty `InputStream`, the worker thread can write the end sentinel before the consumer has chained `.endHandler(...)`. `StreamFlowController` checked `endHandler` at sentinel time, saw `null`, and dropped the end signal — `endHandler` was never invoked.

`StreamFlowController` now tracks the end signal under a lock and fires a late-registered `endHandler` immediately. An `endDelivered` latch ensures end is delivered at most once, per the Vert.x `ReadStream` contract.

Fixes #7698