### PR TITLE
chore(deps): bump the metal3-io group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 * Fix #6923: Make the crd-generator-maven-plugin be toolchain aware
 
 #### Dependency Upgrade
+* Fix #PLACEHOLDER: bump baremetal-operator/apis from 0.12.4 to 0.13.0
+* Fix #PLACEHOLDER: bump cluster-api-provider-metal3 from 1.12.4 to 1.13.0
 * Fix #7651: bump k8s.io/apimachinery from 0.35.4 to 0.36.0
 * Fix #7579: bump istio.io/client-go from 1.28.0 to 1.29.1
 * Fix #7551: bump jackson-bom from 2.20.0 to 2.21.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@
 * Fix #6923: Make the crd-generator-maven-plugin be toolchain aware
 
 #### Dependency Upgrade
-* Fix #PLACEHOLDER: bump baremetal-operator/apis from 0.12.4 to 0.13.0
-* Fix #PLACEHOLDER: bump cluster-api-provider-metal3 from 1.12.4 to 1.13.0
+* Fix #7754: bump baremetal-operator/apis from 0.12.4 to 0.13.0
+* Fix #7754: bump cluster-api-provider-metal3 from 1.12.4 to 1.13.0
 * Fix #7651: bump k8s.io/apimachinery from 0.35.4 to 0.36.0
 * Fix #7579: bump istio.io/client-go from 1.28.0 to 1.29.1
 * Fix #7551: bump jackson-bom from 2.20.0 to 2.21.1

--- a/kubernetes-model-generator/openapi/generator/go.mod
+++ b/kubernetes-model-generator/openapi/generator/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/getkin/kin-openapi v0.137.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.4.0
-	github.com/metal3-io/baremetal-operator/apis v0.12.4
-	github.com/metal3-io/cluster-api-provider-metal3/api v1.12.4
-	github.com/metal3-io/ip-address-manager/api v1.12.4 // indirect
+	github.com/metal3-io/baremetal-operator/apis v0.13.0
+	github.com/metal3-io/cluster-api-provider-metal3/api v1.13.0
+	github.com/metal3-io/ip-address-manager/api v1.13.0 // indirect
 	// Match latest commit in the version branch (e.g. release-4.17)
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/cloud-credential-operator v0.0.0-20251126011841-0e03b7a0fa39
@@ -53,7 +53,7 @@ require (
 	open-cluster-management.io/governance-policy-propagator v0.18.0
 	open-cluster-management.io/multicloud-operators-channel v0.16.0
 	open-cluster-management.io/multicloud-operators-subscription v0.16.0
-	sigs.k8s.io/cluster-api v1.12.7
+	sigs.k8s.io/cluster-api v1.13.1
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/kustomize/api v0.21.1
 	// This version is older than v1.10.0 see replacements below
@@ -249,6 +249,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/kubernetes-model-generator/openapi/generator/go.sum
+++ b/kubernetes-model-generator/openapi/generator/go.sum
@@ -3949,10 +3949,16 @@ github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQth
 github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/metal3-io/baremetal-operator/apis v0.12.4 h1:STWIWCCo8cyRHav/+BAoXM2BJ2gyYHmBCYf5byOKmrQ=
 github.com/metal3-io/baremetal-operator/apis v0.12.4/go.mod h1:MIWv52bqIPPBLmW5IWB983ulQeR3RMM8kvdakwuVizg=
+github.com/metal3-io/baremetal-operator/apis v0.13.0 h1:jCqUMbv/qVNY+77fqD7N5nIoWJXHq4rZ5epFY/q4k4Q=
+github.com/metal3-io/baremetal-operator/apis v0.13.0/go.mod h1:BeqKSSGFuC3X36+CN8CIImtXvWwKSR7rJBDP5825Fno=
 github.com/metal3-io/cluster-api-provider-metal3/api v1.12.4 h1:9i2y7rAmOvK8uSwud4Q60SCcvZZQoqjhB8Z3Yas6bKM=
 github.com/metal3-io/cluster-api-provider-metal3/api v1.12.4/go.mod h1:b1HeIcAgreg/gt0/hroY2iL6xf0PPx0q7XjBOYvqId4=
+github.com/metal3-io/cluster-api-provider-metal3/api v1.13.0 h1:+OzjA9IXeB346NLBVw6t3Xqk6M3tpDH7VQ1Nep6oeio=
+github.com/metal3-io/cluster-api-provider-metal3/api v1.13.0/go.mod h1:FPNj7LBez9qDSSPnP4bWHfnmZQ3DB8KRNo05l3DKUjQ=
 github.com/metal3-io/ip-address-manager/api v1.12.4 h1:t3dCAMfyzwbvuIOQm/HMZcMKpgU3lQ5tkTcVoC95e10=
 github.com/metal3-io/ip-address-manager/api v1.12.4/go.mod h1:ns2zBZXN7MRlw9TGeOEI55+5UCaQSCwMTqYduTDrow8=
+github.com/metal3-io/ip-address-manager/api v1.13.0 h1:Yi6XLJZdgd/+kZDEglxcNGsmE3Qcc6qboQ1mhQEh8WM=
+github.com/metal3-io/ip-address-manager/api v1.13.0/go.mod h1:pfhUOnMeD5m2WuKkr7UfRU+7PKqTJ2glQoC4walT40I=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.17/go.mod h1:WgzbA6oji13JREwiNsRDNfl7jYdPnmz+VEuLrA+/48M=
@@ -4094,6 +4100,7 @@ github.com/onsi/ginkgo/v2 v2.25.1/go.mod h1:ppTWQ1dh9KM/F1XgpeRqelR+zHVwV81DGRSD
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
+github.com/onsi/ginkgo/v2 v2.28.2 h1:DTrMfpqxiNUyQ3Y0zhn1n3cOO2euFgQPYIpkWwxVFps=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -6698,6 +6705,8 @@ sigs.k8s.io/structured-merge-diff/v6 v6.2.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099Yo
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80uLmm0wJkk8=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
+sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
+sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/AttachedImageReference.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/AttachedImageReference.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -53,7 +52,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BIOS.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BIOS.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCDetails.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCDetails.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCEventSubscriptionList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCEventSubscriptionList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCEventSubscriptionSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCEventSubscriptionSpec.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -54,7 +53,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCEventSubscriptionStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BMCEventSubscriptionStatus.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -51,7 +50,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHost.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHost.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHostList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHostList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHostSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHostSpec.java
@@ -78,7 +78,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),
@@ -315,7 +315,7 @@ public class BareMetalHostSpec implements Editable<BareMetalHostSpecBuilder>, Ku
     }
 
     /**
-     * ExternallyProvisioned means something else has provisioned the image running on the host, and the operator should only manage the power status. This field is used for integration with already provisioned hosts and when pivoting hosts between clusters. If unsure, leave this field as false.
+     * ExternallyProvisioned means something else has provisioned the image running on the host, and the operator should only manage the power status. This field is used for integration with already provisioned hosts and when pivoting hosts between clusters.<br><p> <br><p> This field can be set to true either: 1. During initial host creation (e.g., for pre-provisioned hosts) 2. After inspection completes when the host reaches Available state<br><p> <br><p> When used in environments with Cluster API Provider Metal3 (CAPM3), ensure hosts are labeled appropriately so CAPM3's host selector can distinguish them from CAPM3-managed hosts. If unsure, leave this field as false.
      */
     @JsonProperty("externallyProvisioned")
     public Boolean getExternallyProvisioned() {
@@ -323,7 +323,7 @@ public class BareMetalHostSpec implements Editable<BareMetalHostSpecBuilder>, Ku
     }
 
     /**
-     * ExternallyProvisioned means something else has provisioned the image running on the host, and the operator should only manage the power status. This field is used for integration with already provisioned hosts and when pivoting hosts between clusters. If unsure, leave this field as false.
+     * ExternallyProvisioned means something else has provisioned the image running on the host, and the operator should only manage the power status. This field is used for integration with already provisioned hosts and when pivoting hosts between clusters.<br><p> <br><p> This field can be set to true either: 1. During initial host creation (e.g., for pre-provisioned hosts) 2. After inspection completes when the host reaches Available state<br><p> <br><p> When used in environments with Cluster API Provider Metal3 (CAPM3), ensure hosts are labeled appropriately so CAPM3's host selector can distinguish them from CAPM3-managed hosts. If unsure, leave this field as false.
      */
     @JsonProperty("externallyProvisioned")
     public void setExternallyProvisioned(Boolean externallyProvisioned) {

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHostStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/BareMetalHostStatus.java
@@ -1,7 +1,9 @@
 
 package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -12,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -20,7 +23,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -38,6 +40,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
+    "conditions",
     "errorCount",
     "errorMessage",
     "errorType",
@@ -64,7 +67,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),
@@ -76,6 +79,9 @@ import lombok.experimental.Accessors;
 public class BareMetalHostStatus implements Editable<BareMetalHostStatusBuilder>, KubernetesResource
 {
 
+    @JsonProperty("conditions")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<Condition> conditions = new ArrayList<>();
     @JsonProperty("errorCount")
     private Integer errorCount;
     @JsonProperty("errorMessage")
@@ -109,8 +115,9 @@ public class BareMetalHostStatus implements Editable<BareMetalHostStatusBuilder>
     public BareMetalHostStatus() {
     }
 
-    public BareMetalHostStatus(Integer errorCount, String errorMessage, String errorType, CredentialsStatus goodCredentials, HardwareDetails hardware, String hardwareProfile, String lastUpdated, OperationHistory operationHistory, String operationalStatus, Boolean poweredOn, ProvisionStatus provisioning, CredentialsStatus triedCredentials) {
+    public BareMetalHostStatus(List<Condition> conditions, Integer errorCount, String errorMessage, String errorType, CredentialsStatus goodCredentials, HardwareDetails hardware, String hardwareProfile, String lastUpdated, OperationHistory operationHistory, String operationalStatus, Boolean poweredOn, ProvisionStatus provisioning, CredentialsStatus triedCredentials) {
         super();
+        this.conditions = conditions;
         this.errorCount = errorCount;
         this.errorMessage = errorMessage;
         this.errorType = errorType;
@@ -123,6 +130,23 @@ public class BareMetalHostStatus implements Editable<BareMetalHostStatusBuilder>
         this.poweredOn = poweredOn;
         this.provisioning = provisioning;
         this.triedCredentials = triedCredentials;
+    }
+
+    /**
+     * Conditions defines current service state of the BareMetalHost.
+     */
+    @JsonProperty("conditions")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Condition> getConditions() {
+        return conditions;
+    }
+
+    /**
+     * Conditions defines current service state of the BareMetalHost.
+     */
+    @JsonProperty("conditions")
+    public void setConditions(List<Condition> conditions) {
+        this.conditions = conditions;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/CredentialsStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/CredentialsStatus.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/CustomDeploy.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/CustomDeploy.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -53,7 +52,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImage.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImage.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageError.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageError.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -54,7 +53,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageSpec.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -53,7 +52,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DataImageStatus.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DetachedAnnotationArguments.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/DetachedAnnotationArguments.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -35,7 +34,8 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "deleteAction"
+    "deleteAction",
+    "force"
 })
 @ToString
 @EqualsAndHashCode
@@ -50,7 +50,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),
@@ -64,6 +64,8 @@ public class DetachedAnnotationArguments implements Editable<DetachedAnnotationA
 
     @JsonProperty("deleteAction")
     private String deleteAction;
+    @JsonProperty("force")
+    private Boolean force;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
@@ -73,9 +75,10 @@ public class DetachedAnnotationArguments implements Editable<DetachedAnnotationA
     public DetachedAnnotationArguments() {
     }
 
-    public DetachedAnnotationArguments(String deleteAction) {
+    public DetachedAnnotationArguments(String deleteAction, Boolean force) {
         super();
         this.deleteAction = deleteAction;
+        this.force = force;
     }
 
     /**
@@ -92,6 +95,22 @@ public class DetachedAnnotationArguments implements Editable<DetachedAnnotationA
     @JsonProperty("deleteAction")
     public void setDeleteAction(String deleteAction) {
         this.deleteAction = deleteAction;
+    }
+
+    /**
+     * Force indicates if detaching should be forced regardless of the host's state
+     */
+    @JsonProperty("force")
+    public Boolean getForce() {
+        return force;
+    }
+
+    /**
+     * Force indicates if detaching should be forced regardless of the host's state
+     */
+    @JsonProperty("force")
+    public void setForce(Boolean force) {
+        this.force = force;
     }
 
     @JsonIgnore

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/Firmware.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/Firmware.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -53,7 +52,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareComponentStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareComponentStatus.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -57,7 +56,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareConfig.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareConfig.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -33,7 +32,7 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * FirmwareConfig contains the configuration that you want to configure BIOS settings in Bare metal server.
+ * FirmwareConfig contains the configuration that you want to configure BIOS settings in Bare metal server.<br><p> <br><p> Deprecated: no longer supported by any driver.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareSchema.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareSchema.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -61,7 +60,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareSchemaList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareSchemaList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareSchemaSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareSchemaSpec.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareUpdate.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/FirmwareUpdate.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -54,7 +53,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareData.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareData.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -61,7 +60,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareDataList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareDataList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareDataSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareDataSpec.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -53,7 +52,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareDetails.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareDetails.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -61,7 +60,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),
@@ -142,7 +141,7 @@ public class HardwareDetails implements Editable<HardwareDetailsBuilder>, Kubern
     }
 
     /**
-     * HardwareDetails collects all of the information about hardware discovered on the host.
+     * Name of the host at the inspection time.
      */
     @JsonProperty("hostname")
     public String getHostname() {
@@ -150,7 +149,7 @@ public class HardwareDetails implements Editable<HardwareDetailsBuilder>, Kubern
     }
 
     /**
-     * HardwareDetails collects all of the information about hardware discovered on the host.
+     * Name of the host at the inspection time.
      */
     @JsonProperty("hostname")
     public void setHostname(String hostname) {

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareRAIDVolume.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareRAIDVolume.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -61,7 +60,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareSystemVendor.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HardwareSystemVendor.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaim.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaim.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * BMCEventSubscription is the Schema for the fast eventing API
+ * HostClaim is the Schema for the hostclaims API.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -75,29 +75,29 @@ import lombok.experimental.Accessors;
 @Version("v1alpha1")
 @Group("metal3.io")
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilder>, HasMetadata, Namespaced
+public class HostClaim implements Editable<HostClaimBuilder>, HasMetadata, Namespaced
 {
 
     @JsonProperty("apiVersion")
     private String apiVersion = "metal3.io/v1alpha1";
     @JsonProperty("kind")
-    private String kind = "BMCEventSubscription";
+    private String kind = "HostClaim";
     @JsonProperty("metadata")
     private ObjectMeta metadata;
     @JsonProperty("spec")
-    private BMCEventSubscriptionSpec spec;
+    private HostClaimSpec spec;
     @JsonProperty("status")
-    private BMCEventSubscriptionStatus status;
+    private HostClaimStatus status;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public BMCEventSubscription() {
+    public HostClaim() {
     }
 
-    public BMCEventSubscription(String apiVersion, String kind, ObjectMeta metadata, BMCEventSubscriptionSpec spec, BMCEventSubscriptionStatus status) {
+    public HostClaim(String apiVersion, String kind, ObjectMeta metadata, HostClaimSpec spec, HostClaimStatus status) {
         super();
         this.apiVersion = apiVersion;
         this.kind = kind;
@@ -139,7 +139,7 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaim is the Schema for the hostclaims API.
      */
     @JsonProperty("metadata")
     public ObjectMeta getMetadata() {
@@ -147,7 +147,7 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaim is the Schema for the hostclaims API.
      */
     @JsonProperty("metadata")
     public void setMetadata(ObjectMeta metadata) {
@@ -155,44 +155,44 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaim is the Schema for the hostclaims API.
      */
     @JsonProperty("spec")
-    public BMCEventSubscriptionSpec getSpec() {
+    public HostClaimSpec getSpec() {
         return spec;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaim is the Schema for the hostclaims API.
      */
     @JsonProperty("spec")
-    public void setSpec(BMCEventSubscriptionSpec spec) {
+    public void setSpec(HostClaimSpec spec) {
         this.spec = spec;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaim is the Schema for the hostclaims API.
      */
     @JsonProperty("status")
-    public BMCEventSubscriptionStatus getStatus() {
+    public HostClaimStatus getStatus() {
         return status;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaim is the Schema for the hostclaims API.
      */
     @JsonProperty("status")
-    public void setStatus(BMCEventSubscriptionStatus status) {
+    public void setStatus(HostClaimStatus status) {
         this.status = status;
     }
 
     @JsonIgnore
-    public BMCEventSubscriptionBuilder edit() {
-        return new BMCEventSubscriptionBuilder(this);
+    public HostClaimBuilder edit() {
+        return new HostClaimBuilder(this);
     }
 
     @JsonIgnore
-    public BMCEventSubscriptionBuilder toBuilder() {
+    public HostClaimBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimList.java
@@ -1,7 +1,9 @@
 
 package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -15,11 +17,12 @@ import io.fabric8.kubernetes.api.builder.Editable;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -37,7 +40,7 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * BMCEventSubscription is the Schema for the fast eventing API
+ * HostClaimList contains a list of HostClaim.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -45,8 +48,7 @@ import lombok.experimental.Accessors;
     "apiVersion",
     "kind",
     "metadata",
-    "spec",
-    "status"
+    "items"
 })
 @ToString
 @EqualsAndHashCode
@@ -75,35 +77,33 @@ import lombok.experimental.Accessors;
 @Version("v1alpha1")
 @Group("metal3.io")
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilder>, HasMetadata, Namespaced
+public class HostClaimList implements Editable<HostClaimListBuilder>, KubernetesResource, KubernetesResourceList<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostClaim>
 {
 
     @JsonProperty("apiVersion")
     private String apiVersion = "metal3.io/v1alpha1";
+    @JsonProperty("items")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostClaim> items = new ArrayList<>();
     @JsonProperty("kind")
-    private String kind = "BMCEventSubscription";
+    private String kind = "HostClaimList";
     @JsonProperty("metadata")
-    private ObjectMeta metadata;
-    @JsonProperty("spec")
-    private BMCEventSubscriptionSpec spec;
-    @JsonProperty("status")
-    private BMCEventSubscriptionStatus status;
+    private ListMeta metadata;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public BMCEventSubscription() {
+    public HostClaimList() {
     }
 
-    public BMCEventSubscription(String apiVersion, String kind, ObjectMeta metadata, BMCEventSubscriptionSpec spec, BMCEventSubscriptionStatus status) {
+    public HostClaimList(String apiVersion, List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostClaim> items, String kind, ListMeta metadata) {
         super();
         this.apiVersion = apiVersion;
+        this.items = items;
         this.kind = kind;
         this.metadata = metadata;
-        this.spec = spec;
-        this.status = status;
     }
 
     /**
@@ -123,6 +123,23 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
+     * HostClaimList contains a list of HostClaim.
+     */
+    @JsonProperty("items")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostClaim> getItems() {
+        return items;
+    }
+
+    /**
+     * HostClaimList contains a list of HostClaim.
+     */
+    @JsonProperty("items")
+    public void setItems(List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostClaim> items) {
+        this.items = items;
+    }
+
+    /**
      * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
      */
     @JsonProperty("kind")
@@ -139,60 +156,28 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaimList contains a list of HostClaim.
      */
     @JsonProperty("metadata")
-    public ObjectMeta getMetadata() {
+    public ListMeta getMetadata() {
         return metadata;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostClaimList contains a list of HostClaim.
      */
     @JsonProperty("metadata")
-    public void setMetadata(ObjectMeta metadata) {
+    public void setMetadata(ListMeta metadata) {
         this.metadata = metadata;
     }
 
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("spec")
-    public BMCEventSubscriptionSpec getSpec() {
-        return spec;
-    }
-
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("spec")
-    public void setSpec(BMCEventSubscriptionSpec spec) {
-        this.spec = spec;
-    }
-
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("status")
-    public BMCEventSubscriptionStatus getStatus() {
-        return status;
-    }
-
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("status")
-    public void setStatus(BMCEventSubscriptionStatus status) {
-        this.status = status;
+    @JsonIgnore
+    public HostClaimListBuilder edit() {
+        return new HostClaimListBuilder(this);
     }
 
     @JsonIgnore
-    public BMCEventSubscriptionBuilder edit() {
-        return new BMCEventSubscriptionBuilder(this);
-    }
-
-    @JsonIgnore
-    public BMCEventSubscriptionBuilder toBuilder() {
+    public HostClaimListBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimNamespaces.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimNamespaces.java
@@ -33,17 +33,12 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
-/**
- * CPU describes one processor on the host.
- */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+    "hasLabels",
+    "nameMatches",
+    "names"
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +62,90 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class HostClaimNamespaces implements Editable<HostClaimNamespacesBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
+    @JsonProperty("hasLabels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
+    private List<NameValuePair> hasLabels = new ArrayList<>();
+    @JsonProperty("nameMatches")
+    private String nameMatches;
+    @JsonProperty("names")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<String> names = new ArrayList<>();
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public CPU() {
+    public HostClaimNamespaces() {
     }
 
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
+    public HostClaimNamespaces(List<NameValuePair> hasLabels, String nameMatches, List<String> names) {
         super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
+        this.hasLabels = hasLabels;
+        this.nameMatches = nameMatches;
+        this.names = names;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HasLabels is a list of label names and their associated value. The namespace should have all of those labels. If the value is specified, it must also match.
      */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
+    @JsonProperty("hasLabels")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
+    public List<NameValuePair> getHasLabels() {
+        return hasLabels;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HasLabels is a list of label names and their associated value. The namespace should have all of those labels. If the value is specified, it must also match.
      */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
+    @JsonProperty("hasLabels")
+    public void setHasLabels(List<NameValuePair> hasLabels) {
+        this.hasLabels = hasLabels;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * NameMatches is a string interpreted as a regular expression that must be matched by the namespace of the HostClaim.
      */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
+    @JsonProperty("nameMatches")
+    public String getNameMatches() {
+        return nameMatches;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * NameMatches is a string interpreted as a regular expression that must be matched by the namespace of the HostClaim.
      */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonProperty("nameMatches")
+    public void setNameMatches(String nameMatches) {
+        this.nameMatches = nameMatches;
+    }
+
+    /**
+     * Namespaces is a list of namespace names where the hostClaim is authorized to reside in.
+     */
+    @JsonProperty("names")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getNames() {
+        return names;
+    }
+
+    /**
+     * Namespaces is a list of namespace names where the hostClaim is authorized to reside in.
+     */
+    @JsonProperty("names")
+    public void setNames(List<String> names) {
+        this.names = names;
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
+    public HostClaimNamespacesBuilder edit() {
+        return new HostClaimNamespacesBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public HostClaimNamespacesBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimSpec.java
@@ -1,5 +1,5 @@
 
-package io.fabric8.openshift.api.model.miscellaneous.metal3.v1beta1;
+package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -34,20 +34,19 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * Metal3MachineSpec defines the desired state of Metal3Machine.
+ * HostClaimSpec defines the desired state of HostClaim.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "automatedCleaningMode",
+    "consumerRef",
     "customDeploy",
-    "dataTemplate",
     "failureDomain",
     "hostSelector",
     "image",
     "metaData",
     "networkData",
-    "providerID",
+    "poweredOn",
     "userData"
 })
 @ToString
@@ -63,7 +62,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),
@@ -72,15 +71,13 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, KubernetesResource
+public class HostClaimSpec implements Editable<HostClaimSpecBuilder>, KubernetesResource
 {
 
-    @JsonProperty("automatedCleaningMode")
-    private String automatedCleaningMode;
+    @JsonProperty("consumerRef")
+    private ObjectReference consumerRef;
     @JsonProperty("customDeploy")
     private CustomDeploy customDeploy;
-    @JsonProperty("dataTemplate")
-    private ObjectReference dataTemplate;
     @JsonProperty("failureDomain")
     private String failureDomain;
     @JsonProperty("hostSelector")
@@ -91,8 +88,8 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     private SecretReference metaData;
     @JsonProperty("networkData")
     private SecretReference networkData;
-    @JsonProperty("providerID")
-    private String providerID;
+    @JsonProperty("poweredOn")
+    private Boolean poweredOn;
     @JsonProperty("userData")
     private SecretReference userData;
     @JsonIgnore
@@ -101,41 +98,40 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     /**
      * No args constructor for use in serialization
      */
-    public Metal3MachineSpec() {
+    public HostClaimSpec() {
     }
 
-    public Metal3MachineSpec(String automatedCleaningMode, CustomDeploy customDeploy, ObjectReference dataTemplate, String failureDomain, HostSelector hostSelector, Image image, SecretReference metaData, SecretReference networkData, String providerID, SecretReference userData) {
+    public HostClaimSpec(ObjectReference consumerRef, CustomDeploy customDeploy, String failureDomain, HostSelector hostSelector, Image image, SecretReference metaData, SecretReference networkData, Boolean poweredOn, SecretReference userData) {
         super();
-        this.automatedCleaningMode = automatedCleaningMode;
+        this.consumerRef = consumerRef;
         this.customDeploy = customDeploy;
-        this.dataTemplate = dataTemplate;
         this.failureDomain = failureDomain;
         this.hostSelector = hostSelector;
         this.image = image;
         this.metaData = metaData;
         this.networkData = networkData;
-        this.providerID = providerID;
+        this.poweredOn = poweredOn;
         this.userData = userData;
     }
 
     /**
-     * When set to disabled, automated cleaning of host disks will be skipped during provisioning and deprovisioning.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
-    @JsonProperty("automatedCleaningMode")
-    public String getAutomatedCleaningMode() {
-        return automatedCleaningMode;
+    @JsonProperty("consumerRef")
+    public ObjectReference getConsumerRef() {
+        return consumerRef;
     }
 
     /**
-     * When set to disabled, automated cleaning of host disks will be skipped during provisioning and deprovisioning.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
-    @JsonProperty("automatedCleaningMode")
-    public void setAutomatedCleaningMode(String automatedCleaningMode) {
-        this.automatedCleaningMode = automatedCleaningMode;
+    @JsonProperty("consumerRef")
+    public void setConsumerRef(ObjectReference consumerRef) {
+        this.consumerRef = consumerRef;
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("customDeploy")
     public CustomDeploy getCustomDeploy() {
@@ -143,7 +139,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("customDeploy")
     public void setCustomDeploy(CustomDeploy customDeploy) {
@@ -151,23 +147,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
-     */
-    @JsonProperty("dataTemplate")
-    public ObjectReference getDataTemplate() {
-        return dataTemplate;
-    }
-
-    /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
-     */
-    @JsonProperty("dataTemplate")
-    public void setDataTemplate(ObjectReference dataTemplate) {
-        this.dataTemplate = dataTemplate;
-    }
-
-    /**
-     * FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+     * FailureDomain is the failure domain unique identifier this HostClaim should be attached to, as defined in Cluster API. It is implemented when set as a preference for binding BareMetalHost having the label infrastructure.cluster.x-k8s.io/failure-domain set to the value of the field.
      */
     @JsonProperty("failureDomain")
     public String getFailureDomain() {
@@ -175,7 +155,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+     * FailureDomain is the failure domain unique identifier this HostClaim should be attached to, as defined in Cluster API. It is implemented when set as a preference for binding BareMetalHost having the label infrastructure.cluster.x-k8s.io/failure-domain set to the value of the field.
      */
     @JsonProperty("failureDomain")
     public void setFailureDomain(String failureDomain) {
@@ -183,7 +163,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("hostSelector")
     public HostSelector getHostSelector() {
@@ -191,7 +171,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("hostSelector")
     public void setHostSelector(HostSelector hostSelector) {
@@ -199,7 +179,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("image")
     public Image getImage() {
@@ -207,7 +187,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("image")
     public void setImage(Image image) {
@@ -215,7 +195,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("metaData")
     public SecretReference getMetaData() {
@@ -223,7 +203,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("metaData")
     public void setMetaData(SecretReference metaData) {
@@ -231,7 +211,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("networkData")
     public SecretReference getNetworkData() {
@@ -239,7 +219,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("networkData")
     public void setNetworkData(SecretReference networkData) {
@@ -247,23 +227,23 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * ProviderID will be the Metal3 machine in ProviderID format (metal3://&lt;namespace&gt;/&lt;bmh-name&gt;/&lt;m3m-name&gt;). The legacy format (metal3://&lt;bmh-uuid&gt;) will be deprecated in CAPM3 v1.13 and removed in CAPM3 v1.14.
+     * Should the compute resource be powered on? Changing this value will trigger a change in power state of the targeted host.
      */
-    @JsonProperty("providerID")
-    public String getProviderID() {
-        return providerID;
+    @JsonProperty("poweredOn")
+    public Boolean getPoweredOn() {
+        return poweredOn;
     }
 
     /**
-     * ProviderID will be the Metal3 machine in ProviderID format (metal3://&lt;namespace&gt;/&lt;bmh-name&gt;/&lt;m3m-name&gt;). The legacy format (metal3://&lt;bmh-uuid&gt;) will be deprecated in CAPM3 v1.13 and removed in CAPM3 v1.14.
+     * Should the compute resource be powered on? Changing this value will trigger a change in power state of the targeted host.
      */
-    @JsonProperty("providerID")
-    public void setProviderID(String providerID) {
-        this.providerID = providerID;
+    @JsonProperty("poweredOn")
+    public void setPoweredOn(Boolean poweredOn) {
+        this.poweredOn = poweredOn;
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("userData")
     public SecretReference getUserData() {
@@ -271,7 +251,7 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     /**
-     * Metal3MachineSpec defines the desired state of Metal3Machine.
+     * HostClaimSpec defines the desired state of HostClaim.
      */
     @JsonProperty("userData")
     public void setUserData(SecretReference userData) {
@@ -279,12 +259,12 @@ public class Metal3MachineSpec implements Editable<Metal3MachineSpecBuilder>, Ku
     }
 
     @JsonIgnore
-    public Metal3MachineSpecBuilder edit() {
-        return new Metal3MachineSpecBuilder(this);
+    public HostClaimSpecBuilder edit() {
+        return new HostClaimSpecBuilder(this);
     }
 
     @JsonIgnore
-    public Metal3MachineSpecBuilder toBuilder() {
+    public HostClaimSpecBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostClaimStatus.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
+import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -34,16 +35,16 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * CPU describes one processor on the host.
+ * HostClaimStatus defines the observed state of HostClaim.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+    "bareMetalHost",
+    "conditions",
+    "hardwareData",
+    "lastUpdated",
+    "poweredOn"
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +68,126 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class HostClaimStatus implements Editable<HostClaimStatusBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
+    @JsonProperty("bareMetalHost")
+    private ObjectReference bareMetalHost;
+    @JsonProperty("conditions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
+    private List<Condition> conditions = new ArrayList<>();
+    @JsonProperty("hardwareData")
+    private ObjectReference hardwareData;
+    @JsonProperty("lastUpdated")
+    private String lastUpdated;
+    @JsonProperty("poweredOn")
+    private Boolean poweredOn;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public CPU() {
+    public HostClaimStatus() {
     }
 
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
+    public HostClaimStatus(ObjectReference bareMetalHost, List<Condition> conditions, ObjectReference hardwareData, String lastUpdated, Boolean poweredOn) {
         super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
+        this.bareMetalHost = bareMetalHost;
+        this.conditions = conditions;
+        this.hardwareData = hardwareData;
+        this.lastUpdated = lastUpdated;
+        this.poweredOn = poweredOn;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HostClaimStatus defines the observed state of HostClaim.
      */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
+    @JsonProperty("bareMetalHost")
+    public ObjectReference getBareMetalHost() {
+        return bareMetalHost;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HostClaimStatus defines the observed state of HostClaim.
      */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
+    @JsonProperty("bareMetalHost")
+    public void setBareMetalHost(ObjectReference bareMetalHost) {
+        this.bareMetalHost = bareMetalHost;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Conditions defines current service state of the HostClaim.
      */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
+    @JsonProperty("conditions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
+    public List<Condition> getConditions() {
+        return conditions;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Conditions defines current service state of the HostClaim.
      */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
+    @JsonProperty("conditions")
+    public void setConditions(List<Condition> conditions) {
+        this.conditions = conditions;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HostClaimStatus defines the observed state of HostClaim.
      */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
+    @JsonProperty("hardwareData")
+    public ObjectReference getHardwareData() {
+        return hardwareData;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HostClaimStatus defines the observed state of HostClaim.
      */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonProperty("hardwareData")
+    public void setHardwareData(ObjectReference hardwareData) {
+        this.hardwareData = hardwareData;
+    }
+
+    /**
+     * HostClaimStatus defines the observed state of HostClaim.
+     */
+    @JsonProperty("lastUpdated")
+    public String getLastUpdated() {
+        return lastUpdated;
+    }
+
+    /**
+     * HostClaimStatus defines the observed state of HostClaim.
+     */
+    @JsonProperty("lastUpdated")
+    public void setLastUpdated(String lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    /**
+     * The currently detected power state of the host. This field may get briefly out of sync with the actual state of the hardware while provisioning processes are running.
+     */
+    @JsonProperty("poweredOn")
+    public Boolean getPoweredOn() {
+        return poweredOn;
+    }
+
+    /**
+     * The currently detected power state of the host. This field may get briefly out of sync with the actual state of the hardware while provisioning processes are running.
+     */
+    @JsonProperty("poweredOn")
+    public void setPoweredOn(Boolean poweredOn) {
+        this.poweredOn = poweredOn;
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
+    public HostClaimStatusBuilder edit() {
+        return new HostClaimStatusBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public HostClaimStatusBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicy.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicy.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * BMCEventSubscription is the Schema for the fast eventing API
+ * HostDeployPolicy is the Schema for the hostdeploypolicies API.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -75,29 +75,29 @@ import lombok.experimental.Accessors;
 @Version("v1alpha1")
 @Group("metal3.io")
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilder>, HasMetadata, Namespaced
+public class HostDeployPolicy implements Editable<HostDeployPolicyBuilder>, HasMetadata, Namespaced
 {
 
     @JsonProperty("apiVersion")
     private String apiVersion = "metal3.io/v1alpha1";
     @JsonProperty("kind")
-    private String kind = "BMCEventSubscription";
+    private String kind = "HostDeployPolicy";
     @JsonProperty("metadata")
     private ObjectMeta metadata;
     @JsonProperty("spec")
-    private BMCEventSubscriptionSpec spec;
+    private HostDeployPolicySpec spec;
     @JsonProperty("status")
-    private BMCEventSubscriptionStatus status;
+    private HostDeployPolicyStatus status;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public BMCEventSubscription() {
+    public HostDeployPolicy() {
     }
 
-    public BMCEventSubscription(String apiVersion, String kind, ObjectMeta metadata, BMCEventSubscriptionSpec spec, BMCEventSubscriptionStatus status) {
+    public HostDeployPolicy(String apiVersion, String kind, ObjectMeta metadata, HostDeployPolicySpec spec, HostDeployPolicyStatus status) {
         super();
         this.apiVersion = apiVersion;
         this.kind = kind;
@@ -139,7 +139,7 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicy is the Schema for the hostdeploypolicies API.
      */
     @JsonProperty("metadata")
     public ObjectMeta getMetadata() {
@@ -147,7 +147,7 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicy is the Schema for the hostdeploypolicies API.
      */
     @JsonProperty("metadata")
     public void setMetadata(ObjectMeta metadata) {
@@ -155,44 +155,44 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicy is the Schema for the hostdeploypolicies API.
      */
     @JsonProperty("spec")
-    public BMCEventSubscriptionSpec getSpec() {
+    public HostDeployPolicySpec getSpec() {
         return spec;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicy is the Schema for the hostdeploypolicies API.
      */
     @JsonProperty("spec")
-    public void setSpec(BMCEventSubscriptionSpec spec) {
+    public void setSpec(HostDeployPolicySpec spec) {
         this.spec = spec;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicy is the Schema for the hostdeploypolicies API.
      */
     @JsonProperty("status")
-    public BMCEventSubscriptionStatus getStatus() {
+    public HostDeployPolicyStatus getStatus() {
         return status;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicy is the Schema for the hostdeploypolicies API.
      */
     @JsonProperty("status")
-    public void setStatus(BMCEventSubscriptionStatus status) {
+    public void setStatus(HostDeployPolicyStatus status) {
         this.status = status;
     }
 
     @JsonIgnore
-    public BMCEventSubscriptionBuilder edit() {
-        return new BMCEventSubscriptionBuilder(this);
+    public HostDeployPolicyBuilder edit() {
+        return new HostDeployPolicyBuilder(this);
     }
 
     @JsonIgnore
-    public BMCEventSubscriptionBuilder toBuilder() {
+    public HostDeployPolicyBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicyList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicyList.java
@@ -1,7 +1,9 @@
 
 package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -15,11 +17,12 @@ import io.fabric8.kubernetes.api.builder.Editable;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
-import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -37,7 +40,7 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * BMCEventSubscription is the Schema for the fast eventing API
+ * HostDeployPolicyList contains a list of HostDeployPolicy.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -45,8 +48,7 @@ import lombok.experimental.Accessors;
     "apiVersion",
     "kind",
     "metadata",
-    "spec",
-    "status"
+    "items"
 })
 @ToString
 @EqualsAndHashCode
@@ -75,35 +77,33 @@ import lombok.experimental.Accessors;
 @Version("v1alpha1")
 @Group("metal3.io")
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilder>, HasMetadata, Namespaced
+public class HostDeployPolicyList implements Editable<HostDeployPolicyListBuilder>, KubernetesResource, KubernetesResourceList<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostDeployPolicy>
 {
 
     @JsonProperty("apiVersion")
     private String apiVersion = "metal3.io/v1alpha1";
+    @JsonProperty("items")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostDeployPolicy> items = new ArrayList<>();
     @JsonProperty("kind")
-    private String kind = "BMCEventSubscription";
+    private String kind = "HostDeployPolicyList";
     @JsonProperty("metadata")
-    private ObjectMeta metadata;
-    @JsonProperty("spec")
-    private BMCEventSubscriptionSpec spec;
-    @JsonProperty("status")
-    private BMCEventSubscriptionStatus status;
+    private ListMeta metadata;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public BMCEventSubscription() {
+    public HostDeployPolicyList() {
     }
 
-    public BMCEventSubscription(String apiVersion, String kind, ObjectMeta metadata, BMCEventSubscriptionSpec spec, BMCEventSubscriptionStatus status) {
+    public HostDeployPolicyList(String apiVersion, List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostDeployPolicy> items, String kind, ListMeta metadata) {
         super();
         this.apiVersion = apiVersion;
+        this.items = items;
         this.kind = kind;
         this.metadata = metadata;
-        this.spec = spec;
-        this.status = status;
     }
 
     /**
@@ -123,6 +123,23 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
+     * HostDeployPolicyList contains a list of HostDeployPolicy.
+     */
+    @JsonProperty("items")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostDeployPolicy> getItems() {
+        return items;
+    }
+
+    /**
+     * HostDeployPolicyList contains a list of HostDeployPolicy.
+     */
+    @JsonProperty("items")
+    public void setItems(List<io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1.HostDeployPolicy> items) {
+        this.items = items;
+    }
+
+    /**
      * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
      */
     @JsonProperty("kind")
@@ -139,60 +156,28 @@ public class BMCEventSubscription implements Editable<BMCEventSubscriptionBuilde
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicyList contains a list of HostDeployPolicy.
      */
     @JsonProperty("metadata")
-    public ObjectMeta getMetadata() {
+    public ListMeta getMetadata() {
         return metadata;
     }
 
     /**
-     * BMCEventSubscription is the Schema for the fast eventing API
+     * HostDeployPolicyList contains a list of HostDeployPolicy.
      */
     @JsonProperty("metadata")
-    public void setMetadata(ObjectMeta metadata) {
+    public void setMetadata(ListMeta metadata) {
         this.metadata = metadata;
     }
 
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("spec")
-    public BMCEventSubscriptionSpec getSpec() {
-        return spec;
-    }
-
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("spec")
-    public void setSpec(BMCEventSubscriptionSpec spec) {
-        this.spec = spec;
-    }
-
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("status")
-    public BMCEventSubscriptionStatus getStatus() {
-        return status;
-    }
-
-    /**
-     * BMCEventSubscription is the Schema for the fast eventing API
-     */
-    @JsonProperty("status")
-    public void setStatus(BMCEventSubscriptionStatus status) {
-        this.status = status;
+    @JsonIgnore
+    public HostDeployPolicyListBuilder edit() {
+        return new HostDeployPolicyListBuilder(this);
     }
 
     @JsonIgnore
-    public BMCEventSubscriptionBuilder edit() {
-        return new BMCEventSubscriptionBuilder(this);
-    }
-
-    @JsonIgnore
-    public BMCEventSubscriptionBuilder toBuilder() {
+    public HostDeployPolicyListBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicySpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicySpec.java
@@ -1,9 +1,7 @@
 
 package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -34,16 +32,12 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * CPU describes one processor on the host.
+ * HostDeployPolicySpec defines the desired state of HostDeployPolicy.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+    "hostClaimNamespaces"
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +61,48 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class HostDeployPolicySpec implements Editable<HostDeployPolicySpecBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
+    @JsonProperty("hostClaimNamespaces")
+    private HostClaimNamespaces hostClaimNamespaces;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public CPU() {
+    public HostDeployPolicySpec() {
     }
 
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
+    public HostDeployPolicySpec(HostClaimNamespaces hostClaimNamespaces) {
         super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
+        this.hostClaimNamespaces = hostClaimNamespaces;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HostDeployPolicySpec defines the desired state of HostDeployPolicy.
      */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
+    @JsonProperty("hostClaimNamespaces")
+    public HostClaimNamespaces getHostClaimNamespaces() {
+        return hostClaimNamespaces;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * HostDeployPolicySpec defines the desired state of HostDeployPolicy.
      */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonProperty("hostClaimNamespaces")
+    public void setHostClaimNamespaces(HostClaimNamespaces hostClaimNamespaces) {
+        this.hostClaimNamespaces = hostClaimNamespaces;
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
+    public HostDeployPolicySpecBuilder edit() {
+        return new HostDeployPolicySpecBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public HostDeployPolicySpecBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicyStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostDeployPolicyStatus.java
@@ -1,16 +1,13 @@
 
 package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.builder.Editable;
@@ -34,16 +31,12 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * CPU describes one processor on the host.
+ * HostDeployPolicyStatus defines the observed state of HostDeployPolicy.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +60,19 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class HostDeployPolicyStatus implements Editable<HostDeployPolicyStatusBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
-    /**
-     * No args constructor for use in serialization
-     */
-    public CPU() {
-    }
-
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
-        super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonIgnore
+    public HostDeployPolicyStatusBuilder edit() {
+        return new HostDeployPolicyStatusBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
-    }
-
-    @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public HostDeployPolicyStatusBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponents.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponents.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponentsList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponentsList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponentsSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponentsSpec.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponentsStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareComponentsStatus.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -59,7 +58,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettings.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettings.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettingsList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettingsList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettingsSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettingsSpec.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -53,7 +52,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettingsStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostFirmwareSettingsStatus.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -59,7 +58,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostSelector.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostSelector.java
@@ -34,16 +34,14 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 
 /**
- * CPU describes one processor on the host.
+ * HostSelector specifies matching criteria for labels on BareMetalHosts. This is used to limit the set of BareMetalHost objects considered for claiming for a Machine.
  */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+    "inNamespace",
+    "matchExpressions",
+    "matchLabels"
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +65,90 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class HostSelector implements Editable<HostSelectorBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
+    @JsonProperty("inNamespace")
+    private String inNamespace;
+    @JsonProperty("matchExpressions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
+    private List<HostSelectorRequirement> matchExpressions = new ArrayList<>();
+    @JsonProperty("matchLabels")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> matchLabels = new LinkedHashMap<>();
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public CPU() {
+    public HostSelector() {
     }
 
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
+    public HostSelector(String inNamespace, List<HostSelectorRequirement> matchExpressions, Map<String, String> matchLabels) {
         super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
+        this.inNamespace = inNamespace;
+        this.matchExpressions = matchExpressions;
+        this.matchLabels = matchLabels;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * InNamespace specifies a single namespace where the BareMetalHost should reside. If not specified, the selection will be done over all available namespaces with a compliant policy.
      */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
+    @JsonProperty("inNamespace")
+    public String getInNamespace() {
+        return inNamespace;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * InNamespace specifies a single namespace where the BareMetalHost should reside. If not specified, the selection will be done over all available namespaces with a compliant policy.
      */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
+    @JsonProperty("inNamespace")
+    public void setInNamespace(String inNamespace) {
+        this.inNamespace = inNamespace;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Label match expressions that must be true on a chosen BareMetalHost
      */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
+    @JsonProperty("matchExpressions")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
+    public List<HostSelectorRequirement> getMatchExpressions() {
+        return matchExpressions;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Label match expressions that must be true on a chosen BareMetalHost
      */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
+    @JsonProperty("matchExpressions")
+    public void setMatchExpressions(List<HostSelectorRequirement> matchExpressions) {
+        this.matchExpressions = matchExpressions;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Key/value pairs of labels that must exist on a chosen BareMetalHost
      */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
+    @JsonProperty("matchLabels")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getMatchLabels() {
+        return matchLabels;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Key/value pairs of labels that must exist on a chosen BareMetalHost
      */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonProperty("matchLabels")
+    public void setMatchLabels(Map<String, String> matchLabels) {
+        this.matchLabels = matchLabels;
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
+    public HostSelectorBuilder edit() {
+        return new HostSelectorBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public HostSelectorBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostSelectorRequirement.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostSelectorRequirement.java
@@ -33,17 +33,12 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
-/**
- * CPU describes one processor on the host.
- */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+    "key",
+    "operator",
+    "values"
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +62,70 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class HostSelectorRequirement implements Editable<HostSelectorRequirementBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
+    @JsonProperty("key")
+    private String key;
+    @JsonProperty("operator")
+    private String operator;
+    @JsonProperty("values")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
+    private List<String> values = new ArrayList<>();
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public CPU() {
+    public HostSelectorRequirement() {
     }
 
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
+    public HostSelectorRequirement(String key, String operator, List<String> values) {
         super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
+        this.key = key;
+        this.operator = operator;
+        this.values = values;
     }
 
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
+    @JsonProperty("key")
+    public String getKey() {
+        return key;
     }
 
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
+    @JsonProperty("key")
+    public void setKey(String key) {
+        this.key = key;
     }
 
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
+    @JsonProperty("operator")
+    public String getOperator() {
+        return operator;
     }
 
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
+    @JsonProperty("operator")
+    public void setOperator(String operator) {
+        this.operator = operator;
     }
 
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
+    @JsonProperty("values")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
+    public List<String> getValues() {
+        return values;
     }
 
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonProperty("values")
+    public void setValues(List<String> values) {
+        this.values = values;
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
+    public HostSelectorRequirementBuilder edit() {
+        return new HostSelectorRequirementBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public HostSelectorRequirementBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicy.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicy.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicyList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicyList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicySpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicySpec.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -54,7 +53,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicyStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/HostUpdatePolicyStatus.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -52,7 +51,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/Image.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/Image.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -41,6 +40,7 @@ import lombok.experimental.Accessors;
     "checksum",
     "checksumType",
     "format",
+    "ociAuthSecretName",
     "url"
 })
 @ToString
@@ -56,7 +56,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),
@@ -74,6 +74,8 @@ public class Image implements Editable<ImageBuilder>, KubernetesResource
     private String checksumType;
     @JsonProperty("format")
     private String format;
+    @JsonProperty("ociAuthSecretName")
+    private String ociAuthSecretName;
     @JsonProperty("url")
     private String url;
     @JsonIgnore
@@ -85,11 +87,12 @@ public class Image implements Editable<ImageBuilder>, KubernetesResource
     public Image() {
     }
 
-    public Image(String checksum, String checksumType, String format, String url) {
+    public Image(String checksum, String checksumType, String format, String ociAuthSecretName, String url) {
         super();
         this.checksum = checksum;
         this.checksumType = checksumType;
         this.format = format;
+        this.ociAuthSecretName = ociAuthSecretName;
         this.url = url;
     }
 
@@ -139,6 +142,22 @@ public class Image implements Editable<ImageBuilder>, KubernetesResource
     @JsonProperty("format")
     public void setFormat(String format) {
         this.format = format;
+    }
+
+    /**
+     * OCIAuthSecretName optionally names a Docker-config secret containing registry credentials for oci:// images. Must be in the same namespace as the BareMetalHost. Allowed types: kubernetes.io/dockerconfigjson|dockercfg. Only used when Image.URL has the oci:// scheme.
+     */
+    @JsonProperty("ociAuthSecretName")
+    public String getOciAuthSecretName() {
+        return ociAuthSecretName;
+    }
+
+    /**
+     * OCIAuthSecretName optionally names a Docker-config secret containing registry credentials for oci:// images. Must be in the same namespace as the BareMetalHost. Allowed types: kubernetes.io/dockerconfigjson|dockercfg. Only used when Image.URL has the oci:// scheme.
+     */
+    @JsonProperty("ociAuthSecretName")
+    public void setOciAuthSecretName(String ociAuthSecretName) {
+        this.ociAuthSecretName = ociAuthSecretName;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/LLDP.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/LLDP.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/NIC.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/NIC.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -45,6 +44,7 @@ import lombok.experimental.Accessors;
     "mac",
     "model",
     "name",
+    "pciAddress",
     "pxe",
     "speedGbps",
     "vlanId",
@@ -63,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),
@@ -85,6 +85,8 @@ public class NIC implements Editable<NICBuilder>, KubernetesResource
     private String model;
     @JsonProperty("name")
     private String name;
+    @JsonProperty("pciAddress")
+    private String pciAddress;
     @JsonProperty("pxe")
     private Boolean pxe;
     @JsonProperty("speedGbps")
@@ -103,13 +105,14 @@ public class NIC implements Editable<NICBuilder>, KubernetesResource
     public NIC() {
     }
 
-    public NIC(String ip, LLDP lldp, String mac, String model, String name, Boolean pxe, Integer speedGbps, Integer vlanId, List<VLAN> vlans) {
+    public NIC(String ip, LLDP lldp, String mac, String model, String name, String pciAddress, Boolean pxe, Integer speedGbps, Integer vlanId, List<VLAN> vlans) {
         super();
         this.ip = ip;
         this.lldp = lldp;
         this.mac = mac;
         this.model = model;
         this.name = name;
+        this.pciAddress = pciAddress;
         this.pxe = pxe;
         this.speedGbps = speedGbps;
         this.vlanId = vlanId;
@@ -194,6 +197,22 @@ public class NIC implements Editable<NICBuilder>, KubernetesResource
     @JsonProperty("name")
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * The NIC PCI address
+     */
+    @JsonProperty("pciAddress")
+    public String getPciAddress() {
+        return pciAddress;
+    }
+
+    /**
+     * The NIC PCI address
+     */
+    @JsonProperty("pciAddress")
+    public void setPciAddress(String pciAddress) {
+        this.pciAddress = pciAddress;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/NameValuePair.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/NameValuePair.java
@@ -1,9 +1,7 @@
 
 package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -33,17 +31,11 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
-/**
- * CPU describes one processor on the host.
- */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+    "name",
+    "value"
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +59,67 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class NameValuePair implements Editable<NameValuePairBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("value")
+    private String value;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public CPU() {
+    public NameValuePair() {
     }
 
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
+    public NameValuePair(String name, String value) {
         super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
+        this.name = name;
+        this.value = value;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Name of the expected label.
      */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
+    @JsonProperty("name")
+    public String getName() {
+        return name;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * Name of the expected label.
      */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * If specified, expected value of the label.
      */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
+    @JsonProperty("value")
+    public String getValue() {
+        return value;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * If specified, expected value of the label.
      */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonProperty("value")
+    public void setValue(String value) {
+        this.value = value;
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
+    public NameValuePairBuilder edit() {
+        return new NameValuePairBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public NameValuePairBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/ObjectReference.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/ObjectReference.java
@@ -1,9 +1,7 @@
 
 package io.fabric8.openshift.api.model.miscellaneous.metal3.v1alpha1;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -33,17 +31,11 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
-/**
- * CPU describes one processor on the host.
- */
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "arch",
-    "clockMegahertz",
-    "count",
-    "flags",
-    "model"
+    "name",
+    "namespace"
 })
 @ToString
 @EqualsAndHashCode
@@ -67,126 +59,67 @@ import lombok.experimental.Accessors;
     @BuildableReference(VolumeMount.class)
 })
 @Generated("io.fabric8.kubernetes.schema.generator.model.ModelGenerator")
-public class CPU implements Editable<CPUBuilder>, KubernetesResource
+public class ObjectReference implements Editable<ObjectReferenceBuilder>, KubernetesResource
 {
 
-    @JsonProperty("arch")
-    private String arch;
-    @JsonProperty("clockMegahertz")
-    private Double clockMegahertz;
-    @JsonProperty("count")
-    private Integer count;
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private List<String> flags = new ArrayList<>();
-    @JsonProperty("model")
-    private String model;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("namespace")
+    private String namespace;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
     /**
      * No args constructor for use in serialization
      */
-    public CPU() {
+    public ObjectReference() {
     }
 
-    public CPU(String arch, Double clockMegahertz, Integer count, List<String> flags, String model) {
+    public ObjectReference(String name, String namespace) {
         super();
-        this.arch = arch;
-        this.clockMegahertz = clockMegahertz;
-        this.count = count;
-        this.flags = flags;
-        this.model = model;
+        this.name = name;
+        this.namespace = namespace;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * `name` is the name of the object bound
      */
-    @JsonProperty("arch")
-    public String getArch() {
-        return arch;
+    @JsonProperty("name")
+    public String getName() {
+        return name;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * `name` is the name of the object bound
      */
-    @JsonProperty("arch")
-    public void setArch(String arch) {
-        this.arch = arch;
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * `namespace` is the namespace of the object bound
      */
-    @JsonProperty("clockMegahertz")
-    public Double getClockMegahertz() {
-        return clockMegahertz;
+    @JsonProperty("namespace")
+    public String getNamespace() {
+        return namespace;
     }
 
     /**
-     * CPU describes one processor on the host.
+     * `namespace` is the namespace of the object bound
      */
-    @JsonProperty("clockMegahertz")
-    public void setClockMegahertz(Double clockMegahertz) {
-        this.clockMegahertz = clockMegahertz;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public Integer getCount() {
-        return count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("count")
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public List<String> getFlags() {
-        return flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("flags")
-    public void setFlags(List<String> flags) {
-        this.flags = flags;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public String getModel() {
-        return model;
-    }
-
-    /**
-     * CPU describes one processor on the host.
-     */
-    @JsonProperty("model")
-    public void setModel(String model) {
-        this.model = model;
+    @JsonProperty("namespace")
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
     }
 
     @JsonIgnore
-    public CPUBuilder edit() {
-        return new CPUBuilder(this);
+    public ObjectReferenceBuilder edit() {
+        return new ObjectReferenceBuilder(this);
     }
 
     @JsonIgnore
-    public CPUBuilder toBuilder() {
+    public ObjectReferenceBuilder toBuilder() {
         return edit();
     }
 

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/OperationHistory.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/OperationHistory.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -56,7 +55,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/OperationMetric.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/OperationMetric.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -54,7 +53,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImage.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImage.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImageList.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImageList.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListMeta;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -64,7 +63,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImageSpec.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImageSpec.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -57,7 +56,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImageStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/PreprovisioningImageStatus.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/ProvisionStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/ProvisionStatus.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -60,7 +59,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/RAIDConfig.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/RAIDConfig.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -56,7 +55,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/RebootAnnotationArguments.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/RebootAnnotationArguments.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -54,7 +53,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/RootDeviceHints.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/RootDeviceHints.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SchemaReference.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SchemaReference.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -51,7 +50,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SchemaSettingError.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SchemaSettingError.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -49,7 +48,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SecretStatus.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SecretStatus.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -51,7 +50,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SettingSchema.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SettingSchema.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -62,7 +61,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SoftwareRAIDVolume.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/SoftwareRAIDVolume.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -57,7 +56,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/Storage.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/Storage.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -66,7 +65,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/VLAN.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1alpha1/VLAN.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -54,7 +53,7 @@ import lombok.experimental.Accessors;
     @BuildableReference(PodTemplateSpec.class),
     @BuildableReference(ResourceRequirements.class),
     @BuildableReference(IntOrString.class),
-    @BuildableReference(ObjectReference.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
     @BuildableReference(LocalObjectReference.class),
     @BuildableReference(PersistentVolumeClaim.class),
     @BuildableReference(EnvVar.class),

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/MetaDataHostInterface.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/MetaDataHostInterface.java
@@ -38,6 +38,7 @@ import lombok.experimental.Accessors;
 @JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
+    "fromBootMAC",
     "interface",
     "key"
 })
@@ -66,6 +67,8 @@ import lombok.experimental.Accessors;
 public class MetaDataHostInterface implements Editable<MetaDataHostInterfaceBuilder>, KubernetesResource
 {
 
+    @JsonProperty("fromBootMAC")
+    private Boolean fromBootMAC;
     @JsonProperty("interface")
     private String _interface;
     @JsonProperty("key")
@@ -79,10 +82,27 @@ public class MetaDataHostInterface implements Editable<MetaDataHostInterfaceBuil
     public MetaDataHostInterface() {
     }
 
-    public MetaDataHostInterface(String _interface, String key) {
+    public MetaDataHostInterface(Boolean fromBootMAC, String _interface, String key) {
         super();
+        this.fromBootMAC = fromBootMAC;
         this._interface = _interface;
         this.key = key;
+    }
+
+    /**
+     * FromBootMAC will fetch the MAC address from the BareMetalHost Spec BootMACAddress field.
+     */
+    @JsonProperty("fromBootMAC")
+    public Boolean getFromBootMAC() {
+        return fromBootMAC;
+    }
+
+    /**
+     * FromBootMAC will fetch the MAC address from the BareMetalHost Spec BootMACAddress field.
+     */
+    @JsonProperty("fromBootMAC")
+    public void setFromBootMAC(Boolean fromBootMAC) {
+        this.fromBootMAC = fromBootMAC;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/NetworkDataLinkBond.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/NetworkDataLinkBond.java
@@ -47,6 +47,7 @@ import lombok.experimental.Accessors;
     "id",
     "macAddress",
     "mtu",
+    "name",
     "parameters"
 })
 @ToString
@@ -87,6 +88,8 @@ public class NetworkDataLinkBond implements Editable<NetworkDataLinkBondBuilder>
     private NetworkLinkEthernetMac macAddress;
     @JsonProperty("mtu")
     private Integer mtu;
+    @JsonProperty("name")
+    private String name;
     @JsonProperty("parameters")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, JsonNode> parameters = new LinkedHashMap<>();
@@ -99,7 +102,7 @@ public class NetworkDataLinkBond implements Editable<NetworkDataLinkBondBuilder>
     public NetworkDataLinkBond() {
     }
 
-    public NetworkDataLinkBond(List<String> bondLinks, String bondMode, String bondXmitHashPolicy, String id, NetworkLinkEthernetMac macAddress, Integer mtu, Map<String, JsonNode> parameters) {
+    public NetworkDataLinkBond(List<String> bondLinks, String bondMode, String bondXmitHashPolicy, String id, NetworkLinkEthernetMac macAddress, Integer mtu, String name, Map<String, JsonNode> parameters) {
         super();
         this.bondLinks = bondLinks;
         this.bondMode = bondMode;
@@ -107,6 +110,7 @@ public class NetworkDataLinkBond implements Editable<NetworkDataLinkBondBuilder>
         this.id = id;
         this.macAddress = macAddress;
         this.mtu = mtu;
+        this.name = name;
         this.parameters = parameters;
     }
 
@@ -205,6 +209,22 @@ public class NetworkDataLinkBond implements Editable<NetworkDataLinkBondBuilder>
     @JsonProperty("mtu")
     public void setMtu(Integer mtu) {
         this.mtu = mtu;
+    }
+
+    /**
+     * Name is the interface name to be used by cloud-init. When combined with MACAddress, cloud-init will rename the interface matching the MAC to this name. When MACAddress is omitted, cloud-init will use this name directly.
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Name is the interface name to be used by cloud-init. When combined with MACAddress, cloud-init will rename the interface matching the MAC to this name. When MACAddress is omitted, cloud-init will use this name directly.
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/NetworkDataLinkEthernet.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/NetworkDataLinkEthernet.java
@@ -41,6 +41,7 @@ import lombok.experimental.Accessors;
     "id",
     "macAddress",
     "mtu",
+    "name",
     "type"
 })
 @ToString
@@ -74,6 +75,8 @@ public class NetworkDataLinkEthernet implements Editable<NetworkDataLinkEthernet
     private NetworkLinkEthernetMac macAddress;
     @JsonProperty("mtu")
     private Integer mtu;
+    @JsonProperty("name")
+    private String name;
     @JsonProperty("type")
     private String type;
     @JsonIgnore
@@ -85,11 +88,12 @@ public class NetworkDataLinkEthernet implements Editable<NetworkDataLinkEthernet
     public NetworkDataLinkEthernet() {
     }
 
-    public NetworkDataLinkEthernet(String id, NetworkLinkEthernetMac macAddress, Integer mtu, String type) {
+    public NetworkDataLinkEthernet(String id, NetworkLinkEthernetMac macAddress, Integer mtu, String name, String type) {
         super();
         this.id = id;
         this.macAddress = macAddress;
         this.mtu = mtu;
+        this.name = name;
         this.type = type;
     }
 
@@ -139,6 +143,22 @@ public class NetworkDataLinkEthernet implements Editable<NetworkDataLinkEthernet
     @JsonProperty("mtu")
     public void setMtu(Integer mtu) {
         this.mtu = mtu;
+    }
+
+    /**
+     * Name is the interface name to be used by cloud-init. When combined with MACAddress, cloud-init will rename the interface matching the MAC to this name. When MACAddress is omitted, cloud-init will use this name directly.
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Name is the interface name to be used by cloud-init. When combined with MACAddress, cloud-init will rename the interface matching the MAC to this name. When MACAddress is omitted, cloud-init will use this name directly.
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**

--- a/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/NetworkDataLinkVlan.java
+++ b/kubernetes-model-generator/openshift-model-miscellaneous/src/generated/java/io/fabric8/openshift/api/model/miscellaneous/metal3/v1beta1/NetworkDataLinkVlan.java
@@ -41,6 +41,7 @@ import lombok.experimental.Accessors;
     "id",
     "macAddress",
     "mtu",
+    "name",
     "vlanID",
     "vlanLink"
 })
@@ -75,6 +76,8 @@ public class NetworkDataLinkVlan implements Editable<NetworkDataLinkVlanBuilder>
     private NetworkLinkEthernetMac macAddress;
     @JsonProperty("mtu")
     private Integer mtu;
+    @JsonProperty("name")
+    private String name;
     @JsonProperty("vlanID")
     private Integer vlanID;
     @JsonProperty("vlanLink")
@@ -88,11 +91,12 @@ public class NetworkDataLinkVlan implements Editable<NetworkDataLinkVlanBuilder>
     public NetworkDataLinkVlan() {
     }
 
-    public NetworkDataLinkVlan(String id, NetworkLinkEthernetMac macAddress, Integer mtu, Integer vlanID, String vlanLink) {
+    public NetworkDataLinkVlan(String id, NetworkLinkEthernetMac macAddress, Integer mtu, String name, Integer vlanID, String vlanLink) {
         super();
         this.id = id;
         this.macAddress = macAddress;
         this.mtu = mtu;
+        this.name = name;
         this.vlanID = vlanID;
         this.vlanLink = vlanLink;
     }
@@ -143,6 +147,22 @@ public class NetworkDataLinkVlan implements Editable<NetworkDataLinkVlanBuilder>
     @JsonProperty("mtu")
     public void setMtu(Integer mtu) {
         this.mtu = mtu;
+    }
+
+    /**
+     * Name is the interface name to be used by cloud-init. When combined with MACAddress, cloud-init will rename the interface matching the MAC to this name. When MACAddress is omitted, cloud-init will use this name directly.
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Name is the interface name to be used by cloud-init. When combined with MACAddress, cloud-init will rename the interface matching the MAC to this name. When MACAddress is omitted, cloud-init will use this name directly.
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Bump `github.com/metal3-io/baremetal-operator/apis` from 0.12.4 to 0.13.0
- Bump `github.com/metal3-io/cluster-api-provider-metal3/api` from 1.12.4 to 1.13.0
- Bump `github.com/metal3-io/ip-address-manager/api` from 1.12.4 to 1.13.0 (indirect)

Regenerated `openshift-generated.json` and the `openshift-model-miscellaneous` metal3 models. The bump introduces the new `HostClaim` and `HostDeployPolicy` CRDs (added in BMO v0.13). `FirmwareConfig`'s javadoc now reflects upstream deprecation (no longer supported by any driver). The generator auto-disambiguates between the new local `metal3.v1alpha1.ObjectReference` and `io.fabric8.kubernetes.api.model.ObjectReference`; no existing Java classes were removed, so no breaking changes.

Closes #7749