### PR TITLE
chore(mockwebserver,kubernetes-client): remove [#7756] WS diagnostic logs

### DIFF
--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/internal/WebSocketSession.java
@@ -33,12 +33,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class WebSocketSession extends WebSocketListener {
-
-  private static final Logger logger = Logger.getLogger(WebSocketSession.class.getName());
 
   private final List<WebSocketMessage> open;
   private final WebSocketMessage failure;
@@ -160,33 +156,11 @@ public class WebSocketSession extends WebSocketListener {
     final UUID id = UUID.randomUUID();
     pendingMessages.add(id);
     executor.schedule(() -> {
-      // Diagnostic for #7756: confirm the scheduled task actually runs. If this never logs for a
-      // hung test, the scheduled executor lost or dropped the task.
-      logger.log(Level.INFO, () -> String.format(
-          "WebSocketSession send task entered (id=%s, ws=%s, binary=%s, length=%d, delayMs=%d, pending=%d, activeSockets=%d)",
-          id, Integer.toHexString(System.identityHashCode(ws)),
-          message.isBinary(), message.getBytes().length, message.getDelay(),
-          pendingMessages.size(), activeSockets.size()));
       if (ws != null) {
-        try {
-          if (message.isBinary()) {
-            ws.send(message.getBytes());
-          } else {
-            ws.send(message.getBody());
-          }
-        } catch (RuntimeException e) {
-          // Diagnostic for #7756: if writeBinaryMessage / writeTextMessage throws (e.g. Vert.x
-          // IllegalStateException on a closed WebSocket), the scheduled task aborts here,
-          // pendingMessages keeps the id, and closeActiveSocketsIfApplicable() never runs, so the
-          // server never initiates a close and clients wait on listener.onClose. Capture state to
-          // confirm this is the failure mode on the next CI hit, then rethrow.
-          logger.log(Level.SEVERE, e,
-              () -> String.format(
-                  "WebSocketSession message send failed (ws=%s, binary=%s, length=%d, delayMs=%d, pending=%d, activeSockets=%d)",
-                  Integer.toHexString(System.identityHashCode(ws)),
-                  message.isBinary(), message.getBytes().length, message.getDelay(),
-                  pendingMessages.size(), activeSockets.size()));
-          throw e;
+        if (message.isBinary()) {
+          ws.send(message.getBytes());
+        } else {
+          ws.send(message.getBody());
         }
         pendingMessages.remove(id);
       }
@@ -195,14 +169,8 @@ public class WebSocketSession extends WebSocketListener {
   }
 
   public void closeActiveSocketsIfApplicable() {
-    final boolean applicable = pendingMessages.isEmpty() && requestEvents.isEmpty() && httpRequestEvents.isEmpty()
-        && sentWebSocketMessagesRequestEvents.isEmpty();
-    // Diagnostic for #7756: capture whether the close path was reached and what state it observed.
-    logger.log(Level.INFO, () -> String.format(
-        "WebSocketSession.closeActiveSocketsIfApplicable applicable=%s (pending=%d, requestEvents=%d, httpRequestEvents=%d, sentWebSocketMessagesRequestEvents=%d, activeSockets=%d)",
-        applicable, pendingMessages.size(), requestEvents.size(), httpRequestEvents.size(),
-        sentWebSocketMessagesRequestEvents.size(), activeSockets.size()));
-    if (applicable) {
+    if (pendingMessages.isEmpty() && requestEvents.isEmpty() && httpRequestEvents.isEmpty()
+        && sentWebSocketMessagesRequestEvents.isEmpty()) {
       activeSockets.forEach(ws -> ws.close(1000, "Closing..."));
     }
   }

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
@@ -21,12 +21,7 @@ import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 public class VertxMockWebSocket implements WebSocket {
-
-  private static final Logger logger = Logger.getLogger(VertxMockWebSocket.class.getName());
 
   private final RecordedRequest request;
   private final ServerWebSocket webSocket;
@@ -45,17 +40,7 @@ public class VertxMockWebSocket implements WebSocket {
 
   @Override
   public boolean send(String text) {
-    final String wsId = Integer.toHexString(System.identityHashCode(webSocket));
-    logger.log(Level.INFO, () -> String.format(
-        "VertxMockWebSocket.writeTextMessage entered (ws=%s, length=%d)", wsId, text.length()));
     final Future<Void> send = webSocket.writeTextMessage(text);
-    // Diagnostic for #7756: writeTextMessage completes asynchronously. Logging both outcomes makes
-    // the "future never completed" case distinguishable from "succeeded" or "failed" — silence
-    // after the entry log now strictly means the future never settled.
-    send.onSuccess(v -> logger.log(Level.INFO,
-        () -> String.format("VertxMockWebSocket.writeTextMessage succeeded (ws=%s, length=%d)", wsId, text.length())));
-    send.onFailure(t -> logger.log(Level.SEVERE, t,
-        () -> String.format("VertxMockWebSocket.writeTextMessage future failed (ws=%s, length=%d)", wsId, text.length())));
     if (send.isComplete()) {
       return send.succeeded();
     }
@@ -64,15 +49,7 @@ public class VertxMockWebSocket implements WebSocket {
 
   @Override
   public boolean send(byte[] bytes) {
-    final String wsId = Integer.toHexString(System.identityHashCode(webSocket));
-    logger.log(Level.INFO, () -> String.format(
-        "VertxMockWebSocket.writeBinaryMessage entered (ws=%s, length=%d)", wsId, bytes.length));
     final Future<Void> send = webSocket.writeBinaryMessage(Buffer.buffer(bytes));
-    // Diagnostic for #7756: see send(String) above.
-    send.onSuccess(v -> logger.log(Level.INFO,
-        () -> String.format("VertxMockWebSocket.writeBinaryMessage succeeded (ws=%s, length=%d)", wsId, bytes.length)));
-    send.onFailure(t -> logger.log(Level.SEVERE, t,
-        () -> String.format("VertxMockWebSocket.writeBinaryMessage future failed (ws=%s, length=%d)", wsId, bytes.length)));
     if (send.isComplete()) {
       return send.succeeded();
     }
@@ -83,16 +60,7 @@ public class VertxMockWebSocket implements WebSocket {
   public synchronized boolean close(int code, String reason) {
     if (!closing) {
       closing = true;
-      final String wsId = Integer.toHexString(System.identityHashCode(webSocket));
-      logger.log(Level.INFO, () -> String.format(
-          "VertxMockWebSocket.close entered (ws=%s, code=%d, reason=%s)", wsId, code, reason));
-      // Diagnostic for #7756: capture both close outcomes (success vs ClosedChannelException) so we
-      // can correlate with the matching writeBinaryMessage / writeTextMessage result on the same ws.
-      final Future<Void> closeFuture = webSocket.close((short) code, reason);
-      closeFuture.onSuccess(v -> logger.log(Level.INFO,
-          () -> String.format("VertxMockWebSocket.close succeeded (ws=%s, code=%d, reason=%s)", wsId, code, reason)));
-      closeFuture.onFailure(t -> logger.log(Level.SEVERE, t,
-          () -> String.format("VertxMockWebSocket.close future failed (ws=%s, code=%d, reason=%s)", wsId, code, reason)));
+      webSocket.close((short) code, reason);
     }
     return true;
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/ExecWebSocketListener.java
@@ -234,11 +234,6 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
   private void closeWebSocketOnce(int code, String reason) {
     try {
       WebSocket ws = webSocketRef.get();
-      // Diagnostic for #7756: log every client-initiated sendClose. We want to confirm whether the
-      // client actually issues a close frame after receiving the error stream message (the
-      // terminateOnError path) before suspecting transport-level loss of the close frame.
-      LOGGER.error("[#7756] closeWebSocketOnce code={} reason={} wsPresent={}",
-          code, reason, ws != null);
       if (ws != null) {
         ws.sendClose(code, reason);
       }
@@ -267,11 +262,6 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
 
   @Override
   public void onError(WebSocket webSocket, Throwable t) {
-    // Diagnostic for #7756: log every transport-level error reaching the listener so we can tell
-    // whether a server-side ClosedChannelException is surfaced to the client (and if so, in what
-    // form) when the server's close frame fails to write.
-    LOGGER.error("[#7756] onError ws={} t={}",
-        Integer.toHexString(System.identityHashCode(webSocket)), t == null ? "null" : t.toString());
     closed.set(true);
     HttpResponse<?> response = null;
 
@@ -340,11 +330,6 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
         webSocket.request();
         return;
       }
-      // Diagnostic for #7756: confirm channel 2 (error stream) arrives at the client and triggers
-      // terminateOnError close. Used together with the VertxMockWebSocket close/write probes to
-      // pinpoint which side of the close handshake stalls.
-      LOGGER.error("[#7756] Exec Web Socket: onMessage streamID={} remaining={} terminateOnError={} ws={}",
-          streamID, byteString.remaining(), terminateOnError, Integer.toHexString(System.identityHashCode(webSocket)));
       switch (streamID) {
         case 1:
           out.handle(byteString, webSocket);
@@ -405,11 +390,6 @@ public class ExecWebSocketListener implements ExecWatch, AutoCloseable, WebSocke
 
   @Override
   public void onClose(WebSocket webSocket, int code, String reason) {
-    // Diagnostic for #7756: log every onClose entry (even ones suppressed by the `closed` flag) so
-    // we can tell whether the framework ever delivers onClose for a hung exec — its absence
-    // confirms the server's close frame never arrives at the client listener.
-    LOGGER.error("[#7756] onClose entered code={} reason={} alreadyClosed={} ws={}",
-        code, reason, closed.get(), Integer.toHexString(System.identityHashCode(webSocket)));
     //If we already called onClosed() or onFailed() before, we need to abort.
     if (!closed.compareAndSet(false, true)) {
       return;


### PR DESCRIPTION
The `[#7756]` diagnostic logs added across #7756, #7762 and
d14b0987dc to root-cause the `testExecExplicitDefaultContainerMissing`
flake have served their purpose — #7779 (the underlying
`ExecListener` notification bug) is fixed in #7780 and #7756 is
closed. The remaining logs are dead weight: `ERROR`/`SEVERE`/`INFO`
lines firing on every exec WS lifecycle event and every server-side
send/close, even on the happy path.

This PR removes:

- `ExecWebSocketListener`: `closeWebSocketOnce` / `onError` /
  `onMessage` / `onClose` `[#7756]` `LOGGER.error` entry probes.
- `VertxMockWebSocket`: `writeTextMessage` / `writeBinaryMessage` /
  `close` "entered" + `onSuccess` + `onFailure` log triplets, plus
  the now-unused `java.util.logging` `Logger` / `Level` imports.
- `WebSocketSession`: `send` scheduled-task entry log and
  `closeActiveSocketsIfApplicable` applicable-flag log, plus the
  try/catch SEVERE-on-throw probe added in the original #7756 fix,
  plus the now-unused `java.util.logging` `Logger` / `Level`
  imports.

No behavior change — diagnostic logging only. If a similar race is
investigated in the future, fresh diagnostics can be added with
context-appropriate logging levels rather than left in place at
ERROR.

Refs #7779 #7756