### PR TITLE
fix: extend #7756 diagnostics across client/server WS close handshake

### DIFF
--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
@@ -45,13 +45,17 @@ public class VertxMockWebSocket implements WebSocket {
 
   @Override
   public boolean send(String text) {
+    final String wsId = Integer.toHexString(System.identityHashCode(webSocket));
+    logger.log(Level.INFO, () -> String.format(
+        "VertxMockWebSocket.writeTextMessage entered (ws=%s, length=%d)", wsId, text.length()));
     final Future<Void> send = webSocket.writeTextMessage(text);
-    // Diagnostic for #7756: writeTextMessage completes asynchronously; without an explicit failure
-    // handler any async write error is silently dropped, which would leave the server believing the
-    // message was delivered while the client never sees it. Log and swallow (preserve behavior).
+    // Diagnostic for #7756: writeTextMessage completes asynchronously. Logging both outcomes makes
+    // the "future never completed" case distinguishable from "succeeded" or "failed" — silence
+    // after the entry log now strictly means the future never settled.
+    send.onSuccess(v -> logger.log(Level.INFO,
+        () -> String.format("VertxMockWebSocket.writeTextMessage succeeded (ws=%s, length=%d)", wsId, text.length())));
     send.onFailure(t -> logger.log(Level.SEVERE, t,
-        () -> String.format("VertxMockWebSocket.writeTextMessage future failed (ws=%s, length=%d)",
-            Integer.toHexString(System.identityHashCode(webSocket)), text.length())));
+        () -> String.format("VertxMockWebSocket.writeTextMessage future failed (ws=%s, length=%d)", wsId, text.length())));
     if (send.isComplete()) {
       return send.succeeded();
     }
@@ -60,11 +64,15 @@ public class VertxMockWebSocket implements WebSocket {
 
   @Override
   public boolean send(byte[] bytes) {
+    final String wsId = Integer.toHexString(System.identityHashCode(webSocket));
+    logger.log(Level.INFO, () -> String.format(
+        "VertxMockWebSocket.writeBinaryMessage entered (ws=%s, length=%d)", wsId, bytes.length));
     final Future<Void> send = webSocket.writeBinaryMessage(Buffer.buffer(bytes));
     // Diagnostic for #7756: see send(String) above.
+    send.onSuccess(v -> logger.log(Level.INFO,
+        () -> String.format("VertxMockWebSocket.writeBinaryMessage succeeded (ws=%s, length=%d)", wsId, bytes.length)));
     send.onFailure(t -> logger.log(Level.SEVERE, t,
-        () -> String.format("VertxMockWebSocket.writeBinaryMessage future failed (ws=%s, length=%d)",
-            Integer.toHexString(System.identityHashCode(webSocket)), bytes.length)));
+        () -> String.format("VertxMockWebSocket.writeBinaryMessage future failed (ws=%s, length=%d)", wsId, bytes.length)));
     if (send.isComplete()) {
       return send.succeeded();
     }
@@ -75,10 +83,16 @@ public class VertxMockWebSocket implements WebSocket {
   public synchronized boolean close(int code, String reason) {
     if (!closing) {
       closing = true;
-      // Diagnostic for #7756: capture async close failures (same rationale as send() above).
-      webSocket.close((short) code, reason).onFailure(t -> logger.log(Level.SEVERE, t,
-          () -> String.format("VertxMockWebSocket.close future failed (ws=%s, code=%d, reason=%s)",
-              Integer.toHexString(System.identityHashCode(webSocket)), code, reason)));
+      final String wsId = Integer.toHexString(System.identityHashCode(webSocket));
+      logger.log(Level.INFO, () -> String.format(
+          "VertxMockWebSocket.close entered (ws=%s, code=%d, reason=%s)", wsId, code, reason));
+      // Diagnostic for #7756: capture both close outcomes (success vs ClosedChannelException) so we
+      // can correlate with the matching writeBinaryMessage / writeTextMessage result on the same ws.
+      final Future<Void> closeFuture = webSocket.close((short) code, reason);
+      closeFuture.onSuccess(v -> logger.log(Level.INFO,
+          () -> String.format("VertxMockWebSocket.close succeeded (ws=%s, code=%d, reason=%s)", wsId, code, reason)));
+      closeFuture.onFailure(t -> logger.log(Level.SEVERE, t,
+          () -> String.format("VertxMockWebSocket.close future failed (ws=%s, code=%d, reason=%s)", wsId, code, reason)));
     }
     return true;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -229,6 +229,11 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
   private void closeWebSocketOnce(int code, String reason) {
     try {
       WebSocket ws = webSocketRef.get();
+      // Diagnostic for #7756: log every client-initiated sendClose. We want to confirm whether the
+      // client actually issues a close frame after receiving the error stream message (the
+      // terminateOnError path) before suspecting transport-level loss of the close frame.
+      LOGGER.error("[#7756] closeWebSocketOnce code={} reason={} wsPresent={}",
+          code, reason, ws != null);
       if (ws != null) {
         ws.sendClose(code, reason);
       }
@@ -257,6 +262,11 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
 
   @Override
   public void onError(WebSocket webSocket, Throwable t) {
+    // Diagnostic for #7756: log every transport-level error reaching the listener so we can tell
+    // whether a server-side ClosedChannelException is surfaced to the client (and if so, in what
+    // form) when the server's close frame fails to write.
+    LOGGER.error("[#7756] onError ws={} t={}",
+        Integer.toHexString(System.identityHashCode(webSocket)), t == null ? "null" : t.toString());
     closed.set(true);
     HttpResponse<?> response = null;
 
@@ -317,6 +327,11 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
         webSocket.request();
         return;
       }
+      // Diagnostic for #7756: confirm channel 2 (error stream) arrives at the client and triggers
+      // terminateOnError close. Used together with the VertxMockWebSocket close/write probes to
+      // pinpoint which side of the close handshake stalls.
+      LOGGER.error("[#7756] Exec Web Socket: onMessage streamID={} remaining={} terminateOnError={} ws={}",
+          streamID, byteString.remaining(), terminateOnError, Integer.toHexString(System.identityHashCode(webSocket)));
       switch (streamID) {
         case 1:
           out.handle(byteString, webSocket);
@@ -377,6 +392,11 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
 
   @Override
   public void onClose(WebSocket webSocket, int code, String reason) {
+    // Diagnostic for #7756: log every onClose entry (even ones suppressed by the `closed` flag) so
+    // we can tell whether the framework ever delivers onClose for a hung exec — its absence
+    // confirms the server's close frame never arrives at the client listener.
+    LOGGER.error("[#7756] onClose entered code={} reason={} alreadyClosed={} ws={}",
+        code, reason, closed.get(), Integer.toHexString(System.identityHashCode(webSocket)));
     //If we already called onClosed() or onFailed() before, we need to abort.
     if (!closed.compareAndSet(false, true)) {
       return;


### PR DESCRIPTION
## Summary

Continuation of the #7756 investigation. The Windows hit in [run 25736234937][1] (attempt 1) confirmed case (c) from #7762: `VertxMockWebSocket.close` future failed with `io.netty.channel.StacklessClosedChannelException` at `AbstractUnsafe.write` — the underlying Netty channel was already closed when the server tried to write the close frame, so the close frame never reached the client and the test latch waited 60s.

Two blind spots remain after #7762:

1. We only logged `.onFailure` on `writeTextMessage` / `writeBinaryMessage`, so we cannot tell whether the matching binary write for the failing ws actually completed (the failing test had no `writeBinaryMessage` failure log — meaning "succeeded" and "future never settled" are currently indistinguishable).
2. We have no client-side visibility — did the channel-2 error message reach `onMessage`, did `closeWebSocketOnce` issue a close, did `onClose` or `onError` ever fire on the listener?

Three additions to disambiguate on the next CI hit:

- `VertxMockWebSocket.send(String)` / `send(byte[])` / `close`: log an INFO "entered" line at the call site plus `.onSuccess` paired with the existing `.onFailure`. Silence after "entered" now strictly means the Vert.x future never settled.
- `ExecWebSocketListener.onMessage`: log `streamID`, `remaining`, and `terminateOnError` on entry to confirm channel 2 reaches the client.
- `ExecWebSocketListener.closeWebSocketOnce` / `onError` / `onClose`: log every entry (including `onClose` calls suppressed by the `closed` flag) so absence of the line confirms the framework never delivered the callback.

Diagnostic only — no behavior change. Server-side async failures are still logged and swallowed, preserving the prior fire-and-forget semantics.

Refs #7756.

[1]: https://github.com/fabric8io/kubernetes-client/actions/runs/25736234937/job/75573905407