### PR TITLE
chore(ci): flip build.yml Java 21 cell to ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           - java: 17
             os: ubuntu-24.04-arm
           - java: 21
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
     name: Java ${{ matrix.environment.java }} Maven
     runs-on: ${{ matrix.environment.os }}
     steps:


### PR DESCRIPTION
Follow-up to #7799 / #7803 — completes the `build.yml` ARM64 migration. Java 11 and Java 17 cells moved in #7799; the Java 21 cell was held on `ubuntu-latest` pending the #7800 flake investigation.

### Why now

All three Java-21 flakes from #7800 are fixed on `main`:

| # | Test | Fix landed in | Location |
|---|---|---|---|
| 1 | `MasterProtocolTest.testWithoutSSL` (YAML leak from `~/.kubeapitest/`) | #7802 | `\$HOME` scoped per surefire fork in `junit/kube-api-test/{core,client-inject}/pom.xml` |
| 2 | `KubeApiServerTest.creatingClientFromConfigString` (60s readiness, RBAC-403) | #7802 | mTLS `/readyz` overload in `ProcessReadinessChecker.java` |
| 3 | `DefaultMockServerWebSocketTest … should emit onClose` (10s WS timeout) | #7802 | `try/catch (IllegalStateException)` around `closeHandler` |

Residuals from #7800 do not block this flip:
- **#7806** — Windows-only manifestation of (3); this PR touches Linux ARM only.
- **#7807** — `kube-api-test` 60s `startupTimeout` boundary under heavy `-T 1C` contention. JDK- and arch-agnostic; can hit any matrix cell. Tracked, not in scope here.

### Verification plan

Same protocol as #7799 / #7802: trigger `gh run rerun` on this PR for a statistical sample. Aim for 10+ attempts against the original #7798 baseline of ~37% per-attempt failure on Java 21 ARM (2/4 clean across the original benchmark). If green rate is comparable to Java 11/17 ARM cells (clean across the same #7798 samples), the flakes are gone; if residuals surface, file follow-ups rather than reverting blind.

### Diff

One line: `build.yml:52` — `ubuntu-latest` → `ubuntu-24.04-arm`.

Refs #7798, #7800