### PR TITLE
fix(kubernetes-client): skip doomed informer when readyWaitTimeout=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix #7350: Improper callback timing in leaderelection leads to the dual-leader
 
 #### Improvements
+* Fix #7741: PodOperationUtil.waitUntilReadyOrTerminal short-circuits when readyWaitTimeout=0 (the default) instead of starting a doomed informer LIST that races with the follow-up call (e.g. exec WebSocket upgrade) and produces 404 ERROR log noise
 * Fix #7662: (mockwebserver) new `MockWebServer#setHttp2ClearTextEnabled(boolean)` setter to opt out of HTTP/2 cleartext (h2c) upgrade
 * Fix #7522: improve dependency management for kubernetes-httpclient-okhttp
 * Fix #7550: add a ResourceEventHandler onList method and deprecated onNothing

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtil.java
@@ -119,6 +119,16 @@ public class PodOperationUtil {
   }
 
   public static Pod waitUntilReadyOrTerminal(PodResource podOperation, int logWaitTimeoutMs) {
+    if (logWaitTimeoutMs == 0) {
+      // Caller does not want to wait (the default since DEFAULT_POD_READY_WAIT_TIMEOUT_MS=0):
+      // starting an informer would issue a list/watch whose predicate cannot fire in zero
+      // time, produce log noise on a failed list, and contend with subsequent calls (e.g.
+      // the exec WebSocket upgrade) on the shared HttpClient/event loop for nothing. Skip
+      // and let the caller fall back to getItemOrRequireFromServer().
+      // Negative values are passed through and interpreted by Utils.waitUntilReady as
+      // "wait indefinitely".
+      return null;
+    }
     AtomicReference<Pod> podRef = new AtomicReference<>();
     try {
       // Wait for Pod to become ready or succeeded

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/utils/internal/PodOperationUtilTest.java
@@ -99,6 +99,25 @@ class PodOperationUtilTest {
   }
 
   @Test
+  void waitUntilReadyOrTerminalWithZeroTimeoutShortCircuits() {
+    // When
+    Pod result = PodOperationUtil.waitUntilReadyOrTerminal(podOperations, 0);
+    // Then
+    assertThat(result).isNull();
+    verify(podOperations, Mockito.never()).waitUntilCondition(any(), Mockito.anyLong(), any(TimeUnit.class));
+  }
+
+  @Test
+  void waitUntilReadyOrTerminalWithNegativeTimeoutDelegatesToWaitUntilCondition() {
+    // Negative values are documented by Utils.waitUntilReady as "wait indefinitely";
+    // do not short-circuit them.
+    // When
+    PodOperationUtil.waitUntilReadyOrTerminal(podOperations, -1);
+    // Then
+    verify(podOperations, times(1)).waitUntilCondition(any(), eq(-1L), eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
   void testIsReadyOrTerminal() {
     assertTrue(PodOperationUtil.isReadyOrTerminal(null));
     assertFalse(PodOperationUtil.isReadyOrTerminal(new Pod()));


### PR DESCRIPTION
## Summary

Since #606d3590fc (Nov 2024) made `DEFAULT_POD_READY_WAIT_TIMEOUT_MS = 0`, every default `client.pods()...exec()` / `attach()` / `getLog()` call issues a doomed `LIST /…/pods?fieldSelector=metadata.name=…` before the actual operation: a list/watch is started, the wait times out synchronously (`Utils.waitUntilReady(future, 0, MS)` returns `false`), the future is cancelled. In mocks this surfaces as a 404 plus a `Reflector` ERROR stack trace; on real clusters it's one wasted round-trip plus event-loop contention with the follow-up call.

`PodOperationUtil.waitUntilReadyOrTerminal` now short-circuits when `logWaitTimeoutMs == 0` and returns `null` directly. Callers (`PodOperationsImpl` for exec/attach/log, `DeploymentConfigOperationsImpl`/`BuildOperationsImpl` on OpenShift) already tolerate `null` and fall back to `getItemOrRequireFromServer()`. Negative values are still passed through and interpreted by `Utils.waitUntilReady` as "wait indefinitely".

Two new unit tests pin both branches: `0` short-circuits without calling `waitUntilCondition`; `-1` delegates to it as before.

Fixes #7741

## Out of scope

Not a fix for #7737. The flaky `PodTest.testExecEphemeralContainer` was the trigger for this audit, but local A/B testing did not show a measurable change in flake rate from this cleanup alone (17/100 vs 18/100 fail at a 90 ms request timeout, on a 16-core machine where the WS-upgrade race does not surface naturally). #7737 stays open.