### PR TITLE
test(kubernetes-client): stabilize PortForwarderWebsocketListenerTest.onOpen via future

### DIFF
--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/PortForwarderWebsocketListenerTest.java
@@ -31,8 +31,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -42,6 +42,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -73,22 +74,28 @@ class PortForwarderWebsocketListenerTest {
 
   @Test
   void onOpen_shouldPipeInChannelToWebSocket() {
-    // pipe() reuses the same ByteBuffer across iterations, so an ArgumentCaptor
-    // reference races with buffer.clear()/put()/read() in the next iteration.
-    // Snapshot the bytes synchronously inside send() instead.
-    final AtomicReference<String> sent = new AtomicReference<>();
+    // Snapshot the bytes synchronously inside send() and publish via a future.
+    // The ByteBuffer mutates across pipe() iterations (clear/put/read), so the
+    // bytes must be copied before the next iteration. Publishing via a future
+    // also avoids the verify(timeout) -> read race: Mockito records the
+    // invocation BEFORE the doAnswer body runs, so a verify(timeout) barrier
+    // can return while the captured value is still unset.
+    final CompletableFuture<String> sent = new CompletableFuture<>();
     doAnswer(i -> {
       ByteBuffer buf = i.getArgument(0);
       byte[] copy = new byte[buf.remaining()];
       buf.duplicate().get(copy);
-      sent.set(new String(copy, StandardCharsets.UTF_8));
+      sent.complete(new String(copy, StandardCharsets.UTF_8));
       return true;
     }).when(webSocket).send(any(ByteBuffer.class));
     listener = new PortForwarderWebsocketListener(in, out, CommonThreadPool.get());
     listener.onOpen(webSocket);
     // Then
-    verify(webSocket, timeout(10_000).times(1)).send(any(ByteBuffer.class));
-    assertThat(sent.get()).startsWith("\u0000THIS IS A TEST");
+    assertThat(sent)
+        .succeedsWithin(10, TimeUnit.SECONDS, InstanceOfAssertFactories.STRING)
+        .startsWith("\u0000THIS IS A TEST");
+    // Single send for the 14-byte payload; pipe() exits on EOF before a second send.
+    verify(webSocket, times(1)).send(any(ByteBuffer.class));
     assertThat(in.isOpen()).isTrue();
     assertThat(out.isOpen()).isTrue();
   }


### PR DESCRIPTION
## Summary

`PortForwarderWebsocketListenerTest.onOpen_shouldPipeInChannelToWebSocket` was flaking under CI load with `Expecting actual not to be null` at the `assertThat(sent.get())` line.

Root cause: Mockito's `MockHandlerImpl.handle` registers the invocation in its container **before** running the stubbed `doAnswer` body. The previous `verify(webSocket, timeout(10_000).times(1)).send(...)` barrier polled that container from the test thread, so under CPU pressure it could return between "invocation recorded" and "doAnswer assigns `sent`", letting the assertion read `null`.

Fix: replace the `AtomicReference<String>` + `verify(timeout)` synchronization with a `CompletableFuture<String>` completed inside the `doAnswer` body, asserted via AssertJ's `succeedsWithin`. The future completion happens-before any successful observation, eliminating the race. The "exactly once" cardinality check is preserved as a `verify(times(1))` after the future resolves — `pipe()` exits on EOF before a second `send`, so the check is deterministic once the future completes.

Verified locally: 30/30 iterations under `--cpus=2 --memory=7g --cpuset-cpus="0,1"` Maven container with sibling `stress-ng --cpu 4 --cpu-load 80`.

Fixes #7793