### PR TITLE
chore(deps): bump prometheus-operator from 0.90.1 to 0.91.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * Fix #7538: bump cert-manager from 1.18.2 to 1.19.4
 * Fix #7583: bump operator-framework/api from 0.33.0 to 0.41.0
 * Fix #7589: bump prometheus-operator from 0.89.0 to 0.90.0
-* Fix #PLACEHOLDER: bump prometheus-operator from 0.90.1 to 0.91.0
+* Fix #7736: bump prometheus-operator from 0.90.1 to 0.91.0
 * Fix #7578: bump tektoncd/pipeline from 1.9.0 to 1.10.2
 * Fix #7582: bump vertical-pod-autoscaler from 1.4.1 to 1.6.0
 
@@ -59,7 +59,7 @@
 * Fix #7723: knative model `internal.autoscaling.v1alpha1.PodScalableSpec.template` field removed (upstream removed the field in autoscaling.internal.knative.dev v1alpha1)
 * Fix #7580: kustomize model `Patch.options` field type changed from `Map<String, Boolean>` to `PatchArgs` (following upstream kustomize v0.21.0 PatchArgs API type addition)
 * Fix #7543: monitoring model `v1.AuthorizationValidationError`, `v1.OAuth2ValidationError`, `v1.ProbeTargetsValidationError`, and `v1.PrometheusTracingConfig` removed
-* Fix #PLACEHOLDER: monitoring model `v1.ThanosSpec.grpcServerTlsConfig` and `v1.ThanosRulerSpec.grpcServerTlsConfig` field type changed from `TLSConfig` to the new `GRPCServerTLSConfig` (following upstream prometheus-operator v0.91.0)
+* Fix #7736: monitoring model `v1.ThanosSpec.grpcServerTlsConfig` and `v1.ThanosRulerSpec.grpcServerTlsConfig` field type changed from `TLSConfig` to the new `GRPCServerTLSConfig` (following upstream prometheus-operator v0.91.0)
 * Fix #7542: open-cluster-management model `operator.v1.WebhookConfiguration` removed (replaced by `DefaultWebhookConfiguration` and `HostedWebhookConfiguration` upstream)
 
 ### 7.4.1 (2026-03-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Fix #7538: bump cert-manager from 1.18.2 to 1.19.4
 * Fix #7583: bump operator-framework/api from 0.33.0 to 0.41.0
 * Fix #7589: bump prometheus-operator from 0.89.0 to 0.90.0
+* Fix #PLACEHOLDER: bump prometheus-operator from 0.90.1 to 0.91.0
 * Fix #7578: bump tektoncd/pipeline from 1.9.0 to 1.10.2
 * Fix #7582: bump vertical-pod-autoscaler from 1.4.1 to 1.6.0
 
@@ -58,6 +59,7 @@
 * Fix #7723: knative model `internal.autoscaling.v1alpha1.PodScalableSpec.template` field removed (upstream removed the field in autoscaling.internal.knative.dev v1alpha1)
 * Fix #7580: kustomize model `Patch.options` field type changed from `Map<String, Boolean>` to `PatchArgs` (following upstream kustomize v0.21.0 PatchArgs API type addition)
 * Fix #7543: monitoring model `v1.AuthorizationValidationError`, `v1.OAuth2ValidationError`, `v1.ProbeTargetsValidationError`, and `v1.PrometheusTracingConfig` removed
+* Fix #PLACEHOLDER: monitoring model `v1.ThanosSpec.grpcServerTlsConfig` and `v1.ThanosRulerSpec.grpcServerTlsConfig` field type changed from `TLSConfig` to the new `GRPCServerTLSConfig` (following upstream prometheus-operator v0.91.0)
 * Fix #7542: open-cluster-management model `operator.v1.WebhookConfiguration` removed (replaced by `DefaultWebhookConfiguration` and `HostedWebhookConfiguration` upstream)
 
 ### 7.4.1 (2026-03-10)

--- a/kubernetes-model-generator/openapi/generator/go.mod
+++ b/kubernetes-model-generator/openapi/generator/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/operator-framework/api v0.42.0
 	github.com/operator-framework/operator-lifecycle-manager v0.42.0
 	github.com/ovn-org/ovn-kubernetes/go-controller v0.0.0-20241030140127-a68ef49d9441
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.90.1
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stolostron/discovery v0.0.0-20250721184441-6a13204f0907
 	github.com/stolostron/klusterlet-addon-controller v0.0.0-20250324045714-0d7e21c66660

--- a/kubernetes-model-generator/openapi/generator/go.sum
+++ b/kubernetes-model-generator/openapi/generator/go.sum
@@ -4234,8 +4234,8 @@ github.com/pquerna/cachecontrol v0.1.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQ
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/proglottis/gpgme v0.1.6 h1:8WpQ8VWggLdxkuTnW+sZ1r1t92XBNd8GZNDhQ4Rz+98=
 github.com/proglottis/gpgme v0.1.6/go.mod h1:5LoXMgpE4bttgwwdv9bLs/vwqv3qV7F4glEEZ7mRKrM=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.90.1 h1:URbjn501/IBFTzPtGXrYDXHi+ZcbP2W60o6JeTrY3vQ=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.90.1/go.mod h1:Gfzi4500QCMnptFIQc8YdDi8YZ4QA0vs22LROWZ3+YU=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0 h1:m2SZ2z5edgk0nXx7W6VHLfIsKZwgKbr+E5c2RNYyJB8=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0/go.mod h1:Gfzi4500QCMnptFIQc8YdDi8YZ4QA0vs22LROWZ3+YU=
 github.com/prometheus/alertmanager v0.27.0/go.mod h1:8Ia/R3urPmbzJ8OsdvmZvIprDwvwmYCmUbwBL+jlPOE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/AlertmanagerGlobalConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/AlertmanagerGlobalConfig.java
@@ -40,6 +40,7 @@ import lombok.experimental.Accessors;
 @JsonPropertyOrder({
     "httpConfig",
     "jira",
+    "mattermost",
     "opsGenieApiKey",
     "opsGenieApiUrl",
     "pagerdutyUrl",
@@ -81,6 +82,8 @@ public class AlertmanagerGlobalConfig implements Editable<AlertmanagerGlobalConf
     private HTTPConfigWithProxy httpConfig;
     @JsonProperty("jira")
     private GlobalJiraConfig jira;
+    @JsonProperty("mattermost")
+    private GlobalMattermostConfig mattermost;
     @JsonProperty("opsGenieApiKey")
     private SecretKeySelector opsGenieApiKey;
     @JsonProperty("opsGenieApiUrl")
@@ -112,10 +115,11 @@ public class AlertmanagerGlobalConfig implements Editable<AlertmanagerGlobalConf
     public AlertmanagerGlobalConfig() {
     }
 
-    public AlertmanagerGlobalConfig(HTTPConfigWithProxy httpConfig, GlobalJiraConfig jira, SecretKeySelector opsGenieApiKey, SecretKeySelector opsGenieApiUrl, String pagerdutyUrl, String resolveTimeout, GlobalRocketChatConfig rocketChat, SecretKeySelector slackApiUrl, GlobalSMTPConfig smtp, GlobalTelegramConfig telegram, GlobalVictorOpsConfig victorops, GlobalWebexConfig webex, GlobalWeChatConfig wechat) {
+    public AlertmanagerGlobalConfig(HTTPConfigWithProxy httpConfig, GlobalJiraConfig jira, GlobalMattermostConfig mattermost, SecretKeySelector opsGenieApiKey, SecretKeySelector opsGenieApiUrl, String pagerdutyUrl, String resolveTimeout, GlobalRocketChatConfig rocketChat, SecretKeySelector slackApiUrl, GlobalSMTPConfig smtp, GlobalTelegramConfig telegram, GlobalVictorOpsConfig victorops, GlobalWebexConfig webex, GlobalWeChatConfig wechat) {
         super();
         this.httpConfig = httpConfig;
         this.jira = jira;
+        this.mattermost = mattermost;
         this.opsGenieApiKey = opsGenieApiKey;
         this.opsGenieApiUrl = opsGenieApiUrl;
         this.pagerdutyUrl = pagerdutyUrl;
@@ -159,6 +163,22 @@ public class AlertmanagerGlobalConfig implements Editable<AlertmanagerGlobalConf
     @JsonProperty("jira")
     public void setJira(GlobalJiraConfig jira) {
         this.jira = jira;
+    }
+
+    /**
+     * AlertmanagerGlobalConfig configures parameters that are valid in all other configuration contexts. See https://prometheus.io/docs/alerting/latest/configuration/#configuration-file
+     */
+    @JsonProperty("mattermost")
+    public GlobalMattermostConfig getMattermost() {
+        return mattermost;
+    }
+
+    /**
+     * AlertmanagerGlobalConfig configures parameters that are valid in all other configuration contexts. See https://prometheus.io/docs/alerting/latest/configuration/#configuration-file
+     */
+    @JsonProperty("mattermost")
+    public void setMattermost(GlobalMattermostConfig mattermost) {
+        this.mattermost = mattermost;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/CommonPrometheusFields.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/CommonPrometheusFields.java
@@ -132,6 +132,7 @@ import lombok.experimental.Accessors;
     "serviceMonitorNamespaceSelector",
     "serviceMonitorSelector",
     "serviceName",
+    "shardingStrategy",
     "shards",
     "storage",
     "targetLimit",
@@ -364,6 +365,8 @@ public class CommonPrometheusFields implements Editable<CommonPrometheusFieldsBu
     private LabelSelector serviceMonitorSelector;
     @JsonProperty("serviceName")
     private String serviceName;
+    @JsonProperty("shardingStrategy")
+    private ShardingStrategy shardingStrategy;
     @JsonProperty("shards")
     private Integer shards;
     @JsonProperty("storage")
@@ -405,7 +408,7 @@ public class CommonPrometheusFields implements Editable<CommonPrometheusFieldsBu
     public CommonPrometheusFields() {
     }
 
-    public CommonPrometheusFields(List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, Boolean automountServiceAccountToken, String bodySizeLimit, List<String> configMaps, List<Container> containers, Boolean convertClassicHistogramsToNHCB, PodDNSConfig dnsConfig, String dnsPolicy, List<String> enableFeatures, Boolean enableOTLPReceiver, Boolean enableRemoteWriteReceiver, Boolean enableServiceLinks, String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, List<ObjectReference> excludedFromEnforcement, Map<String, String> externalLabels, String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean hostUsers, Boolean ignoreNamespaceSelectors, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, String logFormat, String logLevel, Integer maximumStartupDurationSeconds, Integer minReadySeconds, String nameEscapingScheme, String nameValidationScheme, Map<String, String> nodeSelector, OTLPConfig otlp, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, LabelSelector podMonitorNamespaceSelector, LabelSelector podMonitorSelector, List<String> podTargetLabels, String portName, String priorityClassName, LabelSelector probeNamespaceSelector, LabelSelector probeSelector, String prometheusExternalLabelName, String reloadStrategy, List<RemoteWriteSpec> remoteWrite, List<String> remoteWriteReceiverMessageVersions, String replicaExternalLabelName, Integer replicas, ResourceRequirements resources, String routePrefix, RuntimeConfig runtime, Long sampleLimit, String schedulerName, List<ScrapeClass> scrapeClasses, Boolean scrapeClassicHistograms, LabelSelector scrapeConfigNamespaceSelector, LabelSelector scrapeConfigSelector, String scrapeFailureLogFile, String scrapeInterval, Boolean scrapeNativeHistograms, List<String> scrapeProtocols, String scrapeTimeout, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, String serviceDiscoveryRole, LabelSelector serviceMonitorNamespaceSelector, LabelSelector serviceMonitorSelector, String serviceName, Integer shards, StorageSpec storage, Long targetLimit, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, TracingConfig tracingConfig, TSDBSpec tsdb, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
+    public CommonPrometheusFields(List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, Boolean automountServiceAccountToken, String bodySizeLimit, List<String> configMaps, List<Container> containers, Boolean convertClassicHistogramsToNHCB, PodDNSConfig dnsConfig, String dnsPolicy, List<String> enableFeatures, Boolean enableOTLPReceiver, Boolean enableRemoteWriteReceiver, Boolean enableServiceLinks, String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, List<ObjectReference> excludedFromEnforcement, Map<String, String> externalLabels, String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean hostUsers, Boolean ignoreNamespaceSelectors, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, String logFormat, String logLevel, Integer maximumStartupDurationSeconds, Integer minReadySeconds, String nameEscapingScheme, String nameValidationScheme, Map<String, String> nodeSelector, OTLPConfig otlp, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, LabelSelector podMonitorNamespaceSelector, LabelSelector podMonitorSelector, List<String> podTargetLabels, String portName, String priorityClassName, LabelSelector probeNamespaceSelector, LabelSelector probeSelector, String prometheusExternalLabelName, String reloadStrategy, List<RemoteWriteSpec> remoteWrite, List<String> remoteWriteReceiverMessageVersions, String replicaExternalLabelName, Integer replicas, ResourceRequirements resources, String routePrefix, RuntimeConfig runtime, Long sampleLimit, String schedulerName, List<ScrapeClass> scrapeClasses, Boolean scrapeClassicHistograms, LabelSelector scrapeConfigNamespaceSelector, LabelSelector scrapeConfigSelector, String scrapeFailureLogFile, String scrapeInterval, Boolean scrapeNativeHistograms, List<String> scrapeProtocols, String scrapeTimeout, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, String serviceDiscoveryRole, LabelSelector serviceMonitorNamespaceSelector, LabelSelector serviceMonitorSelector, String serviceName, ShardingStrategy shardingStrategy, Integer shards, StorageSpec storage, Long targetLimit, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, TracingConfig tracingConfig, TSDBSpec tsdb, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
         super();
         this.additionalArgs = additionalArgs;
         this.additionalScrapeConfigs = additionalScrapeConfigs;
@@ -495,6 +498,7 @@ public class CommonPrometheusFields implements Editable<CommonPrometheusFieldsBu
         this.serviceMonitorNamespaceSelector = serviceMonitorNamespaceSelector;
         this.serviceMonitorSelector = serviceMonitorSelector;
         this.serviceName = serviceName;
+        this.shardingStrategy = shardingStrategy;
         this.shards = shards;
         this.storage = storage;
         this.targetLimit = targetLimit;
@@ -1933,6 +1937,22 @@ public class CommonPrometheusFields implements Editable<CommonPrometheusFieldsBu
     @JsonProperty("serviceName")
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
+    }
+
+    /**
+     * CommonPrometheusFields are the options available to both the Prometheus server and agent.
+     */
+    @JsonProperty("shardingStrategy")
+    public ShardingStrategy getShardingStrategy() {
+        return shardingStrategy;
+    }
+
+    /**
+     * CommonPrometheusFields are the options available to both the Prometheus server and agent.
+     */
+    @JsonProperty("shardingStrategy")
+    public void setShardingStrategy(ShardingStrategy shardingStrategy) {
+        this.shardingStrategy = shardingStrategy;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/GRPCServerTLSConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/GRPCServerTLSConfig.java
@@ -1,0 +1,351 @@
+
+package io.fabric8.openshift.api.model.monitoring.v1;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.SecretKeySelector;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * GRPCServerTLSConfig defines TLS configuration for a gRPC server.
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "ca",
+    "caFile",
+    "cert",
+    "certFile",
+    "cipherSuites",
+    "curves",
+    "insecureSkipVerify",
+    "keyFile",
+    "keySecret",
+    "maxVersion",
+    "minVersion",
+    "serverName"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class GRPCServerTLSConfig implements Editable<GRPCServerTLSConfigBuilder>, KubernetesResource
+{
+
+    @JsonProperty("ca")
+    private SecretOrConfigMap ca;
+    @JsonProperty("caFile")
+    private String caFile;
+    @JsonProperty("cert")
+    private SecretOrConfigMap cert;
+    @JsonProperty("certFile")
+    private String certFile;
+    @JsonProperty("cipherSuites")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> cipherSuites = new ArrayList<>();
+    @JsonProperty("curves")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> curves = new ArrayList<>();
+    @JsonProperty("insecureSkipVerify")
+    private Boolean insecureSkipVerify;
+    @JsonProperty("keyFile")
+    private String keyFile;
+    @JsonProperty("keySecret")
+    private SecretKeySelector keySecret;
+    @JsonProperty("maxVersion")
+    private String maxVersion;
+    @JsonProperty("minVersion")
+    private String minVersion;
+    @JsonProperty("serverName")
+    private String serverName;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public GRPCServerTLSConfig() {
+    }
+
+    public GRPCServerTLSConfig(SecretOrConfigMap ca, String caFile, SecretOrConfigMap cert, String certFile, List<String> cipherSuites, List<String> curves, Boolean insecureSkipVerify, String keyFile, SecretKeySelector keySecret, String maxVersion, String minVersion, String serverName) {
+        super();
+        this.ca = ca;
+        this.caFile = caFile;
+        this.cert = cert;
+        this.certFile = certFile;
+        this.cipherSuites = cipherSuites;
+        this.curves = curves;
+        this.insecureSkipVerify = insecureSkipVerify;
+        this.keyFile = keyFile;
+        this.keySecret = keySecret;
+        this.maxVersion = maxVersion;
+        this.minVersion = minVersion;
+        this.serverName = serverName;
+    }
+
+    /**
+     * GRPCServerTLSConfig defines TLS configuration for a gRPC server.
+     */
+    @JsonProperty("ca")
+    public SecretOrConfigMap getCa() {
+        return ca;
+    }
+
+    /**
+     * GRPCServerTLSConfig defines TLS configuration for a gRPC server.
+     */
+    @JsonProperty("ca")
+    public void setCa(SecretOrConfigMap ca) {
+        this.ca = ca;
+    }
+
+    /**
+     * caFile defines the path to the CA cert in the Prometheus container to use for the targets.
+     */
+    @JsonProperty("caFile")
+    public String getCaFile() {
+        return caFile;
+    }
+
+    /**
+     * caFile defines the path to the CA cert in the Prometheus container to use for the targets.
+     */
+    @JsonProperty("caFile")
+    public void setCaFile(String caFile) {
+        this.caFile = caFile;
+    }
+
+    /**
+     * GRPCServerTLSConfig defines TLS configuration for a gRPC server.
+     */
+    @JsonProperty("cert")
+    public SecretOrConfigMap getCert() {
+        return cert;
+    }
+
+    /**
+     * GRPCServerTLSConfig defines TLS configuration for a gRPC server.
+     */
+    @JsonProperty("cert")
+    public void setCert(SecretOrConfigMap cert) {
+        this.cert = cert;
+    }
+
+    /**
+     * certFile defines the path to the client cert file in the Prometheus container for the targets.
+     */
+    @JsonProperty("certFile")
+    public String getCertFile() {
+        return certFile;
+    }
+
+    /**
+     * certFile defines the path to the client cert file in the Prometheus container for the targets.
+     */
+    @JsonProperty("certFile")
+    public void setCertFile(String certFile) {
+        this.certFile = certFile;
+    }
+
+    /**
+     * cipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.<br><p> <br><p> If not defined, the Go default cipher suites are used. Available cipher suites are documented in the Go documentation: https://golang.org/pkg/crypto/tls/#pkg-constants<br><p> <br><p> It requires Thanos &gt;= v0.42.0. Note that the operator doesn't verify if the Thanos version supports the provided values.
+     */
+    @JsonProperty("cipherSuites")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getCipherSuites() {
+        return cipherSuites;
+    }
+
+    /**
+     * cipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.<br><p> <br><p> If not defined, the Go default cipher suites are used. Available cipher suites are documented in the Go documentation: https://golang.org/pkg/crypto/tls/#pkg-constants<br><p> <br><p> It requires Thanos &gt;= v0.42.0. Note that the operator doesn't verify if the Thanos version supports the provided values.
+     */
+    @JsonProperty("cipherSuites")
+    public void setCipherSuites(List<String> cipherSuites) {
+        this.cipherSuites = cipherSuites;
+    }
+
+    /**
+     * curves defines the list of preferred elliptic curves for TLS handshakes.<br><p> <br><p> If not defined, the Go default curves are used. Available curves are documented in the Go documentation: https://golang.org/pkg/crypto/tls/#CurveID<br><p> <br><p> It requires Thanos &gt;= v0.42.0. Note that the operator doesn't verify if the Thanos version supports the provided values.
+     */
+    @JsonProperty("curves")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getCurves() {
+        return curves;
+    }
+
+    /**
+     * curves defines the list of preferred elliptic curves for TLS handshakes.<br><p> <br><p> If not defined, the Go default curves are used. Available curves are documented in the Go documentation: https://golang.org/pkg/crypto/tls/#CurveID<br><p> <br><p> It requires Thanos &gt;= v0.42.0. Note that the operator doesn't verify if the Thanos version supports the provided values.
+     */
+    @JsonProperty("curves")
+    public void setCurves(List<String> curves) {
+        this.curves = curves;
+    }
+
+    /**
+     * insecureSkipVerify defines how to disable target certificate validation.
+     */
+    @JsonProperty("insecureSkipVerify")
+    public Boolean getInsecureSkipVerify() {
+        return insecureSkipVerify;
+    }
+
+    /**
+     * insecureSkipVerify defines how to disable target certificate validation.
+     */
+    @JsonProperty("insecureSkipVerify")
+    public void setInsecureSkipVerify(Boolean insecureSkipVerify) {
+        this.insecureSkipVerify = insecureSkipVerify;
+    }
+
+    /**
+     * keyFile defines the path to the client key file in the Prometheus container for the targets.
+     */
+    @JsonProperty("keyFile")
+    public String getKeyFile() {
+        return keyFile;
+    }
+
+    /**
+     * keyFile defines the path to the client key file in the Prometheus container for the targets.
+     */
+    @JsonProperty("keyFile")
+    public void setKeyFile(String keyFile) {
+        this.keyFile = keyFile;
+    }
+
+    /**
+     * GRPCServerTLSConfig defines TLS configuration for a gRPC server.
+     */
+    @JsonProperty("keySecret")
+    public SecretKeySelector getKeySecret() {
+        return keySecret;
+    }
+
+    /**
+     * GRPCServerTLSConfig defines TLS configuration for a gRPC server.
+     */
+    @JsonProperty("keySecret")
+    public void setKeySecret(SecretKeySelector keySecret) {
+        this.keySecret = keySecret;
+    }
+
+    /**
+     * maxVersion defines the maximum acceptable TLS version.<br><p> <br><p> It requires Prometheus &gt;= v2.41.0 or Thanos &gt;= v0.31.0.
+     */
+    @JsonProperty("maxVersion")
+    public String getMaxVersion() {
+        return maxVersion;
+    }
+
+    /**
+     * maxVersion defines the maximum acceptable TLS version.<br><p> <br><p> It requires Prometheus &gt;= v2.41.0 or Thanos &gt;= v0.31.0.
+     */
+    @JsonProperty("maxVersion")
+    public void setMaxVersion(String maxVersion) {
+        this.maxVersion = maxVersion;
+    }
+
+    /**
+     * minVersion defines the minimum acceptable TLS version.<br><p> <br><p> It requires Prometheus &gt;= v2.35.0 or Thanos &gt;= v0.28.0.
+     */
+    @JsonProperty("minVersion")
+    public String getMinVersion() {
+        return minVersion;
+    }
+
+    /**
+     * minVersion defines the minimum acceptable TLS version.<br><p> <br><p> It requires Prometheus &gt;= v2.35.0 or Thanos &gt;= v0.28.0.
+     */
+    @JsonProperty("minVersion")
+    public void setMinVersion(String minVersion) {
+        this.minVersion = minVersion;
+    }
+
+    /**
+     * serverName is used to verify the hostname for the targets.
+     */
+    @JsonProperty("serverName")
+    public String getServerName() {
+        return serverName;
+    }
+
+    /**
+     * serverName is used to verify the hostname for the targets.
+     */
+    @JsonProperty("serverName")
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
+    }
+
+    @JsonIgnore
+    public GRPCServerTLSConfigBuilder edit() {
+        return new GRPCServerTLSConfigBuilder(this);
+    }
+
+    @JsonIgnore
+    public GRPCServerTLSConfigBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/GlobalMattermostConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/GlobalMattermostConfig.java
@@ -1,0 +1,125 @@
+
+package io.fabric8.openshift.api.model.monitoring.v1;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.SecretKeySelector;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * GlobalMattermostConfig configures global Mattermost parameters.
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "webhookURL"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class GlobalMattermostConfig implements Editable<GlobalMattermostConfigBuilder>, KubernetesResource
+{
+
+    @JsonProperty("webhookURL")
+    private SecretKeySelector webhookURL;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public GlobalMattermostConfig() {
+    }
+
+    public GlobalMattermostConfig(SecretKeySelector webhookURL) {
+        super();
+        this.webhookURL = webhookURL;
+    }
+
+    /**
+     * GlobalMattermostConfig configures global Mattermost parameters.
+     */
+    @JsonProperty("webhookURL")
+    public SecretKeySelector getWebhookURL() {
+        return webhookURL;
+    }
+
+    /**
+     * GlobalMattermostConfig configures global Mattermost parameters.
+     */
+    @JsonProperty("webhookURL")
+    public void setWebhookURL(SecretKeySelector webhookURL) {
+        this.webhookURL = webhookURL;
+    }
+
+    @JsonIgnore
+    public GlobalMattermostConfigBuilder edit() {
+        return new GlobalMattermostConfigBuilder(this);
+    }
+
+    @JsonIgnore
+    public GlobalMattermostConfigBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/PrometheusSpec.java
@@ -153,6 +153,7 @@ import lombok.experimental.Accessors;
     "serviceName",
     "sha",
     "shardRetentionPolicy",
+    "shardingStrategy",
     "shards",
     "storage",
     "tag",
@@ -431,6 +432,8 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder>, Kubernet
     private String sha;
     @JsonProperty("shardRetentionPolicy")
     private ShardRetentionPolicy shardRetentionPolicy;
+    @JsonProperty("shardingStrategy")
+    private ShardingStrategy shardingStrategy;
     @JsonProperty("shards")
     private Integer shards;
     @JsonProperty("storage")
@@ -476,7 +479,7 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder>, Kubernet
     public PrometheusSpec() {
     }
 
-    public PrometheusSpec(SecretKeySelector additionalAlertManagerConfigs, SecretKeySelector additionalAlertRelabelConfigs, List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, AlertingSpec alerting, Boolean allowOverlappingBlocks, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, Boolean automountServiceAccountToken, String baseImage, String bodySizeLimit, List<String> configMaps, List<Container> containers, Boolean convertClassicHistogramsToNHCB, Boolean disableCompaction, PodDNSConfig dnsConfig, String dnsPolicy, Boolean enableAdminAPI, List<String> enableFeatures, Boolean enableOTLPReceiver, Boolean enableRemoteWriteReceiver, Boolean enableServiceLinks, String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, String evaluationInterval, List<ObjectReference> excludedFromEnforcement, Exemplars exemplars, Map<String, String> externalLabels, String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean hostUsers, Boolean ignoreNamespaceSelectors, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, String logFormat, String logLevel, Integer maximumStartupDurationSeconds, Integer minReadySeconds, String nameEscapingScheme, String nameValidationScheme, Map<String, String> nodeSelector, OTLPConfig otlp, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, LabelSelector podMonitorNamespaceSelector, LabelSelector podMonitorSelector, List<String> podTargetLabels, String portName, String priorityClassName, LabelSelector probeNamespaceSelector, LabelSelector probeSelector, String prometheusExternalLabelName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, QuerySpec query, String queryLogFile, String reloadStrategy, List<RemoteReadSpec> remoteRead, List<RemoteWriteSpec> remoteWrite, List<String> remoteWriteReceiverMessageVersions, String replicaExternalLabelName, Integer replicas, ResourceRequirements resources, String retention, String retentionSize, String routePrefix, LabelSelector ruleNamespaceSelector, String ruleQueryOffset, LabelSelector ruleSelector, Rules rules, RuntimeConfig runtime, Long sampleLimit, String schedulerName, List<ScrapeClass> scrapeClasses, Boolean scrapeClassicHistograms, LabelSelector scrapeConfigNamespaceSelector, LabelSelector scrapeConfigSelector, String scrapeFailureLogFile, String scrapeInterval, Boolean scrapeNativeHistograms, List<String> scrapeProtocols, String scrapeTimeout, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, String serviceDiscoveryRole, LabelSelector serviceMonitorNamespaceSelector, LabelSelector serviceMonitorSelector, String serviceName, String sha, ShardRetentionPolicy shardRetentionPolicy, Integer shards, StorageSpec storage, String tag, Long targetLimit, Long terminationGracePeriodSeconds, ThanosSpec thanos, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, TracingConfig tracingConfig, TSDBSpec tsdb, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
+    public PrometheusSpec(SecretKeySelector additionalAlertManagerConfigs, SecretKeySelector additionalAlertRelabelConfigs, List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, AlertingSpec alerting, Boolean allowOverlappingBlocks, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, Boolean automountServiceAccountToken, String baseImage, String bodySizeLimit, List<String> configMaps, List<Container> containers, Boolean convertClassicHistogramsToNHCB, Boolean disableCompaction, PodDNSConfig dnsConfig, String dnsPolicy, Boolean enableAdminAPI, List<String> enableFeatures, Boolean enableOTLPReceiver, Boolean enableRemoteWriteReceiver, Boolean enableServiceLinks, String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, String evaluationInterval, List<ObjectReference> excludedFromEnforcement, Exemplars exemplars, Map<String, String> externalLabels, String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean hostUsers, Boolean ignoreNamespaceSelectors, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, String logFormat, String logLevel, Integer maximumStartupDurationSeconds, Integer minReadySeconds, String nameEscapingScheme, String nameValidationScheme, Map<String, String> nodeSelector, OTLPConfig otlp, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, LabelSelector podMonitorNamespaceSelector, LabelSelector podMonitorSelector, List<String> podTargetLabels, String portName, String priorityClassName, LabelSelector probeNamespaceSelector, LabelSelector probeSelector, String prometheusExternalLabelName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, QuerySpec query, String queryLogFile, String reloadStrategy, List<RemoteReadSpec> remoteRead, List<RemoteWriteSpec> remoteWrite, List<String> remoteWriteReceiverMessageVersions, String replicaExternalLabelName, Integer replicas, ResourceRequirements resources, String retention, String retentionSize, String routePrefix, LabelSelector ruleNamespaceSelector, String ruleQueryOffset, LabelSelector ruleSelector, Rules rules, RuntimeConfig runtime, Long sampleLimit, String schedulerName, List<ScrapeClass> scrapeClasses, Boolean scrapeClassicHistograms, LabelSelector scrapeConfigNamespaceSelector, LabelSelector scrapeConfigSelector, String scrapeFailureLogFile, String scrapeInterval, Boolean scrapeNativeHistograms, List<String> scrapeProtocols, String scrapeTimeout, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, String serviceDiscoveryRole, LabelSelector serviceMonitorNamespaceSelector, LabelSelector serviceMonitorSelector, String serviceName, String sha, ShardRetentionPolicy shardRetentionPolicy, ShardingStrategy shardingStrategy, Integer shards, StorageSpec storage, String tag, Long targetLimit, Long terminationGracePeriodSeconds, ThanosSpec thanos, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, TracingConfig tracingConfig, TSDBSpec tsdb, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
         super();
         this.additionalAlertManagerConfigs = additionalAlertManagerConfigs;
         this.additionalAlertRelabelConfigs = additionalAlertRelabelConfigs;
@@ -587,6 +590,7 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder>, Kubernet
         this.serviceName = serviceName;
         this.sha = sha;
         this.shardRetentionPolicy = shardRetentionPolicy;
+        this.shardingStrategy = shardingStrategy;
         this.shards = shards;
         this.storage = storage;
         this.tag = tag;
@@ -2365,6 +2369,22 @@ public class PrometheusSpec implements Editable<PrometheusSpecBuilder>, Kubernet
     @JsonProperty("shardRetentionPolicy")
     public void setShardRetentionPolicy(ShardRetentionPolicy shardRetentionPolicy) {
         this.shardRetentionPolicy = shardRetentionPolicy;
+    }
+
+    /**
+     * PrometheusSpec is a specification of the desired behavior of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+     */
+    @JsonProperty("shardingStrategy")
+    public ShardingStrategy getShardingStrategy() {
+        return shardingStrategy;
+    }
+
+    /**
+     * PrometheusSpec is a specification of the desired behavior of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+     */
+    @JsonProperty("shardingStrategy")
+    public void setShardingStrategy(ShardingStrategy shardingStrategy) {
+        this.shardingStrategy = shardingStrategy;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/RetainConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/RetainConfig.java
@@ -78,7 +78,7 @@ public class RetainConfig implements Editable<RetainConfigBuilder>, KubernetesRe
     }
 
     /**
-     * retentionPeriod defines the retentionPeriod for shard retention policy.
+     * retentionPeriod defines how long the scaled-down shard(s) need to be kept before being deleted.
      */
     @JsonProperty("retentionPeriod")
     public String getRetentionPeriod() {
@@ -86,7 +86,7 @@ public class RetainConfig implements Editable<RetainConfigBuilder>, KubernetesRe
     }
 
     /**
-     * retentionPeriod defines the retentionPeriod for shard retention policy.
+     * retentionPeriod defines how long the scaled-down shard(s) need to be kept before being deleted.
      */
     @JsonProperty("retentionPeriod")
     public void setRetentionPeriod(String retentionPeriod) {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ShardingStrategy.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ShardingStrategy.java
@@ -1,0 +1,144 @@
+
+package io.fabric8.openshift.api.model.monitoring.v1;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * ShardingStrategy defines the sharding strategy for Prometheus.
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "mode",
+    "topology"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class ShardingStrategy implements Editable<ShardingStrategyBuilder>, KubernetesResource
+{
+
+    @JsonProperty("mode")
+    private String mode;
+    @JsonProperty("topology")
+    private TopologyShardingStrategy topology;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public ShardingStrategy() {
+    }
+
+    public ShardingStrategy(String mode, TopologyShardingStrategy topology) {
+        super();
+        this.mode = mode;
+        this.topology = topology;
+    }
+
+    /**
+     * mode defines the sharding mode. Can be 'Address' or 'Topology'.<br><p> <br><p> 'Address' is the default mode and distributes targets across shards based on a hash of the target address.<br><p> <br><p> 'Topology' enables zone-aware sharding where each shard is assigned to a specific topology zone and only scrapes targets in that zone. (Alpha) Using the 'Topology' mode requires the `PrometheusTopologySharding` feature gate to be enabled.
+     */
+    @JsonProperty("mode")
+    public String getMode() {
+        return mode;
+    }
+
+    /**
+     * mode defines the sharding mode. Can be 'Address' or 'Topology'.<br><p> <br><p> 'Address' is the default mode and distributes targets across shards based on a hash of the target address.<br><p> <br><p> 'Topology' enables zone-aware sharding where each shard is assigned to a specific topology zone and only scrapes targets in that zone. (Alpha) Using the 'Topology' mode requires the `PrometheusTopologySharding` feature gate to be enabled.
+     */
+    @JsonProperty("mode")
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    /**
+     * ShardingStrategy defines the sharding strategy for Prometheus.
+     */
+    @JsonProperty("topology")
+    public TopologyShardingStrategy getTopology() {
+        return topology;
+    }
+
+    /**
+     * ShardingStrategy defines the sharding strategy for Prometheus.
+     */
+    @JsonProperty("topology")
+    public void setTopology(TopologyShardingStrategy topology) {
+        this.topology = topology;
+    }
+
+    @JsonIgnore
+    public ShardingStrategyBuilder edit() {
+        return new ShardingStrategyBuilder(this);
+    }
+
+    @JsonIgnore
+    public ShardingStrategyBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Sigv4.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/Sigv4.java
@@ -39,6 +39,7 @@ import lombok.experimental.Accessors;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "accessKey",
+    "externalId",
     "profile",
     "region",
     "roleArn",
@@ -72,6 +73,8 @@ public class Sigv4 implements Editable<Sigv4Builder>, KubernetesResource
 
     @JsonProperty("accessKey")
     private SecretKeySelector accessKey;
+    @JsonProperty("externalId")
+    private String externalId;
     @JsonProperty("profile")
     private String profile;
     @JsonProperty("region")
@@ -91,9 +94,10 @@ public class Sigv4 implements Editable<Sigv4Builder>, KubernetesResource
     public Sigv4() {
     }
 
-    public Sigv4(SecretKeySelector accessKey, String profile, String region, String roleArn, SecretKeySelector secretKey, Boolean useFIPSSTSEndpoint) {
+    public Sigv4(SecretKeySelector accessKey, String externalId, String profile, String region, String roleArn, SecretKeySelector secretKey, Boolean useFIPSSTSEndpoint) {
         super();
         this.accessKey = accessKey;
+        this.externalId = externalId;
         this.profile = profile;
         this.region = region;
         this.roleArn = roleArn;
@@ -115,6 +119,22 @@ public class Sigv4 implements Editable<Sigv4Builder>, KubernetesResource
     @JsonProperty("accessKey")
     public void setAccessKey(SecretKeySelector accessKey) {
         this.accessKey = accessKey;
+    }
+
+    /**
+     * externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn. It requires Prometheus &gt;= v3.11.0 or Alertmanager &gt;= v0.33.0. Currently not supported by Thanos.
+     */
+    @JsonProperty("externalId")
+    public String getExternalId() {
+        return externalId;
+    }
+
+    /**
+     * externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn. It requires Prometheus &gt;= v3.11.0 or Alertmanager &gt;= v0.33.0. Currently not supported by Thanos.
+     */
+    @JsonProperty("externalId")
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosRulerSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosRulerSpec.java
@@ -178,7 +178,7 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder>, Kubern
     @JsonProperty("externalPrefix")
     private String externalPrefix;
     @JsonProperty("grpcServerTlsConfig")
-    private TLSConfig grpcServerTlsConfig;
+    private GRPCServerTLSConfig grpcServerTlsConfig;
     @JsonProperty("hostAliases")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<HostAlias> hostAliases = new ArrayList<>();
@@ -298,7 +298,7 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder>, Kubern
     public ThanosRulerSpec() {
     }
 
-    public ThanosRulerSpec(List<Argument> additionalArgs, Affinity affinity, List<String> alertDropLabels, String alertQueryUrl, String alertRelabelConfigFile, SecretKeySelector alertRelabelConfigs, SecretKeySelector alertmanagersConfig, List<String> alertmanagersUrl, List<Container> containers, PodDNSConfig dnsConfig, String dnsPolicy, List<String> enableFeatures, Boolean enableServiceLinks, String enforcedNamespaceLabel, String evaluationInterval, List<ObjectReference> excludedFromEnforcement, String externalPrefix, TLSConfig grpcServerTlsConfig, List<HostAlias> hostAliases, Boolean hostUsers, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Map<String, String> labels, Boolean listenLocal, String logFormat, String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, SecretKeySelector objectStorageConfig, String objectStorageConfigFile, Boolean paused, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, String portName, String priorityClassName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, SecretKeySelector queryConfig, List<String> queryEndpoints, List<RemoteWriteSpec> remoteWrite, Integer replicas, String resendDelay, ResourceRequirements resources, String retention, String routePrefix, Integer ruleConcurrentEval, String ruleGracePeriod, LabelSelector ruleNamespaceSelector, String ruleOutageTolerance, String ruleQueryOffset, LabelSelector ruleSelector, String schedulerName, PodSecurityContext securityContext, String serviceAccountName, String serviceName, StorageSpec storage, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, SecretKeySelector tracingConfig, String tracingConfigFile, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, ThanosRulerWebSpec web) {
+    public ThanosRulerSpec(List<Argument> additionalArgs, Affinity affinity, List<String> alertDropLabels, String alertQueryUrl, String alertRelabelConfigFile, SecretKeySelector alertRelabelConfigs, SecretKeySelector alertmanagersConfig, List<String> alertmanagersUrl, List<Container> containers, PodDNSConfig dnsConfig, String dnsPolicy, List<String> enableFeatures, Boolean enableServiceLinks, String enforcedNamespaceLabel, String evaluationInterval, List<ObjectReference> excludedFromEnforcement, String externalPrefix, GRPCServerTLSConfig grpcServerTlsConfig, List<HostAlias> hostAliases, Boolean hostUsers, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Map<String, String> labels, Boolean listenLocal, String logFormat, String logLevel, Integer minReadySeconds, Map<String, String> nodeSelector, SecretKeySelector objectStorageConfig, String objectStorageConfigFile, Boolean paused, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, String portName, String priorityClassName, List<PrometheusRuleExcludeConfig> prometheusRulesExcludedFromEnforce, SecretKeySelector queryConfig, List<String> queryEndpoints, List<RemoteWriteSpec> remoteWrite, Integer replicas, String resendDelay, ResourceRequirements resources, String retention, String routePrefix, Integer ruleConcurrentEval, String ruleGracePeriod, LabelSelector ruleNamespaceSelector, String ruleOutageTolerance, String ruleQueryOffset, LabelSelector ruleSelector, String schedulerName, PodSecurityContext securityContext, String serviceAccountName, String serviceName, StorageSpec storage, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, SecretKeySelector tracingConfig, String tracingConfigFile, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, ThanosRulerWebSpec web) {
         super();
         this.additionalArgs = additionalArgs;
         this.affinity = affinity;
@@ -651,7 +651,7 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder>, Kubern
      * ThanosRulerSpec is a specification of the desired behavior of the ThanosRuler. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
      */
     @JsonProperty("grpcServerTlsConfig")
-    public TLSConfig getGrpcServerTlsConfig() {
+    public GRPCServerTLSConfig getGrpcServerTlsConfig() {
         return grpcServerTlsConfig;
     }
 
@@ -659,7 +659,7 @@ public class ThanosRulerSpec implements Editable<ThanosRulerSpecBuilder>, Kubern
      * ThanosRulerSpec is a specification of the desired behavior of the ThanosRuler. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
      */
     @JsonProperty("grpcServerTlsConfig")
-    public void setGrpcServerTlsConfig(TLSConfig grpcServerTlsConfig) {
+    public void setGrpcServerTlsConfig(GRPCServerTLSConfig grpcServerTlsConfig) {
         this.grpcServerTlsConfig = grpcServerTlsConfig;
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/ThanosSpec.java
@@ -103,7 +103,7 @@ public class ThanosSpec implements Editable<ThanosSpecBuilder>, KubernetesResour
     @JsonProperty("grpcListenLocal")
     private Boolean grpcListenLocal;
     @JsonProperty("grpcServerTlsConfig")
-    private TLSConfig grpcServerTlsConfig;
+    private GRPCServerTLSConfig grpcServerTlsConfig;
     @JsonProperty("httpListenLocal")
     private Boolean httpListenLocal;
     @JsonProperty("image")
@@ -146,7 +146,7 @@ public class ThanosSpec implements Editable<ThanosSpecBuilder>, KubernetesResour
     public ThanosSpec() {
     }
 
-    public ThanosSpec(List<Argument> additionalArgs, String baseImage, String blockSize, String getConfigInterval, String getConfigTimeout, Boolean grpcListenLocal, TLSConfig grpcServerTlsConfig, Boolean httpListenLocal, String image, Boolean listenLocal, String logFormat, String logLevel, String minTime, SecretKeySelector objectStorageConfig, String objectStorageConfigFile, String readyTimeout, ResourceRequirements resources, String sha, String tag, SecretKeySelector tracingConfig, String tracingConfigFile, String version, List<VolumeMount> volumeMounts) {
+    public ThanosSpec(List<Argument> additionalArgs, String baseImage, String blockSize, String getConfigInterval, String getConfigTimeout, Boolean grpcListenLocal, GRPCServerTLSConfig grpcServerTlsConfig, Boolean httpListenLocal, String image, Boolean listenLocal, String logFormat, String logLevel, String minTime, SecretKeySelector objectStorageConfig, String objectStorageConfigFile, String readyTimeout, ResourceRequirements resources, String sha, String tag, SecretKeySelector tracingConfig, String tracingConfigFile, String version, List<VolumeMount> volumeMounts) {
         super();
         this.additionalArgs = additionalArgs;
         this.baseImage = baseImage;
@@ -274,7 +274,7 @@ public class ThanosSpec implements Editable<ThanosSpecBuilder>, KubernetesResour
      * ThanosSpec defines the configuration of the Thanos sidecar.
      */
     @JsonProperty("grpcServerTlsConfig")
-    public TLSConfig getGrpcServerTlsConfig() {
+    public GRPCServerTLSConfig getGrpcServerTlsConfig() {
         return grpcServerTlsConfig;
     }
 
@@ -282,7 +282,7 @@ public class ThanosSpec implements Editable<ThanosSpecBuilder>, KubernetesResour
      * ThanosSpec defines the configuration of the Thanos sidecar.
      */
     @JsonProperty("grpcServerTlsConfig")
-    public void setGrpcServerTlsConfig(TLSConfig grpcServerTlsConfig) {
+    public void setGrpcServerTlsConfig(GRPCServerTLSConfig grpcServerTlsConfig) {
         this.grpcServerTlsConfig = grpcServerTlsConfig;
     }
 

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/TopologyShardingStrategy.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1/TopologyShardingStrategy.java
@@ -1,0 +1,148 @@
+
+package io.fabric8.openshift.api.model.monitoring.v1;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+/**
+ * TopologyShardingStrategy defines the configuration for topology-aware sharding.
+ */
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "externalLabelName",
+    "values"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class TopologyShardingStrategy implements Editable<TopologyShardingStrategyBuilder>, KubernetesResource
+{
+
+    @JsonProperty("externalLabelName")
+    private String externalLabelName;
+    @JsonProperty("values")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> values = new ArrayList<>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public TopologyShardingStrategy() {
+    }
+
+    public TopologyShardingStrategy(String externalLabelName, List<String> values) {
+        super();
+        this.externalLabelName = externalLabelName;
+        this.values = values;
+    }
+
+    /**
+     * externalLabelName defines the name of the Prometheus external label used to communicate the topology zone assigned to the Prometheus instance. If not defined, it defaults to "zone". If set to the empty string, no external label is added to the Prometheus configuration.
+     */
+    @JsonProperty("externalLabelName")
+    public String getExternalLabelName() {
+        return externalLabelName;
+    }
+
+    /**
+     * externalLabelName defines the name of the Prometheus external label used to communicate the topology zone assigned to the Prometheus instance. If not defined, it defaults to "zone". If set to the empty string, no external label is added to the Prometheus configuration.
+     */
+    @JsonProperty("externalLabelName")
+    public void setExternalLabelName(String externalLabelName) {
+        this.externalLabelName = externalLabelName;
+    }
+
+    /**
+     * values defines the list of topology values (e.g. zone names) to be used for sharding. The configured number of shards must be greater than or equal to the number of values.
+     */
+    @JsonProperty("values")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getValues() {
+        return values;
+    }
+
+    /**
+     * values defines the list of topology values (e.g. zone names) to be used for sharding. The configured number of shards must be greater than or equal to the number of values.
+     */
+    @JsonProperty("values")
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    @JsonIgnore
+    public TopologyShardingStrategyBuilder edit() {
+        return new TopologyShardingStrategyBuilder(this);
+    }
+
+    @JsonIgnore
+    public TopologyShardingStrategyBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/ConsulSDConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/ConsulSDConfig.java
@@ -52,6 +52,7 @@ import lombok.experimental.Accessors;
     "enableHTTP2",
     "filter",
     "followRedirects",
+    "healthFilter",
     "namespace",
     "noProxy",
     "nodeMeta",
@@ -109,6 +110,8 @@ public class ConsulSDConfig implements Editable<ConsulSDConfigBuilder>, Kubernet
     private String filter;
     @JsonProperty("followRedirects")
     private Boolean followRedirects;
+    @JsonProperty("healthFilter")
+    private String healthFilter;
     @JsonProperty("namespace")
     private String namespace;
     @JsonProperty("noProxy")
@@ -156,7 +159,7 @@ public class ConsulSDConfig implements Editable<ConsulSDConfigBuilder>, Kubernet
     public ConsulSDConfig() {
     }
 
-    public ConsulSDConfig(Boolean allowStale, SafeAuthorization authorization, BasicAuth basicAuth, String datacenter, Boolean enableHTTP2, String filter, Boolean followRedirects, String namespace, String noProxy, Map<String, String> nodeMeta, OAuth2 oauth2, String partition, String pathPrefix, Map<String, List<SecretKeySelector>> proxyConnectHeader, Boolean proxyFromEnvironment, String proxyUrl, String refreshInterval, String scheme, String server, List<String> services, String tagSeparator, List<String> tags, SafeTLSConfig tlsConfig, SecretKeySelector tokenRef) {
+    public ConsulSDConfig(Boolean allowStale, SafeAuthorization authorization, BasicAuth basicAuth, String datacenter, Boolean enableHTTP2, String filter, Boolean followRedirects, String healthFilter, String namespace, String noProxy, Map<String, String> nodeMeta, OAuth2 oauth2, String partition, String pathPrefix, Map<String, List<SecretKeySelector>> proxyConnectHeader, Boolean proxyFromEnvironment, String proxyUrl, String refreshInterval, String scheme, String server, List<String> services, String tagSeparator, List<String> tags, SafeTLSConfig tlsConfig, SecretKeySelector tokenRef) {
         super();
         this.allowStale = allowStale;
         this.authorization = authorization;
@@ -165,6 +168,7 @@ public class ConsulSDConfig implements Editable<ConsulSDConfigBuilder>, Kubernet
         this.enableHTTP2 = enableHTTP2;
         this.filter = filter;
         this.followRedirects = followRedirects;
+        this.healthFilter = healthFilter;
         this.namespace = namespace;
         this.noProxy = noProxy;
         this.nodeMeta = nodeMeta;
@@ -265,7 +269,7 @@ public class ConsulSDConfig implements Editable<ConsulSDConfigBuilder>, Kubernet
     }
 
     /**
-     * filter defines the filter expression used to filter the catalog results. See https://www.consul.io/api-docs/catalog#list-services It requires Prometheus &gt;= 3.0.0.
+     * filter defines the filter expression used to filter the catalog results. See https://developer.hashicorp.com/consul/api-docs/catalog#filtering It requires Prometheus &gt;= 3.0.0.
      */
     @JsonProperty("filter")
     public String getFilter() {
@@ -273,7 +277,7 @@ public class ConsulSDConfig implements Editable<ConsulSDConfigBuilder>, Kubernet
     }
 
     /**
-     * filter defines the filter expression used to filter the catalog results. See https://www.consul.io/api-docs/catalog#list-services It requires Prometheus &gt;= 3.0.0.
+     * filter defines the filter expression used to filter the catalog results. See https://developer.hashicorp.com/consul/api-docs/catalog#filtering It requires Prometheus &gt;= 3.0.0.
      */
     @JsonProperty("filter")
     public void setFilter(String filter) {
@@ -294,6 +298,22 @@ public class ConsulSDConfig implements Editable<ConsulSDConfigBuilder>, Kubernet
     @JsonProperty("followRedirects")
     public void setFollowRedirects(Boolean followRedirects) {
         this.followRedirects = followRedirects;
+    }
+
+    /**
+     * healthFilter defines the filter expression used to filter the health results. See https://developer.hashicorp.com/consul/api-docs/health#filtering It requires Prometheus &gt;= 3.11.2.
+     */
+    @JsonProperty("healthFilter")
+    public String getHealthFilter() {
+        return healthFilter;
+    }
+
+    /**
+     * healthFilter defines the filter expression used to filter the health results. See https://developer.hashicorp.com/consul/api-docs/health#filtering It requires Prometheus &gt;= 3.11.2.
+     */
+    @JsonProperty("healthFilter")
+    public void setHealthFilter(String healthFilter) {
+        this.healthFilter = healthFilter;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/EmailConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/EmailConfig.java
@@ -55,6 +55,7 @@ import lombok.experimental.Accessors;
     "sendResolved",
     "smarthost",
     "text",
+    "threading",
     "tlsConfig",
     "to"
 })
@@ -110,6 +111,8 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
     private String smarthost;
     @JsonProperty("text")
     private String text;
+    @JsonProperty("threading")
+    private EmailThreadingConfig threading;
     @JsonProperty("tlsConfig")
     private SafeTLSConfig tlsConfig;
     @JsonProperty("to")
@@ -123,7 +126,7 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
     public EmailConfig() {
     }
 
-    public EmailConfig(String authIdentity, SecretKeySelector authPassword, SecretKeySelector authSecret, String authUsername, Boolean forceImplicitTLS, String from, List<KeyValue> headers, String hello, String html, Boolean requireTLS, Boolean sendResolved, String smarthost, String text, SafeTLSConfig tlsConfig, String to) {
+    public EmailConfig(String authIdentity, SecretKeySelector authPassword, SecretKeySelector authSecret, String authUsername, Boolean forceImplicitTLS, String from, List<KeyValue> headers, String hello, String html, Boolean requireTLS, Boolean sendResolved, String smarthost, String text, EmailThreadingConfig threading, SafeTLSConfig tlsConfig, String to) {
         super();
         this.authIdentity = authIdentity;
         this.authPassword = authPassword;
@@ -138,6 +141,7 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
         this.sendResolved = sendResolved;
         this.smarthost = smarthost;
         this.text = text;
+        this.threading = threading;
         this.tlsConfig = tlsConfig;
         this.to = to;
     }
@@ -349,6 +353,22 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
     @JsonProperty("text")
     public void setText(String text) {
         this.text = text;
+    }
+
+    /**
+     * EmailConfig configures notifications via Email.
+     */
+    @JsonProperty("threading")
+    public EmailThreadingConfig getThreading() {
+        return threading;
+    }
+
+    /**
+     * EmailConfig configures notifications via Email.
+     */
+    @JsonProperty("threading")
+    public void setThreading(EmailThreadingConfig threading) {
+        this.threading = threading;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/EmailThreadingConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/EmailThreadingConfig.java
@@ -1,0 +1,122 @@
+
+package io.fabric8.openshift.api.model.monitoring.v1alpha1;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "threadByDate"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class EmailThreadingConfig implements Editable<EmailThreadingConfigBuilder>, KubernetesResource
+{
+
+    @JsonProperty("threadByDate")
+    private String threadByDate;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public EmailThreadingConfig() {
+    }
+
+    public EmailThreadingConfig(String threadByDate) {
+        super();
+        this.threadByDate = threadByDate;
+    }
+
+    /**
+     * threadByDate defines what granularity of current date to thread by. Accepted values: Daily, None. (None means group by alert group key, no date).
+     */
+    @JsonProperty("threadByDate")
+    public String getThreadByDate() {
+        return threadByDate;
+    }
+
+    /**
+     * threadByDate defines what granularity of current date to thread by. Accepted values: Daily, None. (None means group by alert group key, no date).
+     */
+    @JsonProperty("threadByDate")
+    public void setThreadByDate(String threadByDate) {
+        this.threadByDate = threadByDate;
+    }
+
+    @JsonIgnore
+    public EmailThreadingConfigBuilder edit() {
+        return new EmailThreadingConfigBuilder(this);
+    }
+
+    @JsonIgnore
+    public EmailThreadingConfigBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/PrometheusAgentSpec.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/PrometheusAgentSpec.java
@@ -44,6 +44,7 @@ import io.fabric8.openshift.api.model.monitoring.v1.PrometheusWebSpec;
 import io.fabric8.openshift.api.model.monitoring.v1.RemoteWriteSpec;
 import io.fabric8.openshift.api.model.monitoring.v1.RuntimeConfig;
 import io.fabric8.openshift.api.model.monitoring.v1.ScrapeClass;
+import io.fabric8.openshift.api.model.monitoring.v1.ShardingStrategy;
 import io.fabric8.openshift.api.model.monitoring.v1.StatefulSetUpdateStrategy;
 import io.fabric8.openshift.api.model.monitoring.v1.StorageSpec;
 import io.fabric8.openshift.api.model.monitoring.v1.TSDBSpec;
@@ -150,6 +151,7 @@ import lombok.experimental.Accessors;
     "serviceMonitorNamespaceSelector",
     "serviceMonitorSelector",
     "serviceName",
+    "shardingStrategy",
     "shards",
     "storage",
     "targetLimit",
@@ -384,6 +386,8 @@ public class PrometheusAgentSpec implements Editable<PrometheusAgentSpecBuilder>
     private LabelSelector serviceMonitorSelector;
     @JsonProperty("serviceName")
     private String serviceName;
+    @JsonProperty("shardingStrategy")
+    private ShardingStrategy shardingStrategy;
     @JsonProperty("shards")
     private Integer shards;
     @JsonProperty("storage")
@@ -425,7 +429,7 @@ public class PrometheusAgentSpec implements Editable<PrometheusAgentSpecBuilder>
     public PrometheusAgentSpec() {
     }
 
-    public PrometheusAgentSpec(List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, Boolean automountServiceAccountToken, String bodySizeLimit, List<String> configMaps, List<Container> containers, Boolean convertClassicHistogramsToNHCB, PodDNSConfig dnsConfig, String dnsPolicy, List<String> enableFeatures, Boolean enableOTLPReceiver, Boolean enableRemoteWriteReceiver, Boolean enableServiceLinks, String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, List<ObjectReference> excludedFromEnforcement, Map<String, String> externalLabels, String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean hostUsers, Boolean ignoreNamespaceSelectors, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, String logFormat, String logLevel, Integer maximumStartupDurationSeconds, Integer minReadySeconds, String mode, String nameEscapingScheme, String nameValidationScheme, Map<String, String> nodeSelector, OTLPConfig otlp, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, LabelSelector podMonitorNamespaceSelector, LabelSelector podMonitorSelector, List<String> podTargetLabels, String portName, String priorityClassName, LabelSelector probeNamespaceSelector, LabelSelector probeSelector, String prometheusExternalLabelName, String reloadStrategy, List<RemoteWriteSpec> remoteWrite, List<String> remoteWriteReceiverMessageVersions, String replicaExternalLabelName, Integer replicas, ResourceRequirements resources, String routePrefix, RuntimeConfig runtime, Long sampleLimit, String schedulerName, List<ScrapeClass> scrapeClasses, Boolean scrapeClassicHistograms, LabelSelector scrapeConfigNamespaceSelector, LabelSelector scrapeConfigSelector, String scrapeFailureLogFile, String scrapeInterval, Boolean scrapeNativeHistograms, List<String> scrapeProtocols, String scrapeTimeout, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, String serviceDiscoveryRole, LabelSelector serviceMonitorNamespaceSelector, LabelSelector serviceMonitorSelector, String serviceName, Integer shards, StorageSpec storage, Long targetLimit, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, TracingConfig tracingConfig, TSDBSpec tsdb, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
+    public PrometheusAgentSpec(List<Argument> additionalArgs, SecretKeySelector additionalScrapeConfigs, Affinity affinity, APIServerConfig apiserverConfig, ArbitraryFSAccessThroughSMsConfig arbitraryFSAccessThroughSMs, Boolean automountServiceAccountToken, String bodySizeLimit, List<String> configMaps, List<Container> containers, Boolean convertClassicHistogramsToNHCB, PodDNSConfig dnsConfig, String dnsPolicy, List<String> enableFeatures, Boolean enableOTLPReceiver, Boolean enableRemoteWriteReceiver, Boolean enableServiceLinks, String enforcedBodySizeLimit, Long enforcedKeepDroppedTargets, Long enforcedLabelLimit, Long enforcedLabelNameLengthLimit, Long enforcedLabelValueLengthLimit, String enforcedNamespaceLabel, Long enforcedSampleLimit, Long enforcedTargetLimit, List<ObjectReference> excludedFromEnforcement, Map<String, String> externalLabels, String externalUrl, List<HostAlias> hostAliases, Boolean hostNetwork, Boolean hostUsers, Boolean ignoreNamespaceSelectors, String image, String imagePullPolicy, List<LocalObjectReference> imagePullSecrets, List<Container> initContainers, Long keepDroppedTargets, Long labelLimit, Long labelNameLengthLimit, Long labelValueLengthLimit, Boolean listenLocal, String logFormat, String logLevel, Integer maximumStartupDurationSeconds, Integer minReadySeconds, String mode, String nameEscapingScheme, String nameValidationScheme, Map<String, String> nodeSelector, OTLPConfig otlp, Boolean overrideHonorLabels, Boolean overrideHonorTimestamps, Boolean paused, StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy, String podManagementPolicy, EmbeddedObjectMetadata podMetadata, LabelSelector podMonitorNamespaceSelector, LabelSelector podMonitorSelector, List<String> podTargetLabels, String portName, String priorityClassName, LabelSelector probeNamespaceSelector, LabelSelector probeSelector, String prometheusExternalLabelName, String reloadStrategy, List<RemoteWriteSpec> remoteWrite, List<String> remoteWriteReceiverMessageVersions, String replicaExternalLabelName, Integer replicas, ResourceRequirements resources, String routePrefix, RuntimeConfig runtime, Long sampleLimit, String schedulerName, List<ScrapeClass> scrapeClasses, Boolean scrapeClassicHistograms, LabelSelector scrapeConfigNamespaceSelector, LabelSelector scrapeConfigSelector, String scrapeFailureLogFile, String scrapeInterval, Boolean scrapeNativeHistograms, List<String> scrapeProtocols, String scrapeTimeout, List<String> secrets, PodSecurityContext securityContext, String serviceAccountName, String serviceDiscoveryRole, LabelSelector serviceMonitorNamespaceSelector, LabelSelector serviceMonitorSelector, String serviceName, ShardingStrategy shardingStrategy, Integer shards, StorageSpec storage, Long targetLimit, Long terminationGracePeriodSeconds, List<Toleration> tolerations, List<TopologySpreadConstraint> topologySpreadConstraints, TracingConfig tracingConfig, TSDBSpec tsdb, StatefulSetUpdateStrategy updateStrategy, String version, List<VolumeMount> volumeMounts, List<Volume> volumes, Boolean walCompression, PrometheusWebSpec web) {
         super();
         this.additionalArgs = additionalArgs;
         this.additionalScrapeConfigs = additionalScrapeConfigs;
@@ -516,6 +520,7 @@ public class PrometheusAgentSpec implements Editable<PrometheusAgentSpecBuilder>
         this.serviceMonitorNamespaceSelector = serviceMonitorNamespaceSelector;
         this.serviceMonitorSelector = serviceMonitorSelector;
         this.serviceName = serviceName;
+        this.shardingStrategy = shardingStrategy;
         this.shards = shards;
         this.storage = storage;
         this.targetLimit = targetLimit;
@@ -1970,6 +1975,22 @@ public class PrometheusAgentSpec implements Editable<PrometheusAgentSpecBuilder>
     @JsonProperty("serviceName")
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
+    }
+
+    /**
+     * PrometheusAgentSpec is a specification of the desired behavior of the Prometheus agent. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+     */
+    @JsonProperty("shardingStrategy")
+    public ShardingStrategy getShardingStrategy() {
+        return shardingStrategy;
+    }
+
+    /**
+     * PrometheusAgentSpec is a specification of the desired behavior of the Prometheus agent. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+     */
+    @JsonProperty("shardingStrategy")
+    public void setShardingStrategy(ShardingStrategy shardingStrategy) {
+        this.shardingStrategy = shardingStrategy;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/ScalewaySDConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1alpha1/ScalewaySDConfig.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config
+ * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config<br><p> <br><p> Note: The `_file` variants of credential fields (e.g. `secret_key_file`) from the Prometheus configuration are not supported. Use Kubernetes secrets via `secretKey` instead.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -361,7 +361,7 @@ public class ScalewaySDConfig implements Editable<ScalewaySDConfigBuilder>, Kube
     }
 
     /**
-     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config
+     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config<br><p> <br><p> Note: The `_file` variants of credential fields (e.g. `secret_key_file`) from the Prometheus configuration are not supported. Use Kubernetes secrets via `secretKey` instead.
      */
     @JsonProperty("secretKey")
     public SecretKeySelector getSecretKey() {
@@ -369,7 +369,7 @@ public class ScalewaySDConfig implements Editable<ScalewaySDConfigBuilder>, Kube
     }
 
     /**
-     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config
+     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config<br><p> <br><p> Note: The `_file` variants of credential fields (e.g. `secret_key_file`) from the Prometheus configuration are not supported. Use Kubernetes secrets via `secretKey` instead.
      */
     @JsonProperty("secretKey")
     public void setSecretKey(SecretKeySelector secretKey) {
@@ -394,7 +394,7 @@ public class ScalewaySDConfig implements Editable<ScalewaySDConfigBuilder>, Kube
     }
 
     /**
-     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config
+     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config<br><p> <br><p> Note: The `_file` variants of credential fields (e.g. `secret_key_file`) from the Prometheus configuration are not supported. Use Kubernetes secrets via `secretKey` instead.
      */
     @JsonProperty("tlsConfig")
     public SafeTLSConfig getTlsConfig() {
@@ -402,7 +402,7 @@ public class ScalewaySDConfig implements Editable<ScalewaySDConfigBuilder>, Kube
     }
 
     /**
-     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config
+     * ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config<br><p> <br><p> Note: The `_file` variants of credential fields (e.g. `secret_key_file`) from the Prometheus configuration are not supported. Use Kubernetes secrets via `secretKey` instead.
      */
     @JsonProperty("tlsConfig")
     public void setTlsConfig(SafeTLSConfig tlsConfig) {

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1beta1/EmailConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1beta1/EmailConfig.java
@@ -54,6 +54,7 @@ import lombok.experimental.Accessors;
     "sendResolved",
     "smarthost",
     "text",
+    "threading",
     "tlsConfig",
     "to"
 })
@@ -109,6 +110,8 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
     private String smarthost;
     @JsonProperty("text")
     private String text;
+    @JsonProperty("threading")
+    private EmailThreadingConfig threading;
     @JsonProperty("tlsConfig")
     private SafeTLSConfig tlsConfig;
     @JsonProperty("to")
@@ -122,7 +125,7 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
     public EmailConfig() {
     }
 
-    public EmailConfig(String authIdentity, SecretKeySelector authPassword, SecretKeySelector authSecret, String authUsername, Boolean forceImplicitTLS, String from, List<KeyValue> headers, String hello, String html, Boolean requireTLS, Boolean sendResolved, String smarthost, String text, SafeTLSConfig tlsConfig, String to) {
+    public EmailConfig(String authIdentity, SecretKeySelector authPassword, SecretKeySelector authSecret, String authUsername, Boolean forceImplicitTLS, String from, List<KeyValue> headers, String hello, String html, Boolean requireTLS, Boolean sendResolved, String smarthost, String text, EmailThreadingConfig threading, SafeTLSConfig tlsConfig, String to) {
         super();
         this.authIdentity = authIdentity;
         this.authPassword = authPassword;
@@ -137,6 +140,7 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
         this.sendResolved = sendResolved;
         this.smarthost = smarthost;
         this.text = text;
+        this.threading = threading;
         this.tlsConfig = tlsConfig;
         this.to = to;
     }
@@ -348,6 +352,22 @@ public class EmailConfig implements Editable<EmailConfigBuilder>, KubernetesReso
     @JsonProperty("text")
     public void setText(String text) {
         this.text = text;
+    }
+
+    /**
+     * EmailConfig configures notifications via Email.
+     */
+    @JsonProperty("threading")
+    public EmailThreadingConfig getThreading() {
+        return threading;
+    }
+
+    /**
+     * EmailConfig configures notifications via Email.
+     */
+    @JsonProperty("threading")
+    public void setThreading(EmailThreadingConfig threading) {
+        this.threading = threading;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1beta1/EmailThreadingConfig.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1beta1/EmailThreadingConfig.java
@@ -1,0 +1,122 @@
+
+package io.fabric8.openshift.api.model.monitoring.v1beta1;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "threadByDate"
+})
+@ToString
+@EqualsAndHashCode
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class),
+    @BuildableReference(EnvVar.class),
+    @BuildableReference(ContainerPort.class),
+    @BuildableReference(Volume.class),
+    @BuildableReference(VolumeMount.class)
+})
+@Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
+public class EmailThreadingConfig implements Editable<EmailThreadingConfigBuilder>, KubernetesResource
+{
+
+    @JsonProperty("threadByDate")
+    private String threadByDate;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     */
+    public EmailThreadingConfig() {
+    }
+
+    public EmailThreadingConfig(String threadByDate) {
+        super();
+        this.threadByDate = threadByDate;
+    }
+
+    /**
+     * threadByDate defines what granularity of current date to thread by. Accepted values: Daily, None. (None means group by alert group key, no date).
+     */
+    @JsonProperty("threadByDate")
+    public String getThreadByDate() {
+        return threadByDate;
+    }
+
+    /**
+     * threadByDate defines what granularity of current date to thread by. Accepted values: Daily, None. (None means group by alert group key, no date).
+     */
+    @JsonProperty("threadByDate")
+    public void setThreadByDate(String threadByDate) {
+        this.threadByDate = threadByDate;
+    }
+
+    @JsonIgnore
+    public EmailThreadingConfigBuilder edit() {
+        return new EmailThreadingConfigBuilder(this);
+    }
+
+    @JsonIgnore
+    public EmailThreadingConfigBuilder toBuilder() {
+        return edit();
+    }
+
+    @JsonAnyGetter
+    @JsonIgnore
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+}

--- a/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1beta1/Route.java
+++ b/kubernetes-model-generator/openshift-model-monitoring/src/generated/java/io/fabric8/openshift/api/model/monitoring/v1beta1/Route.java
@@ -208,7 +208,7 @@ public class Route implements Editable<RouteBuilder>, KubernetesResource
     }
 
     /**
-     * matchers defines the list of matchers that the alert's labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: &lt;object namespace&gt;` matcher.
+     * matchers defines the list of matchers that the alert's labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: &lt;object namespace&gt;` matcher, unless configured otherwise in Alertmanager's AlertmanagerConfigMatcherStrategyType.
      */
     @JsonProperty("matchers")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -217,7 +217,7 @@ public class Route implements Editable<RouteBuilder>, KubernetesResource
     }
 
     /**
-     * matchers defines the list of matchers that the alert's labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: &lt;object namespace&gt;` matcher.
+     * matchers defines the list of matchers that the alert's labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: &lt;object namespace&gt;` matcher, unless configured otherwise in Alertmanager's AlertmanagerConfigMatcherStrategyType.
      */
     @JsonProperty("matchers")
     public void setMatchers(List<Matcher> matchers) {


### PR DESCRIPTION
## Summary
- Bumps `github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring` from 0.90.1 to 0.91.0 in `kubernetes-model-generator/openapi/generator`
- Regenerates `openshift-model-monitoring` schemas and Java models
- Breaking change: `v1.ThanosSpec.grpcServerTlsConfig` and `v1.ThanosRulerSpec.grpcServerTlsConfig` field type changed from `TLSConfig` to the new `GRPCServerTLSConfig` (following upstream type split)
- Other generator output is additive (`shardingStrategy`/`TopologyShardingStrategy`, `EmailThreadingConfig`, `GlobalMattermostConfig`, `Sigv4.externalId`, `ConsulSDConfig.healthFilter`, etc.)

Closes #7729