### PR TITLE
fix(mockwebserver): await Vert.x write Future in VertxMockWebSocket.send (7775)

### DIFF
--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
@@ -18,10 +18,25 @@ package io.fabric8.mockwebserver.vertx;
 import io.fabric8.mockwebserver.http.RecordedRequest;
 import io.fabric8.mockwebserver.http.WebSocket;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class VertxMockWebSocket implements WebSocket {
+
+  private static final Logger logger = Logger.getLogger(VertxMockWebSocket.class.getName());
+
+  // Bound for the worst-case wait when a write Future is still pending on return.
+  // Writes here are localhost-only and bounded by the test message size (kB-MB), so
+  // 30s is generous enough to absorb CI scheduling jitter without ever masking a real
+  // hang inside Vert.x.
+  private static final long WRITE_AWAIT_SECONDS = 30L;
 
   private final RecordedRequest request;
   private final ServerWebSocket webSocket;
@@ -40,20 +55,44 @@ public class VertxMockWebSocket implements WebSocket {
 
   @Override
   public boolean send(String text) {
-    final Future<Void> send = webSocket.writeTextMessage(text);
-    if (send.isComplete()) {
-      return send.succeeded();
-    }
-    return true;
+    return awaitWrite(webSocket.writeTextMessage(text));
   }
 
   @Override
   public boolean send(byte[] bytes) {
-    final Future<Void> send = webSocket.writeBinaryMessage(Buffer.buffer(bytes));
+    return awaitWrite(webSocket.writeBinaryMessage(Buffer.buffer(bytes)));
+  }
+
+  // Block the calling thread until the Vert.x write Future completes. WebSocketSession
+  // calls this from its dedicated executor and triggers closeActiveSocketsIfApplicable()
+  // immediately afterwards; if we return while a multi-frame write is still in flight,
+  // the close races the trailing frames and the client never receives them (#7775).
+  // When the caller is itself on a Vert.x context (e.g. a custom WebSocketListener
+  // handling onMessage), we can't block — the same event loop has to drive the write to
+  // completion — so we fall through to fire-and-forget.
+  private static boolean awaitWrite(Future<Void> send) {
     if (send.isComplete()) {
       return send.succeeded();
     }
-    return true;
+    if (Vertx.currentContext() != null) {
+      return true;
+    }
+    try {
+      send.toCompletionStage().toCompletableFuture().get(WRITE_AWAIT_SECONDS, TimeUnit.SECONDS);
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (TimeoutException e) {
+      // 30s without a Vert.x write completion is a hang inside Vert.x/Netty, not a normal
+      // path. Log it so a future flake doesn't surface only as "client never received the
+      // message" downstream.
+      logger.log(Level.WARNING, e,
+          () -> String.format("VertxMockWebSocket write did not complete within %ds", WRITE_AWAIT_SECONDS));
+      return false;
+    } catch (ExecutionException e) {
+      return false;
+    }
   }
 
   @Override

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/vertx/VertxMockWebSocket.java
@@ -75,6 +75,9 @@ public class VertxMockWebSocket implements WebSocket {
       return send.succeeded();
     }
     if (Vertx.currentContext() != null) {
+      // TODO(#7775): a custom WebSocketListener.onMessage that re-enters send is still
+      // exposed to the original close/write race because we can't block the very event
+      // loop that has to drive the Future to completion. No known caller hits this today.
       return true;
     }
     try {

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/vertx/VertxMockWebSocketTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/vertx/VertxMockWebSocketTest.groovy
@@ -18,7 +18,14 @@ package io.fabric8.mockwebserver.vertx
 import io.fabric8.mockwebserver.dsl.HttpMethod
 import io.fabric8.mockwebserver.http.Headers
 import io.fabric8.mockwebserver.http.RecordedRequest
+import io.vertx.core.Future
+import io.vertx.core.Promise
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.http.ServerWebSocket
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
 
 class VertxMockWebSocketTest extends Specification {
 
@@ -30,5 +37,72 @@ class VertxMockWebSocketTest extends Specification {
 		def result = serverSocket.request()
 		then:
 		result == recordedRequest
+	}
+
+	def "send(String) blocks until the underlying writeTextMessage Future completes (#7775)"() {
+		given: "A ServerWebSocket whose writeTextMessage Future is pending"
+		Promise<Void> promise = Promise.promise()
+		ServerWebSocket vertxWs = Mock(ServerWebSocket) {
+			writeTextMessage(_ as String) >> promise.future()
+		}
+		def mockWebSocket = new VertxMockWebSocket(null, vertxWs)
+
+		and: "send is invoked from a background thread"
+		def returned = new CompletableFuture<Boolean>()
+		def thread = Thread.start { returned.complete(mockWebSocket.send("hello")) }
+
+		when: "the background thread parks waiting for the write Future"
+		new PollingConditions(timeout: 5).eventually {
+			// TIMED_WAITING means send blocked inside Future.get(timeout); TERMINATED
+			// would mean send returned and the thread exited (the pre-fix bug).
+			assert thread.state == Thread.State.TIMED_WAITING
+		}
+
+		then: "send has not returned"
+		!returned.isDone()
+
+		when: "the Future is completed successfully"
+		promise.complete()
+
+		then: "send returns true"
+		returned.get(5, TimeUnit.SECONDS)
+	}
+
+	def "send(byte[]) blocks until the underlying writeBinaryMessage Future completes (#7775)"() {
+		given: "A ServerWebSocket whose writeBinaryMessage Future is pending"
+		Promise<Void> promise = Promise.promise()
+		ServerWebSocket vertxWs = Mock(ServerWebSocket) {
+			writeBinaryMessage(_ as Buffer) >> promise.future()
+		}
+		def mockWebSocket = new VertxMockWebSocket(null, vertxWs)
+
+		and: "send is invoked from a background thread"
+		def returned = new CompletableFuture<Boolean>()
+		def thread = Thread.start { returned.complete(mockWebSocket.send([1, 2, 3] as byte[])) }
+
+		when: "the background thread parks waiting for the write Future"
+		new PollingConditions(timeout: 5).eventually {
+			assert thread.state == Thread.State.TIMED_WAITING
+		}
+
+		then: "send has not returned"
+		!returned.isDone()
+
+		when: "the Future is completed successfully"
+		promise.complete()
+
+		then: "send returns true"
+		returned.get(5, TimeUnit.SECONDS)
+	}
+
+	def "send(String) returns immediately when the writeTextMessage Future is already complete"() {
+		given:
+		ServerWebSocket vertxWs = Mock(ServerWebSocket) {
+			writeTextMessage(_ as String) >> Future.succeededFuture()
+		}
+		def mockWebSocket = new VertxMockWebSocket(null, vertxWs)
+
+		expect:
+		mockWebSocket.send("hello")
 	}
 }

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/vertx/VertxMockWebSocketTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/vertx/VertxMockWebSocketTest.groovy
@@ -49,7 +49,7 @@ class VertxMockWebSocketTest extends Specification {
 
 		and: "send is invoked from a background thread"
 		def returned = new CompletableFuture<Boolean>()
-		def thread = Thread.start { returned.complete(mockWebSocket.send("hello")) }
+		def thread = Thread.startDaemon { returned.complete(mockWebSocket.send("hello")) }
 
 		when: "the background thread parks waiting for the write Future"
 		new PollingConditions(timeout: 5).eventually {
@@ -78,7 +78,7 @@ class VertxMockWebSocketTest extends Specification {
 
 		and: "send is invoked from a background thread"
 		def returned = new CompletableFuture<Boolean>()
-		def thread = Thread.start { returned.complete(mockWebSocket.send([1, 2, 3] as byte[])) }
+		def thread = Thread.startDaemon { returned.complete(mockWebSocket.send([1, 2, 3] as byte[])) }
 
 		when: "the background thread parks waiting for the write Future"
 		new PollingConditions(timeout: 5).eventually {
@@ -95,7 +95,7 @@ class VertxMockWebSocketTest extends Specification {
 		returned.get(5, TimeUnit.SECONDS)
 	}
 
-	def "send(String) returns immediately when the writeTextMessage Future is already complete"() {
+	def "send(String) returns true on the fast path when the writeTextMessage Future is already complete"() {
 		given:
 		ServerWebSocket vertxWs = Mock(ServerWebSocket) {
 			writeTextMessage(_ as String) >> Future.succeededFuture()


### PR DESCRIPTION
## Summary

- `VertxMockWebSocket.send(String)` / `send(byte[])` now block on the underlying Vert.x `writeTextMessage` / `writeBinaryMessage` Future (max 30s) when the caller is not on a Vert.x context.
- Callers already on a Vert.x context (e.g. user-written `WebSocketListener.onMessage` handlers, which run on the event loop) keep the fire-and-forget path so we don't deadlock the loop that must drive the Future to completion.
- `TimeoutException` from the 30s wait is logged at `WARNING` so a real Vert.x/Netty hang doesn't surface only as "client never received the message" downstream.
- Spock regression tests assert the background thread parks in `TIMED_WAITING` while the write Future is pending — both fail against the pre-fix code.

## Why

`WebSocketSession`'s scheduled-emit task does `ws.send(...)` → `pendingMessages.remove(id)` → `closeActiveSocketsIfApplicable()` (which queues `ws.close(...)` once no other sends are pending). For a 66 KB text message Vert.x splits the write into ≥ 2 WebSocket frames; with the old fire-and-forget `send`, the close could land on the event loop between the multiframe's frame writes and drop the trailing frame, producing the recurring `multiframeReceive` "expected: aaa... but was null" flake.

Same surface symptom as #7665 / #7666 but a server-side root cause that the client-side queue fix doesn't address — hence #7775.

## Caveat

The original CI flake never reproduced locally (45 iters under constrained docker + `stress-ng` without the fix all passed), so this is validated by code analysis + unit-level regression tests + non-regression across the broader suite (212 tests in `mockwebserver`, all `*WebSocketSendReceiveTest` subclasses, `PodExecTest` / `WatchTest`). Final confirmation needs a CI run.

Fixes #7775