### PR TITLE
chore(ci): add -T 1C to Linux build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@
 name: Build
 
 env:
-  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -Dit.test.bom=true
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e -Dit.test.bom=true -T 1C
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Adds `-T 1C` to the `MAVEN_ARGS` env var in `build.yml`, enabling Maven's parallel module build across the three Linux matrix cells (JDK 11/17/21). The local `Makefile` already uses this flag (`Makefile:19`).

## Context

Follow-up to #7768, which applied the same change to `windows-build.yml` and reduced that cell from ~35 min to ~22 min (~37%). The Linux cells are also running modules sequentially in the reactor today.

The earlier attempt to enable `-T 1C` globally (#7684) was reverted because the combined parallelism (`-T 1C` × `forkCount=1C`) surfaced timing-sensitive flakes. The three named blockers are now closed:

- #7685 — `UploadTest#uploadReturnsTrue` (PR #7695)
- #7686 — `Vertx5HttpBodyStreamTest#testStreamFlowControl` (PR #7714)
- #7687 — `AbstractSimultaneousConnectionsTest#http1WebSocketConnections` (PR #7711)

Expected gain on Linux is smaller in percentage terms than Windows: the Linux baseline (~20 min) doesn't have the same NTFS / process-spawn / Defender overhead that Windows benefits from hiding behind parallel work. Realistic estimate: ~3–4 min per cell, ~9–12 runner-minutes per PR across the matrix.

Refs #7675