### PR TITLE
fix(mockwebserver): don't send Content-Length with Transfer-Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
+* Fix #7734: (mockwebserver) avoid sending Content-Length together with Transfer-Encoding for chunked responses
 * Fix #7686: (httpclient-vertx-5) StackBasedRecursionGuard.enter() no longer increments depth when refusing entry, fixing an infinite runOnContext loop that stalled InputStreamReadStream uploads under CPU contention
 * Fix #7700: ExecWebSocketListener.onError now defers failure handling through the SerialExecutor so a pending channel-3 exit-status task runs first and the parsed exit code is preserved instead of being overwritten by a peer-close exception
 * Fix #7698: (httpclient-vertx-5) InputStreamReadStream now fires endHandler when registered after the end signal has already been delivered, fixing a race for empty/fast streams

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/http/MockResponse.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/http/MockResponse.java
@@ -108,7 +108,7 @@ public class MockResponse implements Response {
    */
   public MockResponse setChunkedBody(Buffer body, int maxChunkSize) {
     removeHeader("Content-Length");
-    setHeader("Transfer-encoding", "chunked");
+    setHeader("Transfer-Encoding", "chunked");
 
     final Buffer chunkedBody = new Buffer();
     final byte[] bodyBytes = body.getBytes();

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/HttpServerRequestHandler.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/HttpServerRequestHandler.java
@@ -31,6 +31,7 @@ public abstract class HttpServerRequestHandler implements Handler<HttpServerRequ
 
   private static final String CONTENT_LENGTH = "Content-Length";
   private static final String CONTENT_TYPE = "Content-Type";
+  private static final String TRANSFER_ENCODING = "Transfer-Encoding";
 
   private final Vertx vertx;
 
@@ -75,7 +76,9 @@ public abstract class HttpServerRequestHandler implements Handler<HttpServerRequ
       vertxResponse.setStatusCode(mockResponse.code());
       mockResponse.getHeaders().toMultimap().forEach((key, values) -> vertxResponse.headers().add(key, values));
       if (mockResponse.getBody() != null && mockResponse.getBody().size() > 0) {
-        vertxResponse.headers().add(CONTENT_LENGTH, String.valueOf(mockResponse.getBody().size()));
+        if (!vertxResponse.headers().contains(TRANSFER_ENCODING)) {
+          vertxResponse.headers().add(CONTENT_LENGTH, String.valueOf(mockResponse.getBody().size()));
+        }
         final io.vertx.core.buffer.Buffer toSend = io.vertx.core.buffer.Buffer.buffer(mockResponse.getBody().getBytes());
         if (mockResponse.getBodyDelay() != null) {
           vertx.setTimer(mockResponse.getBodyDelay().toMillis(), timerId -> vertxResponse.send(toSend));

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <jetty.version>11.0.26</jetty.version>
     <maven-core.version>3.9.15</maven-core.version>
     <maven-plugin-annotations.version>3.15.2</maven-plugin-annotations.version>
-    <vertx.version>4.5.26</vertx.version>
+    <vertx.version>4.5.27</vertx.version>
     <vertx5.version>5.0.12</vertx5.version>
     <jandex.version>3.5.3</jandex.version>
     <snakeyaml.version>3.0.1</snakeyaml.version>


### PR DESCRIPTION
## Summary
- Fixes #7734: when a `MockResponse` already declared `Transfer-Encoding`, the Vert.x-backed handler no longer also adds `Content-Length` (HTTP/1.1 forbids both — RFC 7230 §3.3.2).
- Bundles the Vert.x 4.5.27 bump (originally #7732 by dependabot) which exposed the issue: 4.5.27 now rejects responses carrying both headers, breaking `DefaultMockServerTest."when setting a chunked response it should be sent in chunks"`.

Closes #7732.