### PR TITLE
test(kubernetes-tests): widen 410 GONE emit window in shouldReconnectInCaseOf410

### DIFF
--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DefaultSharedIndexInformerTest.java
@@ -320,19 +320,23 @@ class DefaultSharedIndexInformerTest {
             .withItems(Collections.emptyList())
             .build())
         .once();
+    // Use a longer emit window than the global WATCH_EVENT_EMIT_TIME (1 ms): the test
+    // depends on the ADDED event reaching the store before the relist following the 410
+    // GONE so the relist's pod1@endResourceVersion is delivered as an onUpdate (not onAdd).
+    final long emitWindowMs = 50L;
     server.expect()
         .withPath("/api/v1/pods?allowWatchBookmarks=true&resourceVersion=" + startResourceVersion
             + "&timeoutSeconds=600&watch=true")
         .andUpgradeToWebSocket()
         .open()
-        .waitFor(WATCH_EVENT_EMIT_TIME)
+        .waitFor(emitWindowMs)
         .andEmit(new WatchEvent(new PodBuilder().withNewMetadata()
             .withNamespace("test")
             .withName("pod1")
             .withResourceVersion(midResourceVersion)
             .endMetadata()
             .build(), "ADDED"))
-        .waitFor(OUTDATED_WATCH_EVENT_EMIT_TIME)
+        .waitFor(emitWindowMs)
         .andEmit(outdatedEvent)
         .done()
         .always();


### PR DESCRIPTION
## Description

`DefaultSharedIndexInformerTest.shouldReconnectInCaseOf410` was reported flaky
in CI (#7782) with `expected: <0> but was: <1>` — the `relistSuccessful` latch,
gated on an `onUpdate` for `pod1@1003`, did not trip within 10 s.

With `WATCH_EVENT_EMIT_TIME = 1L` and `OUTDATED_WATCH_EVENT_EMIT_TIME = 1L`,
the WebSocket emits `ADDED pod1@1001` and the `410 GONE` only 1 ms apart.
Under CI scheduling pressure the post-410 relist's `store.update([pod1@1003])`
could land before `pod1@1001` was reflected in the cache. With an empty cache
at relist time the relist fires `onAdd(pod1@1003)` instead of `onUpdate`, and
the subsequent watch's `MODIFIED pod1@1003` is then deduped against the same
rv already in the cache, so the latch never trips.

Mirrors the surgical fix from #7676 applied to the sibling test
`shouldDeleteIfMissingOnResync`: inline a local `emitWindowMs = 50L` in this
test only, leaving the global `WATCH_EVENT_EMIT_TIME` /
`OUTDATED_WATCH_EVENT_EMIT_TIME` constants and unrelated tests untouched.

## Audit of sibling tests

Every other `WATCH_EVENT_EMIT_TIME` + `outdatedEvent` call site in the file
was reviewed; none has the same assertion shape (latch gated on an `onUpdate`
that depends on the post-410 relist returning *different* content than the
watch ADDED). No other tests were changed.

## Local reproduction notes

Not reproduced locally: 25 single-test iterations inside a constrained
container (`--cpus=2 --memory=7g --cpuset-cpus="0,1"`) with a sibling
`stress-ng` (per the CLAUDE.md CI-flake-repro recipe) passed 25/25 both
before and after the change. As with #7676, the 1 ms emit window race
only manifests under CI's IO/network jitter, which cgroup quota cannot
simulate; the 50 ms bump is reasoned from the test design and the
empirical precedent of #7676 rather than from a local repro.

Closes #7782