### PR TITLE
test(httpclient): isolate AbstractSimultaneousConnectionsTest in dedicated fork (7687)

### DIFF
--- a/httpclient-jdk/pom.xml
+++ b/httpclient-jdk/pom.xml
@@ -92,6 +92,30 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>simultaneous-connections</excludedGroups>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+          <execution>
+            <id>simultaneous-connections-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <groups>simultaneous-connections</groups>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/httpclient-jetty/pom.xml
+++ b/httpclient-jetty/pom.xml
@@ -106,6 +106,30 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>simultaneous-connections</excludedGroups>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+          <execution>
+            <id>simultaneous-connections-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <groups>simultaneous-connections</groups>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/httpclient-okhttp/pom.xml
+++ b/httpclient-okhttp/pom.xml
@@ -112,6 +112,30 @@
         <configuration>
           <rerunFailingTestsCount>1</rerunFailingTestsCount>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>simultaneous-connections</excludedGroups>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+          <execution>
+            <id>simultaneous-connections-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <groups>simultaneous-connections</groups>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/httpclient-vertx-5/pom.xml
+++ b/httpclient-vertx-5/pom.xml
@@ -169,6 +169,30 @@
         <configuration>
           <rerunFailingTestsCount>1</rerunFailingTestsCount>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>simultaneous-connections</excludedGroups>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+          <execution>
+            <id>simultaneous-connections-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <groups>simultaneous-connections</groups>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/httpclient-vertx/pom.xml
+++ b/httpclient-vertx/pom.xml
@@ -114,6 +114,30 @@
         <configuration>
           <rerunFailingTestsCount>1</rerunFailingTestsCount>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>simultaneous-connections</excludedGroups>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+          <execution>
+            <id>simultaneous-connections-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <groups>simultaneous-connections</groups>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
@@ -33,6 +33,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -50,6 +51,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Tag("simultaneous-connections")
 public abstract class AbstractSimultaneousConnectionsTest {
 
   // TODO:


### PR DESCRIPTION
## Summary

`AbstractSimultaneousConnectionsTest#http1WebSocketConnections` opens 1024
simultaneous WebSocket connections and asserts they all upgrade within a 60s
latch budget. Under `-T 1C` × `forkCount=1C`, the burst contends with sibling
surefire forks for CPU and the budget is breached (observed in #7675's first
push of `-T 1C`).

The 1024 load target is what the test exists to verify and must not be lowered.
Instead, this PR isolates the test class:

- Tag the shared abstract base with `@Tag("simultaneous-connections")` so the
  five concrete subclasses inherit it.
- In each httpclient module's `pom.xml` (`jdk`, `okhttp`, `jetty`, `vertx`,
  `vertx-5`), split surefire into two executions:
  - `default-test` — `excludedGroups=simultaneous-connections` (everything
    else, unchanged behavior).
  - `simultaneous-connections-test` — `groups=simultaneous-connections` with
    `forkCount=1`, `reuseForks=false` (dedicated, sequential JVM).
- Both executions set `failIfNoSpecifiedTests=false` so `-Dtest=Foo` developer
  flows don't fail the non-matching execution.

Tag-based filtering (rather than file-pattern includes/excludes) is required
because `-Dtest=...` overrides surefire's `<includes>`/`<excludes>` but does
not override JUnit-engine tag filters. This means `mvn test -Dtest=SslTest`
runs once (in `default-test` only), and `mvn test -Dtest=Vertx...Simultaneous...`
runs once (in the dedicated execution only) — no double execution.

## Verification

- `mvn -T 1C -pl httpclient-jdk,httpclient-okhttp,httpclient-jetty,httpclient-vertx,httpclient-vertx-5 test` — BUILD SUCCESS; SimultaneousConnections elapsed times 5.7s / 17.2s / 18.0s / 19.4s / 24.3s — all comfortably below the 60s budget.
- Per-module `mvn test` — BUILD SUCCESS; the SimultaneousConnections class
  runs only in the dedicated execution.
- `mvn -pl kubernetes-client-api test` — 621 tests, 0 failures.
- `mvn -pl kubernetes-client-api spotless:check` — clean.

Refs #7675
Fixes #7687