### PR TITLE
test(kubernetes-client-api): assert 1024-WS test via handshake futures

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
@@ -145,44 +145,33 @@ public abstract class AbstractSimultaneousConnectionsTest {
   public void http1WebSocketConnections() throws Exception {
     withHttp1();
     final Collection<io.fabric8.mockwebserver.http.WebSocket> serverSockets = ConcurrentHashMap.newKeySet();
-    final Collection<WebSocket> clientSockets = ConcurrentHashMap.newKeySet();
+    final Collection<CompletableFuture<WebSocket>> clientFutures = ConcurrentHashMap.newKeySet();
     final CyclicBarrier cyclicBarrier = new CyclicBarrier(2);
-    final CountDownLatch latch = new CountDownLatch(MAX_HTTP_1_WS_CONNECTIONS);
     final MockResponse response = new MockResponse()
         .withWebSocketUpgrade(new WebSocketListener() {
           @Override
           public void onOpen(io.fabric8.mockwebserver.http.WebSocket webSocket, Response response) {
+            serverSockets.add(webSocket);
             try {
               cyclicBarrier.await(1, TimeUnit.SECONDS);
             } catch (Exception ignore) {
               // Ignored
             }
-            serverSockets.add(webSocket);
-            webSocket.send("go on");
           }
         });
     IntStream.range(0, MAX_HTTP_1_WS_CONNECTIONS).forEach(i -> mockWebServer.enqueue(response));
     try (final HttpClient client = clientBuilder.build()) {
       for (int it = 0; it < MAX_HTTP_1_WS_CONNECTIONS; it++) {
-        client.newWebSocketBuilder()
+        clientFutures.add(client.newWebSocketBuilder()
             .uri(mockWebServer.url("/").uri())
             .buildAsync(new WebSocket.Listener() {
-
-              @Override
-              public void onMessage(WebSocket webSocket, String text) {
-                clientSockets.add(webSocket);
-                latch.countDown();
-                webSocket.request();
-              }
-            });
+            }));
         cyclicBarrier.await(1, TimeUnit.SECONDS);
       }
-      assertThat(latch.await(60L, TimeUnit.SECONDS)).isTrue();
+      CompletableFuture.allOf(clientFutures.toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
       assertThat(serverSockets.size())
           .isEqualTo(MAX_HTTP_1_WS_CONNECTIONS)
           .isLessThanOrEqualTo(registeredConnections.activeConnections());
-      //      assertThat(clientSockets)
-      //          .hasSize(MAX_HTTP_1_WS_CONNECTIONS);
     } finally {
       for (io.fabric8.mockwebserver.http.WebSocket socket : serverSockets) {
         socket.close(1000, "done");

--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractSimultaneousConnectionsTest.java
@@ -39,15 +39,16 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -145,12 +146,13 @@ public abstract class AbstractSimultaneousConnectionsTest {
   public void http1WebSocketConnections() throws Exception {
     withHttp1();
     final Collection<io.fabric8.mockwebserver.http.WebSocket> serverSockets = ConcurrentHashMap.newKeySet();
-    final Collection<CompletableFuture<WebSocket>> clientFutures = ConcurrentHashMap.newKeySet();
+    final List<CompletableFuture<WebSocket>> clientFutures = new ArrayList<>(MAX_HTTP_1_WS_CONNECTIONS);
     final CyclicBarrier cyclicBarrier = new CyclicBarrier(2);
     final MockResponse response = new MockResponse()
         .withWebSocketUpgrade(new WebSocketListener() {
           @Override
           public void onOpen(io.fabric8.mockwebserver.http.WebSocket webSocket, Response response) {
+            // Register before the pacing barrier so the post-loop count assertion can't race the last iteration's add.
             serverSockets.add(webSocket);
             try {
               cyclicBarrier.await(1, TimeUnit.SECONDS);
@@ -159,7 +161,9 @@ public abstract class AbstractSimultaneousConnectionsTest {
             }
           }
         });
-    IntStream.range(0, MAX_HTTP_1_WS_CONNECTIONS).forEach(i -> mockWebServer.enqueue(response));
+    for (int it = 0; it < MAX_HTTP_1_WS_CONNECTIONS; it++) {
+      mockWebServer.enqueue(response);
+    }
     try (final HttpClient client = clientBuilder.build()) {
       for (int it = 0; it < MAX_HTTP_1_WS_CONNECTIONS; it++) {
         clientFutures.add(client.newWebSocketBuilder()


### PR DESCRIPTION
## Summary

`AbstractSimultaneousConnectionsTest#http1WebSocketConnections` opens
1024 simultaneous WebSocket connections to verify each HttpClient
implementation can sustain that capacity. Its 60s latch on inbound
`onMessage("go on")` callbacks was a throughput-sensitive proxy for
the count/capacity invariant. Under `-T 1C` cross-module CPU contention
the client event loop was starved and the inbound-frame tail did not
drain in 60s — breaching the latch. PR #7711's dedicated-fork
isolation handled intra-module contention but cannot defend against
sibling-module forks scheduled by `-T 1C`.

This change replaces the throughput proxy with the direct signal
exposed by the public API: each `buildAsync` returns a
`CompletableFuture<WebSocket>` that completes after the handshake is
open client-side (per `WebSocket.Builder.buildAsync` javadoc).
Collecting and awaiting `CompletableFuture.allOf(...)` checks the
client-side invariant directly, independent of frame throughput.

The companion `webSocket.send("go on")` on the server is removed
(nothing waits for it). `serverSockets.add(webSocket)` is moved
before the server-side barrier so the count assertion cannot race
the final iteration's add — the removed latch chain previously
provided that ordering implicitly.

The 1024-connection load target, the load-bearing per-iteration
`cyclicBarrier` (paces dispatch so each server `onOpen` fires before
the next), and the per-fork isolation from #7711 are unchanged.

## Verification

- All five `*SimultaneousConnectionsTest` subclasses pass:
  vertx (3.96s), jdk (3.99s), okhttp (7.32s), jetty (6.19s),
  vertx-5 (5.23s) — significantly faster than the previous
  message-flow-bound runtime.
- `mvn spotless:check -pl kubernetes-client-api` clean.
- Stress repro (constrained 2-CPU / 7 GB Docker container, CI shape):
  8/8 pass. The new 60s `allOf` budget is never the timing-sensitive
  spot.

Fixes #7687