### PR TITLE
fix(kubernetes-client): log state on exec WS-upgrade timeout (#7737)

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/core/v1/PodOperationsImpl.java
@@ -374,17 +374,30 @@ public class PodOperationsImpl extends HasMetadataOperation<Pod, PodList, PodRes
   private ExecWebSocketListener setupConnectionToPod(URI uri) {
     ExecWebSocketListener execWebSocketListener = new ExecWebSocketListener(getContext(), this.context.getExecutor(),
         this.getKubernetesSerialization());
+    long requestTimeoutMs = getRequestConfig().getRequestTimeout();
     CompletableFuture<WebSocket> startedFuture = httpClient.newWebSocketBuilder()
         .subprotocol("v4.channel.k8s.io")
         .uri(uri)
-        .connectTimeout(getRequestConfig().getRequestTimeout(), TimeUnit.MILLISECONDS)
+        .connectTimeout(requestTimeoutMs, TimeUnit.MILLISECONDS)
         .buildAsync(execWebSocketListener);
     startedFuture.whenComplete((w, t) -> {
       if (t != null) {
         execWebSocketListener.onError(w, t);
       }
     });
-    Utils.waitUntilReadyOrFail(startedFuture, getRequestConfig().getRequestTimeout(), TimeUnit.MILLISECONDS);
+    final long startNanos = System.nanoTime();
+    try {
+      Utils.waitUntilReadyOrFail(startedFuture, requestTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (RuntimeException e) {
+      // Diagnostic for #7737: capture state when the WS-upgrade future fails to complete.
+      LOG.error("Exec WebSocket upgrade did not complete after {}ms (timeout {}ms). uri={} futureDone={} thread={}",
+          (System.nanoTime() - startNanos) / 1_000_000L,
+          requestTimeoutMs,
+          uri,
+          startedFuture.isDone(),
+          Thread.currentThread().getName());
+      throw e;
+    }
     return execWebSocketListener;
   }
 


### PR DESCRIPTION
## Summary

#7737 (`PodTest.testExecEphemeralContainer`) intermittently fails with `TimeoutException: not ready after 10000 MILLISECONDS` thrown from `Utils.waitUntilReadyOrFail` at `PodOperationsImpl.java:387`. The bare stack trace gives no diagnostic information; the [investigation summary on #7737](https://github.com/fabric8io/kubernetes-client/issues/7737#issuecomment-4397845335) documents 250+ unsuccessful local repro iterations across various CPU-constrained configurations.

This adds a single `LOG.error(...)` at the WS-upgrade failure site so the next CI hit produces actionable data:

- `elapsedMs` — sanity-check vs the configured `requestTimeout`
- `futureDone` — `false` indicates a genuine stall; `true` would expose a race between `Future.get(timeout)` returning `false` and our log call
- `uri` — confirms which exec/attach operation
- `thread` — confirms whether we're on the calling thread or a Vert.x worker

No behavior change. One extra `LOG.error(...)` only on the failure path; success path is untouched.

Fixes #7737 (diagnostic only)