### PR TITLE
test: use ephemeral ports in httpclient-vertx{,-5} SSL/body-stream tests

### DIFF
--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpBodyStreamTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5HttpBodyStreamTest.java
@@ -40,6 +40,7 @@ class Vertx5HttpBodyStreamTest {
 
   private Vertx vertx;
   private HttpServer server;
+  private int port;
   private volatile Handler<HttpServerRequest> requestHandler;
   private HttpClient.Factory clientFactory = new Vertx5HttpClientFactory();
 
@@ -54,7 +55,8 @@ class Vertx5HttpBodyStreamTest {
         req.response().setStatusCode(404).end();
       }
     });
-    server.listen(8080).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    server.listen(0).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    port = server.actualPort();
   }
 
   @AfterEach
@@ -90,7 +92,7 @@ class Vertx5HttpBodyStreamTest {
     HttpClient.Builder builder = clientFactory.newBuilder();
     HttpClient client = builder.build();
 
-    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:8080").post("text/plain", new InputStream() {
+    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:" + port).post("text/plain", new InputStream() {
       @Override
       public int read() throws IOException {
         int ret = data.get();
@@ -112,7 +114,7 @@ class Vertx5HttpBodyStreamTest {
     HttpClient.Builder builder = clientFactory.newBuilder();
     HttpClient client = builder.build();
 
-    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:8080").post("text/plain", new InputStream() {
+    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:" + port).post("text/plain", new InputStream() {
       int bytesSent = 0;
 
       @Override
@@ -173,7 +175,7 @@ class Vertx5HttpBodyStreamTest {
       }
     };
 
-    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:8080").post("text/plain", is, -1).build();
+    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:" + port).post("text/plain", is, -1).build();
     HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
     int val = Integer.parseInt(resp.body());
     assertEquals(contentLength, val);

--- a/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5SslTest.java
+++ b/httpclient-vertx-5/src/test/java/io/fabric8/kubernetes/client/vertx5/Vertx5SslTest.java
@@ -39,6 +39,7 @@ class Vertx5SslTest {
 
   private Vertx vertx;
   private HttpServer server;
+  private int port;
   private volatile Handler<HttpServerRequest> requestHandler;
   private HttpClient.Factory clientFactory = new Vertx5HttpClientFactory();
   private TrustManager[] trustManagers;
@@ -58,7 +59,8 @@ class Vertx5SslTest {
             req.response().setStatusCode(404).end();
           }
         });
-    server.listen(8443).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    server.listen(0).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    port = server.actualPort();
     TrustManagerFactory tmf = cert.trustOptions().getTrustManagerFactory(vertx);
     trustManagers = tmf.getTrustManagers();
   }
@@ -75,7 +77,7 @@ class Vertx5SslTest {
     };
     HttpClient.Builder builder = clientFactory.newBuilder().sslContext(null, trustManagers);
     HttpClient client = builder.build();
-    HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:8443").build();
+    HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:" + port).build();
     HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
     assertEquals(200, resp.code());
     assertEquals("OK", resp.bodyString());

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/HttpBodyStreamTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/HttpBodyStreamTest.java
@@ -40,6 +40,7 @@ class HttpBodyStreamTest {
 
   private Vertx vertx;
   private HttpServer server;
+  private int port;
   private volatile Handler<HttpServerRequest> requestHandler;
   private HttpClient.Factory clientFactory = new VertxHttpClientFactory();
 
@@ -54,7 +55,8 @@ class HttpBodyStreamTest {
         req.response().setStatusCode(404).end();
       }
     });
-    server.listen(8080).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    server.listen(0).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    port = server.actualPort();
   }
 
   @AfterEach
@@ -90,7 +92,7 @@ class HttpBodyStreamTest {
     HttpClient.Builder builder = clientFactory.newBuilder();
     HttpClient client = builder.build();
 
-    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:8080").post("text/plain", new InputStream() {
+    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:" + port).post("text/plain", new InputStream() {
       @Override
       public int read() throws IOException {
         int ret = data.get();
@@ -112,7 +114,7 @@ class HttpBodyStreamTest {
     HttpClient.Builder builder = clientFactory.newBuilder();
     HttpClient client = builder.build();
 
-    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:8080").post("text/plain", new InputStream() {
+    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:" + port).post("text/plain", new InputStream() {
       int bytesSent = 0;
 
       @Override
@@ -173,7 +175,7 @@ class HttpBodyStreamTest {
       }
     };
 
-    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:8080").post("text/plain", is, -1).build();
+    HttpRequest request = client.newHttpRequestBuilder().uri("http://localhost:" + port).post("text/plain", is, -1).build();
     HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
     int val = Integer.parseInt(resp.body());
     assertEquals(contentLength, val);

--- a/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
+++ b/httpclient-vertx/src/test/java/io/fabric8/kubernetes/client/vertx/SslTest.java
@@ -39,6 +39,7 @@ class SslTest {
 
   private Vertx vertx;
   private HttpServer server;
+  private int port;
   private volatile Handler<HttpServerRequest> requestHandler;
   private HttpClient.Factory clientFactory = new VertxHttpClientFactory();
   private TrustManager[] trustManagers;
@@ -58,7 +59,8 @@ class SslTest {
             req.response().setStatusCode(404).end();
           }
         });
-    server.listen(8443).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    server.listen(0).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    port = server.actualPort();
     TrustManagerFactory tmf = cert.trustOptions().getTrustManagerFactory(vertx);
     trustManagers = tmf.getTrustManagers();
   }
@@ -75,7 +77,7 @@ class SslTest {
     };
     HttpClient.Builder builder = clientFactory.newBuilder().sslContext(null, trustManagers);
     HttpClient client = builder.build();
-    HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:8443").build();
+    HttpRequest request = client.newHttpRequestBuilder().uri("https://localhost:" + port).build();
     HttpResponse<String> resp = client.sendAsync(request, String.class).get(10, TimeUnit.SECONDS);
     assertEquals(200, resp.code());
     assertEquals("OK", resp.bodyString());


### PR DESCRIPTION
Internal test stabilization. No CHANGELOG entry.

### What

Switch four `httpclient-vertx*` tests from hardcoded ports to ephemeral:

| Module | Test | Port |
|---|---|---|
| `httpclient-vertx` | `SslTest` | 8443 → 0 |
| `httpclient-vertx` | `HttpBodyStreamTest` | 8080 → 0 |
| `httpclient-vertx-5` | `Vertx5SslTest` | 8443 → 0 |
| `httpclient-vertx-5` | `Vertx5HttpBodyStreamTest` | 8080 → 0 |

`server.listen(0)…; port = server.actualPort();` and the test methods use the captured `port` field.

### Why

Surfaced on the PR #7810 stability sample (attempt 7, Java 17 ARM):

```
[ERROR] SslTest.testGet -- Time elapsed: 1.972 s <<< ERROR!
java.util.concurrent.ExecutionException: java.net.BindException: Address already in use
	at io.fabric8.kubernetes.client.vertx.SslTest.before(SslTest.java:61)
```

Under `mvn -T 1C` the reactor builds `httpclient-vertx` and `httpclient-vertx-5` in parallel; their surefire forks both try to bind 8443 (and 8080 for the body-stream tests). Whichever fork loses the race fails `@BeforeEach`. Same root-cause class as #7807, different listener.

The cascading 10s `TimeoutException` in `VertxHttpClientInterceptorTest.beforeWsModifiesRequestUri` observed in the same run was a sibling in the same surefire fork — not addressed here; will follow up separately if it reappears.

### Verification

- Mechanical change; existing tests retain identical semantics with the system-assigned port.
- CI will validate.

Refs #7810