### PR TITLE
fix(kubernetes-client): wrap WebSocketHandshakeException without initCause IllegalStateException

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientException.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/KubernetesClientException.java
@@ -166,7 +166,7 @@ public class KubernetesClientException extends RuntimeException {
     final String name;
 
     static RequestMetadata from(HttpRequest request) {
-      return from(request.uri());
+      return request == null ? EMPTY : from(request.uri());
     }
 
     static RequestMetadata from(URI request) {

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/KubernetesClientExceptionTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/KubernetesClientExceptionTest.java
@@ -15,8 +15,10 @@
  */
 package io.fabric8.kubernetes.client;
 
+import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,6 +43,18 @@ class KubernetesClientExceptionTest {
         .hasFieldOrPropertyWithValue("resourcePlural", expectedPlural)
         .hasFieldOrPropertyWithValue("namespace", expectedNamespace)
         .hasFieldOrPropertyWithValue("name", expectedName);
+  }
+
+  @Test
+  @DisplayName("Exception with null HttpRequest does not throw and yields empty metadata")
+  void exceptionWithNullHttpRequestYieldsEmptyMetadata() {
+    final KubernetesClientException result = new KubernetesClientException(null, null, -1, null, (HttpRequest) null);
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("group", null)
+        .hasFieldOrPropertyWithValue("version", null)
+        .hasFieldOrPropertyWithValue("resourcePlural", null)
+        .hasFieldOrPropertyWithValue("namespace", null)
+        .hasFieldOrPropertyWithValue("name", null);
   }
 
   static Stream<Arguments> exceptionFromHttpRequestContainsExpectedMetadataInput() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecListener.Response;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext.StreamContext;
+import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
@@ -265,7 +266,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
       if (response != null) {
         Status status = OperationSupport.createStatus(response, serialization);
         status.setMessage(t.getMessage());
-        t = new KubernetesClientException(status).initCause(t);
+        t = new KubernetesClientException(status.getMessage(), t, status.getCode(), status, (HttpRequest) null);
       }
     }
     executorService.shutdownNow();

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecListener.Response;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext.StreamContext;
-import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
@@ -266,7 +265,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
       if (response != null) {
         Status status = OperationSupport.createStatus(response, serialization);
         status.setMessage(t.getMessage());
-        t = new KubernetesClientException(status.getMessage(), t, status.getCode(), status, (HttpRequest) null);
+        t = new KubernetesClientException(status.getMessage(), t, status.getCode(), status, response.request());
       }
     }
     executorService.shutdownNow();

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.StatusCause;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext.StreamContext;
+import io.fabric8.kubernetes.client.http.StandardHttpRequest;
 import io.fabric8.kubernetes.client.http.WebSocket;
 import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
 import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
@@ -301,7 +302,9 @@ class ExecWebSocketListenerTest {
     final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
     listener.onOpen(Mockito.mock(WebSocket.class));
 
-    final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(null, 403);
+    final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(
+        new StandardHttpRequest.Builder().uri("https://localhost:8443/api/v1/namespaces/ns/pods/mypod").build(),
+        403);
     final WebSocketHandshakeException handshakeException = new WebSocketHandshakeException(upgradeResponse);
     listener.onError(null, handshakeException);
 
@@ -313,7 +316,10 @@ class ExecWebSocketListenerTest {
     assertThat(capturedThrowable.get())
         .isInstanceOf(KubernetesClientException.class)
         .hasCause(handshakeException);
-    assertThat(((KubernetesClientException) capturedThrowable.get()).getCode()).isEqualTo(403);
+    final KubernetesClientException kce = (KubernetesClientException) capturedThrowable.get();
+    assertThat(kce.getCode()).isEqualTo(403);
+    assertThat(kce.getNamespace()).isEqualTo("ns");
+    assertThat(kce.getName()).isEqualTo("mypod");
     assertThat(capturedResponse.get()).isNotNull();
     assertThrows(KubernetesClientException.class, listener::checkError);
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -21,6 +21,8 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationContext.StreamContext;
 import io.fabric8.kubernetes.client.http.WebSocket;
+import io.fabric8.kubernetes.client.http.WebSocketHandshakeException;
+import io.fabric8.kubernetes.client.http.WebSocketUpgradeResponse;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -269,6 +271,50 @@ class ExecWebSocketListenerTest {
 
     assertThat(capturedThrowable.get()).isSameAs(boom);
     assertNull(capturedResponse.get(), "non-handshake errors must not provide a SimpleResponse");
+    assertThrows(KubernetesClientException.class, listener::checkError);
+  }
+
+  @Test
+  void onErrorWithWebSocketHandshakeExceptionWrapsCauseWithoutThrowing() {
+    // Reproduces the IllegalStateException reported in #7702: KubernetesClientException(Status)
+    // chains down to super(message, null) which sets cause to null (not the self-reference
+    // sentinel), so a follow-up initCause(t) blows up. The handshake response details must
+    // reach the ExecListener.onFailure callback instead.
+    final Queue<Runnable> manualQueue = new ArrayDeque<>();
+    final Executor manualExecutor = manualQueue::offer;
+    final AtomicReference<Throwable> capturedThrowable = new AtomicReference<>();
+    final AtomicReference<ExecListener.Response> capturedResponse = new AtomicReference<>();
+    final ExecListener execListener = new ExecListener() {
+      @Override
+      public void onFailure(Throwable t, Response failureResponse) {
+        capturedThrowable.set(t);
+        capturedResponse.set(failureResponse);
+      }
+
+      @Override
+      public void onClose(int code, String reason) {
+      }
+    };
+    final PodOperationContext context = new PodOperationContext().toBuilder()
+        .execListener(execListener)
+        .build();
+    final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
+    listener.onOpen(Mockito.mock(WebSocket.class));
+
+    final WebSocketUpgradeResponse upgradeResponse = new WebSocketUpgradeResponse(null, 403);
+    final WebSocketHandshakeException handshakeException = new WebSocketHandshakeException(upgradeResponse);
+    listener.onError(null, handshakeException);
+
+    Runnable next;
+    while ((next = manualQueue.poll()) != null) {
+      next.run();
+    }
+
+    assertThat(capturedThrowable.get())
+        .isInstanceOf(KubernetesClientException.class)
+        .hasCause(handshakeException);
+    assertThat(((KubernetesClientException) capturedThrowable.get()).getCode()).isEqualTo(403);
+    assertThat(capturedResponse.get()).isNotNull();
     assertThrows(KubernetesClientException.class, listener::checkError);
   }
 


### PR DESCRIPTION
## Summary

`KubernetesClientException(Status)` chains down to `super(message, null)`, which sets `Throwable.cause` to `null` instead of the self-reference sentinel. A subsequent `initCause(t)` therefore throws `IllegalStateException: Can't overwrite cause`.

This blew up the `WebSocketHandshakeException` branch in `ExecWebSocketListener.onError` — when an exec websocket upgrade failed with a non-null upgrade response, `onError` threw `IllegalStateException` synchronously and never reached `listener.onFailure(...)` / `exitCode.completeExceptionally(...)`. The handshake response details (status code, body) never reached the user.

## Changes

- `ExecWebSocketListener.onError` now uses the existing `KubernetesClientException(String, Throwable, int, Status, HttpRequest)` constructor, which sets the cause via `super(message, t)` — preserving both the parsed `Status` and the original `WebSocketHandshakeException` as the cause chain.
- `KubernetesClientException.RequestMetadata.from(HttpRequest)` is now null-safe and returns `RequestMetadata.EMPTY` for a null request, so the public 5-arg constructor accepts `(HttpRequest) null`.
- Regression test `onErrorWithWebSocketHandshakeExceptionWrapsCauseWithoutThrowing` in `ExecWebSocketListenerTest` covers the previously broken path: it asserts `onError` no longer throws, the dispatched throwable is a `KubernetesClientException` with the original handshake exception as its cause and the expected status code, and `ExecListener.onFailure` is invoked with a non-null response.

Fixes #7702