### PR TITLE
test(kubernetes-client-api): assert multi-message WS test via per-message futures

### DIFF
--- a/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientNewWebSocketBuilderTest.java
+++ b/kubernetes-client-api/src/test/java/io/fabric8/kubernetes/client/http/AbstractHttpClientNewWebSocketBuilderTest.java
@@ -25,10 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -89,27 +86,24 @@ public abstract class AbstractHttpClientNewWebSocketBuilderTest {
   void buildAsyncReceivesMultipleMessages() throws Exception {
     server.expect().withPath("/websocket-multiple-message")
         .andUpgradeToWebSocket()
-        .open()
-        .waitFor(10L)
-        .andEmit("First")
-        .waitFor(10L)
-        .andEmit("Second")
+        .open("First", "Second")
         .done()
         .always();
-    final CountDownLatch latch = new CountDownLatch(2);
-    final Set<String> messages = ConcurrentHashMap.newKeySet();
+    final CompletableFuture<String> firstReceived = new CompletableFuture<>();
+    final CompletableFuture<String> secondReceived = new CompletableFuture<>();
     httpClient.newWebSocketBuilder()
         .uri(URI.create(server.url("/websocket-multiple-message")))
         .buildAsync(new WebSocket.Listener() {
           @Override
           public void onMessage(WebSocket webSocket, String text) {
-            messages.add(text);
+            if (!firstReceived.complete(text)) {
+              secondReceived.complete(text);
+            }
             webSocket.request();
-            latch.countDown();
           }
         }).get(10L, TimeUnit.SECONDS);
-    assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
-    assertThat(messages).containsExactlyInAnyOrder("First", "Second");
+    assertThat(firstReceived).succeedsWithin(10, TimeUnit.SECONDS).isEqualTo("First");
+    assertThat(secondReceived).succeedsWithin(10, TimeUnit.SECONDS).isEqualTo("Second");
   }
 
   @Test


### PR DESCRIPTION
## Summary

`AbstractHttpClientNewWebSocketBuilderTest#buildAsyncReceivesMultipleMessages`
flaked in CI with `latch.await(60s)` returning false (#7776). Local
repro under `cpus=2,cpuset=0,1` docker + sibling `stress-ng` did not
reproduce (55 iterations). No production-code defect identified; the
recently merged #7787 (`VertxMockWebSocket.send` awaits the Vert.x
write Future) is the most plausible upstream fix already in main.

This change reshapes the assertion so the next flake — if it
recurs — carries a useful signal:

- Replace the `CountDownLatch(2)` + `ConcurrentHashMap` Set with one
  `CompletableFuture<String>` per expected message, asserted via
  AssertJ's `succeedsWithin(10s).isEqualTo(...)`. The failure now
  names which future (first vs. second) timed out instead of
  collapsing to a single boolean.
- Order check via paired `isEqualTo` is strictly stronger than the
  previous `containsExactlyInAnyOrder` — the `WebSocket.Listener`
  contract (`WebSocket.java:28-29`) guarantees serial dispatch, so
  out-of-order delivery is a real regression, not a tolerated case.
- Drop the `.waitFor(10).andEmit("First").waitFor(10).andEmit("Second")`
  cadence in favor of `.open("First", "Second")`. The mock server
  pushes both at `delay=0` on upgrade, removing one incidental
  timing knob. The original 10ms inter-message delay was incidental;
  nothing in the prior assertion verified "messages arriving over
  time".
- Timeout aligned with peer `buildAsyncConnectsAndCloses` (10s vs.
  the old 60s).

## Verification

- `mvn -pl kubernetes-client-api test` → 621 / 0 / 3 skipped.
- `mvn -pl httpclient-jdk,httpclient-vertx,httpclient-vertx-5,httpclient-jetty,httpclient-okhttp -Dtest='*NewWebSocketBuilderTest' test` → all 5 backends green (8/0/0 each).
- 25 iterations of the JDK test inside `--cpus=2 --memory=7g --cpuset-cpus="0,1"` + sibling `stress-ng --cpu 4 --cpu-load 80` → 25/25 pass.
- `java17 && mvn -pl kubernetes-client-api spotless:check` → clean.

Fixes #7776