### PR TITLE
fix(mockwebserver): avoid RejectedExecutionException race in shutdown()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
+* Fix #7747: (mockwebserver) avoid RejectedExecutionException race in MockWebServer#shutdown() between the httpClose listener and await
 * Fix #7734: (mockwebserver) avoid sending Content-Length together with Transfer-Encoding for chunked responses
 * Fix #7686: (httpclient-vertx-5) StackBasedRecursionGuard.enter() no longer increments depth when refusing entry, fixing an infinite runOnContext loop that stalled InputStreamReadStream uploads under CPU contention
 * Fix #7700: ExecWebSocketListener.onError now defers failure handling through the SerialExecutor so a pending channel-3 exit-status task runs first and the parsed exit code is preserved instead of being overwritten by a peer-close exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 7.7-SNAPSHOT
 
 #### Bugs
-* Fix #7747: (mockwebserver) avoid RejectedExecutionException race in MockWebServer#shutdown() between the httpClose listener and await
+* Fix #7747: (mockwebserver) avoid RejectedExecutionException in MockWebServer#shutdown() — linearize close sequence to remove the httpClose-listener vs await race, and make shutdown() idempotent against repeated calls (e.g. JUnit @Nested afterAll cascades)
 * Fix #7734: (mockwebserver) avoid sending Content-Length together with Transfer-Encoding for chunked responses
 * Fix #7686: (httpclient-vertx-5) StackBasedRecursionGuard.enter() no longer increments depth when refusing entry, fixing an infinite runOnContext loop that stalled InputStreamReadStream uploads under CPU contention
 * Fix #7700: ExecWebSocketListener.onError now defers failure handling through the SerialExecutor so a pending channel-3 exit-status task runs first and the parsed exit code is preserved instead of being overwritten by a peer-close exception

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -98,6 +98,7 @@ public class MockWebServer implements Closeable {
   private List<Protocol> protocols;
   private boolean http2ClearTextEnabled;
   private boolean started;
+  private boolean shutdown;
 
   public MockWebServer() {
     vertx = Vertx.vertx();
@@ -174,12 +175,13 @@ public class MockWebServer implements Closeable {
   }
 
   public synchronized void shutdown() {
-    if (!started) {
+    if (!started || shutdown) {
       return;
     }
     if (httpServer == null) {
       throw new IllegalStateException("shutdown() before start()");
     }
+    shutdown = true;
     dispatcher.shutdown();
     await(httpServer.close(), "Unable to close MockWebServer");
     info("done accepting connections");

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -24,9 +24,7 @@ import io.fabric8.mockwebserver.http.RecordedRequest;
 import io.fabric8.mockwebserver.vertx.HttpServerRequestHandler;
 import io.fabric8.mockwebserver.vertx.Protocol;
 import io.netty.handler.ssl.ClientAuth;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
@@ -183,17 +181,8 @@ public class MockWebServer implements Closeable {
       throw new IllegalStateException("shutdown() before start()");
     }
     dispatcher.shutdown();
-    final Future<Void> httpClose = httpServer.close();
-    Handler<AsyncResult<Void>> onComplete = v -> {
-      vertx.close();
-      info("done accepting connections");
-    };
-    if (httpClose.isComplete()) {
-      onComplete.handle(httpClose);
-    } else {
-      httpClose.onComplete(onComplete);
-      await(httpClose, "Unable to close MockWebServer");
-    }
+    await(httpServer.close(), "Unable to close MockWebServer");
+    info("done accepting connections");
     await(vertx.close(), "Unable to close Vertx");
   }
 

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/MockWebServerTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/MockWebServerTest.groovy
@@ -164,6 +164,19 @@ class MockWebServerTest extends Specification {
 		assert result == null
 	}
 
+	def "shutdown, called twice on the same instance, should be idempotent"() {
+		given:
+		def s = new MockWebServer()
+		s.start()
+		s.shutdown()
+
+		when:
+		s.shutdown()
+
+		then:
+		noExceptionThrown()
+	}
+
 	def "takeRequest, should wait until request is received"() {
 		given:
 		def conditions = new PollingConditions(timeout: 10)


### PR DESCRIPTION
## Summary

`MockWebServer#shutdown()` (shipped in `io.fabric8:mockwebserver`) intermittently threw `RejectedExecutionException: event executor terminated` during teardown. The previous code registered an `onComplete` listener on the `httpServer.close()` future that called `vertx.close()` from the Vert.x event loop, then registered a second listener via `await(httpClose, ...)`. If the first listener fired (closing Vertx and terminating the event loop) before the second registered, `await`'s synchronous `emit-success` path tried to dispatch on the terminated executor.

Linearize the shutdown sequence: `await(httpServer.close())` → log → `await(vertx.close())`. Single thread, sequential awaits, no listener closes Vertx as a side effect.

Surfaced as the flaky test reported in #7746 (`ImageTagTest.delete`); root cause filed as #7747.

Fixes #7747
Fixes #7746