### PR TITLE
test(kubernetes-client-api): stabilize AsyncUtilsTest flake (7705)

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/AsyncUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/AsyncUtilsTest.java
@@ -66,7 +66,10 @@ class AsyncUtilsTest {
   void withTimeout_applicableTimeout() {
     final CompletableFuture<Void> future = new CompletableFuture<>();
     withTimeout(future, Duration.ofMillis(1));
-    Awaitility.await().atMost(Duration.ofMillis(101)).until(future::isDone);
+    Awaitility.await()
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(5))
+        .until(future::isDone);
     assertThatThrownBy(() -> future.getNow(null))
         .isInstanceOf(CompletionException.class)
         .hasCauseInstanceOf(TimeoutException.class);


### PR DESCRIPTION
## Description

`AsyncUtilsTest.withTimeout_applicableTimeout` was flaking on CI: it
gives Awaitility a 101 ms budget to observe a 1 ms scheduled timeout,
which leaves no headroom for Awaitility's ~100 ms default poll delay.
On a loaded runner the first `isDone()` poll lands after the budget
has already expired.

This widens `atMost` to 5 s and shortens `pollInterval` to 10 ms so
the first poll fires well inside the scheduled-task firing window.

## Note on timing fidelity

Widening `atMost` to 5 s does mean this specific test would still pass
even if a regression made the scheduler sluggish — it only asserts the
timeout *eventually* fires, not that it fires close to the requested
1 ms. That coverage is intentionally left to the sibling test
`withTimeout_timeout` (`AsyncUtilsTest.java:39-45`), which asserts the
1 ms timeout fires within 100 ms via `future.get(100, MILLISECONDS)`.
Net coverage across the class is unchanged: one test pins the timing
bound, the other pins the synchronous `getNow` / `CompletionException`
contract that this test uniquely exercises.

Fixes #7705