### PR TITLE
fix(informer): prevent SerialExecutor from scheduling tasks after shutdown

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/SerialExecutor.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/SerialExecutor.java
@@ -55,6 +55,7 @@ public class SerialExecutor implements Executor {
   public synchronized void execute(final Runnable r) {
     if (shutdown) {
       logger.debug("Task submitted after the executor was shutdown");
+      return;
     }
     tasks.offer(() -> {
       try {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/SharedProcessorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/informers/impl/cache/SharedProcessorTest.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SharedProcessorTest {
@@ -59,7 +60,7 @@ class SharedProcessorTest {
     ProcessorListener.Notification<Pod> addNotification = new ProcessorListener.AddNotification<>(foo1);
 
     // nothing should happen
-    sharedProcessor.distribute(addNotification, false);
+    assertDoesNotThrow(() -> sharedProcessor.distribute(addNotification, false));
   }
 
   private static class ExpectingNotificationHandler<T> extends ProcessorListener<T> {

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/SerialExecutorTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/SerialExecutorTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,6 +54,20 @@ class SerialExecutorTest {
     Thread t = future.join();
     t.interrupt(); // interrupt the first task
     assertFalse(interrupted.join()); // make sure the second is not interrrupted
+  }
+
+  @Test
+  void executeAfterShutdownDoesNothing() {
+    final AtomicInteger underlyingExecutions = new AtomicInteger();
+    final AtomicInteger taskRuns = new AtomicInteger();
+    final SerialExecutor se = new SerialExecutor(r -> {
+      underlyingExecutions.incrementAndGet();
+      r.run();
+    });
+    se.shutdownNow();
+    se.execute(taskRuns::incrementAndGet);
+    assertThat(taskRuns).hasValue(0);
+    assertThat(underlyingExecutions).hasValue(0);
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes the flaky `SharedProcessorTest.testDistributeAfterStop` reported in #7716.

After `SharedProcessor.stop()`, calling `distribute(...)` was still offering a wrapper task to `SerialExecutor` and delegating it to the underlying executor before the wrapper's own `if (shutdown) return;` guard rejected it. That extra cycle through `scheduleNext()` and the wrapper's `finally` block exposed an intermittent NPE on JDK 11 — most likely the JVM's "fast-throw" optimization misattributing the actual throw site to `SerialExecutor.execute:57` (the `logger.debug` line) once the method was JIT-compiled.

## Change

- `SerialExecutor.execute()` now returns immediately when `shutdown` is set, after logging the debug message. No wrapper is offered, `scheduleNext()` is not called, and the underlying executor is not touched.
- The wrapper-internal `if (shutdown) return;` is intentionally kept: `execute()` is `synchronized(this)` but `shutdownNow()` is not, so a task could still be in flight when shutdown flips. The wrapper guard remains the real safety net for that race.

## Tests

- `SerialExecutorTest.executeAfterShutdownDoesNothing` — pins the contract: after `shutdownNow()`, `execute(task)` neither runs the task nor delegates the wrapper to the underlying executor. Verified to fail without the production change and pass with it.
- `SharedProcessorTest.testDistributeAfterStop` — wraps the post-`stop()` `distribute(...)` call in `assertDoesNotThrow(...)` so a regression of the original flake fails explicitly instead of silently passing on no assertions.

Fixes #7716