### PR TITLE
chore(ci): move additional e2e/style/sonar workflows to ARM64

### DIFF
--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -18,6 +18,11 @@ name: E2E Chaos Tests
 
 on:
   workflow_dispatch:
+  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
+  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
+  pull_request:
+    paths:
+      - '.github/workflows/e2e-chaos-tests.yml'
   schedule:
     - cron: '0 6 * * *' # Every day at 6am
 
@@ -34,7 +39,7 @@ env:
 jobs:
   chaos-tests:
     name: K8S Chaos Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:
@@ -48,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.16.1
+        uses: manusa/actions-setup-minikube@v2.17.0
         with:
           minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -18,11 +18,6 @@ name: E2E Chaos Tests
 
 on:
   workflow_dispatch:
-  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
-  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
-  pull_request:
-    paths:
-      - '.github/workflows/e2e-chaos-tests.yml'
   schedule:
     - cron: '0 6 * * *' # Every day at 6am
 
@@ -39,7 +34,9 @@ env:
 jobs:
   chaos-tests:
     name: K8S Chaos Test
-    runs-on: ubuntu-24.04-arm
+    # Stays on x64: jkube java-exec base image (quay.io/jkube/jkube-java) is amd64-only.
+    # See #7805 for the multi-arch path forward.
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:

--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -18,11 +18,6 @@ name: E2E Chaos Tests
 
 on:
   workflow_dispatch:
-  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
-  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
-  pull_request:
-    paths:
-      - '.github/workflows/e2e-chaos-tests.yml'
   schedule:
     - cron: '0 6 * * *' # Every day at 6am
 
@@ -39,7 +34,7 @@ env:
 jobs:
   chaos-tests:
     name: K8S Chaos Test
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:

--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -18,6 +18,11 @@ name: E2E Chaos Tests
 
 on:
   workflow_dispatch:
+  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
+  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
+  pull_request:
+    paths:
+      - '.github/workflows/e2e-chaos-tests.yml'
   schedule:
     - cron: '0 6 * * *' # Every day at 6am
 
@@ -34,7 +39,7 @@ env:
 jobs:
   chaos-tests:
     name: K8S Chaos Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -18,6 +18,11 @@ name: E2E HTTPClient Tests
 
 on:
   workflow_dispatch:
+  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
+  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
+  pull_request:
+    paths:
+      - '.github/workflows/e2e-httpclient-tests.yml'
   schedule:
     - cron: '0 5 * * *' # Every day at 5am
 
@@ -33,7 +38,7 @@ env:
 jobs:
   minikube:
     name: K8S
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -18,11 +18,6 @@ name: E2E HTTPClient Tests
 
 on:
   workflow_dispatch:
-  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
-  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
-  pull_request:
-    paths:
-      - '.github/workflows/e2e-httpclient-tests.yml'
   schedule:
     - cron: '0 5 * * *' # Every day at 5am
 

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -18,11 +18,6 @@ name: E2E HTTPClient Tests
 
 on:
   workflow_dispatch:
-  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
-  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
-  pull_request:
-    paths:
-      - '.github/workflows/e2e-httpclient-tests.yml'
   schedule:
     - cron: '0 5 * * *' # Every day at 5am
 
@@ -38,7 +33,7 @@ env:
 jobs:
   minikube:
     name: K8S
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-httpclient-tests.yml
+++ b/.github/workflows/e2e-httpclient-tests.yml
@@ -18,6 +18,11 @@ name: E2E HTTPClient Tests
 
 on:
   workflow_dispatch:
+  # TEMPORARY: trigger on PRs that modify this workflow so the ARM64 runner change can be
+  # validated end-to-end before merge. Remove this `pull_request:` block once verified.
+  pull_request:
+    paths:
+      - '.github/workflows/e2e-httpclient-tests.yml'
   schedule:
     - cron: '0 5 * * *' # Every day at 5am
 
@@ -33,7 +38,7 @@ env:
 jobs:
   minikube:
     name: K8S
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:
       fail-fast: false
@@ -44,7 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.16.1
+        uses: manusa/actions-setup-minikube@v2.17.0
         with:
           minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   buildWithoutTests:
     name: BuildWithoutTests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'fabric8io/kubernetes-client'
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
   minikube_baremetal:
     name: Baremetal K8S
     needs: buildWithoutTests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,8 +63,7 @@ jobs:
   minikube_baremetal:
     name: Baremetal K8S
     needs: buildWithoutTests
-    # Stays on x64 until manusa/actions-setup-minikube#147 lands ARM64 binary support.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:
       fail-fast: false
@@ -74,7 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.16.1
+        uses: manusa/actions-setup-minikube@v2.17.0
         with:
           minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,7 +63,8 @@ jobs:
   minikube_baremetal:
     name: Baremetal K8S
     needs: buildWithoutTests
-    runs-on: ubuntu-24.04-arm
+    # Stays on x64 until manusa/actions-setup-minikube#147 lands ARM64 binary support.
+    runs-on: ubuntu-latest
     if: github.repository == 'fabric8io/kubernetes-client'
     strategy:
       fail-fast: false

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   sonar:
     name: Sonar
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,11 +20,6 @@ on:
   push:
     branches:
       - main
-  # TEMPORARY: trigger on PRs that edit this workflow so the ARM64 runner change
-  # can be validated before merge. Remove this `pull_request:` block once verified.
-  pull_request:
-    paths:
-      - '.github/workflows/sonar.yml'
 #  pull_request:
 #    paths-ignore:
 #      - 'doc/**'
@@ -57,12 +52,5 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      # TEMPORARY split: `make sonar` is a single `mvn -Pcoverage,sonar install sonar:sonar`
-      # invocation; split here so PRs (which lack SONAR_TOKEN) can validate the build on
-      # ubuntu-24.04-arm without the publish step 401-ing. Collapse back into `make sonar`
-      # when the temporary PR trigger above is removed.
-      - name: Sonar build (coverage)
-        run: mvn -Pcoverage,sonar clean install
-      - name: Sonar publish
-        if: github.event_name == 'push'
-        run: mvn -Pcoverage,sonar sonar:sonar
+      - name: Sonar
+        run: make sonar

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,6 +20,11 @@ on:
   push:
     branches:
       - main
+  # TEMPORARY: trigger on PRs that edit this workflow so the ARM64 runner change
+  # can be validated before merge. Remove this `pull_request:` block once verified.
+  pull_request:
+    paths:
+      - '.github/workflows/sonar.yml'
 #  pull_request:
 #    paths-ignore:
 #      - 'doc/**'
@@ -52,5 +57,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Sonar
-        run: make sonar
+      # TEMPORARY split: `make sonar` is a single `mvn -Pcoverage,sonar install sonar:sonar`
+      # invocation; split here so PRs (which lack SONAR_TOKEN) can validate the build on
+      # ubuntu-24.04-arm without the publish step 401-ing. Collapse back into `make sonar`
+      # when the temporary PR trigger above is removed.
+      - name: Sonar build (coverage)
+        run: mvn -Pcoverage,sonar clean install
+      - name: Sonar publish
+        if: github.event_name == 'push'
+        run: mvn -Pcoverage,sonar sonar:sonar

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   style-check:
     name: License & Code Style Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Follow-up to #7799. Same `ubuntu-latest` → `ubuntu-24.04-arm` flip applied to the remaining ARM-safe Linux workflows.

### Runner flips

- `e2e-tests.yml`: `BuildWithoutTests` and `Baremetal K8S` (8-cell matrix)
- `e2e-httpclient-tests.yml`: `K8S` (20-cell matrix)
- `style-checks.yml`: `License & Code Style Checks`
- `sonar.yml`: `Sonar`

### Action bump

- `manusa/actions-setup-minikube`: `v2.16.1` → `v2.17.0`. v2.16.1 hardcoded `linux-amd64` for `minikube`, CNI, `crictl`, and `cri-dockerd`, causing `Exec format error` on ARM runners (manusa/actions-setup-minikube#147). Fixed upstream in manusa/actions-setup-minikube#148.

### Not flipped (with reason)

- `e2e-chaos-tests.yml`: stays on `ubuntu-latest`. jkube's default `java-exec` base image `quay.io/jkube/jkube-java:0.0.26` is amd64-only, so `chaos-test-checker:latest` / `chaos-test-control:latest` built on the ARM runner can't `exec` inside the pod (`exec /usr/local/s2i/run: exec format error`). All 30 matrix cells fail identically. Tracked as #7805.
- `e2e-crc-okd-tests.yml`: CRC ships `linux-amd64` only — cannot move.
- `e2e-osci-tests.yml`: untouched (out of scope this round).
- `windows-build.yml`: GitHub-hosted Windows-ARM runners are still beta.
- `build.yml` Java 21: kept on x64 per #7800 (ARM-specific flakes).

### ARM safety notes (verified against PR CI)

- All matrix K8s versions (1.29+) ship multi-arch images.
- `kube-api-test` resolves `aarch64` → `arm64` for envtest control-plane binaries (`OSInfo.java:28`), so `kubernetes-itests-envtest` works on ARM.
- HTTP-client matrix (jdk/jetty/okhttp/vertx-5) is all pure-Java.
- `BuildWithoutTests` runtime: 346 s on ARM vs ~485 s baseline on x64 (≈ −29 %, matching the build.yml savings from #7799).

Refs #7798
Refs #7805
Refs manusa/actions-setup-minikube#148