### PR TITLE
test(httpclient): fix flaky testHttpRetryWithMoreFailuresThanRetries

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/StandardHttpClientTest.java
@@ -137,16 +137,15 @@ class StandardHttpClientTest {
     IntStream.range(0, 3).forEach(i -> client.expect(".*", new IOException("Unreachable!")));
     client.expect(".*", new TestHttpResponse<AsyncBody>().withCode(403));
 
+    long start = System.currentTimeMillis();
     CompletableFuture<HttpResponse<AsyncBody>> consumeFuture = client.consumeBytes(
         client.newHttpRequestBuilder().uri("http://localhost").build(),
         (value, asyncBody) -> {
 
         });
 
-    long start = System.currentTimeMillis();
-
     // should ultimately error with the final 500
-    assertEquals(403, consumeFuture.get().code());
+    assertEquals(403, consumeFuture.get(2, TimeUnit.MINUTES).code());
     long stop = System.currentTimeMillis();
 
     // should take longer than the delay


### PR DESCRIPTION
## Description

Fixes the flaky `StandardHttpClientTest.testHttpRetryWithMoreFailuresThanRetries` reported in #7720.

## Root cause

The retry chain begins synchronously inside `consumeBytes()`: on the first immediate `IOException`, the inline `whenComplete` callback already schedules retry #1 with a 50ms delay **before** `consumeBytes` returns. The previous test captured `start` after the call, so part of the 350ms backoff window (50+100+200) sat outside the measurement. Under scheduler/GC jitter the observed elapsed time could fall below the asserted lower bound, producing the intermittent failure:

```
expected: <true> but was: <false>
  at StandardHttpClientTest.testHttpRetryWithMoreFailuresThanRetries(StandardHttpClientTest.java:153)
```

Reproduced locally by injecting a 60ms `Thread.sleep` between `consumeBytes()` and the `start` capture — the assertion failed deterministically.

## Changes

- Move `long start = System.currentTimeMillis()` above `consumeBytes(...)` so the timing window encloses the entire retry chain.
- Add a 2-minute timeout to `consumeFuture.get(...)`, aligning with the sibling `testHttpRetryWithLessFailuresThanRetries` and guarding against indefinite hangs if retry logic ever regresses.

Closes #7720