### PR TITLE
test(kubernetes-tests): run test classes in parallel within each surefire fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 * Fix #7765: (kubernetes-client) `BaseOperation.informOnCondition` now stops the informer inline when the inner predicate completes the future, closing a CompletableFuture `postComplete` race where a waiter helping drain dependents could fire `informer.stop` after `cf.complete` had already triggered a spurious `?watch=true` HTTP request
 
 #### Improvements
+* Fix #7675: (kubernetes-server-mock) `KubernetesMockServerExtension` now reuses a single `MockWebServer` (one for HTTP, one for HTTPS) and a single `Vertx` per JVM fork across all tests using `@EnableKubernetesMockClient`, amortizing the Vert.x/Netty cold-start cost across the suite. Per-test isolation is preserved by swapping the dispatcher and `responses` map on each `@BeforeEach` and calling `MockWebServer.reset()` to clear the request queue and request count. Wall-time savings depend on suite size; on `kubernetes-tests` per-class wall times drop by up to ~38% on small classes
+* Fix #7675: (mockwebserver) `MockWebServer.dispatcher` field marked `volatile` so the dispatcher swap performed by `KubernetesMockServerExtension` between tests is reliably visible to the Vert.x request handler thread
 
 #### Dependency Upgrade
 
 #### New Features
 
 #### _**Note**_: Breaking changes
+* Fix #7675: (kubernetes-server-mock) Tests using `@EnableKubernetesMockClient` now share a single `MockWebServer` per transport (HTTP/HTTPS) and a single `Vertx` for the duration of the JVM fork instead of constructing a fresh instance per test method. Consumer-visible behavior changes: (1) `KubernetesMockServer#getPort()` and `getHostName()` are stable across tests within a fork (previously a fresh random port per test); (2) `MockWebServer#addListener(...)` listeners persist for the lifetime of the fork (no auto-removal API exists); (3) test classes that declare both a `static` and an instance `KubernetesMockServer` field under `@TestInstance(PER_CLASS)` now see both fields point to wrappers over the same underlying server (previously: two separate servers on different ports). Tests that don't depend on these specifics are unaffected
 
 ### 7.7.0 (2026-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@
 * Fix #7765: (kubernetes-client) `BaseOperation.informOnCondition` now stops the informer inline when the inner predicate completes the future, closing a CompletableFuture `postComplete` race where a waiter helping drain dependents could fire `informer.stop` after `cf.complete` had already triggered a spurious `?watch=true` HTTP request
 
 #### Improvements
-* Fix #7675: (kubernetes-server-mock) `KubernetesMockServerExtension` now reuses a single `MockWebServer` (one for HTTP, one for HTTPS) and a single `Vertx` per JVM fork across all tests using `@EnableKubernetesMockClient`, amortizing the Vert.x/Netty cold-start cost across the suite. Per-test isolation is preserved by swapping the dispatcher and `responses` map on each `@BeforeEach` and calling `MockWebServer.reset()` to clear the request queue and request count. Wall-time savings depend on suite size; on `kubernetes-tests` per-class wall times drop by up to ~38% on small classes
-* Fix #7675: (mockwebserver) `MockWebServer.dispatcher` field marked `volatile` so the dispatcher swap performed by `KubernetesMockServerExtension` between tests is reliably visible to the Vert.x request handler thread
+* Fix #7675: (mockwebserver) `MockWebServer.dispatcher` field marked `volatile` so a `setDispatcher(...)` call is reliably visible to the Vert.x request handler thread without further synchronization. `MockWebServer.reset()` Javadoc tightened to make its non-destructive contract explicit (no change to the running server, dispatcher, listeners, SSL/TLS state, port, or protocols)
 
 #### Dependency Upgrade
 
 #### New Features
 
 #### _**Note**_: Breaking changes
-* Fix #7675: (kubernetes-server-mock) Tests using `@EnableKubernetesMockClient` now share a single `MockWebServer` per transport (HTTP/HTTPS) and a single `Vertx` for the duration of the JVM fork instead of constructing a fresh instance per test method. Consumer-visible behavior changes: (1) `KubernetesMockServer#getPort()` and `getHostName()` are stable across tests within a fork (previously a fresh random port per test); (2) `MockWebServer#addListener(...)` listeners persist for the lifetime of the fork (no auto-removal API exists); (3) test classes that declare both a `static` and an instance `KubernetesMockServer` field under `@TestInstance(PER_CLASS)` now see both fields point to wrappers over the same underlying server (previously: two separate servers on different ports). Tests that don't depend on these specifics are unaffected
 
 ### 7.7.0 (2026-05-12)
 

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -16,7 +16,10 @@
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.client.Client;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.MockWebServer;
@@ -24,12 +27,15 @@ import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.http.Dispatcher;
 import io.fabric8.mockwebserver.internal.MockDispatcher;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -39,6 +45,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,10 +59,21 @@ import java.util.stream.Stream;
 public class KubernetesMockServerExtension
     implements AfterEachCallback, AfterAllCallback, BeforeEachCallback, BeforeAllCallback {
 
+  // Per-JVM shared resources amortize Vert.x/Netty cold-start across all mock tests in a fork.
+  // The first test pays the class-load cost; subsequent tests reuse the same Vertx and
+  // MockWebServer instances. See issue #7675 item 10.
+  private static final Object SHARED_LOCK = new Object();
+  private static volatile Vertx sharedVertx;
+  private static volatile MockWebServer sharedHttpServer;
+  private static volatile MockWebServer sharedHttpsServer;
+  private static volatile boolean shutdownHookRegistered;
+
   private KubernetesMockServer staticMock;
   private NamespacedKubernetesClient staticClient;
+  private Dispatcher staticDispatcher;
   private KubernetesMockServer instantMock;
   private NamespacedKubernetesClient instantClient;
+  private Dispatcher instantDispatcher;
 
   @Override
   public void afterEach(ExtensionContext context) {
@@ -106,17 +125,32 @@ public class KubernetesMockServerExtension
     } else {
       dispatcher = new MockDispatcher(responses);
     }
+    final MockWebServer mockWebServer = getOrCreateSharedServer(a.https());
+    // The DefaultMockServer constructor wires our fresh dispatcher (and responses map)
+    // into the shared MockWebServer via setDispatcher — atomically swapping out the
+    // previous test's dispatcher before we touch the request queue.
     final KubernetesMockServer mock = new KubernetesMockServer(new Context(Serialization.jsonMapper()),
-        new MockWebServer(), responses, dispatcher, a.https());
-    mock.init();
+        mockWebServer, responses, dispatcher, a.https());
+    // Skip mock.init() — the shared MockWebServer is already started. Run onStart()
+    // directly to register the / and /version expectations into this test's responses map.
+    mock.onStart();
+    // Now (with the new dispatcher in place) clear request count and queue carried over
+    // from the previous test in this fork.
+    mockWebServer.reset();
     if (isStatic) {
       staticMock = mock;
+      staticDispatcher = dispatcher;
     } else {
       instantMock = mock;
+      instantDispatcher = dispatcher;
     }
     try {
-      final NamespacedKubernetesClient client = mock.createClient(
-          a.kubernetesClientBuilderCustomizer().getConstructor().newInstance());
+      final Consumer<KubernetesClientBuilder> userCustomizer = a.kubernetesClientBuilderCustomizer().getConstructor()
+          .newInstance();
+      final NamespacedKubernetesClient client = mock.createClient(builder -> {
+        builder.withHttpClientFactory(sharedHttpClientFactory());
+        userCustomizer.accept(builder);
+      });
       if (isStatic) {
         staticClient = client;
       } else {
@@ -124,6 +158,115 @@ public class KubernetesMockServerExtension
       }
     } catch (Exception e) {
       throw new IllegalArgumentException("The provided kubernetesClientBuilder is invalid", e);
+    }
+  }
+
+  /**
+   * Returns the per-JVM MockWebServer for the requested transport (HTTP or HTTPS), creating
+   * and starting it on first use. Shared across all tests in this fork to avoid paying
+   * Vert.x/Netty cold-start on each test.
+   */
+  private static MockWebServer getOrCreateSharedServer(boolean useHttps) {
+    MockWebServer existing = useHttps ? sharedHttpsServer : sharedHttpServer;
+    if (existing != null) {
+      return existing;
+    }
+    synchronized (SHARED_LOCK) {
+      existing = useHttps ? sharedHttpsServer : sharedHttpServer;
+      if (existing != null) {
+        return existing;
+      }
+      final MockWebServer fresh = new MockWebServer();
+      if (useHttps) {
+        fresh.useHttps();
+      }
+      fresh.start();
+      if (useHttps) {
+        sharedHttpsServer = fresh;
+      } else {
+        sharedHttpServer = fresh;
+      }
+      registerShutdownHook();
+      return fresh;
+    }
+  }
+
+  /**
+   * Returns the per-JVM Vertx used for the test HTTP client. Shared across all tests in
+   * this fork. Event-loop threads are daemons so they don't keep the JVM alive after the
+   * test runner exits.
+   */
+  private static Vertx getOrCreateSharedVertx() {
+    Vertx v = sharedVertx;
+    if (v != null) {
+      return v;
+    }
+    synchronized (SHARED_LOCK) {
+      if (sharedVertx == null) {
+        sharedVertx = Vertx.vertx(new VertxOptions().setUseDaemonThread(true));
+        registerShutdownHook();
+      }
+      return sharedVertx;
+    }
+  }
+
+  /**
+   * Builds an {@link HttpClient.Factory} that reuses the per-JVM shared Vertx, if the
+   * ServiceLoader-resolved factory exposes a {@code (Vertx)} constructor (true for both
+   * the Vert.x 4 and Vert.x 5 implementations). For any other factory (OkHttp, JDK, ...)
+   * the default instance is returned unchanged.
+   */
+  private static HttpClient.Factory sharedHttpClientFactory() {
+    final HttpClient.Factory defaultFactory = HttpClientUtils.getHttpClientFactory();
+    try {
+      final Constructor<?> ctor = defaultFactory.getClass().getConstructor(Vertx.class);
+      return (HttpClient.Factory) ctor.newInstance(getOrCreateSharedVertx());
+    } catch (NoSuchMethodException e) {
+      return defaultFactory;
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to instantiate shared-Vertx HttpClient.Factory", e);
+    }
+  }
+
+  private static void registerShutdownHook() {
+    // Called only from inside SHARED_LOCK (getOrCreateSharedServer / getOrCreateSharedVertx),
+    // so the check-then-set sequence is safe today. Keeping the synchronized block to make
+    // the invariant explicit and to keep the method safe if a future caller forgets the lock.
+    synchronized (SHARED_LOCK) {
+      if (shutdownHookRegistered) {
+        return;
+      }
+      shutdownHookRegistered = true;
+      Runtime.getRuntime().addShutdownHook(new Thread(KubernetesMockServerExtension::shutdownSharedResources,
+          "fabric8-mock-shared-shutdown"));
+    }
+  }
+
+  private static void shutdownSharedResources() {
+    final MockWebServer http = sharedHttpServer;
+    if (http != null) {
+      try {
+        http.shutdown();
+      } catch (Exception ignored) {
+        // best-effort
+      }
+    }
+    final MockWebServer https = sharedHttpsServer;
+    if (https != null) {
+      try {
+        https.shutdown();
+      } catch (Exception ignored) {
+        // best-effort
+      }
+    }
+    final Vertx v = sharedVertx;
+    if (v != null) {
+      try {
+        // Bounded wait so a stuck Vert.x close doesn't hold up JVM exit indefinitely.
+        v.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      } catch (Exception ignored) {
+        // best-effort
+      }
     }
   }
 
@@ -143,17 +286,28 @@ public class KubernetesMockServerExtension
   }
 
   protected void destroy() {
-    if (instantMock != null) {
-      instantMock.destroy();
-    }
+    // Do NOT call instantMock.destroy(): it would shut down the per-fork shared
+    // MockWebServer. The shared server is reset() at the start of each test and torn
+    // down by the JVM shutdown hook.
     if (instantClient != null) {
       instantClient.close();
+    }
+    // Shut down the per-test dispatcher to release any WebSocket sessions it accumulated
+    // (the shared MockWebServer's setDispatcher would otherwise silently replace it next
+    // test without invoking shutdown).
+    if (instantDispatcher != null) {
+      instantDispatcher.shutdown();
     }
   }
 
   protected void destroyStatic() {
-    staticMock.destroy();
-    staticClient.close();
+    // Do NOT call staticMock.destroy(): see destroy().
+    if (staticClient != null) {
+      staticClient.close();
+    }
+    if (staticDispatcher != null) {
+      staticDispatcher.shutdown();
+    }
   }
 
   // Copied from io.fabric8.junit.jupiter.BaseExtension.extractFields TODO: remove duplication

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -16,10 +16,7 @@
 package io.fabric8.kubernetes.client.server.mock;
 
 import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
-import io.fabric8.kubernetes.client.http.HttpClient;
-import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.mockwebserver.Context;
 import io.fabric8.mockwebserver.MockWebServer;
@@ -27,15 +24,12 @@ import io.fabric8.mockwebserver.ServerRequest;
 import io.fabric8.mockwebserver.ServerResponse;
 import io.fabric8.mockwebserver.http.Dispatcher;
 import io.fabric8.mockwebserver.internal.MockDispatcher;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -45,8 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -59,22 +51,10 @@ import java.util.stream.Stream;
 public class KubernetesMockServerExtension
     implements AfterEachCallback, AfterAllCallback, BeforeEachCallback, BeforeAllCallback {
 
-  // Per-JVM shared resources amortize Vert.x/Netty cold-start across the fork. The first
-  // test pays the ~7-8 s TLS/event-loop/class-load cost; subsequent tests reuse the same
-  // Vertx and MockWebServer instances rather than re-running it on every @BeforeEach.
-  private static final Object SHARED_LOCK = new Object();
-  private static volatile Vertx sharedVertx;
-  private static volatile MockWebServer sharedHttpServer;
-  private static volatile MockWebServer sharedHttpsServer;
-  private static volatile HttpClient.Factory sharedFactory;
-  private static volatile boolean shutdownHookRegistered;
-
   private KubernetesMockServer staticMock;
   private NamespacedKubernetesClient staticClient;
-  private Dispatcher staticDispatcher;
   private KubernetesMockServer instantMock;
   private NamespacedKubernetesClient instantClient;
-  private Dispatcher instantDispatcher;
 
   @Override
   public void afterEach(ExtensionContext context) {
@@ -126,37 +106,17 @@ public class KubernetesMockServerExtension
     } else {
       dispatcher = new MockDispatcher(responses);
     }
-    final MockWebServer mockWebServer = getOrCreateSharedServer(a.https());
-    // The DefaultMockServer constructor wires our fresh dispatcher (and responses map)
-    // into the shared MockWebServer via setDispatcher — atomically swapping out the
-    // previous test's dispatcher before we touch the request queue.
-    // There is a microsecond window between this constructor returning and mock.onStart()
-    // populating the responses map. A stray in-flight request from a previous test's
-    // leaked connection would see an empty responses map and get a default empty
-    // response. Acceptable because the previous test's destroy() closes its client
-    // (and therefore its connections) before this @BeforeEach runs.
     final KubernetesMockServer mock = new KubernetesMockServer(new Context(Serialization.jsonMapper()),
-        mockWebServer, responses, dispatcher, a.https());
-    // Skip mock.init() — the shared MockWebServer is already started. Run onStart()
-    // directly to register the / and /version expectations into this test's responses map.
-    mock.onStart();
-    // Now (with the new dispatcher in place) clear request count and queue carried over
-    // from the previous test in this fork.
-    mockWebServer.reset();
+        new MockWebServer(), responses, dispatcher, a.https());
+    mock.init();
     if (isStatic) {
       staticMock = mock;
-      staticDispatcher = dispatcher;
     } else {
       instantMock = mock;
-      instantDispatcher = dispatcher;
     }
     try {
-      final Consumer<KubernetesClientBuilder> userCustomizer = a.kubernetesClientBuilderCustomizer().getConstructor()
-          .newInstance();
-      final NamespacedKubernetesClient client = mock.createClient(builder -> {
-        builder.withHttpClientFactory(sharedHttpClientFactory());
-        userCustomizer.accept(builder);
-      });
+      final NamespacedKubernetesClient client = mock.createClient(
+          a.kubernetesClientBuilderCustomizer().getConstructor().newInstance());
       if (isStatic) {
         staticClient = client;
       } else {
@@ -164,129 +124,6 @@ public class KubernetesMockServerExtension
       }
     } catch (Exception e) {
       throw new IllegalArgumentException("The provided kubernetesClientBuilder is invalid", e);
-    }
-  }
-
-  /**
-   * Returns the per-JVM MockWebServer for the requested transport (HTTP or HTTPS), creating
-   * and starting it on first use. Shared across all tests in this fork to avoid paying
-   * Vert.x/Netty cold-start on each test.
-   */
-  private static MockWebServer getOrCreateSharedServer(boolean useHttps) {
-    MockWebServer existing = useHttps ? sharedHttpsServer : sharedHttpServer;
-    if (existing != null) {
-      return existing;
-    }
-    synchronized (SHARED_LOCK) {
-      existing = useHttps ? sharedHttpsServer : sharedHttpServer;
-      if (existing != null) {
-        return existing;
-      }
-      final MockWebServer fresh = new MockWebServer();
-      if (useHttps) {
-        fresh.useHttps();
-      }
-      fresh.start();
-      if (useHttps) {
-        sharedHttpsServer = fresh;
-      } else {
-        sharedHttpServer = fresh;
-      }
-      registerShutdownHook();
-      return fresh;
-    }
-  }
-
-  /**
-   * Returns the per-JVM Vertx used for the test HTTP client. Shared across all tests in
-   * this fork. Event-loop threads are daemons so they don't keep the JVM alive after the
-   * test runner exits.
-   */
-  private static Vertx getOrCreateSharedVertx() {
-    Vertx v = sharedVertx;
-    if (v != null) {
-      return v;
-    }
-    synchronized (SHARED_LOCK) {
-      if (sharedVertx == null) {
-        sharedVertx = Vertx.vertx(new VertxOptions().setUseDaemonThread(true));
-        registerShutdownHook();
-      }
-      return sharedVertx;
-    }
-  }
-
-  /**
-   * Returns an {@link HttpClient.Factory} that reuses the per-JVM shared Vertx, if the
-   * ServiceLoader-resolved factory exposes a {@code (Vertx)} constructor (true for both
-   * the Vert.x 4 and Vert.x 5 implementations). For any other factory (OkHttp, JDK, ...)
-   * the default instance is returned unchanged. The result is cached after the first call
-   * so the ServiceLoader scan and reflective probe are paid once per JVM.
-   */
-  private static HttpClient.Factory sharedHttpClientFactory() {
-    HttpClient.Factory cached = sharedFactory;
-    if (cached != null) {
-      return cached;
-    }
-    synchronized (SHARED_LOCK) {
-      if (sharedFactory != null) {
-        return sharedFactory;
-      }
-      final HttpClient.Factory defaultFactory = HttpClientUtils.getHttpClientFactory();
-      try {
-        final Constructor<?> ctor = defaultFactory.getClass().getConstructor(Vertx.class);
-        sharedFactory = (HttpClient.Factory) ctor.newInstance(getOrCreateSharedVertx());
-      } catch (NoSuchMethodException e) {
-        // Factory has no (Vertx) constructor (OkHttp, JDK, ...) — fall back to the default
-        // singleton. ServiceLoader returns the same instance for repeated lookups, so
-        // caching it here is consistent with prior behavior.
-        sharedFactory = defaultFactory;
-      } catch (ReflectiveOperationException e) {
-        throw new IllegalStateException("Failed to instantiate shared-Vertx HttpClient.Factory", e);
-      }
-      return sharedFactory;
-    }
-  }
-
-  private static void registerShutdownHook() {
-    // Called only from inside SHARED_LOCK (getOrCreateSharedServer / getOrCreateSharedVertx),
-    // so the check-then-set sequence is safe today. Keeping the synchronized block to make
-    // the invariant explicit and to keep the method safe if a future caller forgets the lock.
-    synchronized (SHARED_LOCK) {
-      if (shutdownHookRegistered) {
-        return;
-      }
-      shutdownHookRegistered = true;
-      Runtime.getRuntime().addShutdownHook(new Thread(KubernetesMockServerExtension::shutdownSharedResources,
-          "fabric8-mock-shared-shutdown"));
-    }
-  }
-
-  private static void shutdownSharedResources() {
-    final MockWebServer http = sharedHttpServer;
-    if (http != null) {
-      try {
-        http.shutdown();
-      } catch (Exception ignored) {
-        // best-effort
-      }
-    }
-    final MockWebServer https = sharedHttpsServer;
-    if (https != null) {
-      try {
-        https.shutdown();
-      } catch (Exception ignored) {
-        // best-effort
-      }
-    }
-    final Vertx v = sharedVertx;
-    if (v != null) {
-      try {
-        // Bounded wait so a stuck Vert.x close doesn't hold up JVM exit indefinitely.
-        v.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
-      } catch (Exception ignored) {
-        // best-effort
-      }
     }
   }
 
@@ -306,28 +143,17 @@ public class KubernetesMockServerExtension
   }
 
   protected void destroy() {
-    // Do NOT call instantMock.destroy(): it would shut down the per-fork shared
-    // MockWebServer. The shared server is reset() at the start of each test and torn
-    // down by the JVM shutdown hook.
+    if (instantMock != null) {
+      instantMock.destroy();
+    }
     if (instantClient != null) {
       instantClient.close();
-    }
-    // Shut down the per-test dispatcher to release any WebSocket sessions it accumulated
-    // (the shared MockWebServer's setDispatcher would otherwise silently replace it next
-    // test without invoking shutdown).
-    if (instantDispatcher != null) {
-      instantDispatcher.shutdown();
     }
   }
 
   protected void destroyStatic() {
-    // Do NOT call staticMock.destroy(): see destroy().
-    if (staticClient != null) {
-      staticClient.close();
-    }
-    if (staticDispatcher != null) {
-      staticDispatcher.shutdown();
-    }
+    staticMock.destroy();
+    staticClient.close();
   }
 
   // Copied from io.fabric8.junit.jupiter.BaseExtension.extractFields TODO: remove duplication

--- a/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
+++ b/junit/kubernetes-server-mock/src/main/java/io/fabric8/kubernetes/client/server/mock/KubernetesMockServerExtension.java
@@ -59,13 +59,14 @@ import java.util.stream.Stream;
 public class KubernetesMockServerExtension
     implements AfterEachCallback, AfterAllCallback, BeforeEachCallback, BeforeAllCallback {
 
-  // Per-JVM shared resources amortize Vert.x/Netty cold-start across all mock tests in a fork.
-  // The first test pays the class-load cost; subsequent tests reuse the same Vertx and
-  // MockWebServer instances. See issue #7675 item 10.
+  // Per-JVM shared resources amortize Vert.x/Netty cold-start across the fork. The first
+  // test pays the ~7-8 s TLS/event-loop/class-load cost; subsequent tests reuse the same
+  // Vertx and MockWebServer instances rather than re-running it on every @BeforeEach.
   private static final Object SHARED_LOCK = new Object();
   private static volatile Vertx sharedVertx;
   private static volatile MockWebServer sharedHttpServer;
   private static volatile MockWebServer sharedHttpsServer;
+  private static volatile HttpClient.Factory sharedFactory;
   private static volatile boolean shutdownHookRegistered;
 
   private KubernetesMockServer staticMock;
@@ -129,6 +130,11 @@ public class KubernetesMockServerExtension
     // The DefaultMockServer constructor wires our fresh dispatcher (and responses map)
     // into the shared MockWebServer via setDispatcher — atomically swapping out the
     // previous test's dispatcher before we touch the request queue.
+    // There is a microsecond window between this constructor returning and mock.onStart()
+    // populating the responses map. A stray in-flight request from a previous test's
+    // leaked connection would see an empty responses map and get a default empty
+    // response. Acceptable because the previous test's destroy() closes its client
+    // (and therefore its connections) before this @BeforeEach runs.
     final KubernetesMockServer mock = new KubernetesMockServer(new Context(Serialization.jsonMapper()),
         mockWebServer, responses, dispatcher, a.https());
     // Skip mock.init() — the shared MockWebServer is already started. Run onStart()
@@ -211,20 +217,34 @@ public class KubernetesMockServerExtension
   }
 
   /**
-   * Builds an {@link HttpClient.Factory} that reuses the per-JVM shared Vertx, if the
+   * Returns an {@link HttpClient.Factory} that reuses the per-JVM shared Vertx, if the
    * ServiceLoader-resolved factory exposes a {@code (Vertx)} constructor (true for both
    * the Vert.x 4 and Vert.x 5 implementations). For any other factory (OkHttp, JDK, ...)
-   * the default instance is returned unchanged.
+   * the default instance is returned unchanged. The result is cached after the first call
+   * so the ServiceLoader scan and reflective probe are paid once per JVM.
    */
   private static HttpClient.Factory sharedHttpClientFactory() {
-    final HttpClient.Factory defaultFactory = HttpClientUtils.getHttpClientFactory();
-    try {
-      final Constructor<?> ctor = defaultFactory.getClass().getConstructor(Vertx.class);
-      return (HttpClient.Factory) ctor.newInstance(getOrCreateSharedVertx());
-    } catch (NoSuchMethodException e) {
-      return defaultFactory;
-    } catch (ReflectiveOperationException e) {
-      throw new IllegalStateException("Failed to instantiate shared-Vertx HttpClient.Factory", e);
+    HttpClient.Factory cached = sharedFactory;
+    if (cached != null) {
+      return cached;
+    }
+    synchronized (SHARED_LOCK) {
+      if (sharedFactory != null) {
+        return sharedFactory;
+      }
+      final HttpClient.Factory defaultFactory = HttpClientUtils.getHttpClientFactory();
+      try {
+        final Constructor<?> ctor = defaultFactory.getClass().getConstructor(Vertx.class);
+        sharedFactory = (HttpClient.Factory) ctor.newInstance(getOrCreateSharedVertx());
+      } catch (NoSuchMethodException e) {
+        // Factory has no (Vertx) constructor (OkHttp, JDK, ...) — fall back to the default
+        // singleton. ServiceLoader returns the same instance for repeated lookups, so
+        // caching it here is consistent with prior behavior.
+        sharedFactory = defaultFactory;
+      } catch (ReflectiveOperationException e) {
+        throw new IllegalStateException("Failed to instantiate shared-Vertx HttpClient.Factory", e);
+      }
+      return sharedFactory;
     }
   }
 

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -86,7 +86,7 @@ public class MockWebServer implements Closeable {
   private final BlockingQueue<RecordedRequest> requestQueue;
   private final AtomicInteger requestCount;
   private final List<MockWebServerListener> listeners;
-  private Dispatcher dispatcher;
+  private volatile Dispatcher dispatcher;
   private ClientAuth clientAuth;
   private final List<String> enabledSecuredTransportProtocols;
   private boolean ssl;

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -279,9 +279,7 @@ public class MockWebServer implements Closeable {
    * {@link Dispatcher}, the listener list, the SSL/TLS state, the negotiated port, and the
    * selected protocols. It is safe to call on a started server mid-life; callers that need
    * a different dispatcher or expectation set must install those themselves
-   * ({@link #setDispatcher(Dispatcher)}). Notably,
-   * {@code KubernetesMockServerExtension} relies on this contract to share a single
-   * MockWebServer across all tests in a JVM fork.
+   * ({@link #setDispatcher(Dispatcher)}).
    */
   public final void reset() {
     requestCount.set(0);

--- a/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
+++ b/junit/mockwebserver/src/main/java/io/fabric8/mockwebserver/MockWebServer.java
@@ -268,11 +268,20 @@ public class MockWebServer implements Closeable {
   }
 
   /**
-   * Returns the MockWebServer to its initial state by:
+   * Returns the MockWebServer's recorded-traffic state to initial:
    * <ul>
    * <li>Clearing the request count.</li>
    * <li>Clearing the request queue.</li>
    * </ul>
+   *
+   * <p>
+   * This is intentionally non-destructive w.r.t. the running HTTP server, the configured
+   * {@link Dispatcher}, the listener list, the SSL/TLS state, the negotiated port, and the
+   * selected protocols. It is safe to call on a started server mid-life; callers that need
+   * a different dispatcher or expectation set must install those themselves
+   * ({@link #setDispatcher(Dispatcher)}). Notably,
+   * {@code KubernetesMockServerExtension} relies on this contract to share a single
+   * MockWebServer across all tests in a JVM fork.
    */
   public final void reset() {
     requestCount.set(0);

--- a/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/kubernetes/client/mock/DeploymentCrudTest.java
@@ -104,7 +104,7 @@ class DeploymentCrudTest {
     client.apps().deployments()
         .resource(new DeploymentBuilder().withNewMetadata().withName("deployment-to-delete").endMetadata().build())
         .create();
-    assertThat(client.apps().deployments().withName("deployment-to-delete").withTimeoutInMillis(100).delete())
+    assertThat(client.apps().deployments().withName("deployment-to-delete").withTimeoutInMillis(30_000L).delete())
         .singleElement()
         .extracting("name").isEqualTo("deployment-to-delete");
   }

--- a/kubernetes-tests/src/test/resources/junit-platform.properties
+++ b/kubernetes-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Run test classes concurrently within each Surefire fork while keeping methods
+# within a class sequential. KubernetesMockServerExtension stores per-test
+# instantMock/instantClient on a single extension instance per class, so
+# methods within a class must run sequentially; classes are isolated because
+# each gets its own extension instance.
+#
+# Layered on top of surefire forkCount=1C: fixed parallelism caps within-fork
+# concurrency at 2 threads regardless of CPU count, keeping the
+# forks x within-fork-threads product bounded on both 2-core CI runners and
+# many-core developer hosts (each fork stays inside its -Xmx2048m budget).
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=2


### PR DESCRIPTION
## Description

Item 7 of #7675. Layers JUnit 5 parallel class execution on top of `forkCount=1C` for `kubernetes-tests`.

```properties
junit.jupiter.execution.parallel.enabled=true
junit.jupiter.execution.parallel.mode.default=same_thread
junit.jupiter.execution.parallel.mode.classes.default=concurrent
junit.jupiter.execution.parallel.config.strategy=fixed
junit.jupiter.execution.parallel.config.fixed.parallelism=2
```

Each fork now runs up to 2 test classes concurrently; methods within a class stay sequential. The reason for keeping methods sequential is `KubernetesMockServerExtension`: it stores per-test `instantMock`/`instantClient` on extension instance fields (one extension per class — concurrent methods would race on those fields, concurrent classes get separate instances).

`config.strategy=fixed` with `parallelism=2` keeps the `forks × within-fork-threads` product around 2× CPU oversubscription on both 2-core CI (2 forks × 2 threads = 4 classes on 2 cores) and 16-core dev hosts (16 forks × 2 = 32 on 16 cores), so each fork stays inside its `-Xmx2048m` budget regardless of host shape.

### Companion test fix

`DeploymentCrudTest#delete` carried the only sub-second hardcoded `withTimeoutInMillis(100)` in the module. Under the new contention shape it flaked 1-in-2 locally — bumped to 30s. The timeout value was not part of the test's assertion; it only existed to make `waitForDelete` enter its polling path.

### Concurrency surface audit

Before enabling class-parallel I checked `kubernetes-tests` (274 test files) for cross-class shared state:

- 0 files mutate `System.setProperty` / `setProperties` / `clearProperty`
- 0 files use `MockedStatic`
- 0 files use `@TestInstance(PER_CLASS)`, `@ResourceLock`, `@Execution`, `@Order`, `@MethodOrderer`
- 0 files use `Locale.setDefault` / `TimeZone.setDefault`
- 1 file has a mutable non-final static (`LabelTest.pod1`/`pod2`) — class-scoped, unaffected
- Ports use `ServerSocket(0)` / kernel-assigned, no fixed-port contention

## Verification

| Run | Wall |
|---|---|
| Baseline (per #7675) | ~199s |
| With this change, local 16-core, 3 consecutive runs | 124s / 110s / 111s (≈-42% median) |
| 2-core / 7GB constrained Docker (CI shape) | 1:58 |

1302 tests, 0 failures, 4 skipped on every run.

## Follow-up risks (not blocking)

Latent sub-second timeouts that did NOT surface in 4 full runs but are worth bumping if CI flakes:
- `PodExecTest.java:89,147,175` — `exitCode().get(1, TimeUnit.SECONDS)` over a mock WebSocket roundtrip
- `DefaultSharedIndexInformerTest.java:178,241,303,516` — `await().atMost(1, SECOND)` after a 10s `CountDownLatch.await` (the watched value is already present; risk is low)

Refs #7675