### PR TITLE
test(leader-election): fix flaky singleLeader*Update tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,34 @@ mvn -Pitests -pl kubernetes-itests verify
 mvn -Pitests -pl kubernetes-itests verify -Dtest="io.fabric8.openshift.**"
 ```
 
+### Reproducing CI flakes locally
+
+CI runs on 2-core GitHub Actions VMs with limited RAM. Surefire `forkCount=1C` and Vert.x event-loop sizing both scale with `Runtime.availableProcessors()`, so a flake that surfaces under CI scheduling pressure often won't reproduce with a plain `mvn test` on a 16+ core developer host. Run the test inside a constrained `docker` (or `podman`) container with the project and `~/.m2` bind-mounted — this is the closest local approximation to CI shape and almost always the fastest way to confirm or rule out a race.
+
+```bash
+# Constrained container — 2 cores, ~7 GB RAM, cgroup-enforced
+docker run --rm \
+  --cpus=2 --memory=7g --cpuset-cpus="0,1" \
+  --user $(id -u):$(id -g) -e HOME=/tmp \
+  -v "$PWD:/work" \
+  -v "$HOME/.m2:/host-m2" \
+  -w /work \
+  maven:3.9-eclipse-temurin-11 \
+  mvn -pl kubernetes-tests \
+      -Dtest='SomeFlakyTest#someFlakyMethod' \
+      -Dmaven.repo.local=/host-m2/repository \
+      test
+```
+
+For harder contention, run a sibling `stress-ng` container pinned to the same `cpuset` as a noisy neighbor, then loop the test 25–50 times under that stress.
+
+```bash
+docker run --rm -d --name stressor --cpus=2 --cpuset-cpus="0,1" \
+  alpine:latest sh -c 'apk add --no-cache stress-ng && stress-ng --cpu 4 --cpu-load 80 --timeout 600s'
+```
+
+Caveat: not every CI flake reproduces locally — GH Actions VMs add IO/network jitter that cgroup quota cannot simulate. After ~20 unsuccessful iterations, switch to instrument-and-wait (add timing logs on a debug branch and watch the next CI hit) rather than burning more local hours.
+
 ### Running Examples
 
 ```bash

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/LeaderElectionTest.java
@@ -192,6 +192,7 @@ class LeaderElectionTest {
     // Given
     final CountDownLatch leaderLatch = new CountDownLatch(1);
     final AtomicReference<String> newLeaderRecord = new AtomicReference<>();
+    final AtomicReference<String> leaderOnStart = new AtomicReference<>();
     final CountDownLatch stoppedLeading = new CountDownLatch(1);
     final ExecutorService executorService = Executors.newSingleThreadExecutor();
     // When
@@ -204,7 +205,10 @@ class LeaderElectionTest {
                 .withRenewDeadline(Duration.ofSeconds(10L))
                 .withRetryPeriod(Duration.ofSeconds(2L))
                 .withLeaderCallbacks(new LeaderCallbacks(
-                    leaderLatch::countDown,
+                    () -> {
+                      leaderOnStart.set(newLeaderRecord.get());
+                      leaderLatch.countDown();
+                    },
                     stoppedLeading::countDown,
                     newLeaderRecord::set))
                 .build())
@@ -212,7 +216,7 @@ class LeaderElectionTest {
             .run()));
     // Then
     assertTrue(leaderLatch.await(10, TimeUnit.SECONDS));
-    assertEquals(id, newLeaderRecord.get());
+    assertEquals(id, leaderOnStart.get());
     assertEquals(0, leaderLatch.getCount());
     leaderElectorTask.cancel(true);
     executorService.shutdownNow();


### PR DESCRIPTION
## Summary

- Snapshot the elected leader inside the `onStartLeading` callback in `testAndAssertSingleLeader` so the assertion captures the leader at the moment leadership is acquired, immune to the renew loop's first immediate iteration overwriting `newLeaderRecord` with the stale mock GET response.
- Add an `AGENTS.md` subsection documenting the constrained-container recipe (`docker run --cpus=2 --memory=7g --cpuset-cpus="0,1"` with bind-mounted `~/.m2`, optional sibling `stress-ng`) for reproducing CI flakes locally.

## Root cause

After `acquire()` succeeds, `LeaderElector.start()` immediately schedules `renewWithTimeout()`, whose loop runs its first iteration at delay=0. That GET returns the mock's `.always()` "not-lead" record and `updateObserved(oldRecord)` fires `onNewLeader("not-lead-*")`, overwriting the test's `newLeaderRecord`. The test thread, unblocked by `leaderLatch.countDown()` (fired earlier in the same `tryAcquireOrRenew`), races to read `newLeaderRecord.get()` and sometimes loses.

The fix snapshots the value while still inside the `onStartLeading` callback — guaranteed to be `lead-*` because `onNewLeader(self)` is called before `onStartLeading()` in the same `synchronized` region of `updateObserved`.

Closes #7744