### PR TITLE
Support for shard selectors for list and watch - including informers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Improvements
 * Fix #7675: (mockwebserver) `MockWebServer.dispatcher` field marked `volatile` so a `setDispatcher(...)` call is reliably visible to the Vert.x request handler thread without further synchronization. `MockWebServer.reset()` Javadoc tightened to make its non-destructive contract explicit (no change to the running server, dispatcher, listeners, SSL/TLS state, port, or protocols)
-* Fix #7809: (kubernetes-client) Support for shard selectors for listing and informers
+* Fix #7809: (kubernetes-client) Support for shard selectors for list and watch - including informers
 
 #### Dependency Upgrade
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Improvements
 * Fix #7675: (mockwebserver) `MockWebServer.dispatcher` field marked `volatile` so a `setDispatcher(...)` call is reliably visible to the Vert.x request handler thread without further synchronization. `MockWebServer.reset()` Javadoc tightened to make its non-destructive contract explicit (no change to the running server, dispatcher, listeners, SSL/TLS state, port, or protocols)
+* Fix #7809: (kubernetes-client) Support for shard selectors for listing and informers
 
 #### Dependency Upgrade
 

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
@@ -76,8 +76,19 @@ public interface Filterable<T> {
   T withLabelSelector(String selectorAsString);
 
   /**
+   * Sets the {@code shardSelector} list option propagated to subsequent list and watch
+   * (including informer) requests. The selector is sent verbatim as a query parameter and
+   * is honored by API servers that support the {@code StorageVersionAPI} / shard-aware
+   * list-watch alpha. On servers that do not understand the parameter it is ignored.
+   *
+   * @param shardSelector the shard selector expression, or {@code null} to clear
+   * @return filtered resource
+   */
+  T withShardSelector(String shardSelector);
+
+  /**
    * Filter with the object that this event is about.
-   * 
+   *
    * @param objectReference {@link ObjectReference} for providing information of referred object
    * @return filtered resource
    */

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
@@ -79,7 +79,8 @@ public interface Filterable<T> {
    * Sets the {@code shardSelector} list option propagated to subsequent list and watch
    * (including informer) requests. The selector is sent verbatim as a query parameter.
    * This feature is in alpha version, introduced in Kubernetes version 1.36.
-   * Therefore, explicitly needs to be turned on with feature flag ShardedListAndWatch.
+   * Therefore, explicitly needs to be turned on with feature flag "ShardedListAndWatch"
+   * for your API server.
    *
    * @param shardSelector the shard selector expression, or {@code null} to clear
    * @return filtered resource

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/Filterable.java
@@ -77,9 +77,9 @@ public interface Filterable<T> {
 
   /**
    * Sets the {@code shardSelector} list option propagated to subsequent list and watch
-   * (including informer) requests. The selector is sent verbatim as a query parameter and
-   * is honored by API servers that support the {@code StorageVersionAPI} / shard-aware
-   * list-watch alpha. On servers that do not understand the parameter it is ignored.
+   * (including informer) requests. The selector is sent verbatim as a query parameter.
+   * This feature is in alpha version, introduced in Kubernetes version 1.36.
+   * Therefore, explicitly needs to be turned on with feature flag ShardedListAndWatch.
    *
    * @param shardSelector the shard selector expression, or {@code null} to clear
    * @return filtered resource

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -402,6 +402,11 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   }
 
   @Override
+  public FilterWatchListDeletable<T, L, R> withShardSelector(String shardSelector) {
+    return withNewFilter().withShardSelector(shardSelector).endFilter();
+  }
+
+  @Override
   public FilterWatchListDeletable<T, L, R> withFields(Map<String, String> fields) {
     return withNewFilter().withFields(fields).endFilter();
   }
@@ -555,6 +560,10 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     if (labelQueryParam != null) {
       options.setLabelSelector(labelQueryParam);
     }
+    String shardSelector = context.getShardSelector();
+    if (shardSelector != null) {
+      options.setShardSelector(shardSelector);
+    }
     if (resourceVersion != null) {
       options.setResourceVersion(resourceVersion);
     }
@@ -614,6 +623,11 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
           String labelQueryParam = context.getLabelQueryParam();
           if (labelQueryParam != null) {
             options.setLabelSelector(labelQueryParam);
+            useOptions = true;
+          }
+          String shardSelector = context.getShardSelector();
+          if (shardSelector != null) {
+            options.setShardSelector(shardSelector);
             useOptions = true;
           }
         }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/FilterNestedImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/FilterNestedImpl.java
@@ -58,6 +58,7 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
     // Use a multi-value map as its possible to define keyA != foo && keyA != bar
     context.fieldsNot = new LinkedHashMap<>(this.baseOperation.context.getFieldsNot());
     context.selectorAsString = this.baseOperation.context.selectorAsString;
+    context.shardSelector = this.baseOperation.context.shardSelector;
   }
 
   @Override
@@ -202,6 +203,12 @@ final class FilterNestedImpl<T extends HasMetadata, L extends KubernetesResource
   @Override
   public FilterNested<FilterWatchListDeletable<T, L, R>> withLabelSelector(String selectorAsString) {
     this.context.selectorAsString = selectorAsString;
+    return this;
+  }
+
+  @Override
+  public FilterNested<FilterWatchListDeletable<T, L, R>> withShardSelector(String shardSelector) {
+    this.context.shardSelector = shardSelector;
     return this;
   }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationContext.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationContext.java
@@ -68,6 +68,7 @@ public class OperationContext {
   protected Map<String, String> fields;
   protected Map<String, String[]> fieldsNot;
   protected String selectorAsString;
+  protected String shardSelector;
 
   protected Client client;
   protected RequestConfig requestConfig;
@@ -84,6 +85,7 @@ public class OperationContext {
         other.fieldsNot, other.resourceVersion, other.gracePeriodSeconds, other.propagationPolicy,
         other.dryRun, other.selectorAsString, other.defaultNamespace, other.fieldValidation, other.fieldManager,
         other.forceConflicts, other.timeout, other.timeoutUnit, other.requestConfig);
+    this.shardSelector = other.shardSelector;
   }
 
   @SuppressWarnings("java:S107")
@@ -496,6 +498,19 @@ public class OperationContext {
     }
     final OperationContext context = new OperationContext(this);
     context.selectorAsString = selectorAsString;
+    return context;
+  }
+
+  public String getShardSelector() {
+    return shardSelector;
+  }
+
+  public OperationContext withShardSelector(String shardSelector) {
+    if (Objects.equals(this.shardSelector, shardSelector)) {
+      return this;
+    }
+    final OperationContext context = new OperationContext(this);
+    context.shardSelector = shardSelector;
     return context;
   }
 

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
@@ -16,6 +16,7 @@
 package io.fabric8.kubernetes.client.dsl.internal;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -246,6 +247,47 @@ class BaseOperationTest {
             .withShardSelector(SHARD_RANGE)
             .withWatch(true)
             .build()).toString());
+  }
+
+  @Test
+  void testDeleteAllPropagatesShardSelector() throws Exception {
+    // Captures the URL emitted by deleteAll() so the test asserts shardSelector is
+    // appended to the DELETECOLLECTION request — guards BaseOperation#deleteAll against
+    // a refactor that drops context.getShardSelector() from the ListOptions assembly.
+    final URL[] capturedUrl = { null };
+    BaseOperation<Pod, PodList, Resource<Pod>> baseOp = new BaseOperation<Pod, PodList, Resource<Pod>>(new OperationContext()
+        .withNamespace("default")
+        .withPlural("pods")
+        .withShardSelector(SHARD_RANGE)) {
+      @Override
+      public KubernetesSerialization getKubernetesSerialization() {
+        return new KubernetesSerialization();
+      }
+
+      @Override
+      public URL getResourceUrl() {
+        try {
+          return new URL("https://172.17.0.2:8443/api/v1/namespaces/default/pods");
+        } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      @Override
+      protected KubernetesResource handleDelete(URL requestUrl, long gracePeriodSeconds,
+          DeletionPropagation propagationPolicy, String resourceVersion) {
+        capturedUrl[0] = requestUrl;
+        return null;
+      }
+    };
+    baseOp.setType(Pod.class);
+    baseOp.setListType(PodList.class);
+
+    baseOp.delete();
+
+    assertNotNull(capturedUrl[0]);
+    assertThat(capturedUrl[0].toString(),
+        containsString("shardSelector=" + URLEncoder.encode(SHARD_RANGE, StandardCharsets.UTF_8)));
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
@@ -45,6 +45,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +70,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BaseOperationTest {
+
+  public static final String SHARD_RANGE = "shardRange(object.metadata.uid,'0x0000000000000000','0x8000000000000000')";
 
   @Test
   void testSimpleFieldQueryParamConcatenation() {
@@ -229,16 +233,17 @@ class BaseOperationTest {
     // shardSelector is appended like any other ListOptions field (alphabetical)
     assertEquals(
         URLUtils.join(url.toString(),
-            "?shardSelector=shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')"),
+            "?shardSelector=" + URLEncoder.encode(SHARD_RANGE, StandardCharsets.UTF_8)),
         operation.fetchListUrl(url, new ListOptionsBuilder()
-            .withShardSelector("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')")
+            .withShardSelector(SHARD_RANGE)
             .build()).toString());
     assertEquals(URLUtils.join(url.toString(),
-        "?labelSelector=app%3Dfoo&limit=5&shardSelector=shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')&watch=true"),
+        "?labelSelector=app%3Dfoo&limit=5&shardSelector=" + URLEncoder.encode(SHARD_RANGE, StandardCharsets.UTF_8)
+            + "&watch=true"),
         operation.fetchListUrl(url, new ListOptionsBuilder()
             .withLimit(5L)
             .withLabelSelector("app=foo")
-            .withShardSelector("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')")
+            .withShardSelector(SHARD_RANGE)
             .withWatch(true)
             .build()).toString());
   }

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperationTest.java
@@ -226,6 +226,21 @@ class BaseOperationTest {
             .withResourceVersion("")
             .withResourceVersionMatch("NotOlderThan")
             .build()).toString());
+    // shardSelector is appended like any other ListOptions field (alphabetical)
+    assertEquals(
+        URLUtils.join(url.toString(),
+            "?shardSelector=shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')"),
+        operation.fetchListUrl(url, new ListOptionsBuilder()
+            .withShardSelector("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')")
+            .build()).toString());
+    assertEquals(URLUtils.join(url.toString(),
+        "?labelSelector=app%3Dfoo&limit=5&shardSelector=shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')&watch=true"),
+        operation.fetchListUrl(url, new ListOptionsBuilder()
+            .withLimit(5L)
+            .withLabelSelector("app=foo")
+            .withShardSelector("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')")
+            .withWatch(true)
+            .build()).toString());
   }
 
   @Test

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationContextTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/dsl/internal/OperationContextTest.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -110,5 +112,32 @@ class OperationContextTest {
     assertEquals(selectorAsString, operationContext.getLabelQueryParam());
     assertEquals("metadata.name=operand-name,test=field,test!=fieldsNot", operationContext.getFieldQueryParam());
     assertEquals(1, operationContext.getRequestConfig().getLoggingInterval());
+  }
+
+  @Test
+  void testShardSelectorIsPreservedAndOrthogonalToOtherSelectors() {
+    OperationContext context = new OperationContext()
+        .withShardSelector("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')");
+
+    // returned by the getter
+    assertEquals("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')", context.getShardSelector());
+
+    // identity when called with the same value (mirrors withLabelSelector)
+    assertSame(context,
+        context.withShardSelector("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')"));
+
+    // preserved across unrelated context mutations (i.e. through the copy constructor)
+    OperationContext extended = context.withName("foo").withNamespace("ns").withLabelSelector("a=b");
+    assertEquals("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')", extended.getShardSelector());
+    // and orthogonal to the label selector
+    assertEquals("a=b", extended.getLabelQueryParam());
+
+    // overwrite
+    assertEquals("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')",
+        context.withShardSelector("shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')")
+            .getShardSelector());
+
+    // clear
+    assertNull(context.withShardSelector(null).getShardSelector());
   }
 }

--- a/kubernetes-itests-envtest/pom.xml
+++ b/kubernetes-itests-envtest/pom.xml
@@ -55,6 +55,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
+++ b/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
@@ -52,7 +52,7 @@ public class ShardingIT {
 
   @Test
   void shardedList() {
-    client.resource(configMap("cm1")).create();
+    client.resource(configMap()).create();
 
     var shard1 = client.configMaps()
         .withLabelSelector(LABEL_SELECTOR)
@@ -66,7 +66,7 @@ public class ShardingIT {
 
   @Test
   void shardedInformer() {
-    client.resource(configMap("cm1")).create();
+    client.resource(configMap()).create();
     AtomicInteger eventCounter = new AtomicInteger(0);
 
     try (var ignored = client.configMaps()
@@ -82,7 +82,7 @@ public class ShardingIT {
 
   @Test
   void shardedWatch() {
-    client.resource(configMap("cm1")).create();
+    client.resource(configMap()).create();
     AtomicInteger eventCounter = new AtomicInteger(0);
 
     try (var ignored = client.configMaps()
@@ -151,6 +151,10 @@ public class ShardingIT {
       public void onDelete(ConfigMap configMap, boolean b) {
       }
     };
+  }
+
+  private ConfigMap configMap() {
+    return configMap("cm1");
   }
 
   private ConfigMap configMap(String name) {

--- a/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
+++ b/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
@@ -20,6 +20,8 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +38,7 @@ public class ShardingIT {
   public static final String LABEL_SELECTOR = "test=true";
   public static final String SHARD1 = "shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')";
   public static final String SHARD2 = "shardRange(object.metadata.uid, '0x8000000000000000', '0x10000000000000000')";
+  public static final int EVENT_CHECK_DELAY = 100;
   static KubernetesClient client;
 
   @Test
@@ -64,10 +67,40 @@ public class ShardingIT {
         var ignored1 = client.configMaps()
             .withLabelSelector(LABEL_SELECTOR)
             .withShardSelector(SHARD2).inform(getHandler(eventCounter))) {
-      await().pollDelay(Duration.ofMillis(150))
+      await().pollDelay(Duration.ofMillis(EVENT_CHECK_DELAY))
           .untilAsserted(() -> assertThat(eventCounter.get()).isEqualTo(1));
       client.resource(cm).delete();
     }
+  }
+
+  @Test
+  void shardedWatch() {
+    var cm = client.resource(configMap()).create();
+    AtomicInteger eventCounter = new AtomicInteger(0);
+
+    try (var ignored = client.configMaps()
+        .withLabelSelector(LABEL_SELECTOR)
+        .withShardSelector(SHARD1).watch(getWatcher(eventCounter));
+        var ignored1 = client.configMaps()
+            .withLabelSelector(LABEL_SELECTOR)
+            .withShardSelector(SHARD2).watch(getWatcher(eventCounter))) {
+      await().pollDelay(Duration.ofMillis(EVENT_CHECK_DELAY))
+          .untilAsserted(() -> assertThat(eventCounter.get()).isEqualTo(1));
+      client.resource(cm).delete();
+    }
+  }
+
+  private static Watcher<ConfigMap> getWatcher(AtomicInteger eventCounter) {
+    return new Watcher<>() {
+      @Override
+      public void eventReceived(Action action, ConfigMap configMap) {
+        eventCounter.getAndAdd(1);
+      }
+
+      @Override
+      public void onClose(WatcherException cause) {
+      }
+    };
   }
 
   private static ResourceEventHandler<ConfigMap> getHandler(AtomicInteger eventCounter) {

--- a/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
+++ b/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@EnableKubeAPIServer(kubeAPIVersion = "1.36.0",apiServerFlags = "--feature-gates=ShardedListAndWatch=true")
+@EnableKubeAPIServer(kubeAPIVersion = "1.36.0", apiServerFlags = "--feature-gates=ShardedListAndWatch=true")
 public class ShardingIT {
 
   public static final String LABEL_SELECTOR = "test=true";
@@ -44,13 +43,13 @@ public class ShardingIT {
     var cm = client.resource(configMap()).create();
 
     var shard1 = client.configMaps()
-      .withLabelSelector(LABEL_SELECTOR)
-      .withShardSelector(SHARD1).list();
+        .withLabelSelector(LABEL_SELECTOR)
+        .withShardSelector(SHARD1).list();
     var shard2 = client.configMaps()
-      .withLabelSelector(LABEL_SELECTOR)
-      .withShardSelector(SHARD2).list();
+        .withLabelSelector(LABEL_SELECTOR)
+        .withShardSelector(SHARD2).list();
 
-    assertThat(shard1.getItems().size()+shard2.getItems().size()).isEqualTo(1);
+    assertThat(shard1.getItems().size() + shard2.getItems().size()).isEqualTo(1);
     client.resource(cm).delete();
   }
 
@@ -60,13 +59,13 @@ public class ShardingIT {
     AtomicInteger eventCounter = new AtomicInteger(0);
 
     try (var ignored = client.configMaps()
-      .withLabelSelector(LABEL_SELECTOR)
-      .withShardSelector(SHARD1).inform(getHandler(eventCounter));
-         var ignored1 = client.configMaps()
-           .withLabelSelector(LABEL_SELECTOR)
-           .withShardSelector(SHARD2).inform(getHandler(eventCounter))) {
+        .withLabelSelector(LABEL_SELECTOR)
+        .withShardSelector(SHARD1).inform(getHandler(eventCounter));
+        var ignored1 = client.configMaps()
+            .withLabelSelector(LABEL_SELECTOR)
+            .withShardSelector(SHARD2).inform(getHandler(eventCounter))) {
       await().pollDelay(Duration.ofMillis(150))
-        .untilAsserted(() -> assertThat(eventCounter.get()).isEqualTo(1));
+          .untilAsserted(() -> assertThat(eventCounter.get()).isEqualTo(1));
       client.resource(cm).delete();
     }
   }
@@ -91,12 +90,12 @@ public class ShardingIT {
 
   private ConfigMap configMap() {
     return new ConfigMapBuilder()
-      .withMetadata(new ObjectMetaBuilder()
-        .withName("cm1")
-        .withLabels(Map.of("test","true"))
-        .withNamespace("default")
-        .build())
-      .build();
+        .withMetadata(new ObjectMetaBuilder()
+            .withName("cm1")
+            .withLabels(Map.of("test", "true"))
+            .withNamespace("default")
+            .build())
+        .build();
   }
 
 }

--- a/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
+++ b/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
@@ -23,6 +23,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -41,9 +43,16 @@ public class ShardingIT {
   public static final int EVENT_CHECK_DELAY = 100;
   static KubernetesClient client;
 
+  // The apiserver is class-scoped, so labelled ConfigMaps from one method would otherwise
+  // leak into the next and turn create() into AlreadyExists, masking the original failure.
+  @AfterEach
+  void cleanup() {
+    client.configMaps().inNamespace("default").withLabelSelector(LABEL_SELECTOR).delete();
+  }
+
   @Test
   void shardedList() {
-    var cm = client.resource(configMap()).create();
+    client.resource(configMap("cm1")).create();
 
     var shard1 = client.configMaps()
         .withLabelSelector(LABEL_SELECTOR)
@@ -53,12 +62,11 @@ public class ShardingIT {
         .withShardSelector(SHARD2).list();
 
     assertThat(shard1.getItems().size() + shard2.getItems().size()).isEqualTo(1);
-    client.resource(cm).delete();
   }
 
   @Test
   void shardedInformer() {
-    var cm = client.resource(configMap()).create();
+    client.resource(configMap("cm1")).create();
     AtomicInteger eventCounter = new AtomicInteger(0);
 
     try (var ignored = client.configMaps()
@@ -69,13 +77,12 @@ public class ShardingIT {
             .withShardSelector(SHARD2).inform(getHandler(eventCounter))) {
       await().pollDelay(Duration.ofMillis(EVENT_CHECK_DELAY))
           .untilAsserted(() -> assertThat(eventCounter.get()).isEqualTo(1));
-      client.resource(cm).delete();
     }
   }
 
   @Test
   void shardedWatch() {
-    var cm = client.resource(configMap()).create();
+    client.resource(configMap("cm1")).create();
     AtomicInteger eventCounter = new AtomicInteger(0);
 
     try (var ignored = client.configMaps()
@@ -86,8 +93,33 @@ public class ShardingIT {
             .withShardSelector(SHARD2).watch(getWatcher(eventCounter))) {
       await().pollDelay(Duration.ofMillis(EVENT_CHECK_DELAY))
           .untilAsserted(() -> assertThat(eventCounter.get()).isEqualTo(1));
-      client.resource(cm).delete();
     }
+  }
+
+  @Test
+  void shardedDelete() {
+    for (int i = 0; i < 10; i++) {
+      client.resource(configMap("cm-" + i)).create();
+    }
+
+    int totalBefore = client.configMaps().withLabelSelector(LABEL_SELECTOR).list().getItems().size();
+    int shard1Before = client.configMaps()
+        .withLabelSelector(LABEL_SELECTOR).withShardSelector(SHARD1).list().getItems().size();
+    int shard2Before = client.configMaps()
+        .withLabelSelector(LABEL_SELECTOR).withShardSelector(SHARD2).list().getItems().size();
+    assertThat(shard1Before + shard2Before).isEqualTo(totalBefore);
+    Assumptions.assumeTrue(shard1Before > 0 && shard2Before > 0,
+        "UID hashing didn't populate both shards — re-run");
+
+    client.configMaps()
+        .withLabelSelector(LABEL_SELECTOR).withShardSelector(SHARD1).delete();
+
+    // SHARD1 must be empty and SHARD2 untouched — guards against the apiserver ignoring
+    // shardSelector on DELETECOLLECTION (which would silently delete the whole label set).
+    assertThat(client.configMaps().withLabelSelector(LABEL_SELECTOR)
+        .withShardSelector(SHARD1).list().getItems()).isEmpty();
+    assertThat(client.configMaps().withLabelSelector(LABEL_SELECTOR)
+        .withShardSelector(SHARD2).list().getItems()).hasSize(shard2Before);
   }
 
   private static Watcher<ConfigMap> getWatcher(AtomicInteger eventCounter) {
@@ -121,10 +153,10 @@ public class ShardingIT {
     };
   }
 
-  private ConfigMap configMap() {
+  private ConfigMap configMap(String name) {
     return new ConfigMapBuilder()
         .withMetadata(new ObjectMetaBuilder()
-            .withName("cm1")
+            .withName(name)
             .withLabels(Map.of("test", "true"))
             .withNamespace("default")
             .build())

--- a/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
+++ b/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.fabric8.kubernetes;
 
 import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;

--- a/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
+++ b/kubernetes-itests-envtest/src/test/java/io/fabric8/kubernetes/ShardingIT.java
@@ -1,0 +1,87 @@
+package io.fabric8.kubernetes;
+
+import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@EnableKubeAPIServer(kubeAPIVersion = "1.36.0",apiServerFlags = "--feature-gates=ShardedListAndWatch=true")
+public class ShardingIT {
+
+  public static final String LABEL_SELECTOR = "test=true";
+  public static final String SHARD1 = "shardRange(object.metadata.uid, '0x0000000000000000', '0x8000000000000000')";
+  public static final String SHARD2 = "shardRange(object.metadata.uid, '0x8000000000000000', '0x10000000000000000')";
+  static KubernetesClient client;
+
+  @Test
+  void shardedList() {
+    var cm = client.resource(configMap()).create();
+
+    var shard1 = client.configMaps()
+      .withLabelSelector(LABEL_SELECTOR)
+      .withShardSelector(SHARD1).list();
+    var shard2 = client.configMaps()
+      .withLabelSelector(LABEL_SELECTOR)
+      .withShardSelector(SHARD2).list();
+
+    assertThat(shard1.getItems().size()+shard2.getItems().size()).isEqualTo(1);
+    client.resource(cm).delete();
+  }
+
+  @Test
+  void shardedInformer() {
+    var cm = client.resource(configMap()).create();
+    AtomicInteger eventCounter = new AtomicInteger(0);
+
+    try (var ignored = client.configMaps()
+      .withLabelSelector(LABEL_SELECTOR)
+      .withShardSelector(SHARD1).inform(getHandler(eventCounter));
+         var ignored1 = client.configMaps()
+           .withLabelSelector(LABEL_SELECTOR)
+           .withShardSelector(SHARD2).inform(getHandler(eventCounter))) {
+      await().pollDelay(Duration.ofMillis(150))
+        .untilAsserted(() -> assertThat(eventCounter.get()).isEqualTo(1));
+      client.resource(cm).delete();
+    }
+  }
+
+  private static ResourceEventHandler<ConfigMap> getHandler(AtomicInteger eventCounter) {
+    return new ResourceEventHandler<>() {
+      @Override
+      public void onAdd(ConfigMap configMap) {
+        eventCounter.getAndAdd(1);
+      }
+
+      @Override
+      public void onUpdate(ConfigMap configMap, ConfigMap t1) {
+        eventCounter.getAndAdd(1);
+      }
+
+      @Override
+      public void onDelete(ConfigMap configMap, boolean b) {
+      }
+    };
+  }
+
+  private ConfigMap configMap() {
+    return new ConfigMapBuilder()
+      .withMetadata(new ObjectMetaBuilder()
+        .withName("cm1")
+        .withLabels(Map.of("test","true"))
+        .withNamespace("default")
+        .build())
+      .build();
+  }
+
+}


### PR DESCRIPTION
Allows to pass shardSelector for Filterable, this is mainly important for informers, so we can have sharding in JOSDK.
Might be used both for list and watch subsequently in informer implementation.

Signed-off-by: Attila Mészáros <a_meszaros@apple.com>
