### PR TITLE
chore(ci): add Kubernetes 1.36 and 1.35 to E2E test matrices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -102,6 +102,9 @@ body:
       label: Kubernetes API Server version
       description: Kubernetes API Server version
       options:
+        - "1.36"
+        - "1.35"
+        - "1.34"
         - "1.33"
         - "1.32"
         - "next (development version)"

--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.34.2]
+        kubernetes: [v1.36.0]
         java-version: [11,17]
         http-client: [okhttp,jdk,jetty,vertx,vertx-5]
         chaos-test: ["network-delay.yaml", "network-loss.yaml", "network-duplicate.yaml"]
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.16.1
         with:
-          minikube version: v1.37.0
+          minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Java ${{ matrix.java-version }}

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.34.2,v1.33.0,v1.32.4,v1.31.8,v1.30.12]
+        kubernetes: [v1.36.0,v1.35.4,v1.34.2,v1.33.0,v1.32.4]
         httpclient: [jdk,jetty,okhttp,vertx-5]
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.16.1
         with:
-          minikube version: v1.37.0
+          minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--force'

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.36.0,v1.35.4,v1.34.2,v1.33.0,v1.32.4]
+        kubernetes: [v1.36.0,v1.35.4,v1.34.7,v1.33.11,v1.32.13]
         httpclient: [jdk,jetty,okhttp,vertx-5]
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.36.0,v1.35.4,v1.34.2,v1.33.0,v1.32.4,v1.31.8,v1.30.12,v1.29.14]
+        kubernetes: [v1.36.0,v1.35.4,v1.34.7,v1.33.11,v1.32.13,v1.31.14,v1.30.14,v1.29.15]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,14 +68,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.34.2,v1.33.0,v1.32.4,v1.31.8,v1.30.12,v1.29.14,v1.28.15,v1.27.16]
+        kubernetes: [v1.36.0,v1.35.4,v1.34.2,v1.33.0,v1.32.4,v1.31.8,v1.30.12,v1.29.14]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.16.1
         with:
-          minikube version: v1.37.0
+          minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--force'


### PR DESCRIPTION
Closes: #7712

## Summary
- Add Kubernetes `v1.36.0` and `v1.35.4` to E2E test matrices, drop oldest two versions from each workflow to keep matrix size constant
- Refresh all retained minor versions to their latest patches
- Bump minikube from `v1.37.0` to `v1.38.1` for K8s 1.35+ support
- Add `1.36`, `1.35`, and `1.34` to the bug report template K8s version dropdown

## Changes per workflow

**e2e-tests.yml**
- Added: `v1.36.0`, `v1.35.4`
- Removed: `v1.28.15`, `v1.27.16`
- Refreshed patches: `v1.34.2→v1.34.7`, `v1.33.0→v1.33.11`, `v1.32.4→v1.32.13`, `v1.31.8→v1.31.14`, `v1.30.12→v1.30.14`, `v1.29.14→v1.29.15`
- Minikube: `v1.37.0` → `v1.38.1`

**e2e-httpclient-tests.yml**
- Added: `v1.36.0`, `v1.35.4`
- Removed: `v1.31.8`, `v1.30.12`
- Refreshed patches: `v1.34.2→v1.34.7`, `v1.33.0→v1.33.11`, `v1.32.4→v1.32.13`
- Minikube: `v1.37.0` → `v1.38.1`

**e2e-chaos-tests.yml**
- Bumped: `v1.34.2` → `v1.36.0`
- Minikube: `v1.37.0` → `v1.38.1`

## Notes
- K8s `v1.36.0` is not yet in minikube's built-in version list but is in minikube master's `ValidKubernetesVersions`. Minikube fetches it from GitHub at runtime. The `--force` flag is already set in CI.
- K8s `v1.35.4` is within minikube `v1.38.1`'s supported range.
- Matrix sizes kept constant (8, 5, 1 respectively).

## Test plan
- [ ] Verify E2E tests pass on `v1.36.0` and `v1.35.4` matrix entries
- [ ] Verify chaos tests pass with `v1.36.0`
- [ ] Confirm minikube `v1.38.1` starts cleanly with all K8s versions in the matrix
- [ ] All three workflows green on the new matrix