### PR TITLE
chore(deps): bump spotless-maven-plugin from 3.4.0 to 3.5.0

### DIFF
--- a/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
+++ b/kubernetes-model-generator/kubernetes-model-core/src/main/java/io/fabric8/kubernetes/api/model/GenericKubernetesResource.java
@@ -94,6 +94,7 @@ public class GenericKubernetesResource implements Editable<GenericKubernetesReso
     return MAPPER.convertValue(getAdditionalProperties(), JsonNode.class);
   }
 
+  // spotless:off
   /**
    * Allows the retrieval of field values from this Resource for the provided path segments.
    *
@@ -139,6 +140,7 @@ public class GenericKubernetesResource implements Editable<GenericKubernetesReso
    * @param <T> type of the returned object.
    * @return the value of the traversed path or null if the field does not exist.
    */
+  // spotless:on
   public <T> T get(Object... path) {
     return get(getAdditionalProperties(), path);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
     <central-publishing-maven-plugin>0.10.0</central-publishing-maven-plugin>
     <properties.maven.plugin.version>1.0.0</properties.maven.plugin.version>
-    <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.5.0</spotless-maven-plugin.version>
     <really-executable-jar-maven-plugin.version>2.1.1</really-executable-jar-maven-plugin.version>
 
     <!-- Other options -->


### PR DESCRIPTION
Supersedes #7797.

Spotless 3.5.0 bumps the bundled `eclipse-jdt` formatter from 4.35 to 4.39, which changes how it formats continuation lines inside `<pre>{@code ...}</pre>` javadoc blocks — leading whitespace is stripped, so the JSON example in `GenericKubernetesResource#get(Object...)` would be flattened from this:

```
* {
*   "field": {
*     "value": 42
*     "list": [
*       {entry: 1}, {entry: 2}, {entry: 3}
*     ],
*     "1": "one"
*   }
* }
```

to this:

```
* {
* "field": {
* "value": 42
* "list": [
* {entry: 1}, {entry: 2}, {entry: 3}
* ],
* "1": "one"
* }
* }
```

The new shape is a real loss of readability — the JSON nesting is no longer visible. Pinning `eclipse-jdt` to 4.35 would freeze it on a version Spotless will keep moving past, so instead the affected javadoc is guarded with the existing `toggleOffOn` markers (`// spotless:off` / `// spotless:on`) and the indentation is kept intact. The rest of the codebase is unaffected by the upgrade.