### PR TITLE
chore(ci): pipeline-specific caches, runner flips, Sonar install parallelism

### DIFF
--- a/.github/workflows/generate-model.yml
+++ b/.github/workflows/generate-model.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   generate-model:
     name: Kubernetes Model Generator Build
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -46,11 +46,13 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache-dependency-path: kubernetes-model-generator/openapi/generator/go.sum
       - name: Setup Java 17
         uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Generate model
         run: make generate-model
       - name: Check No Schema file modified

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   javadoc:
     name: JavaDocs
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -49,5 +49,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Check Java Docs
         run: make javadoc MAVEN_ARGS="${MAVEN_ARGS}"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,14 +20,11 @@ on:
   push:
     branches:
       - main
-  # TEMPORARY: pull_request trigger enabled to validate the install/sonar:sonar split (#7814).
-  # Scoped to only the files this PR touches so contributor PRs aren't dragged through
-  # a 15-min sonar build that would fail at sonar:sonar (SONAR_TOKEN is not exposed to
-  # fork PRs). Revert (re-comment) before merging.
-  pull_request:
-    paths:
-      - '.github/workflows/sonar.yml'
-      - 'Makefile'
+#  pull_request:
+#    paths-ignore:
+#      - 'doc/**'
+#      - 'ide-config/**'
+#      - '**.md'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,11 +20,14 @@ on:
   push:
     branches:
       - main
-#  pull_request:
-#    paths-ignore:
-#      - 'doc/**'
-#      - 'ide-config/**'
-#      - '**.md'
+  # TEMPORARY: pull_request trigger enabled to validate the install/sonar:sonar split (#7814).
+  # Scoped to only the files this PR touches so contributor PRs aren't dragged through
+  # a 15-min sonar build that would fail at sonar:sonar (SONAR_TOKEN is not exposed to
+  # fork PRs). Revert (re-comment) before merging.
+  pull_request:
+    paths:
+      - '.github/workflows/sonar.yml'
+      - 'Makefile'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
@@ -52,5 +55,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Sonar
         run: make sonar

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   style-check:
     name: License & Code Style Checks
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Check License Headers
         run: ./mvnw ${MAVEN_ARGS} -Pitests -N license:check
       - name: Check Format (only on touched files)

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'maven'
       - name: Check License Headers
         run: ./mvnw ${MAVEN_ARGS} -Pitests -N license:check
       - name: Check Format (only on touched files)

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ generate-model: openapi-generate-schema openapi-generate-java-classes
 
 .PHONY: sonar
 sonar: clean
-	# $(MAVEN_ARGS) ---> -T 1C won't work with sonar analysis (yet)
-	mvn -Pcoverage,sonar install sonar:sonar
+	mvn $(MAVEN_ARGS) -Pcoverage install
+	mvn -Pcoverage,sonar sonar:sonar -DskipTests
 
 .PHONY: javadoc
 javadoc: clean


### PR DESCRIPTION
Follow-up to #7675 and #7798. Round 4 of CI tweaks — three speed-ups from the original issue plan, plus an empirical correction on item 1.

## Changes

1. **`style-checks.yml`** — runner reverted `ubuntu-24.04-arm` → `ubuntu-latest`. The issue's prescribed fix (add `cache: 'maven'`) was investigated on this branch and found to make things _worse_, not better — see "Why style-checks is special" below. The ARM regression from #7803 is fixed by reverting just the runner flip; this is the smallest diff that restores the pre-#7803 fast path.

2. **`generate-model.yml`** — flip `macos-latest` → `ubuntu-24.04-arm`, add `cache: 'maven'`, and pass `cache-dependency-path: kubernetes-model-generator/openapi/generator/go.sum` so `setup-go`'s cache stops silently disabling (the generator's `go.mod` isn't at repo root). Measured 9 m 13 s on PR vs ~10 m 30 s on the prior macOS runs.

3. **`javadocs.yml`** — flip `macos-latest` → `ubuntu-24.04-arm`, add `cache: 'maven'`. Java 11 stays.

4. **Sonar** — split `make sonar` into:
   ```
   mvn $(MAVEN_ARGS) -Pcoverage install         # parallel (-T 1C)
   mvn -Pcoverage,sonar sonar:sonar -DskipTests # serial
   ```
   `sonar:sonar` itself can't parallelize, but the upstream lifecycle can. The second invocation re-reads the JaCoCo XML reports written by the first. Also adds `cache: 'maven'` to `sonar.yml`.

## Why style-checks is special

Empirical Check Format timings across five runs explored on this branch:

| Runner | Cache | Check Format |
|---|---|---|
| `ubuntu-latest` (pre-#7803) | none | 1 m 41 s |
| `ubuntu-24.04-arm` (post-#7803, no fix) | none | 16 m 47 s |
| `ubuntu-24.04-arm` (this PR, first attempt) | hit | 12 m 7 s |
| `ubuntu-latest` (this PR, second attempt) | hit | 9 m 5 s |
| **`ubuntu-latest` (this PR, final)** | **none** | **1 m 31 s** |

There are **two independent slowdowns** at play, and they reinforce each other in ways the issue's original diagnosis conflated:

### (a) ARM runner image isn't pre-seeded with the spotless plugin classpath

On the post-#7803 ARM run (16 m 47 s, no cache), the spotless step on the root pom ran from `08:03:32` to `08:19:06` — **15 m 34 s of complete log silence**, then a single `Index file does not exist. Fallback to an empty index` line and the next module starts. No verification-storm lines, no progress markers. With `-ntp` suppressing transfer chatter, those 15+ minutes were Maven silently downloading the Eclipse JDT formatter classpath (~50–100 MB of plugin JARs) on a cold `~/.m2`.

GitHub-hosted `ubuntu-latest` images ship with a partially pre-seeded `~/.m2/repository` from the [actions/runner-images](https://github.com/actions/runner-images) build pipeline. `ubuntu-24.04-arm` is newer and its image is leaner; the spotless plugin classpath isn't pre-seeded there. Java bytecode runs the same on both architectures — the gap is purely what's already on disk when the runner starts.

### (b) `cache: 'maven'` triggers a Maven 3.9.x verification storm on cache hit

When `setup-java`'s built-in maven cache restores `~/.m2` from the shared `setup-java-${os}-${arch}-maven-${pomHash}` cache (populated by build.yml's `mvn install`), the cached artifacts carry `_remote.repositories` markers from build.yml's Maven session. style-checks's Maven session uses a different effective repo config and sees the markers as mismatched, then **re-verifies every artifact against central** (the `cached from a remote repository ID that is unavailable in current build context` log lines).

On run 26030376223 (this PR, x64 with cache hit), spotless:check on the root pom ran from `11:22:54` to `11:30:40` — 7 m 45 s of wall-to-wall verification-storm lines.

### How they combine

| Setup | Behaviour | Net |
|---|---|---|
| x64 + no cache | Pre-seeded `~/.m2` → tiny incremental downloads | **1 m 31 s** |
| ARM + no cache | Cold `~/.m2` (image not pre-seeded) → full Eclipse JDT download under `-ntp` silence | 16 m 47 s |
| x64 or ARM + cache | Cache restored over pre-seeded state with mismatched repo markers → verification storm | 9–12 min |

style-checks is the only workflow where the entire job is `spotless:check` — neither cost has anywhere to hide. The other workflows in this PR (build, generate-model, javadocs, sonar) all run heavy `mvn install` work that dwarfs both: they download everything they need either way, so pre-seeding is a wash, and the storm cost is buried in real compile/test time. They keep their cache adds.

## Sonar trial-run validation

The temporary `pull_request:` trigger added earlier on this branch (and now reverted) confirmed the Makefile split works at the architecture level: `mvn -Pcoverage install` ran ~13 min on PR #7816, all reactor modules + JaCoCo green; `sonar:sonar` fired as a second JVM and only failed at auth (expected — `SONAR_TOKEN` is not exposed to cross-fork PRs, so it 401s in ~14 s). The coverage-ingestion delta will need to be verified on the first `push:main` run after merge — compare against the prior baseline on SonarCloud, and revert if the delta looks wrong.

## Future work (out of scope here)

If style-checks should go back to ARM at some point, the fix would be to either (a) pre-warm the spotless plugin classpath in a separate step before `spotless:check` (e.g. `./mvnw -N dependency:resolve-plugins -Pitests`), or (b) build a workflow-specific cache with a unique key so it doesn't inherit build.yml's mismatched `_remote.repositories` markers.

Refs #7814