### PR TITLE
test(kubernetes-tests): stabilize PodTest exec default-container fallback flake (7719)

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/PodTest.java
@@ -562,11 +562,11 @@ class PodTest {
   }
 
   @Test
-  void testExecExplicitDefaultContainerMissing() {
+  void testExecExplicitDefaultContainerMissing() throws InterruptedException {
     server.expect()
         .withPath("/api/v1/namespaces/test/pods/pod1/exec?command=ls&container=first&stderr=true")
         .andUpgradeToWebSocket()
-        .open()
+        .open(new ErrorStreamMessage("err"))
         .done()
         .always();
 
@@ -585,11 +585,14 @@ class PodTest {
         .once();
 
     // When
+    final CountDownLatch execLatch = new CountDownLatch(1);
     ExecWatch watch = client.pods()
         .withName("pod1")
         .terminateOnError()
+        .usingListener(createCountDownLatchListener(execLatch))
         .exec("ls");
 
+    assertTrue(execLatch.await(1, TimeUnit.MINUTES));
     watch.close();
   }
 


### PR DESCRIPTION
## Summary

Stabilize `PodTest.testExecExplicitDefaultContainerMissing`, which was the only exec/attach mock in the suite using bare `.open().done()` with no stream payload, no `.expect(...)` clauses, and no listener-based gate. Under fork reuse (#7657, #7673) the mock's immediate peer-close during the WebSocket upgrade could race past the 10 s `requestTimeout` and surface as `TimeoutException` at `setupConnectionToPod` (`PodOperationsImpl.java:387`).

The fix mirrors the deterministic pattern already used by sibling exec tests:
- Emit a non-empty `ErrorStreamMessage` so the upgrade settles cleanly (also makes the existing `terminateOnError()` modifier load-bearing instead of dead config).
- Gate completion on a `CountDownLatch` via `createCountDownLatchListener`, awaited up to 1 minute.

Audit confirmed this is the only test in `kubernetes-tests` with the vulnerable pattern; all other exec/attach mocks already ship a payload, chain `.expect(...)` clauses, follow with `.immediately().andEmit(...)`, or wait on a listener latch.

Fixes #7719