### PR TITLE
test(kubernetes-client): stabilize PortForwarderWebsocketListenerTest.onOpen_shouldPipeInChannelToWebSocket flake

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
@@ -22,18 +22,17 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -74,15 +73,22 @@ class PortForwarderWebsocketListenerTest {
 
   @Test
   void onOpen_shouldPipeInChannelToWebSocket() {
+    // pipe() reuses the same ByteBuffer across iterations, so an ArgumentCaptor
+    // reference races with buffer.clear()/put()/read() in the next iteration.
+    // Snapshot the bytes synchronously inside send() instead.
+    final AtomicReference<String> sent = new AtomicReference<>();
+    doAnswer(i -> {
+      ByteBuffer buf = i.getArgument(0);
+      byte[] copy = new byte[buf.remaining()];
+      buf.duplicate().get(copy);
+      sent.set(new String(copy, StandardCharsets.UTF_8));
+      return true;
+    }).when(webSocket).send(any(ByteBuffer.class));
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
     listener.onOpen(webSocket);
-    ArgumentCaptor<ByteBuffer> contentTypeCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
     // Then
-    verify(webSocket, timeout(10_000).times(1)).send(contentTypeCaptor.capture());
-    assertThat(contentTypeCaptor.getValue())
-        .extracting(StandardCharsets.UTF_8::decode)
-        .extracting(CharBuffer::toString).asString()
-        .startsWith("THIS IS A TEST");
+    verify(webSocket, timeout(10_000).times(1)).send(any(ByteBuffer.class));
+    assertThat(sent.get()).startsWith("\u0000THIS IS A TEST");
     assertThat(in.isOpen()).isTrue();
     assertThat(out.isOpen()).isTrue();
   }


### PR DESCRIPTION
## Description

`PortForwarderWebsocketListenerTest.onOpen_shouldPipeInChannelToWebSocket` is flaky on CI. The visible failure is `actual = "THIS IS A TEST"` failing `startsWith("THIS IS A TEST")` — visually identical strings.

### Root cause

`PortForwarderWebsocketListener.pipe()` reuses a single `ByteBuffer` across iterations (`clear()` → `put((byte) 0)` → `read()` → `flip()` → `send()`). Mockito's `ArgumentCaptor` stores a reference to that buffer, not a snapshot. Once the pumper thread re-enters the loop after `send()` returns, the next `clear()` + `put((byte) 0)` + `read()` (which returns -1 at EOF) mutates the captured buffer before the assertion runs.

Depending on race timing the captured content was either:
- channel byte (`0x00`) + `THIS IS A TEST` (pos=0, limit=15) — `startsWith("THIS IS A TEST")` fails (the leading NUL renders invisibly in the AssertJ output, making both strings *look* identical), or
- `THIS IS A TEST` + 4081 NULs (after clear+put+EOF) — passes by accident but silently drops the channel byte from the assertion.

### Fix

Snapshot the bytes synchronously inside a Mockito `doAnswer` on `send()` and assert on the copy. The new assertion also covers the leading channel byte (`0x00`) that `pipe()` writes before the payload, which the original assertion was unintentionally missing.

Production code (`PortForwarderWebsocketListener.pipe()`) is untouched — real `WebSocket.send` implementations consume the buffer synchronously, so buffer reuse is safe in production; the race is purely a test-side issue.

Closes #7757
