### PR TITLE
fix(kubernetes-client): notify ExecListener when onError observes exitCode is already done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.8-SNAPSHOT
 
 #### Bugs
+* Fix #7779: (kubernetes-client) ExecWebSocketListener now notifies the user-supplied ExecListener on transport-level errors that race with `terminateOnError` / channel-3 exit-status completion — `listener.onFailure` (or `onClose`) fires exactly once, gated by a dedicated flag, instead of being silently swallowed when the deferred onError task observes `exitCode.isDone()`
 * Fix #7765: (kubernetes-client) `BaseOperation.informOnCondition` now stops the informer inline when the inner predicate completes the future, closing a CompletableFuture `postComplete` race where a waiter helping drain dependents could fire `informer.stop` after `cf.complete` had already triggered a spurious `?watch=true` HTTP request
 
 #### Improvements

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -141,6 +141,11 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
   private final SerialExecutor serialExecutor;
   private final AtomicBoolean closed = new AtomicBoolean(false);
+  // Gates the user-facing ExecListener.onClose/onFailure callbacks so exactly one fires for the
+  // lifecycle of the exec session. Distinct from `closed`, which guards transport-level state:
+  // when onError fires after exitCode is already complete (e.g. the terminateOnError + abrupt
+  // close race in #7779), `closed` is already set but the listener has not yet been notified.
+  private final AtomicBoolean listenerNotified = new AtomicBoolean(false);
   private final CompletableFuture<Integer> exitCode = new CompletableFuture<>();
   private KubernetesSerialization serialization;
 
@@ -287,20 +292,28 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
     final HttpResponse<?> finalResponse = response;
     serialExecutor.execute(() -> {
       try {
-        if (exitCode.isDone()) {
+        final boolean exitCodeAlreadyDone = exitCode.isDone();
+        if (exitCodeAlreadyDone) {
+          // exitCode was already captured (normal exit via channel 3, or terminateOnError via
+          // channel 2). Preserve the captured value — do not overwrite it with the close
+          // exception — but still notify the listener below so callers waiting on the
+          // onClose/onFailure pair are not stranded (#7779).
           LOGGER.debug("Exec failure after done", finalT);
-        } else {
-          try {
+        }
+        try {
+          if (listenerNotified.compareAndSet(false, true)) {
             if (listener != null) {
               ExecListener.Response execResponse = null;
               if (finalResponse != null) {
                 execResponse = new SimpleResponse(finalResponse);
               }
               listener.onFailure(finalT, execResponse);
-            } else {
+            } else if (!exitCodeAlreadyDone) {
               LOGGER.error("Exec Failure", finalT);
             }
-          } finally {
+          }
+        } finally {
+          if (!exitCodeAlreadyDone) {
             exitCode.completeExceptionally(finalT);
           }
         }
@@ -411,7 +424,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
         }
         cleanUpOnce();
       } finally {
-        if (listener != null) {
+        if (listenerNotified.compareAndSet(false, true) && listener != null) {
           listener.onClose(code, reason);
         }
       }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -424,7 +424,7 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
         }
         cleanUpOnce();
       } finally {
-        if (listenerNotified.compareAndSet(false, true) && listener != null) {
+        if (listener != null && listenerNotified.compareAndSet(false, true)) {
           listener.onClose(code, reason);
         }
       }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -453,6 +454,51 @@ class ExecWebSocketListenerTest {
         .as("exitCode must keep the terminateOnError value, not be overwritten by the transport close")
         .isInstanceOf(KubernetesClientException.class)
         .hasMessageContaining("boom");
+  }
+
+  @Test
+  void execListenerCallbackFiresExactlyOnceAcrossMultipleLifecycleEvents() {
+    // Locks down the once-and-only-once contract on ExecListener.onClose/onFailure that the
+    // class-level javadoc declares: even if the framework delivers multiple terminal events
+    // (e.g. a transport onError after a server-side onClose, or onError called twice), the
+    // user-supplied listener must receive exactly one notification.
+    final Queue<Runnable> manualQueue = new ArrayDeque<>();
+    final Executor manualExecutor = manualQueue::offer;
+    final AtomicInteger failureCount = new AtomicInteger();
+    final AtomicInteger closeCount = new AtomicInteger();
+    final ExecListener execListener = new ExecListener() {
+      @Override
+      public void onFailure(Throwable t, Response failureResponse) {
+        failureCount.incrementAndGet();
+      }
+
+      @Override
+      public void onClose(int code, String reason) {
+        closeCount.incrementAndGet();
+      }
+    };
+    final PodOperationContext context = new PodOperationContext().toBuilder()
+        .execListener(execListener)
+        .build();
+    final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
+    final WebSocket mockedWebSocket = Mockito.mock(WebSocket.class);
+    listener.onOpen(mockedWebSocket);
+
+    // First terminal event: transport-level error.
+    listener.onError(mockedWebSocket, new IOException("first"));
+    // Follow-up events that the framework may still deliver: a second onError, plus a late onClose.
+    listener.onError(mockedWebSocket, new IOException("second"));
+    listener.onClose(mockedWebSocket, 1000, "late");
+
+    Runnable next;
+    while ((next = manualQueue.poll()) != null) {
+      next.run();
+    }
+
+    assertEquals(1, failureCount.get(),
+        "ExecListener.onFailure must fire exactly once across repeat terminal events");
+    assertEquals(0, closeCount.get(),
+        "ExecListener.onClose must not fire once onFailure has already notified the listener");
   }
 
 }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListenerTest.java
@@ -397,4 +397,62 @@ class ExecWebSocketListenerTest {
     }
   }
 
+  @Test
+  void onErrorAfterChannel2TerminateOnErrorStillNotifiesListener() {
+    // Reproduces #7779. The channel-2 stderr message with terminateOnError=true queues
+    // exitCode.completeExceptionally(...) on the SerialExecutor; the transport is then torn
+    // down before the server's reciprocal close frame arrives, so the framework delivers
+    // onError instead of onClose. Pre-fix: the deferred onError task observed exitCode was
+    // already done and went silent, so neither ExecListener.onFailure nor onClose ever
+    // fired and any latch tied to those callbacks waited forever.
+    final Queue<Runnable> manualQueue = new ArrayDeque<>();
+    final Executor manualExecutor = manualQueue::offer;
+    final AtomicReference<Throwable> capturedThrowable = new AtomicReference<>();
+    final AtomicReference<Integer> capturedCloseCode = new AtomicReference<>();
+    final ExecListener execListener = new ExecListener() {
+      @Override
+      public void onFailure(Throwable t, Response failureResponse) {
+        capturedThrowable.set(t);
+      }
+
+      @Override
+      public void onClose(int code, String reason) {
+        capturedCloseCode.set(code);
+      }
+    };
+    final PodOperationContext context = new PodOperationContext().toBuilder()
+        .execListener(execListener)
+        .terminateOnError(true)
+        .build();
+    final ExecWebSocketListener listener = new ExecWebSocketListener(context, manualExecutor, new KubernetesSerialization());
+    listener.onOpen(Mockito.mock(WebSocket.class));
+
+    // Channel 2 with terminateOnError=true: queues exitCode.completeExceptionally(...)
+    listener.onMessage(null,
+        ByteBuffer.wrap(new byte[] { (byte) 2, (byte) 'b', (byte) 'o', (byte) 'o', (byte) 'm' }));
+
+    // Transport torn down before the server's reciprocal close — framework delivers onError
+    final IOException transportClose = new IOException("Connection was closed");
+    listener.onError(null, transportClose);
+
+    // Drain: stderr task runs first (exitCode completes exceptionally), then onError task
+    // observes exitCode is already done but must still notify the listener.
+    Runnable next;
+    while ((next = manualQueue.poll()) != null) {
+      next.run();
+    }
+
+    assertThat(capturedThrowable.get())
+        .as("ExecListener.onFailure must fire so callers waiting on onClose/onFailure are not stranded")
+        .isSameAs(transportClose);
+    assertNull(capturedCloseCode.get(),
+        "exactly one of onClose/onFailure should fire; onError chose onFailure");
+    final ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> listener.exitCode().get(2, TimeUnit.SECONDS));
+    assertThat(ex.getCause())
+        .as("exitCode must keep the terminateOnError value, not be overwritten by the transport close")
+        .isInstanceOf(KubernetesClientException.class)
+        .hasMessageContaining("boom");
+  }
+
 }


### PR DESCRIPTION
Fixes #7779.

When `ExecWebSocketListener.onError` runs after `exitCode` is already
complete — either via a channel-3 exit-status frame or a channel-2
stderr message with `terminateOnError=true` — the deferred failure
task went silent because `exitCode.isDone()` was being reused as a
notification gate.

Combined with #7695 (channel-2 completion deferred onto the
SerialExecutor) and #7703 (onError handling deferred onto the same
SerialExecutor), the silent branch became deterministic in the
`terminateOnError` + abrupt-transport-close shape that surfaced as
the #7756 flake: the stderr task completes `exitCode` first, the
deferred onError task observes `isDone()` and skips
`listener.onFailure`, and callers waiting on the listener's
`onClose`/`onFailure` pair are stranded until their own timeout.

This change introduces a dedicated `listenerNotified` `AtomicBoolean`
guarding the user-facing `ExecListener.onClose`/`onFailure`
callbacks so exactly one fires per session. `onError` always invokes
`listener.onFailure` (gated by `listenerNotified`) even when
`exitCode` is already done, but only completes `exitCode`
exceptionally when it wasn't — preserving the fix from #7695 /
#7703 that keeps the captured exit code intact.

A new unit test
(`onErrorAfterChannel2TerminateOnErrorStillNotifiesListener`) drives
the failing sequence through a manual `Executor` and asserts that
`listener.onFailure` fires while `exitCode` retains the
`terminateOnError` value.

The `[#7756]` diagnostic loggers added by #7762 and d14b0987dc are
intentionally left in place in this PR — a follow-up should remove
or downgrade them now that the root cause is fixed.

Fixes #7779
Fixes #7756
Refs #7695 #7700 #7703