### PR TITLE
fix(mockwebserver): log state on WebSocketSession.send exception (#7756)

### DIFF
--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -33,8 +33,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class WebSocketSession extends WebSocketListener {
+
+  private static final Logger logger = Logger.getLogger(WebSocketSession.class.getName());
 
   private final List<WebSocketMessage> open;
   private final WebSocketMessage failure;
@@ -157,10 +161,25 @@ public class WebSocketSession extends WebSocketListener {
     pendingMessages.add(id);
     executor.schedule(() -> {
       if (ws != null) {
-        if (message.isBinary()) {
-          ws.send(message.getBytes());
-        } else {
-          ws.send(message.getBody());
+        try {
+          if (message.isBinary()) {
+            ws.send(message.getBytes());
+          } else {
+            ws.send(message.getBody());
+          }
+        } catch (RuntimeException e) {
+          // Diagnostic for #7756: if writeBinaryMessage / writeTextMessage throws (e.g. Vert.x
+          // IllegalStateException on a closed WebSocket), the scheduled task aborts here,
+          // pendingMessages keeps the id, and closeActiveSocketsIfApplicable() never runs, so the
+          // server never initiates a close and clients wait on listener.onClose. Capture state to
+          // confirm this is the failure mode on the next CI hit, then rethrow.
+          logger.log(Level.SEVERE, e,
+              () -> String.format(
+                  "WebSocketSession message send failed (ws=%s, binary=%s, length=%d, delayMs=%d, pending=%d, activeSockets=%d)",
+                  Integer.toHexString(System.identityHashCode(ws)),
+                  message.isBinary(), message.getBytes().length, message.getDelay(),
+                  pendingMessages.size(), activeSockets.size()));
+          throw e;
         }
         pendingMessages.remove(id);
       }


### PR DESCRIPTION
## Summary

#7756 (`PodTest.testExecExplicitDefaultContainerMissing`) intermittently fails at the post-WS-upgrade latch wait (`latch.await(1, TimeUnit.MINUTES)`). The diagnostic added by #7743 only fires on WS-upgrade timeouts; this failure mode is different — the upgrade completes (HTTP 101) and then the close handshake never finishes. The [investigation summary on #7756](https://github.com/fabric8io/kubernetes-client/issues/7756#issuecomment-4427124656) documents the CI-log analysis and unsuccessful local repro.

This adds a single `logger.log(Level.SEVERE, ...)` at the most plausible failure site in `WebSocketSession.send`'s scheduled task, so the next CI hit produces actionable data:

- `ws` — identity hash to correlate with the HTTP 101 in the mock-server log
- `binary` / `length` / `delayMs` — message metadata (helps spot whether the throw is on the open message or a later one)
- `pending` / `activeSockets` — session state at the failure point

The hypothesis: if `ws.send(...)` throws (e.g. Vert.x `IllegalStateException` on a closed `ServerWebSocket`), the scheduled task aborts before `pendingMessages.remove(id)` and `closeActiveSocketsIfApplicable()` run, so the server never issues a close and the client's `onClose` listener (which counts down the test's latch) never fires.

No behavior change. One extra `logger.log(...)` only on the failure path; success path is untouched. `RuntimeException` is rethrown after logging.

Fixes #7756 (diagnostic only)