### PR TITLE
test(kubernetes-client,kubernetes-model-common): stabilize SharedProcessorTest.testDistributeAfterStop flake

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
@@ -23,9 +23,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -45,7 +42,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -193,29 +189,24 @@ class PortForwarderWebsocketListenerTest {
 
   @Test
   void onMessage_withWrongChannel_shouldLogAndEndWithError() {
-    try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
-      final Logger logger = mock(Logger.class);
-      loggerFactory.when(() -> LoggerFactory.getLogger(PortForwarderWebsocketListener.class)).thenReturn(logger);
-      listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
-      doAnswer(i -> {
-        listener.onMessage(webSocket, "SKIP 2");
-        return true;
-      }).doAnswer(i -> {
-        listener.onMessage(webSocket, ByteBuffer.wrap(
-            ByteBuffer.allocate(18).put((byte) 5).put("WRONG CHANNEL".getBytes(StandardCharsets.UTF_8)).array()));
-        return true;
-      })
-          .doNothing()
-          .when(webSocket).request();
-      listener.onMessage(webSocket, "SKIP 1");
-      // Then
-      verify(webSocket, timeout(10_000)).sendClose(1002, "Protocol error");
-      await().atMost(10, TimeUnit.SECONDS).until(() -> !listener.isAlive());
-      assertThat(outputContent.toString()).isEmpty();
-      assertThat(listener.errorOccurred()).isTrue();
-      assertThat(listener.getServerThrowables().iterator().next().getMessage())
-          .isEqualTo("Received a wrong channel from the remote socket: 5");
-    }
-
+    listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
+    doAnswer(i -> {
+      listener.onMessage(webSocket, "SKIP 2");
+      return true;
+    }).doAnswer(i -> {
+      listener.onMessage(webSocket, ByteBuffer.wrap(
+          ByteBuffer.allocate(18).put((byte) 5).put("WRONG CHANNEL".getBytes(StandardCharsets.UTF_8)).array()));
+      return true;
+    })
+        .doNothing()
+        .when(webSocket).request();
+    listener.onMessage(webSocket, "SKIP 1");
+    // Then
+    verify(webSocket, timeout(10_000)).sendClose(1002, "Protocol error");
+    await().atMost(10, TimeUnit.SECONDS).until(() -> !listener.isAlive());
+    assertThat(outputContent.toString()).isEmpty();
+    assertThat(listener.errorOccurred()).isTrue();
+    assertThat(listener.getServerThrowables().iterator().next().getMessage())
+        .isEqualTo("Received a wrong channel from the remote socket: 5");
   }
 }

--- a/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/UnmatchedFieldTypeModuleTest.java
+++ b/kubernetes-model-generator/kubernetes-model-common/src/test/java/io/fabric8/kubernetes/model/jackson/UnmatchedFieldTypeModuleTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -170,7 +171,7 @@ class UnmatchedFieldTypeModuleTest {
   @Test
   @DisplayName("writeValueAsString, with additionalProperties overriding fields and enabled log, should log warning")
   void writeValueAsStringWithAdditionalPropertiesOverridingFieldsShouldLogWarning() throws JsonProcessingException {
-    try (MockedStatic<LoggerFactory> lfMock = mockStatic(LoggerFactory.class)) {
+    try (MockedStatic<LoggerFactory> lfMock = mockStatic(LoggerFactory.class, CALLS_REAL_METHODS)) {
       // Given
       unmatchedFieldTypeModule.setLogWarnings(true);
       final ExampleWithAnySetter exampleWithAnySetter = new ExampleWithAnySetter();
@@ -193,7 +194,7 @@ class UnmatchedFieldTypeModuleTest {
   @Test
   @DisplayName("writeValueAsString, with additionalProperties overriding fields and disabled log, should NOT log warning")
   void writeValueAsStringWithAdditionalPropertiesOverridingFieldsShouldNotLogWarning() throws JsonProcessingException {
-    try (MockedStatic<LoggerFactory> lfMock = mockStatic(LoggerFactory.class)) {
+    try (MockedStatic<LoggerFactory> lfMock = mockStatic(LoggerFactory.class, CALLS_REAL_METHODS)) {
       // Given
       final ObjectMapper om = new ObjectMapper();
       final UnmatchedFieldTypeModule module = new UnmatchedFieldTypeModule();


### PR DESCRIPTION
## Description

Fixes the flaky `SharedProcessorTest.testDistributeAfterStop` reported in #7722, which intermittently failed with:

```
java.lang.NullPointerException: Cannot invoke "org.slf4j.Logger.debug(String)"
because "io.fabric8.kubernetes.client.utils.internal.SerialExecutor.logger" is null
```

## Root cause

`mockStatic(LoggerFactory.class)` (without `CALLS_REAL_METHODS`) returns `null` for every unstubbed `LoggerFactory.getLogger(...)` call JVM-wide while the mock is active. Any class whose `<clinit>` happens to run during that window has its `private static final Logger logger` field permanently set to `null`.

With `forkCount=1C` sharing JVMs across tests in the same surefire fork, `PortForwarderWebsocketListenerTest.onMessage_withWrongChannel_shouldLogAndEndWithError` was poisoning `SerialExecutor.logger`, surfacing as the flaky NPE in `SharedProcessorTest.testDistributeAfterStop` whenever it ran later in the same fork.

The previous fix in #7716 short-circuited `SerialExecutor.execute()` after shutdown but kept the `logger.debug(...)` call right above the new `return;`, so the NPE could still happen on a poisoned logger field.

Hypothesis confirmed with a synthetic reproducer: a class loaded inside `try (MockedStatic<LoggerFactory> = mockStatic(LoggerFactory.class)) { ... }` has its `static final` logger field assigned `null` after the block exits.

## Changes

- `PortForwarderWebsocketListenerTest.onMessage_withWrongChannel_shouldLogAndEndWithError` — the mocked logger was never `verify(...)`'d, it was dead infrastructure. The whole `MockedStatic<LoggerFactory>` wrapper is removed; all real assertions (`sendClose(1002, "Protocol error")`, `errorOccurred()`, exception message) are preserved.
- `UnmatchedFieldTypeModuleTest` — the two methods that genuinely verify log calls now use `mockStatic(LoggerFactory.class, CALLS_REAL_METHODS)`. The explicit `LoggerFactory.getLogger(any(Class.class))` stub continues to win for matching calls; only unstubbed calls now fall through to the real `LoggerFactory`, eliminating the JVM-wide poisoning.

Refs #7722, #7716