### PR TITLE
fix(mockwebserver): broaden #7756 diagnostics for WS post-upgrade hang

### DIFF
--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -160,6 +160,13 @@ public class WebSocketSession extends WebSocketListener {
     final UUID id = UUID.randomUUID();
     pendingMessages.add(id);
     executor.schedule(() -> {
+      // Diagnostic for #7756: confirm the scheduled task actually runs. If this never logs for a
+      // hung test, the scheduled executor lost or dropped the task.
+      logger.log(Level.INFO, () -> String.format(
+          "WebSocketSession send task entered (id=%s, ws=%s, binary=%s, length=%d, delayMs=%d, pending=%d, activeSockets=%d)",
+          id, Integer.toHexString(System.identityHashCode(ws)),
+          message.isBinary(), message.getBytes().length, message.getDelay(),
+          pendingMessages.size(), activeSockets.size()));
       if (ws != null) {
         try {
           if (message.isBinary()) {
@@ -188,8 +195,14 @@ public class WebSocketSession extends WebSocketListener {
   }
 
   public void closeActiveSocketsIfApplicable() {
-    if (pendingMessages.isEmpty() && requestEvents.isEmpty() && httpRequestEvents.isEmpty()
-        && sentWebSocketMessagesRequestEvents.isEmpty()) {
+    final boolean applicable = pendingMessages.isEmpty() && requestEvents.isEmpty() && httpRequestEvents.isEmpty()
+        && sentWebSocketMessagesRequestEvents.isEmpty();
+    // Diagnostic for #7756: capture whether the close path was reached and what state it observed.
+    logger.log(Level.INFO, () -> String.format(
+        "WebSocketSession.closeActiveSocketsIfApplicable applicable=%s (pending=%d, requestEvents=%d, httpRequestEvents=%d, sentWebSocketMessagesRequestEvents=%d, activeSockets=%d)",
+        applicable, pendingMessages.size(), requestEvents.size(), httpRequestEvents.size(),
+        sentWebSocketMessagesRequestEvents.size(), activeSockets.size()));
+    if (applicable) {
       activeSockets.forEach(ws -> ws.close(1000, "Closing..."));
     }
   }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
@@ -21,7 +21,13 @@ import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class VertxMockWebSocket implements WebSocket {
+
+  private static final Logger logger = Logger.getLogger(VertxMockWebSocket.class.getName());
+
   private final RecordedRequest request;
   private final ServerWebSocket webSocket;
   private volatile boolean closing;
@@ -40,6 +46,12 @@ public class VertxMockWebSocket implements WebSocket {
   @Override
   public boolean send(String text) {
     final Future<Void> send = webSocket.writeTextMessage(text);
+    // Diagnostic for #7756: writeTextMessage completes asynchronously; without an explicit failure
+    // handler any async write error is silently dropped, which would leave the server believing the
+    // message was delivered while the client never sees it. Log and swallow (preserve behavior).
+    send.onFailure(t -> logger.log(Level.SEVERE, t,
+        () -> String.format("VertxMockWebSocket.writeTextMessage future failed (ws=%s, length=%d)",
+            Integer.toHexString(System.identityHashCode(webSocket)), text.length())));
     if (send.isComplete()) {
       return send.succeeded();
     }
@@ -49,6 +61,10 @@ public class VertxMockWebSocket implements WebSocket {
   @Override
   public boolean send(byte[] bytes) {
     final Future<Void> send = webSocket.writeBinaryMessage(Buffer.buffer(bytes));
+    // Diagnostic for #7756: see send(String) above.
+    send.onFailure(t -> logger.log(Level.SEVERE, t,
+        () -> String.format("VertxMockWebSocket.writeBinaryMessage future failed (ws=%s, length=%d)",
+            Integer.toHexString(System.identityHashCode(webSocket)), bytes.length)));
     if (send.isComplete()) {
       return send.succeeded();
     }
@@ -59,7 +75,10 @@ public class VertxMockWebSocket implements WebSocket {
   public synchronized boolean close(int code, String reason) {
     if (!closing) {
       closing = true;
-      webSocket.close((short) code, reason);
+      // Diagnostic for #7756: capture async close failures (same rationale as send() above).
+      webSocket.close((short) code, reason).onFailure(t -> logger.log(Level.SEVERE, t,
+          () -> String.format("VertxMockWebSocket.close future failed (ws=%s, code=%d, reason=%s)",
+              Integer.toHexString(System.identityHashCode(webSocket)), code, reason)));
     }
     return true;
   }


### PR DESCRIPTION
Follow-up to #7756.

The SEVERE diagnostic added in #7756 (synchronous throw from `ws.send`) did not fire on the latest CI hit of `PodTest.testExecExplicitDefaultContainerMissing` ([run 25713274796][1]): MockWebServer logged `101 Switching Protocols`, then 60 s of silence on the WS until the test latch timed out. That rules out the "scheduled task aborts on `ws.send` throw" hypothesis; the bug must be one of:

- **(a)** the scheduled task never ran;
- **(b)** `ws.send` returned without throwing but the underlying Vert.x `writeTextMessage` / `writeBinaryMessage` future failed asynchronously (silently swallowed today);
- **(c)** the server-side close was issued but never reached the client.

This PR adds three probes to distinguish those on the next CI hit:

- `WebSocketSession.send`: INFO at scheduled lambda entry — its absence for a hung test confirms case (a).
- `WebSocketSession.closeActiveSocketsIfApplicable`: INFO including the computed `applicable` flag and all four queue sizes, so absence vs. `applicable=false` distinguishes "never reached" vs. "reached but skipped".
- `VertxMockWebSocket.send(String)` / `send(byte[])` / `close`: attach `.onFailure` to each Vert.x `Future` and log SEVERE — covers case (b).

Diagnostic only — no behavior change. Async failures are logged and swallowed, preserving the prior fire-and-forget semantics.

[1]: https://github.com/fabric8io/kubernetes-client/actions/runs/25713274796/job/75497813891