### PR TITLE
fix(informer): stop informer inline when informOnCondition predicate matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.8-SNAPSHOT
 
 #### Bugs
+* Fix #7765: (kubernetes-client) `BaseOperation.informOnCondition` now stops the informer inline when the inner predicate completes the future, closing a CompletableFuture `postComplete` race where a waiter helping drain dependents could fire `informer.stop` after `cf.complete` had already triggered a spurious `?watch=true` HTTP request
 
 #### Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -1045,18 +1045,27 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
     informer.initialState(Stream.empty());
 
-    // prevent unnecessary watches and handle closure
+    // prevent unnecessary watches and handle closure - safety net for cancellation /
+    // exceptional completion paths that don't go through `test` below.
     future.whenComplete((r, t) -> informer.stop());
 
-    // use the cache to evaluate the list predicate, trapping any exceptions
+    // use the cache to evaluate the list predicate, trapping any exceptions.
+    // When `test` is the one completing the future, stop the informer inline on the same
+    // thread so any subsequent informer activity (e.g. the watch start that follows a list)
+    // observes the stop deterministically. Relying solely on `future.whenComplete` is racy:
+    // when a thread is blocked in `future.thenApply(...).get(...)`, the JDK lets the waiter
+    // help drain `postComplete`, and it can `claim()` the whenComplete dependent first — so
+    // `future.complete` can return on the completer thread before `informer.stop` has run.
     Consumer<List<T>> test = list -> {
       try {
         // could skip if lastResourceVersion has not changed
-        if (condition.test(list)) {
-          future.complete(list);
+        if (condition.test(list) && future.complete(list)) {
+          informer.stop();
         }
       } catch (Exception e) {
-        future.completeExceptionally(e);
+        if (future.completeExceptionally(e)) {
+          informer.stop();
+        }
       }
     };
 


### PR DESCRIPTION
Fixes #7765
Closes #7760

## Summary
- **#7765** is the underlying production bug: `BaseOperation.informOnCondition` could issue a stale `?watch=true` HTTP request when the wait condition is satisfied on the first list, due to a JDK CompletableFuture `postComplete` race in which a waiter blocked in `future.thenApply(...).get(...)` could `claim()` the `whenComplete` dependent before the completer thread did.
- **#7760** is the test-side surface: `ResourceListTest.testCreateOrReplaceWithDeleteExisting` (`expected: <6> but was: <7>`) flakes under CPU contention because of #7765.
- Fix: in `informOnCondition`'s `test` Consumer, call `informer.stop()` inline on the same thread as `future.complete(list)` / `completeExceptionally(e)`. The `whenComplete` stays as a safety net for cancellation / external-completion paths. `informer.stop()` is synchronized and idempotent.
- Verified under cgroup-constrained docker (`--cpus=2 --cpuset-cpus="0,1"` + neighbor `stress-ng`): before the fix, ~27% iteration failure rate (16/80 across two runs); after the fix, **50/50** target-test pass and **30/30** full-`ResourceListTest` pass under the same contention. All `kubernetes-client` informer/reflector/SerialExecutor unit tests still pass.

## Follow-ups (out of scope here)
- Add a contract-pinning unit test in `BaseOperationTest` that asserts inline `informer.stop()` on the completer thread (needs `createInformer` made overridable or a heavier test scaffold).
- Re-evaluate `ResourceTest.testFromServerWaitUntilConditionAlwaysGetsResourceFromServer`'s previous test-side workaround (#7677 / cb77ce1e45) — likely the same root cause masked test-side; the dropped redundant emit may be safe to restore now.