### PR TITLE
chore(ci): add -T 1C to Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -54,7 +54,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build Project
-        run: ./mvnw clean install
+        run: ./mvnw -T 1C clean install
       - name: Drop in-repo artifacts before cache save
         # Don't let io.fabric8:* jars installed by this run leak into the cache that future
         # runs restore. Only third-party dependencies should be cached.


### PR DESCRIPTION
## Summary

Adds `-T 1C` to the Windows build workflow to enable Maven's parallel module build. The local `Makefile` already uses this flag (`Makefile:19`); applying it to CI recovers parallel module compilation/test on the 4-core `windows-latest` runner.

## Context

`windows-build.yml` is the slowest cell in the CI matrix (~35 min vs ~20 min for the Linux cells). Per the measurements in #7675, parallel module builds typically recover 20–30% of wall time.

The earlier attempt to enable `-T 1C` across all CI workflows (#7684) was reverted because the combined parallelism (`-T 1C` × `forkCount=1C`) surfaced timing-sensitive test flakes. The three named blockers are now fixed:

- #7685 — `UploadTest#uploadReturnsTrue` (PR #7695)
- #7686 — `Vertx5HttpBodyStreamTest#testStreamFlowControl` (PR #7714)
- #7687 — `AbstractSimultaneousConnectionsTest#http1WebSocketConnections` (PR #7711)

This change is intentionally scoped to Windows only as a smaller-blast-radius trial before re-considering the Linux workflows.

Refs #7675