### PR TITLE
test(kubernetes-client-api): stabilize AsyncUtilsTest retryWithExponentialBackoff cancel/complete flakes

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/AsyncUtilsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/utils/AsyncUtilsTest.java
@@ -104,7 +104,7 @@ class AsyncUtilsTest {
     final AsyncUtils.ShouldRetry<Void> shouldRetry = (v, t, retryInterval) -> -1;
     // When
     final CompletableFuture<Void> result = retryWithExponentialBackoff(actionSupplier, onCancel::complete,
-        Duration.ofMillis(100), retryIntervalCalculator, shouldRetry);
+        Duration.ZERO, retryIntervalCalculator, shouldRetry);
     result.cancel(false);
     action.complete(null);
     // Then
@@ -125,7 +125,7 @@ class AsyncUtilsTest {
     final AsyncUtils.ShouldRetry<Boolean> shouldRetry = (v, t, retryInterval) -> retryInterval;
     // When
     CompletableFuture<Boolean> result = retryWithExponentialBackoff(actionSupplier, onCancel::complete,
-        Duration.ofMillis(100), retryIntervalCalculator, shouldRetry);
+        Duration.ZERO, retryIntervalCalculator, shouldRetry);
     action.complete(true);
     result.get(150, TimeUnit.MILLISECONDS);
     // Then
@@ -146,7 +146,7 @@ class AsyncUtilsTest {
     final AsyncUtils.ShouldRetry<Void> shouldRetry = (v, t, retryInterval) -> -1;
     // When
     final CompletableFuture<Void> result = retryWithExponentialBackoff(actionSupplier, onCancel::complete,
-        Duration.ofMillis(100), retryIntervalCalculator, shouldRetry);
+        Duration.ZERO, retryIntervalCalculator, shouldRetry);
     action.complete(null);
     // Then
     assertThat(onCancel).isNotDone();


### PR DESCRIPTION
## Description

`AsyncUtilsTest.retryWithExponentialBackoff_withCancelledFuture_onCancel` is flaky on CI. Failure assertion:

```
Expecting <CompletableFuture[Incomplete]> to be done.
```

### Root cause

`AsyncUtils.retryWithExponentialBackoff` internally calls `withTimeout(action.get(), timeout)`. When `timeout > 0`, `withTimeout` (`AsyncUtils.java:42`) schedules `action.completeExceptionally(new TimeoutException())` on `SHARED_SCHEDULER` after the configured duration.

Three tests passed `Duration.ofMillis(100)` and then drove the `action` future synchronously:

- `retryWithExponentialBackoff_withCancelledFuture_onCancel`
- `retryWithExponentialBackoff_withCompletedResult_onCancel`
- `retryWithExponentialBackoff_complete`

On a contended CI 2-core worker the timer could fire before the test body advanced. The action would then complete exceptionally, the retry callback would take the `t != null` branch (`AsyncUtils.java:89`) — `result.completeExceptionally(t)` is a no-op on the cancelled `result`, and `onCancel` is never invoked.

### Fix

Pass `Duration.ZERO` so `withTimeout` short-circuits at the `timeout.toMillis() > 0` guard (`AsyncUtils.java:41`). The tests no longer depend on wall-clock timing for a code path they aren't exercising.

Dedicated timeout coverage at `retryWithExponentialBackoff_timeout` (`Duration.ofMillis(1)`) is unchanged. Production code is untouched — the behaviour under the race is correct; the tests were just timing-fragile.

Closes #7772