### PR TITLE
test(kube-api-test): stabilize KubernetesValidationHookHandlingTest.validatingWebhookRejectsInvalidResource flake

### DIFF
--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/sample/KubernetesValidationHookHandlingTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/sample/KubernetesValidationHookHandlingTest.java
@@ -41,12 +41,15 @@ import io.fabric8.mockwebserver.MockWebServer;
 import io.fabric8.mockwebserver.http.Dispatcher;
 import io.fabric8.mockwebserver.http.MockResponse;
 import io.fabric8.mockwebserver.http.RecordedRequest;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -102,10 +105,23 @@ class KubernetesValidationHookHandlingTest {
     KubernetesClient client = new KubernetesClientBuilder().withConfig(Config.fromKubeconfig(kubeConfig)).build();
     applyConfig(client);
 
-    NamespaceableResource<Ingress> ingressResource = client.resource(invalidIngress());
-    assertThatThrownBy(ingressResource::create)
-        .isInstanceOf(KubernetesClientException.class)
-        .hasMessageContaining("Ingress with annotation 'reject=true' is not allowed");
+    // Webhook activation has a brief propagation delay after applyConfig; poll with a fresh
+    // resource name each attempt so a slipped-through create on an early poll does not
+    // shadow later attempts via AlreadyExists.
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(200))
+        .untilAsserted(() -> {
+          Ingress invalid = invalidIngress("invalid-ingress-" + UUID.randomUUID());
+          NamespaceableResource<Ingress> ingressResource = client.resource(invalid);
+          try {
+            assertThatThrownBy(ingressResource::create)
+                .isInstanceOf(KubernetesClientException.class)
+                .hasMessageContaining("Ingress with annotation 'reject=true' is not allowed");
+          } finally {
+            client.resource(invalid).delete();
+          }
+        });
   }
 
   static MockResponse handleValidatingWebhook(RecordedRequest request) {
@@ -183,10 +199,10 @@ class KubernetesValidationHookHandlingTest {
         .build();
   }
 
-  public static Ingress invalidIngress() {
+  public static Ingress invalidIngress(String name) {
     return new IngressBuilder()
         .withNewMetadata()
-        .withName("invalid-ingress")
+        .withName(name)
         .addToAnnotations("reject", "true")
         .endMetadata()
         .withSpec(new IngressSpecBuilder()


### PR DESCRIPTION
## Description

`KubernetesValidationHookHandlingTest.validatingWebhookRejectsInvalidResource` was failing intermittently on CI with `Expecting code to raise a throwable`. The test applies a `ValidatingWebhookConfiguration` via `serverSideApply()` and immediately calls `create()` on an invalid Ingress; the kube-apiserver has a brief propagation delay before the webhook is wired into the admission chain, and when `create()` landed inside that window the resource was admitted and the assertion failed.

The fix wraps the assertion in `Awaitility.await().atMost(30s).pollInterval(200ms).untilAsserted(...)`, generating a UUID-suffixed Ingress name on every attempt and deleting any slipped-through resource in a `finally` block so the loop converges deterministically once the webhook becomes active without leaking Ingresses on the embedded API server.

Fixes #7727