### PR TITLE
fix(httpclient-vertx-5): prevent StackBasedRecursionGuard depth leak on failed enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
+* Fix #7686: (httpclient-vertx-5) StackBasedRecursionGuard.enter() no longer increments depth when refusing entry, fixing an infinite runOnContext loop that stalled InputStreamReadStream uploads under CPU contention
 * Fix #7700: ExecWebSocketListener.onError now defers failure handling through the SerialExecutor so a pending channel-3 exit-status task runs first and the parsed exit code is preserved instead of being overwritten by a peer-close exception
 * Fix #7698: (httpclient-vertx-5) InputStreamReadStream now fires endHandler when registered after the end signal has already been delivered, fixing a race for empty/fast streams
 * Fix #7696: (httpclient-vertx) clear response exception handler before reset in cancel() to prevent StreamResetException from racing with future cancellation

--- a/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/StackBasedRecursionGuard.java
+++ b/httpclient-vertx-5/src/main/java/io/fabric8/kubernetes/client/vertx5/StackBasedRecursionGuard.java
@@ -67,7 +67,11 @@ class StackBasedRecursionGuard {
    *         {@code false} if recursion depth is too high and caller should use async scheduling
    */
   boolean enter() {
-    return depth++ < MAX_RECURSION_DEPTH;
+    if (depth >= MAX_RECURSION_DEPTH) {
+      return false;
+    }
+    depth++;
+    return true;
   }
 
   /**

--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/StackBasedRecursionGuardTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/StackBasedRecursionGuardTest.java
@@ -53,8 +53,8 @@ class StackBasedRecursionGuardTest {
     assertThat(guard.enter()).isFalse();
     hitFalse.set(true);
 
-    // Clean up all levels (including the failed one)
-    for (int i = 0; i < 9; i++) {
+    // Clean up the 8 successful levels
+    for (int i = 0; i < 8; i++) {
       guard.exit();
     }
 
@@ -116,8 +116,8 @@ class StackBasedRecursionGuardTest {
   }
 
   @Test
-  @DisplayName("resets depth after failed enter")
-  void resetsAfterFailedEnter() {
+  @DisplayName("does not increment depth on failed enter")
+  void doesNotIncrementOnFailedEnter() {
     StackBasedRecursionGuard guard = new StackBasedRecursionGuard();
 
     // Fill up to the limit
@@ -126,12 +126,15 @@ class StackBasedRecursionGuardTest {
     }
     assertThat(guard.getCurrentDepth()).isEqualTo(8);
 
-    // Next enter should fail but still increment depth internally
+    // Repeated failed enters must not climb the depth — otherwise readChunk's
+    // runOnContext fallback (which does not call exit()) would loop forever.
     assertThat(guard.enter()).isFalse();
-    assertThat(guard.getCurrentDepth()).isEqualTo(9);
+    assertThat(guard.getCurrentDepth()).isEqualTo(8);
+    assertThat(guard.enter()).isFalse();
+    assertThat(guard.getCurrentDepth()).isEqualTo(8);
 
-    // Exit all levels
-    for (int i = 0; i < 9; i++) {
+    // Exit the 8 successful levels
+    for (int i = 0; i < 8; i++) {
       guard.exit();
     }
     assertThat(guard.getCurrentDepth()).isZero();


### PR DESCRIPTION
## Summary

Fixes the deadlock behind the `Vertx5HttpBodyStreamTest#testStreamFlowControl` flake (#7686). Despite the original symptom (timeout under module-parallel CI) suggesting "test budget too tight under CPU pressure," empirical investigation showed the test isn't slow — it deadlocks. The root cause is a depth-counter leak in `StackBasedRecursionGuard.enter()` that traps `InputStreamReadStream.readChunk` in an infinite `runOnContext` loop on the Vert.x event loop.

## Root cause

`StackBasedRecursionGuard.enter()` was:

```java
boolean enter() {
  return depth++ < MAX_RECURSION_DEPTH;
}
```

`depth++` runs unconditionally, but the only caller (`InputStreamReadStream.readChunk`) calls `exit()` only on the success path — matching the documented usage example in the class Javadoc. Under CPU contention, `executeBlocking` callbacks can synchronously re-enter `readChunk` and drive `depth` above 8 once. From there, every subsequent `enter()` keeps incrementing and keeps returning `false`; the `runOnContext` fallback busy-loops on the event loop forever — `Vertx5HttpBodyStreamTest#testStreamFlowControl` then deadlocks indefinitely (the issue body has the captured thread dump).

The existing `StackBasedRecursionGuardTest#resetsAfterFailedEnter` actually encoded the bug as expected behavior (asserted `getCurrentDepth() == 9` after a failed enter), so unit tests never caught it.

## Fix

- `StackBasedRecursionGuard.enter()` only increments `depth` when entry actually succeeds.
- `StackBasedRecursionGuardTest`: update `exceedsLimit` and rename `resetsAfterFailedEnter` → `doesNotIncrementOnFailedEnter` to pin the regression (a second consecutive failed `enter()` must still leave depth at 8).
- No timeout bump in the test — the original 10 s budget is sufficient once the deadlock is fixed.

## Verification

Reproducer: `taskset -c 0,1` + 24 background CPU burners (emulates `-T 1C × forkCount=1C` on a 2-vCPU GitHub runner).

| Variant | Pass / 10 | Time elapsed |
|---|---:|---|
| Before fix, 10 s timeout | 0/10 | 12-13 s (timeouts) |
| Before fix, 30 s timeout (originally suggested mitigation) | 2/10 | 32-33 s (timeouts) |
| **After fix, 10 s timeout (no test change)** | **10/10** | **6.9-9.8 s** |

Plus all 5 `StackBasedRecursionGuardTest` tests, all 3 `Vertx5HttpBodyStreamTest` tests, and the full `httpclient-vertx-5` module (179 tests + 3 simultaneous-connections tests) pass without any contention.

Refs #7675
Fixes #7686