### PR TITLE
test(mockwebserver): tolerate null closeReason on Windows (#7806)

### DIFF
--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
@@ -25,6 +25,7 @@ import io.vertx.core.http.RequestOptions
 import io.vertx.core.http.WebSocket
 import io.vertx.core.http.WebSocketClient
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.stream.IntStream
 import spock.lang.Shared
 import spock.lang.Specification
@@ -106,7 +107,7 @@ class DefaultMockServerWebSocketTest extends Specification {
 		wsReq.result().closeReason() == "Closing..."
 	}
 
-	def "andUpgradeToWebSocket, with no events, should emit onClose"() {
+	def "andUpgradeToWebSocket, with no events, should fire onClose notification"() {
 		given: "A WebSocket expectation"
 		server.expect()
 				.withPath("/websocket")
@@ -114,37 +115,69 @@ class DefaultMockServerWebSocketTest extends Specification {
 		and: "A WebSocket request"
 		def wsReq = wsClient.webSocket().connect(server.port, server.getHostName(), "/websocket")
 		and: "A WebSocket listener"
-		String closeReason
+		// closeHandler() throws IllegalStateException if registered against an already-closed
+		// WebSocket (#7800 race); the catch + isClosed() post-check record the close in that case.
+		// Diagnostic logging at each decision point per #7806 — surfaces in surefire output so
+		// the next CI failure is triageable without rerunning.
+		def closeObserved = new AtomicBoolean()
+		def diag = "[7806/" + System.getProperty("os.name") + "]"
 		wsReq.onComplete { ws ->
+			if (ws.failed() || ws.result() == null) {
+				System.err.println("$diag onComplete failed: " + ws.cause())
+				return
+			}
 			def w = ws.result()
-			// closeHandler() throws IllegalStateException if the WebSocket has already
-			// closed, so the previous check-then-register pattern was racy: under load,
-			// the close frame can land between isClosed() and closeHandler(), surfacing
-			// as a silently-swallowed Vert.x exception and a 10 s test timeout (#7800).
-			// Try to register the handler unconditionally, then read closeReason from
-			// whichever path actually saw the close.
 			try {
 				w.closeHandler { _ ->
+					System.err.println("$diag closeHandler fired; closeReason=" + w.closeReason())
+					closeObserved.set(true)
 					w.close()
-					closeReason = w.closeReason()
 				}
 			} catch (IllegalStateException ignored) {
-				// WS already closed before we could register; isClosed() check below handles it.
+				System.err.println("$diag closeHandler ISE: WS already closed at registration; closeReason=" + w.closeReason())
+				closeObserved.set(true)
 			}
 			if (w.isClosed()) {
-				closeReason = w.closeReason()
+				System.err.println("$diag post-register isClosed; closeReason=" + w.closeReason())
+				closeObserved.set(true)
 			}
 		}
 		and: "An instance of PollingConditions"
 		def conditions = new PollingConditions(timeout: 10)
 
-		when: "The request is sent and completed"
+		expect: "The client to be notified of the close (via handler, registration race, or post-check)"
 		conditions.eventually {
-			assert closeReason != null
+			assert closeObserved.get()
+		}
+	}
+
+	def "andUpgradeToWebSocket, with no events, should populate closeReason"() {
+		given: "A WebSocket expectation"
+		server.expect()
+				.withPath("/websocket")
+				.andUpgradeToWebSocket().open().done().always()
+		and: "A WebSocket request"
+		def wsReq = wsClient.webSocket().connect(server.port, server.getHostName(), "/websocket")
+		and: "An instance of PollingConditions"
+		def conditions = new PollingConditions(timeout: 10)
+
+		when: "The WebSocket has reached closed state"
+		conditions.eventually {
+			assert wsReq.isComplete()
+			assert wsReq.result() != null
+			assert wsReq.result().isClosed()
 		}
 
-		then: "Expect the onClose reason"
-		closeReason == "Closing..."
+		then: "closeReason holds the server's reason on non-Windows; on Windows null is accepted"
+		// Vert.x 4.5 surfaces WebSocket close through two paths: handleCloseFrame() populates
+		// closeReason before firing closeHandler; handleConnectionClosed() (TCP drop before
+		// CLOSE-frame parse) fires the handler with closeReason left null. Windows reaches
+		// the second path intermittently (#7806), so the strict assertion only runs there.
+		def closeReason = wsReq.result().closeReason()
+		def osName = System.getProperty("os.name")
+		System.err.println("[7806/" + osName + "] closeReason=" + closeReason)
+		def isWindows = osName.toLowerCase().contains("windows")
+		isWindows ? (closeReason == null || closeReason == "Closing...") : closeReason == "Closing..."
 	}
 
 	// https://github.com/fabric8io/mockwebserver/pull/66#issuecomment-944289335

--- a/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
+++ b/junit/mockwebserver/src/test/groovy/io/fabric8/mockwebserver/DefaultMockServerWebSocketTest.groovy
@@ -35,6 +35,8 @@ class DefaultMockServerWebSocketTest extends Specification {
 
 	@Shared
 	static def vertx = Vertx.vertx()
+	@Shared
+	static final String DIAG_PREFIX = "[7806/" + System.getProperty("os.name") + "]"
 	WebSocketClient wsClient
 	DefaultMockServer server
 
@@ -120,25 +122,24 @@ class DefaultMockServerWebSocketTest extends Specification {
 		// Diagnostic logging at each decision point per #7806 — surfaces in surefire output so
 		// the next CI failure is triageable without rerunning.
 		def closeObserved = new AtomicBoolean()
-		def diag = "[7806/" + System.getProperty("os.name") + "]"
 		wsReq.onComplete { ws ->
 			if (ws.failed() || ws.result() == null) {
-				System.err.println("$diag onComplete failed: " + ws.cause())
+				System.err.println("$DIAG_PREFIX onComplete failed: " + ws.cause())
 				return
 			}
 			def w = ws.result()
 			try {
 				w.closeHandler { _ ->
-					System.err.println("$diag closeHandler fired; closeReason=" + w.closeReason())
+					System.err.println("$DIAG_PREFIX closeHandler fired; closeReason=" + w.closeReason())
 					closeObserved.set(true)
 					w.close()
 				}
 			} catch (IllegalStateException ignored) {
-				System.err.println("$diag closeHandler ISE: WS already closed at registration; closeReason=" + w.closeReason())
+				System.err.println("$DIAG_PREFIX closeHandler ISE: WS already closed at registration; closeReason=" + w.closeReason())
 				closeObserved.set(true)
 			}
 			if (w.isClosed()) {
-				System.err.println("$diag post-register isClosed; closeReason=" + w.closeReason())
+				System.err.println("$DIAG_PREFIX post-register isClosed; closeReason=" + w.closeReason())
 				closeObserved.set(true)
 			}
 		}
@@ -174,10 +175,9 @@ class DefaultMockServerWebSocketTest extends Specification {
 		// CLOSE-frame parse) fires the handler with closeReason left null. Windows reaches
 		// the second path intermittently (#7806), so the strict assertion only runs there.
 		def closeReason = wsReq.result().closeReason()
-		def osName = System.getProperty("os.name")
-		System.err.println("[7806/" + osName + "] closeReason=" + closeReason)
-		def isWindows = osName.toLowerCase().contains("windows")
-		isWindows ? (closeReason == null || closeReason == "Closing...") : closeReason == "Closing..."
+		System.err.println("$DIAG_PREFIX closeReason=" + closeReason)
+		def isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
+		assert isWindows ? (closeReason == null || closeReason == "Closing...") : closeReason == "Closing..."
 	}
 
 	// https://github.com/fabric8io/mockwebserver/pull/66#issuecomment-944289335


### PR DESCRIPTION
Closes #7806. Follow-up to #7802's `try/catch (IllegalStateException)` fix, which addressed the #7800 ISE race but did not eliminate the Windows flake.

## Why the previous fix was not enough

Across 13 reruns of #7802 the test still failed once on Windows Java 17 with `closeReason != null` failing the polling condition. Source review of `WebSocketImplBase` (Vert.x 4.5.27) explains the residual:

| Path | `closeReason` set? | `closeHandler` fired? |
| --- | --- | --- |
| `handleCloseFrame()` (CLOSE frame parsed) | yes, before handler | yes |
| `handleConnectionClosed()` (TCP socket drops first) | no — stays null | yes |

Windows reaches the second path intermittently (TCP RST or scheduler delay reordering FIN vs CLOSE-frame decode). Bumping Vert.x does not help — 4.5.27 is the tip of 4.5.x with no WebSocket commits since 4.5.16, and the closest 5.x fix ([eclipse-vertx/vert.x#5611](https://github.com/eclipse-vertx/vert.x/pull/5611), status code `1006` on missing CLOSE frame) still leaves `closeReason` null.

## What this changes

Splits the test in two so the failure modes are observable independently:

- **`should fire onClose notification`** — race-safe assertion that the client is notified via *any* mechanism (handler closure, ISE on registration, or `isClosed()` post-check). This is the contract the test name implies.
- **`should populate closeReason`** — strict assertion `== "Closing..."` on non-Windows; allows `null` on Windows.

Adds decision-point logging on `System.err` with a `[7806/<os.name>]` prefix so the next CI failure dumps which Vert.x path fired (handler, ISE, post-check) and the observed `closeReason` value — no rerun needed for triage.

No CHANGELOG entry — internal test stabilization, no user-visible behavior change.