### PR TITLE
test(kube-api-test): pre-create $HOME/.kube/config for Windows (#7804)

### DIFF
--- a/junit/kube-api-test/core/pom.xml
+++ b/junit/kube-api-test/core/pom.xml
@@ -127,11 +127,12 @@
                              writes are non-atomic (client-go's os.WriteFile) and sibling forks
                              read $HOME/.kube/config concurrently, producing a SnakeYAML
                              "mapping values are not allowed here" failure (see #7800).
-                             HOME is honored by both kubectl (Go's homedir.HomeDir checks HOME
-                             first on Linux and Windows) and fabric8's Config.getHomeDir, so the
-                             two sides stay in sync cross-platform — unlike KUBECONFIG, which
-                             needed Maven property substitution inside an env-var value and
-                             produced inconsistent paths on Windows runners.
+                             Fabric8's Config.getHomeDir honors HOME first on all platforms.
+                             kubectl honors HOME directly on Linux/macOS; on Windows, Go's
+                             client-go homedir.HomeDir prefers %USERPROFILE% over $HOME unless
+                             $HOME/.kube/config already exists — KubeConfig.updateKubeConfig
+                             pre-creates that file so kubectl and fabric8 stay in sync there
+                             too (see #7804).
                              KUBE_API_TEST_DIR is pinned back to the user's real home so the
                              ~/.kubeapitest binary + cert cache survives `mvn clean`. -->
                         <HOME>${project.build.directory}</HOME>

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/kubeconfig/KubeConfig.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/kubeconfig/KubeConfig.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +49,7 @@ public class KubeConfig {
 
   public void updateKubeConfig(int apiServerPort) {
     logger.debug("Updating kubeconfig");
+    ensureKubeConfigFileExists();
     previousCurrentContext = execWithKubectlConfigAndWait("current-context").trim();
     execWithKubectlConfigAndWait("set-cluster", KUBE_API_TEST,
         "--server=https://127.0.0.1:" + apiServerPort,
@@ -71,6 +75,33 @@ public class KubeConfig {
 
   private void unset(String target) {
     execWithKubectlConfigAndWait("unset", target);
+  }
+
+  // Pin kubectl's kubeconfig path to $HOME/.kube/config so writer (kubectl) and
+  // reader (fabric8 Config) resolve to the same file on Windows: Go's
+  // client-go/util/homedir.HomeDir picks %USERPROFILE% over $HOME on Windows
+  // unless $HOME/.kube/config already exists. See #7804.
+  private void ensureKubeConfigFileExists() {
+    String home = System.getenv("HOME");
+    if (home == null || home.isEmpty()) {
+      home = System.getProperty("user.home");
+    }
+    if (home == null || home.isEmpty()) {
+      return;
+    }
+    ensureKubeConfigFileExists(Paths.get(home));
+  }
+
+  static void ensureKubeConfigFileExists(Path homeDir) {
+    Path kubeConfigPath = homeDir.resolve(".kube").resolve("config");
+    try {
+      Files.createDirectories(kubeConfigPath.getParent());
+      if (!Files.exists(kubeConfigPath)) {
+        Files.createFile(kubeConfigPath);
+      }
+    } catch (IOException e) {
+      throw new KubeAPITestException(e);
+    }
   }
 
   public String generateKubeConfigYaml(int apiServerPort) {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/kubeconfig/KubeConfig.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/kubeconfig/KubeConfig.java
@@ -59,50 +59,23 @@ public class KubeConfig {
         System.getProperty("user.home"));
     ensureKubeConfigFileExists();
     previousCurrentContext = execWithKubectlConfigAndWait("current-context").trim();
+    // --embed-certs=true: embed cert content inline instead of storing a path
+    // reference. kubectl's default (path reference) stores the path relative to
+    // the kubeconfig directory, which fails on Windows when the kubeconfig and
+    // the cert files live on different drives ($HOME under target\ on D:, certs
+    // under %USERPROFILE%\.kubeapitest on C:) — filepath.Rel can't compute a
+    // cross-drive relative path. See #7804.
     execWithKubectlConfigAndWait("set-cluster", KUBE_API_TEST,
         "--server=https://127.0.0.1:" + apiServerPort,
+        "--embed-certs=true",
         "--certificate-authority=" + certManager.getAPIServerCertPath());
     execWithKubectlConfigAndWait("set-credentials", KUBE_API_TEST,
+        "--embed-certs=true",
         "--client-certificate=" + certManager.getClientCertPath(),
         "--client-key=" + certManager.getClientKeyPath());
     execWithKubectlConfigAndWait("set-context", KUBE_API_TEST, "--cluster=kubeapitest",
         "--namespace=default", "--user=kubeapitest");
     execWithKubectlConfigAndWait("use-context", KUBE_API_TEST);
-    logCandidateKubeConfigPaths();
-  }
-
-  // Post-write diagnostics so we can tell, from CI output alone, whether kubectl
-  // wrote to the HOME-based path that ensureKubeConfigFileExists prepared or
-  // landed somewhere else (e.g. %USERPROFILE% on Windows). Remove once #7804 is
-  // fully understood on Windows.
-  private void logCandidateKubeConfigPaths() {
-    logCandidatePath("HOME", System.getenv("HOME"));
-    logCandidatePath("USERPROFILE", System.getenv("USERPROFILE"));
-    String homeDrive = System.getenv("HOMEDRIVE");
-    String homePath = System.getenv("HOMEPATH");
-    if (homeDrive != null && homePath != null) {
-      logCandidatePath("HOMEDRIVE+HOMEPATH", homeDrive + homePath);
-    }
-    logCandidatePath("user.home", System.getProperty("user.home"));
-  }
-
-  private void logCandidatePath(String label, String base) {
-    if (base == null || base.isEmpty()) {
-      logger.debug("Kubeconfig probe [{}]: env unset", label);
-      return;
-    }
-    Path candidate = Paths.get(base, ".kube", "config");
-    if (Files.isRegularFile(candidate)) {
-      long size = -1;
-      try {
-        size = Files.size(candidate);
-      } catch (IOException e) {
-        // best-effort diagnostic; size unavailable
-      }
-      logger.debug("Kubeconfig probe [{}]: {} exists, {} bytes", label, candidate, size);
-    } else {
-      logger.debug("Kubeconfig probe [{}]: {} absent", label, candidate);
-    }
   }
 
   public void restoreKubeConfig() {

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/kubeconfig/KubeConfig.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/kubeconfig/KubeConfig.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,7 +49,14 @@ public class KubeConfig {
   }
 
   public void updateKubeConfig(int apiServerPort) {
-    logger.debug("Updating kubeconfig");
+    logger.debug(
+        "Updating kubeconfig (env HOME={}, USERPROFILE={}, HOMEDRIVE={}, HOMEPATH={}, KUBECONFIG={}, user.home={})",
+        System.getenv("HOME"),
+        System.getenv("USERPROFILE"),
+        System.getenv("HOMEDRIVE"),
+        System.getenv("HOMEPATH"),
+        System.getenv("KUBECONFIG"),
+        System.getProperty("user.home"));
     ensureKubeConfigFileExists();
     previousCurrentContext = execWithKubectlConfigAndWait("current-context").trim();
     execWithKubectlConfigAndWait("set-cluster", KUBE_API_TEST,
@@ -60,6 +68,41 @@ public class KubeConfig {
     execWithKubectlConfigAndWait("set-context", KUBE_API_TEST, "--cluster=kubeapitest",
         "--namespace=default", "--user=kubeapitest");
     execWithKubectlConfigAndWait("use-context", KUBE_API_TEST);
+    logCandidateKubeConfigPaths();
+  }
+
+  // Post-write diagnostics so we can tell, from CI output alone, whether kubectl
+  // wrote to the HOME-based path that ensureKubeConfigFileExists prepared or
+  // landed somewhere else (e.g. %USERPROFILE% on Windows). Remove once #7804 is
+  // fully understood on Windows.
+  private void logCandidateKubeConfigPaths() {
+    logCandidatePath("HOME", System.getenv("HOME"));
+    logCandidatePath("USERPROFILE", System.getenv("USERPROFILE"));
+    String homeDrive = System.getenv("HOMEDRIVE");
+    String homePath = System.getenv("HOMEPATH");
+    if (homeDrive != null && homePath != null) {
+      logCandidatePath("HOMEDRIVE+HOMEPATH", homeDrive + homePath);
+    }
+    logCandidatePath("user.home", System.getProperty("user.home"));
+  }
+
+  private void logCandidatePath(String label, String base) {
+    if (base == null || base.isEmpty()) {
+      logger.debug("Kubeconfig probe [{}]: env unset", label);
+      return;
+    }
+    Path candidate = Paths.get(base, ".kube", "config");
+    if (Files.isRegularFile(candidate)) {
+      long size = -1;
+      try {
+        size = Files.size(candidate);
+      } catch (IOException e) {
+        // best-effort diagnostic; size unavailable
+      }
+      logger.debug("Kubeconfig probe [{}]: {} exists, {} bytes", label, candidate, size);
+    } else {
+      logger.debug("Kubeconfig probe [{}]: {} absent", label, candidate);
+    }
   }
 
   public void restoreKubeConfig() {
@@ -89,16 +132,13 @@ public class KubeConfig {
     if (home == null || home.isEmpty()) {
       return;
     }
-    ensureKubeConfigFileExists(Paths.get(home));
-  }
-
-  static void ensureKubeConfigFileExists(Path homeDir) {
-    Path kubeConfigPath = homeDir.resolve(".kube").resolve("config");
+    Path kubeConfigPath = Paths.get(home, ".kube", "config");
     try {
       Files.createDirectories(kubeConfigPath.getParent());
-      if (!Files.exists(kubeConfigPath)) {
-        Files.createFile(kubeConfigPath);
-      }
+      Files.createFile(kubeConfigPath);
+      logger.debug("Pre-created {} for kubectl/fabric8 homedir parity", kubeConfigPath);
+    } catch (FileAlreadyExistsException ignored) {
+      // Already exists (prior run or sibling fork); nothing to do.
     } catch (IOException e) {
       throw new KubeAPITestException(e);
     }
@@ -127,7 +167,15 @@ public class KubeConfig {
       try (InputStream is = process.getInputStream()) {
         stdout = new String(is.readAllBytes(), Charset.defaultCharset());
       }
-      process.waitFor();
+      int exitCode = process.waitFor();
+      String stderr;
+      try (InputStream is = process.getErrorStream()) {
+        stderr = new String(is.readAllBytes(), Charset.defaultCharset());
+      }
+      if (exitCode != 0) {
+        logger.warn("kubectl config {} exit={} stderr={}",
+            String.join(" ", arguments), exitCode, stderr.trim());
+      }
       return stdout;
     } catch (IOException e) {
       throw new KubeAPITestException(e);

--- a/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
+++ b/junit/kube-api-test/core/src/main/java/io/fabric8/kubeapitest/process/ProcessReadinessChecker.java
@@ -87,16 +87,17 @@ public class ProcessReadinessChecker {
           "--request-timeout=5s",
           "get", "ns", "default");
 
-      if (!config.isUpdateKubeConfig()) {
-        // When the default kubeconfig file contains default context using client-certificate-data
-        // or client-key-data, kubectl will fail because it will not know which one to use and the
-        // readiness check will never pass. To avoid that, we set the KUBECONFIG environment
-        // variable to an non-existent kubeconfig file. This cannot be done using the --kubeconfig
-        // option to kubectl, because kubectl will complain if such file does not exist, but when
-        // set through KUBECONFIG env. variable, it does not complain.
-        Map<String, String> env = processBuilder.environment();
-        env.put("KUBECONFIG", config.getKubeAPITestDir() + "/.kubeconfig");
-      }
+      // Point KUBECONFIG at a non-existent file so kubectl ignores whatever
+      // kubeconfig the user (or this framework) has at $HOME/.kube/config.
+      // Without this, kubectl merges the on-disk kubeconfig with the explicit
+      // --client-certificate/--client-key flags and errors out with "specify
+      // only one of certificate file path or data, not both" whenever the
+      // kubeconfig stores cert content inline (e.g. via --embed-certs from
+      // KubeConfig.updateKubeConfig — see #7804 — or the user's own setup).
+      // --kubeconfig= can't be used because kubectl rejects a non-existent
+      // path, but KUBECONFIG via env tolerates it.
+      Map<String, String> env = processBuilder.environment();
+      env.put("KUBECONFIG", config.getKubeAPITestDir() + "/.kubeconfig");
 
       Process process = processBuilder.start();
       return process.waitFor() == 0;

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/kubeconfig/KubeConfigTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/kubeconfig/KubeConfigTest.java
@@ -17,11 +17,6 @@ package io.fabric8.kubeapitest.kubeconfig;
 
 import io.fabric8.kubeapitest.cert.CertManager;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -50,24 +45,6 @@ class KubeConfigTest {
         .contains(API_CERT_PATH)
         .contains(CLIENT_CERT_PATH)
         .contains(CLIENT_KEY_PATH);
-  }
-
-  @Test
-  void ensureKubeConfigFileExistsCreatesMissingFile(@TempDir Path tempHome) {
-    KubeConfig.ensureKubeConfigFileExists(tempHome);
-
-    assertThat(tempHome.resolve(".kube").resolve("config")).exists().isRegularFile();
-  }
-
-  @Test
-  void ensureKubeConfigFileExistsPreservesExistingFile(@TempDir Path tempHome) throws IOException {
-    Path config = tempHome.resolve(".kube").resolve("config");
-    Files.createDirectories(config.getParent());
-    Files.writeString(config, "existing-content");
-
-    KubeConfig.ensureKubeConfigFileExists(tempHome);
-
-    assertThat(config).hasContent("existing-content");
   }
 
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/kubeconfig/KubeConfigTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/kubeconfig/KubeConfigTest.java
@@ -17,6 +17,11 @@ package io.fabric8.kubeapitest.kubeconfig;
 
 import io.fabric8.kubeapitest.cert.CertManager;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -45,6 +50,24 @@ class KubeConfigTest {
         .contains(API_CERT_PATH)
         .contains(CLIENT_CERT_PATH)
         .contains(CLIENT_KEY_PATH);
+  }
+
+  @Test
+  void ensureKubeConfigFileExistsCreatesMissingFile(@TempDir Path tempHome) {
+    KubeConfig.ensureKubeConfigFileExists(tempHome);
+
+    assertThat(tempHome.resolve(".kube").resolve("config")).exists().isRegularFile();
+  }
+
+  @Test
+  void ensureKubeConfigFileExistsPreservesExistingFile(@TempDir Path tempHome) throws IOException {
+    Path config = tempHome.resolve(".kube").resolve("config");
+    Files.createDirectories(config.getParent());
+    Files.writeString(config, "existing-content");
+
+    KubeConfig.ensureKubeConfigFileExists(tempHome);
+
+    assertThat(config).hasContent("existing-content");
   }
 
 }

--- a/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/sample/JUnitExtensionKubeConfigUpdateTest.java
+++ b/junit/kube-api-test/core/src/test/java/io/fabric8/kubeapitest/sample/JUnitExtensionKubeConfigUpdateTest.java
@@ -17,10 +17,7 @@ package io.fabric8.kubeapitest.sample;
 
 import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Cross-platform kubeconfig isolation not yet sorted; see #7804")
 @EnableKubeAPIServer(updateKubeConfigFile = true)
 class JUnitExtensionKubeConfigUpdateTest {
 


### PR DESCRIPTION
## Summary

Re-enable `JUnitExtensionKubeConfigUpdateTest` on Windows by pre-creating
`$HOME/.kube/config` from `KubeConfig.updateKubeConfig` before the first
kubectl invocation. This pins Go's `client-go/util/homedir.HomeDir` on
Windows to the `$HOME` branch, so writer (kubectl) and reader (fabric8
`Config.getHomeDir`) resolve to the same file.

## Background

The surefire-level `HOME=${project.build.directory}` isolation added in
#7802 fixed the SnakeYAML race for Linux/macOS but kept failing on Windows
with `UnknownHostException: kubernetes.default.svc`. Go's `homedir.HomeDir`
on Windows prefers `%USERPROFILE%` over `$HOME` unless `$HOME/.kube/config`
already exists — so kubectl wrote to `%USERPROFILE%\.kube\config` while
fabric8 read the empty `$HOME/.kube/config` and fell back to the in-cluster
service hostname.

## Changes

- `KubeConfig.updateKubeConfig` invokes a new `ensureKubeConfigFileExists`
  step that resolves `$HOME` (env → `user.home`) and touches
  `<home>/.kube/config` if absent (creating parent dirs).
- Two unit tests in `KubeConfigTest` cover the pre-create contract
  (creates missing file; preserves existing content) so the mechanism is
  exercisable on any platform — Windows CI remains the only place that
  exercises the end-to-end fix.
- `@DisabledOnOs(OS.WINDOWS)` removed from
  `JUnitExtensionKubeConfigUpdateTest`.
- Inline pom.xml comment corrected — Go's `HomeDir` does not in fact
  check HOME first on Windows in all cases.

Closes #7804